### PR TITLE
Run experiments using AWS Batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 ## Introduction
 
-This goal of this project is to implement a variety of deep learning architectures for analyzing aerial and satellite imagery. At the moment, we have implemented approaches for semantic segmentation, and are about to begin work on tagging/recognition. In the future we may add support for object detection. There is code for building Docker containers, running experiments on AWS EC2, loading and processing data, and constructing, training and evaluating models
+The goal of this project is to create a system for analyzing aerial and satellite imagery using deep learning that works on a variety of tasks and datasets. At the moment, we have implemented approaches for semantic segmentation, and are working on tagging/recognition. In the future we may add support for object detection. There is code for building Docker containers, running experiments on AWS EC2 using [AWS Batch](https://aws.amazon.com/batch/), loading and processing data, and constructing, training and evaluating models
 using the [Keras](https://keras.io/) and [Tensorflow](https://www.tensorflow.org/) libraries.
 
-⚠️ 🚧 This project is under construction. Some things are poorly documented, may change drastically without notice, and are tied to the particular experiments that we are running.
-
 ### Semantic Segmentation
-The goal of semantic segmentation is to infer a meaningful label such as "road" or "building for each pixel in an image. Here is an example of an aerial image segmented using a model learned by our system.
+The goal of semantic segmentation is to infer a meaningful label such as "road" or "building" for each pixel in an image. Here is an example of an aerial image segmented using a model learned by our system.
 
 ![Example segmentation](results/unet/img/good1.png)
 
@@ -54,6 +52,8 @@ The goal of tagging is to infer a set of labels for each image. The following da
 | `test`   | Run unit tests and lint on source code |
 | `run` | Run container locally or remotely |
 | `setup`  | Bring up the virtual machine and install dependent software on it |
+| `setup_aws_batch`  | Setup AWS Batch |
+| `submit_jobs`  | Submit jobs to AWS Batch |
 | `update` | Install dependent software inside virtual machine |
 | `upload_code` | Upload code to EC2 instance for rapid debugging |
 
@@ -122,23 +122,34 @@ python -m rastervision.run experiments/tests/semseg/potsdam_quick_test.json plot
 ```
 This will generate a directory structure in `results/<run_name>/` which contains the options file, the learned model, and various metrics and visualization files.
 
+### Generating experiment files
+
+When running a large number of experiments in parallel, it is convenient to generate the experiment files via a script. You can do this by extending the `ExperimentGenerator` class and then running it. For example, running `python experiments/tests/generator/generate_experiments.py` will create an `experiments` subdirectory, and fill it with generated experiment files.
+
 ## Running remotely on AWS EC2 GPUs
 
-Support for Amazon EC2 GPU instances is provided through a combination of the AWS CLI and Terraform. The AWS CLI is used to produce a local AWS profile with valid credentials, and Terraform is used to bring up the appropriate EC2 instances using spot pricing.
+In order to run experiments on GPUs and in parallel, we use AWS EC2. There are two ways to use EC2: by manually spinning up an EC2 instance and then ssh'ing into it, or by submitting a set of jobs to run in parallel via AWS Batch. The results are saved to the S3 bucket after each epoch and the final evaluation. If a run is terminated for any reason and you would like to resume it, simply restart the run, and it should pick up where it left off.
 
-### Spot Fleet
+### Publishing the container to ECR
 
-Once an AWS profile exists, use the `infra` script to interact with Amazon EC2 Spot Fleet API, which will request the lowest priced P2 GPU instance across all availability zones. The following command will start 2 instances and print their
+The latest Docker image should be stored in ECR so that it can be downloaded onto EC2 instances. To build and publish the container, run `./scripts/cipublish`.
+
+### Submit jobs to AWS Batch
+To setup the AWS Batch stack, which should only be done once per AWS account, run `./scripts/setup_aws_batch`. To submit a set of jobs to Batch, use the `submit_jobs` script. The syntax for invoking it is `./scripts/submit_jobs <branch_name> <experiment_dir> <space separated list of tasks>`. The `branch_name` should be the name of the branch with the code to run, `experiment_dir` should be a directory full of experiment json files rooted at `experiments`, and the list of tasks should contain the task you want to run. For example, you could run
+```shell
+./scripts/submit_jobs lf/batch experiments/tests/generator/experiments train_model validation_eval
+```
+After submitting jobs, AWS Batch will start an EC2 instance for each experiment and will shut them down when finished.
+
+### Run directly on EC2
+
+For debugging purposes, it may be desirable to start an EC2 spot instance (with the container image and this repo downloaded), log into the instance, and run the container manually. This can be done with Terraform using the `infra` script. The following command will start 1 instance and print their
 public DNS names.
 ```bash
-vagrant@vagrant-ubuntu-trusty-64:/vagrant$ ./scripts/infra start 2
+vagrant@vagrant-ubuntu-trusty-64:/vagrant$ ./scripts/infra start 1
 ```
 
 Afterwards, navigate to the [spot request](https://console.aws.amazon.com/ec2sp/v1/spot/home?region=us-east-1#) section of the EC2 console to monitor the request's progress. Once fulfilled, a running instance will visible in the [instances](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:sort=instanceId) section.
-
-After initializing, the instance should have `nvidia-docker`, the GPU-enabled Docker image for this repo, and this repo + datasets in the home directory.
-
-### Running Models on GPUs
 
 After starting an instance, `ssh` into it with
 ```shell
@@ -153,14 +164,7 @@ cd raster-vision
 root@230fb62d8ecd:/opt/src# python -m rastervision.run experiments/tests/semseg/potsdam_quick_test.json
 ```
 
-When running on EC2, the results will be saved to the S3 bucket after each epoch and the final evaluation. If a run is terminated for any reason and you would like to resume it,
-simply run the above command with the same options file, and it should pick up where it left off.
-
 ⚠️️ When finished with all the instances, you should shut them down with
 ```shell
 ./scripts/infra destroy
 ```
-
-### Publishing the Docker container to ECR
-
-To enable fast bootup, we publish the latest Docker image to ECR and then download it when initializing the EC2 instance. To build and publish the container, run `./scripts/cipublish`.

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -2,7 +2,7 @@
 aws_region: "us-east-1"
 aws_profile: "raster-vision"
 
-aws_cli_version: "1.11.8"
+aws_cli_version: "1.11.84"
 
 terraform_version: "0.7.7"
 

--- a/deployment/batch/compute_environment.json
+++ b/deployment/batch/compute_environment.json
@@ -1,0 +1,30 @@
+{
+    "computeEnvironmentName": "raster-vision-p2",
+    "type": "MANAGED",
+    "state": "ENABLED",
+    "computeResources": {
+        "type": "SPOT",
+        "minvCpus": 0,
+        "maxvCpus": 400,
+        "desiredvCpus": 0,
+        "instanceTypes": [
+            "p2.xlarge"
+        ],
+        "subnets": [
+            "subnet-e121d7cd",
+            "subnet-b2f915e8",
+            "subnet-804804bc",
+            "subnet-173c9c5f",
+            "subnet-7f16321a"
+        ],
+        "spotIamFleetRole": "arn:aws:iam::279682201306:role/aws-ec2-spot-fleet-role",
+        "securityGroupIds": [
+            "sg-4c00d332"
+        ],
+        "imageId": "ami-d09fd7c6",
+        "bidPercentage": 50,
+        "instanceRole": "arn:aws:iam::279682201306:instance-profile/raster-vision-instance-profile",
+        "ec2KeyPair": "raster-vision"
+    },
+    "serviceRole": "arn:aws:iam::279682201306:role/service-role/AWSBatchServiceRole"
+}

--- a/deployment/batch/job_def.json
+++ b/deployment/batch/job_def.json
@@ -1,0 +1,60 @@
+{
+    "jobDefinitionName": "raster-vision-experiment",
+    "type": "container",
+    "parameters": {},
+    "retryStrategy": {
+        "attempts": 1
+    },
+    "containerProperties": {
+        "image": "279682201306.dkr.ecr.us-east-1.amazonaws.com/raster-vision-gpu:latest",
+        "vcpus": 4,
+        "memory": 2000,
+        "command": [
+            "run_experiment.sh",
+            "raster-vision",
+            "lf/batch",
+            "experiments/tests/semseg/potsdam_quick_test.json",
+            "validation_eval"
+        ],
+        "volumes": [
+            {
+                "host": {
+                    "sourcePath": "/usr"
+                },
+                "name": "usr"
+            },
+            {
+                "host": {
+                    "sourcePath": "/lib"
+                },
+                "name": "lib"
+            },
+            {
+                "host": {
+                    "sourcePath": "/home/ec2-user"
+                },
+                "name": "home"
+            }
+        ],
+        "mountPoints": [
+            {
+                "containerPath": "/hostusr",
+                "readOnly": false,
+                "sourceVolume": "usr"
+            },
+            {
+                "containerPath": "/hostlib",
+                "readOnly": false,
+                "sourceVolume": "lib"
+            },
+            {
+                "containerPath": "/opt/data",
+                "readOnly": false,
+                "sourceVolume": "home"
+            }
+        ],
+        "readonlyRootFilesystem": false,
+        "privileged": true,
+        "ulimits": []
+    }
+}

--- a/deployment/batch/job_queue.json
+++ b/deployment/batch/job_queue.json
@@ -1,0 +1,11 @@
+{
+  "jobQueueName": "raster-vision-experiments",
+  "state": "ENABLED",
+  "priority": 1,
+  "computeEnvironmentOrder": [
+    {
+      "order": 1,
+      "computeEnvironment": "raster-vision-p2"
+    }
+  ]
+}

--- a/deployment/terraform/config-ec2
+++ b/deployment/terraform/config-ec2
@@ -6,14 +6,7 @@ echo "export S3_BUCKET=\"$S3_BUCKET\"" >> /etc/environment
 cd /home/ec2-user
 
 # Install command line tools
-sudo yum install -y aws-cli git unzip
-
-# Install nvidia-docker and nvidia-docker-plugin
-wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1_amd64.tar.xz
-sudo tar --strip-components=1 -C /usr/bin -xvf /tmp/nvidia-docker*.tar.xz && rm /tmp/nvidia-docker*.tar.xz
-
-# Run nvidia-docker-plugin
-sudo -b nohup nvidia-docker-plugin > /tmp/nvidia-docker.log
+sudo yum install -y aws git unzip aws-cli
 
 # Setup data directory
 sudo mkdir /home/ec2-user/data

--- a/scripts/run
+++ b/scripts/run
@@ -28,10 +28,11 @@ then
             raster-vision-cpu "${@:2}"
     elif [ "${1:-}" = "--gpu" ]
     then
-        sudo nvidia-docker run --rm -it \
+        sudo docker run --rm -it \
             -e "S3_BUCKET=$S3_BUCKET" \
             -v ~/raster-vision/src:/opt/src \
             -v ~/data:/opt/data \
+            --privileged -v /usr:/hostusr -v /lib:/hostlib  \
             279682201306.dkr.ecr.us-east-1.amazonaws.com/raster-vision-gpu:latest "${@:2}"
     else
         usage

--- a/scripts/setup_aws_batch
+++ b/scripts/setup_aws_batch
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0")
+Setup AWS Batch with a compute environment, job queue and job definition. This
+should only be done once per AWS account.
+"
+}
+
+PROJECT_ROOT="$(dirname "$(dirname "$(readlink -f "${0}")")")"
+BATCH_CONFIG=$PROJECT_ROOT/deployment/batch
+
+echo aws batch create-compute-environment --cli-input-json file://$BATCH_CONFIG/compute_environment.json
+echo aws batch create-job-queue --cli-input-json file://$BATCH_CONFIG/job_queue.json
+echo aws batch register-job-definition --cli-input-json file://$BATCH_CONFIG/job_def.json

--- a/scripts/submit_jobs
+++ b/scripts/submit_jobs
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0") <branch_name> <experiment_dir> <space separated list of tasks>
+Submits a set of jobs to AWS Batch. experiment_dir should be a directory containing experiment json files with root at experiments/
+"
+}
+
+PROJECT_ROOT="$(dirname "$(dirname "$(readlink -f "${0}")")")"
+
+if [[ (("$#" < 2)) || "${1:-}" = "--help" ]]; then
+    usage
+    exit
+fi
+
+branch_name=$1
+exp_dir=$2
+tasks=${@:3}
+file_paths="$PROJECT_ROOT"/src/"$exp_dir"/*.json
+nb_files=$(echo $file_paths | wc -w)
+
+echo "Branch name: $branch_name"
+echo "Experiment dir: $exp_dir"
+echo "Tasks: $tasks"
+
+function prompt() {
+    read -r response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            ;;
+        *)
+            exit
+            ;;
+    esac
+}
+
+echo "Are your experiment files pushed to $branch_name? [y/N]"
+prompt
+echo "Do you really want to run $nb_files jobs? [y/N]"
+prompt
+
+echo "Ok, launching $nb_files jobs..."
+for file_path in $file_paths; do
+    exp_path="$exp_dir"/$(basename "$file_path")
+    job_name=$(echo $exp_path | tr \/. _)
+    if [ -z "$tasks" ]; then
+        command="command=[run_experiment.sh,$S3_BUCKET,$branch_name,$exp_path]"
+    else
+        command="command=[run_experiment.sh,$S3_BUCKET,$branch_name,$exp_path,$(echo $tasks | tr ' ' ,)]"
+    fi
+
+    aws batch submit-job --job-name $job_name --job-queue raster-vision-experiments \
+        --job-definition raster-vision-experiment \
+        --container-overrides $command
+done

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -37,3 +37,10 @@ RUN conda install -y python=${python_version} scikit-learn six h5py \
 
 RUN pip install git+git://github.com/jakebian/quiver.git && \
     pip install flake8 awscli
+
+WORKDIR /opt/src
+
+# Ensure that the keras user will have permission to write model into /opt/data
+USER root
+RUN mkdir /opt/data
+RUN chown -R keras:root /opt/data

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -22,7 +22,7 @@ RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p /src && \
     chown keras /src
 
-ENV PYTHONPATH='/src/:$PYTHONPATH'
+ENV PYTHONPATH=/src/:$PYTHONPATH
 
 ENV KERAS_BACKEND tensorflow
 
@@ -39,6 +39,7 @@ RUN pip install git+git://github.com/jakebian/quiver.git && \
     pip install flake8 awscli
 
 WORKDIR /opt/src
+ENV PYTHONPATH=/opt/src/:$PYTHONPATH
 
 # Ensure that the keras user will have permission to write model into /opt/data
 USER root

--- a/src/Dockerfile-cpu
+++ b/src/Dockerfile-cpu
@@ -1,22 +1,11 @@
 # Based on https://github.com/fchollet/keras/blob/7c6463da6f972ffaa466b0f55d06b760a98caf8e/docker/Dockerfile
 FROM raster-vision-base
 
-USER keras
-
 # Python
 ARG tensorflow_version=1.0.1-cp35-cp35m
 ARG architecture=cpu
 
 RUN pip install https://storage.googleapis.com/tensorflow/linux/${architecture}/tensorflow-${tensorflow_version}-linux_x86_64.whl && \
     pip install git+git://github.com/fchollet/keras.git@7c6463da6f972ffaa466b0f55d06b760a98caf8e
-
-WORKDIR /opt/src
-
-COPY . /opt/src
-
-# Ensure that the keras user will have permission to write model into /opt/data
-USER root
-RUN mkdir /opt/data
-RUN chown -R keras:root /opt/data
 
 CMD ["bash"]

--- a/src/Dockerfile-gpu
+++ b/src/Dockerfile-gpu
@@ -1,22 +1,11 @@
 # Based on https://github.com/fchollet/keras/blob/7c6463da6f972ffaa466b0f55d06b760a98caf8e/docker/Dockerfile
 FROM raster-vision-base
 
-USER keras
-
-# Python
-
 ARG tensorflow_version=1.0.1-cp35-cp35m
 
 RUN pip install https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-${tensorflow_version}-linux_x86_64.whl && \
     pip install git+git://github.com/fchollet/keras.git@7c6463da6f972ffaa466b0f55d06b760a98caf8e
 
-WORKDIR /opt/src
-
-COPY . /opt/src
-
-# Ensure that the keras user will have permission to write model into /opt/data
-USER root
-RUN mkdir /opt/data
-RUN chown -R keras:root /opt/data
-
-CMD ["bash"]
+COPY gpu_startup.sh /usr/local/bin/
+COPY run_experiment.sh /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/gpu_startup.sh"]

--- a/src/experiments/tests/generator/experiments/0.json
+++ b/src/experiments/tests/generator/experiments/0.json
@@ -1,0 +1,36 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2,
+        4,
+        5
+    ],
+    "batch_size": 1,
+    "dataset_name": "isprs/potsdam",
+    "epochs": 2,
+    "eval_target_size": [
+        2000,
+        2000
+    ],
+    "generator_name": "numpy",
+    "git_commit": null,
+    "init_lr": 0.001,
+    "kernel_size": [
+        5,
+        5
+    ],
+    "model_type": "conv_logistic",
+    "nb_eval_samples": 1,
+    "nb_labels": 6,
+    "optimizer": "adam",
+    "problem_type": "semseg",
+    "run_name": "tests/semseg/potsdam_generator_quick_test/0",
+    "steps_per_epoch": 2,
+    "target_size": [
+        256,
+        256
+    ],
+    "train_ratio": 0.8,
+    "validation_steps": 1
+}

--- a/src/experiments/tests/generator/experiments/1.json
+++ b/src/experiments/tests/generator/experiments/1.json
@@ -1,0 +1,36 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2,
+        4,
+        5
+    ],
+    "batch_size": 1,
+    "dataset_name": "isprs/potsdam",
+    "epochs": 2,
+    "eval_target_size": [
+        2000,
+        2000
+    ],
+    "generator_name": "numpy",
+    "git_commit": null,
+    "init_lr": 0.0001,
+    "kernel_size": [
+        5,
+        5
+    ],
+    "model_type": "conv_logistic",
+    "nb_eval_samples": 1,
+    "nb_labels": 6,
+    "optimizer": "adam",
+    "problem_type": "semseg",
+    "run_name": "tests/semseg/potsdam_generator_quick_test/1",
+    "steps_per_epoch": 2,
+    "target_size": [
+        256,
+        256
+    ],
+    "train_ratio": 0.8,
+    "validation_steps": 1
+}

--- a/src/experiments/tests/generator/generate_experiments.py
+++ b/src/experiments/tests/generator/generate_experiments.py
@@ -1,0 +1,48 @@
+from os.path import join
+from copy import deepcopy
+
+from rastervision.experiment_generator import (
+    ExperimentGenerator, get_parent_dir)
+
+
+class TestExperimentGenerator(ExperimentGenerator):
+    def generate_experiments(self):
+        base_exp = {
+            'batch_size': 1,
+            'git_commit': None,
+            'problem_type': 'semseg',
+            'dataset_name': 'isprs/potsdam',
+            'generator_name': 'numpy',
+            'active_input_inds': [0, 1, 2, 4, 5],
+            'optimizer': 'adam',
+            'init_lr': 1e-3,
+            'target_size': [256, 256],
+            'eval_target_size': [2000, 2000],
+            'model_type': 'conv_logistic',
+            'train_ratio': 0.8,
+            'kernel_size': [5, 5],
+            'epochs': 2,
+            'nb_labels': 6,
+            'validation_steps': 1,
+            'nb_eval_samples': 1,
+            'run_name': 'tests/semseg/potsdam_generator_quick_test',
+            'steps_per_epoch': 2
+        }
+
+        init_lrs = [1e-3, 1e-4]
+
+        exps = []
+        exp_count = 0
+        for init_lr in init_lrs:
+            exp = deepcopy(base_exp)
+            exp['init_lr'] = init_lr
+            exp['run_name'] = join(exp['run_name'], str(exp_count))
+            exps.append(exp)
+            exp_count += 1
+
+        return exps
+
+
+if __name__ == '__main__':
+    path = get_parent_dir(__file__)
+    gen = TestExperimentGenerator().run(path)

--- a/src/gpu_startup.sh
+++ b/src/gpu_startup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Modified from https://blog.cloudsight.ai/deep-learning-image-recognition-using-gpus-in-amazon-ecs-docker-containers-5bdb1956f30e
+
+set -e
+
+echo "Copying the NVidia drivers from the parent..."
+find /hostusr -name "*nvidia*" -o -name "*cuda*" -o -name "*GL*" | while read path
+do
+  newpath="/usr${path#/hostusr}"
+  mkdir -p `dirname $newpath` && \
+    cp -a $path $newpath
+done
+
+cp -ar /hostlib/modules /lib
+
+echo "/usr/lib64" > /etc/ld.so.conf.d/nvidia.conf
+ldconfig
+
+set -x
+$@

--- a/src/rastervision/experiment_generator.py
+++ b/src/rastervision/experiment_generator.py
@@ -1,0 +1,40 @@
+from os.path import dirname, abspath, join
+import json
+
+from rastervision.options import make_options
+
+from rastervision.common.utils import _makedirs
+
+
+def get_parent_dir(f):
+    return dirname(abspath(f))
+
+
+class ExperimentGenerator():
+    def run(self, path):
+        exps = self.generate_experiments()
+        self.save_to_dir(exps, path)
+
+    def save_to_dir(self, experiments, path):
+        if not self.has_unique_run_names(experiments):
+            raise ValueError('Each run_name needs to be unique.')
+
+        for exp_ind, exp in enumerate(experiments):
+            self.parse_experiment(exp)
+
+            json_str = json.dumps(exp, sort_keys=True, indent=4)
+            exp_path = join(path, 'experiments', '{}.json'.format(exp_ind))
+            _makedirs(dirname(exp_path))
+            with open(exp_path, 'w') as exp_file:
+                exp_file.write(json_str)
+
+    def parse_experiment(self, experiment):
+        # Will raise exception if it can't be parsed.
+        make_options(experiment)
+
+    def has_unique_run_names(self, experiments):
+        run_names = [exp['run_name'] for exp in experiments]
+        return len(run_names) == len(set(run_names))
+
+    def generate_experiments(self):
+        raise NotImplementedError()

--- a/src/rastervision/options.py
+++ b/src/rastervision/options.py
@@ -1,0 +1,19 @@
+from rastervision.semseg.options import SemsegOptions
+from rastervision.semseg.settings import SEMSEG
+
+from rastervision.tagging.options import TaggingOptions
+from rastervision.tagging.settings import TAGGING
+
+
+def make_options(options_dict):
+    problem_type = options_dict.get('problem_type')
+
+    options = None
+    if problem_type is None:
+        raise ValueError('problem_type must be specified in options file')
+    elif problem_type == SEMSEG:
+        options = SemsegOptions(options_dict)
+    elif problem_type == TAGGING:
+        options = TaggingOptions(options_dict)
+
+    return options

--- a/src/rastervision/run.py
+++ b/src/rastervision/run.py
@@ -5,6 +5,8 @@ run. Example usage: `python run.py options.json train_model`
 import argparse
 import json
 
+from rastervision.options import make_options
+
 from rastervision.semseg.settings import SEMSEG
 from rastervision.semseg.run import run_tasks as semseg_run_tasks
 
@@ -29,18 +31,14 @@ def run_tasks():
     args = parse_args()
     with open(args.file_path) as options_file:
         options_dict = json.load(options_file)
-        problem_type = options_dict.get('problem_type')
-
-        if problem_type is None:
-            raise ValueError('problem_type must be specified in options file')
-
-        if problem_type == SEMSEG:
-            semseg_run_tasks(options_dict, args.tasks)
-        elif problem_type == TAGGING:
-            tagging_run_tasks(options_dict, args.tasks)
+        options = make_options(options_dict)
+        if options.problem_type == SEMSEG:
+            semseg_run_tasks(options, args.tasks)
+        elif options.problem_type == TAGGING:
+            tagging_run_tasks(options, args.tasks)
         else:
             raise ValueError('{} is not a valid problem_type'.format(
-                problem_type))
+                options.problem_type))
 
 
 if __name__ == '__main__':

--- a/src/rastervision/semseg/run.py
+++ b/src/rastervision/semseg/run.py
@@ -6,7 +6,6 @@ from rastervision.common.tasks.plot_curves import plot_curves, PLOT_CURVES
 from rastervision.common.tasks.train_model import TRAIN_MODEL
 from rastervision.common.settings import results_path, datasets_path
 
-from rastervision.semseg.options import SemsegOptions
 from rastervision.semseg.data.factory import SemsegDataGeneratorFactory
 from rastervision.semseg.models.factory import SemsegModelFactory
 from rastervision.semseg.tasks.train_model import SemsegTrainModel
@@ -21,13 +20,12 @@ valid_tasks = [TRAIN_MODEL, PLOT_CURVES,
                MAKE_VIDEOS]
 
 
-def run_tasks(options_dict, tasks):
+def run_tasks(options, tasks):
     """Run tasks specified on command line.
 
     This creates the RunOptions object from the json file specified on the
     command line, creates a data generator, and then runs the tasks.
     """
-    options = SemsegOptions(options_dict)
     model_factory = SemsegModelFactory()
     generator = SemsegDataGeneratorFactory().get_data_generator(options)
     run_path = join(results_path, options.run_name)

--- a/src/rastervision/tagging/run.py
+++ b/src/rastervision/tagging/run.py
@@ -6,7 +6,6 @@ from rastervision.common.tasks.plot_curves import plot_curves, PLOT_CURVES
 from rastervision.common.tasks.train_model import TRAIN_MODEL
 from rastervision.common.settings import results_path
 
-from rastervision.tagging.options import TaggingOptions
 from rastervision.tagging.data.factory import TaggingDataGeneratorFactory
 from rastervision.tagging.models.factory import TaggingModelFactory
 from rastervision.tagging.tasks.train_model import TaggingTrainModel
@@ -19,13 +18,12 @@ valid_tasks = [TRAIN_MODEL, PLOT_CURVES, VALIDATION_PREDICT,
                VALIDATION_EVAL, TEST_PREDICT]
 
 
-def run_tasks(options_dict, tasks):
+def run_tasks(options, tasks):
     """Run tasks specified on command line.
 
     This creates the RunOptions object from the json file specified on the
     command line, creates a data generator, and then runs the tasks.
     """
-    options = TaggingOptions(options_dict)
     model_factory = TaggingModelFactory()
     generator = TaggingDataGeneratorFactory().get_data_generator(options)
     run_path = join(results_path, options.run_name)

--- a/src/run_experiment.sh
+++ b/src/run_experiment.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Copies the git branch into the right place inside the container and then runs
+# Raster Vision.
+
+export S3_BUCKET=$1
+branch=$2
+run_args=${@:3}
+git clone -b $branch https://github.com/azavea/raster-vision.git /tmp/raster-vision
+cp -R /tmp/raster-vision/src/* /opt/src/
+python -m rastervision.run $run_args


### PR DESCRIPTION
This PR makes it so that we can run experiments in parallel using AWS Batch. The new workflow is to generate experiment files programmatically by extending the `ExperimentGenerator` class and then submit jobs based on these experiment files to AWS Batch using `./scripts/submit_jobs`. AWS Batch will start the appropriate number of instances and then shut them down. We are also no longer using `nvidia-docker`, which fixes #22. See commit messages and updated README.md for more details.

The AMI we are using for Batch instances was generated as follows:
* Start an instance with a 128 GB root volume and 22 GB data volume using the ECS-optimized AMI with id ami-275ffe1 (see http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI_launch_latest.html)
* Install NVIDIA drivers 375.51 using instructions in http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html
* Run `sudo stop ecs` and then `sudo rm /var/lib/ecs/data/ecs_agent_data.json`
* Create the AMI

Connects #10 
