### PR TITLE
Add predict and eval tasks for Planet Kaggle

### DIFF
--- a/src/experiments/tagging/5_17_17/baseline.json
+++ b/src/experiments/tagging/5_17_17/baseline.json
@@ -1,0 +1,17 @@
+{
+    "batch_size": 32,
+    "git_commit": "609600",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "tiff",
+    "active_input_inds": [0, 1, 2, 3],
+    "use_pretraining": false,
+    "optimizer": "adam",
+    "lr_schedule": [[0, 0.001], [100, 0.0001], [125, 0.00001]],
+    "model_type": "baseline_resnet",
+    "train_ratio": 0.8,
+    "epochs": 150,
+    "validation_steps": 32,
+    "run_name": "tagging/5_17_17/baseline",
+    "steps_per_epoch": 128
+}

--- a/src/experiments/tests/tagging/planet_kaggle_quick_test.json
+++ b/src/experiments/tests/tagging/planet_kaggle_quick_test.json
@@ -12,7 +12,6 @@
     "train_ratio": 0.8,
     "epochs": 2,
     "validation_steps": 1,
-    "nb_eval_samples": 1,
     "run_name": "tests/tagging/planet_kaggle_quick_test",
     "steps_per_epoch": 2
 }

--- a/src/rastervision/common/options.py
+++ b/src/rastervision/common/options.py
@@ -32,3 +32,8 @@ class Options():
         self.cross_validation = options.get('cross_validation')
         self.delta_model_checkpoint = options.get(
             'delta_model_checkpoint', None)
+
+        # Controls how many samples to use in the final evaluation.
+        # Setting this to a low value can be useful when testing
+        # the code, since it will save time.
+        self.nb_eval_samples = options.get('nb_eval_samples')

--- a/src/rastervision/semseg/options.py
+++ b/src/rastervision/semseg/options.py
@@ -16,11 +16,6 @@ class SemsegOptions(Options):
 
         self.nb_videos = options.get('nb_videos')
 
-        # Controls how many samples to use in the final evaluation.
-        # Setting this to a low value can be useful when testing
-        # the code, since it will save time.
-        self.nb_eval_samples = options.get('nb_eval_samples')
-
         if self.model_type == CONV_LOGISTIC:
             self.kernel_size = options['kernel_size']
         elif self.model_type == FC_DENSENET:

--- a/src/rastervision/tagging/tasks/predict.py
+++ b/src/rastervision/tagging/tasks/predict.py
@@ -1,0 +1,72 @@
+from os.path import join
+
+import numpy as np
+
+from rastervision.common.settings import VALIDATION, TEST
+from rastervision.tagging.data.planet_kaggle import TagStore
+
+VALIDATION_PREDICT = 'validation_predict'
+TEST_PREDICT = 'test_predict'
+
+
+def predict(run_path, model, options, generator, split):
+    """Generate predictions for split data.
+
+    For each image in a split, create a prediction, add it to the TagStore,
+    and then save the TagStore to a csv file.
+
+    # Arguments
+        run_path: the path to the files for a run
+        model: a Keras model that has been trained
+        options: RunOptions object that specifies the run
+        generator: a Generator object to generate the test data
+        split: name of the split eg. validation
+    """
+    predictions_path = join(run_path, '{}_predictions.csv'.format(split))
+
+    batch_size = options.batch_size
+    split_gen = generator.make_split_generator(
+        split, target_size=None,
+        batch_size=batch_size, shuffle=False, augment=False,
+        normalize=True, only_xy=False)
+
+    tag_store = TagStore()
+    atmos_inds = [generator.dataset.tag_to_ind[tag]
+                  for tag in generator.dataset.atmos_tags]
+
+    for batch_ind, batch in enumerate(split_gen):
+        y_prob = model.predict(batch.x)
+
+        # TODO experimenting with a different threshold
+        # remove this after the loss function is a better approximate
+        # of f2
+        y_pred = (y_prob > 0.2).astype(np.float32)
+        for sample_ind in range(batch.x.shape[0]):
+            y_pred_sample = y_pred[sample_ind, :]
+            y_prob_sample = y_prob[sample_ind, :]
+
+            # TODO remove this post-processing step once our model
+            # enforces the constraint that there is at least one atmospheric
+            # tag.
+            if np.sum(y_pred_sample[atmos_inds]) == 0:
+                max_ind = np.argmax(y_prob_sample[atmos_inds])
+                max_tag = generator.dataset.atmos_tags[max_ind]
+                max_ind = generator.dataset.tag_to_ind[max_tag]
+                y_pred_sample[max_ind] = 1
+
+            tag_store.add_tags(
+                batch.file_inds[sample_ind], y_pred_sample)
+
+        if (options.nb_eval_samples is not None and
+                batch_ind * options.batch_size >= options.nb_eval_samples):
+            break
+
+    tag_store.save(predictions_path)
+
+
+def validation_predict(run_path, model, options, generator):
+    predict(run_path, model, options, generator, VALIDATION)
+
+
+def test_predict(run_path, model, options, generator):
+    predict(run_path, model, options, generator, TEST)

--- a/src/rastervision/tagging/tasks/validation_eval.py
+++ b/src/rastervision/tagging/tasks/validation_eval.py
@@ -1,0 +1,38 @@
+from os.path import join, isfile
+import json
+
+from rastervision.tagging.data.planet_kaggle import TagStore
+from rastervision.tagging.utils import f2_score
+
+VALIDATION_EVAL = 'validation_eval'
+
+
+class Scores():
+    """A set of scores for the performance of a model on a dataset."""
+    def __init__(self):
+        self.f2 = None
+
+    def to_json(self):
+        return json.dumps(self.__dict__, sort_keys=True, indent=4)
+
+    def save(self, path):
+        scores_json = self.to_json()
+        with open(path, 'w') as scores_file:
+            scores_file.write(scores_json)
+
+
+def validation_eval(run_path, generator):
+    y_true = generator.tag_store.get_tag_array(generator.validation_file_inds)
+
+    predictions_path = join(run_path, 'validation_predictions.csv')
+    if not isfile(predictions_path):
+        raise Exception(
+            'validation_predict needs to be run before validation_eval.')
+    predictions_tag_store = TagStore(predictions_path)
+    y_pred = predictions_tag_store.get_tag_array(
+        generator.validation_file_inds)
+
+    scores = Scores()
+    scores.f2 = f2_score(y_true, y_pred)
+    scores_path = join(run_path, 'scores.json')
+    scores.save(scores_path)

--- a/src/rastervision/tagging/utils.py
+++ b/src/rastervision/tagging/utils.py
@@ -1,0 +1,14 @@
+from sklearn.metrics import fbeta_score
+import numpy as np
+
+
+# Copied from https://www.kaggle.com/anokas/fixed-f2-score-in-python
+def f2_score(y_true, y_pred):
+    """Compute F2 score.
+       Note that with f2 score, your predictions need to be binary.
+    """
+    # fbeta_score throws a confusing error if inputs are not numpy arrays
+    y_true, y_pred, = np.array(y_true), np.array(y_pred)
+    # We need to use average='samples' here, any other average method
+    # will generate bogus results
+    return fbeta_score(y_true, y_pred, beta=2, average='samples')


### PR DESCRIPTION
This PR adds `validation_predict`, `validation_eval`, and `test_predict` tasks, which allows us to generate a submission for the Kaggle leaderboard. We also ran an experiment with our baseline model for our first submission to the contest.