### PR TITLE
Sequence jobs on AWS Batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ In order to run experiments on GPUs and in parallel, we use AWS EC2. There are t
 The latest Docker image should be stored in ECR so that it can be downloaded onto EC2 instances. To build and publish the container, run `./scripts/cipublish`.
 
 ### Submit jobs to AWS Batch
-To setup the AWS Batch stack, which should only be done once per AWS account, run `./scripts/setup_aws_batch`. To submit a set of jobs to Batch, use the `submit_jobs` script. The syntax for invoking it is `./scripts/submit_jobs <branch_name> <experiment_dir> <space separated list of tasks>`. The `branch_name` should be the name of the branch with the code to run, `experiment_dir` should be a directory full of experiment json files rooted at `experiments`, and the list of tasks should contain the task you want to run. For example, you could run
+To setup the AWS Batch stack, which should only be done once per AWS account, run `./scripts/setup_aws_batch`. To submit a set of jobs to Batch, use the `submit_jobs` script. The syntax for invoking it is `./scripts/submit_jobs <branch_name> <experiment_path> <space separated list of tasks>`. The `branch_name` should be the name of the branch with the code to run, `experiment_path` should be a directory full of experiment json files rooted at `src/experiments` (or a single json file), and the list of tasks should contain the task you want to run. For example, you could run
 ```shell
-./scripts/submit_jobs lf/batch experiments/tests/generator/experiments train_model validation_eval
+./scripts/submit_jobs lf/batch src/experiments/tests/generator/experiments train_model validation_eval
 ```
 After submitting jobs, AWS Batch will start an EC2 instance for each experiment and will shut them down when finished.
 

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,5 +1,6 @@
 ---
 aws_region: "us-east-1"
+
 aws_profile: "raster-vision"
 
 aws_cli_version: "1.11.84"
@@ -9,3 +10,7 @@ terraform_version: "0.7.7"
 docker_version: "1.11.*"
 
 docker_compose_version: "1.8.0"
+
+boto3_version: "1.4.4"
+
+networkx_version: "1.11"

--- a/deployment/ansible/raster-vision.yml
+++ b/deployment/ansible/raster-vision.yml
@@ -14,3 +14,4 @@
     - { role: "raster-vision.awscli" }
     - { role: "raster-vision.nvidia-docker" }
     - { role: "raster-vision.compose-docker" }
+    - { role: "raster-vision.submit-job" }

--- a/deployment/ansible/roles/raster-vision.submit-job/tasks/main.yml
+++ b/deployment/ansible/roles/raster-vision.submit-job/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Install boto3
+  pip: name=boto3 version="{{ boto3_version }}"
+
+- name: Install networkx
+  pip: name=networkx version="{{ networkx_version }}"

--- a/scripts/setup_aws_batch
+++ b/scripts/setup_aws_batch
@@ -17,6 +17,6 @@ should only be done once per AWS account.
 PROJECT_ROOT="$(dirname "$(dirname "$(readlink -f "${0}")")")"
 BATCH_CONFIG=$PROJECT_ROOT/deployment/batch
 
-echo aws batch create-compute-environment --cli-input-json file://$BATCH_CONFIG/compute_environment.json
-echo aws batch create-job-queue --cli-input-json file://$BATCH_CONFIG/job_queue.json
-echo aws batch register-job-definition --cli-input-json file://$BATCH_CONFIG/job_def.json
+aws batch create-compute-environment --cli-input-json file://$BATCH_CONFIG/compute_environment.json
+aws batch create-job-queue --cli-input-json file://$BATCH_CONFIG/job_queue.json
+aws batch register-job-definition --cli-input-json file://$BATCH_CONFIG/job_def.json

--- a/scripts/submit_jobs
+++ b/scripts/submit_jobs
@@ -1,62 +1,175 @@
-#!/bin/bash
+#!/usr/bin/env python
 
-set -e
+from os.path import join, isdir, isfile
+import argparse
+import glob
+import json
+from os import environ
+import sys
 
-if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
-    set -x
-fi
+import boto3
+import networkx as nx
 
-function usage() {
-    echo -n \
-         "Usage: $(basename "$0") <branch_name> <experiment_dir> <space separated list of tasks>
-Submits a set of jobs to AWS Batch. experiment_dir should be a directory containing experiment json files with root at experiments/
-"
-}
 
-PROJECT_ROOT="$(dirname "$(dirname "$(readlink -f "${0}")")")"
+# From https://stackoverflow.com/questions/3041986/apt-command-line-interface-like-yes-no-input # noqa
+def query_yes_no(question, default="yes"):
+    """Ask a yes/no question via raw_input() and return their answer.
 
-if [[ (("$#" < 2)) || "${1:-}" = "--help" ]]; then
-    usage
-    exit
-fi
+    "question" is a string that is presented to the user.
+    "default" is the presumed answer if the user just hits <Enter>.
+        It must be "yes" (the default), "no" or None (meaning
+        an answer is required of the user).
 
-branch_name=$1
-exp_dir=$2
-tasks=${@:3}
-file_paths="$PROJECT_ROOT"/src/"$exp_dir"/*.json
-nb_files=$(echo $file_paths | wc -w)
+    The "answer" return value is True for "yes" or False for "no".
+    """
+    valid = {"yes": True, "y": True, "ye": True,
+             "no": False, "n": False}
+    if default is None:
+        prompt = " [y/n] "
+    elif default == "yes":
+        prompt = " [Y/n] "
+    elif default == "no":
+        prompt = " [y/N] "
+    else:
+        raise ValueError("invalid default answer: '%s'" % default)
 
-echo "Branch name: $branch_name"
-echo "Experiment dir: $exp_dir"
-echo "Tasks: $tasks"
+    while True:
+        sys.stdout.write(question + prompt)
+        choice = raw_input().lower()
+        if default is not None and choice == '':
+            return valid[default]
+        elif choice in valid:
+            return valid[choice]
+        else:
+            sys.stdout.write("Please respond with 'yes' or 'no' "
+                             "(or 'y' or 'n').\n")
 
-function prompt() {
-    read -r response
-    case "$response" in
-        [yY][eE][sS]|[yY])
-            ;;
-        *)
-            exit
-            ;;
-    esac
-}
 
-echo "Are your experiment files pushed to $branch_name? [y/N]"
-prompt
-echo "Do you really want to run $nb_files jobs? [y/N]"
-prompt
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('branch_name', help='Branch with code to run on AWS')
+    parser.add_argument(
+        'experiment_path',
+        help='Directory with experiment files rooted at src/experiments/...')
+    parser.add_argument(
+        'tasks', nargs='*',
+        help='Space-delimited list of tasks to run on AWS. ' +
+             'Can be empty to run all tasks.')
+    return parser.parse_args()
 
-echo "Ok, launching $nb_files jobs..."
-for file_path in $file_paths; do
-    exp_path="$exp_dir"/$(basename "$file_path")
-    job_name=$(echo $exp_path | tr \/. _)
-    if [ -z "$tasks" ]; then
-        command="command=[run_experiment.sh,$S3_BUCKET,$branch_name,$exp_path]"
-    else
-        command="command=[run_experiment.sh,$S3_BUCKET,$branch_name,$exp_path,$(echo $tasks | tr ' ' ,)]"
-    fi
 
-    aws batch submit-job --job-name $job_name --job-queue raster-vision-experiments \
-        --job-definition raster-vision-experiment \
-        --container-overrides $command
-done
+def read_experiment_files(path):
+    run_name_to_file_path = {}
+    run_name_to_parent_run_names = {}
+
+    for file_path in glob.iglob(path):
+        with open(file_path, 'r') as exp_file:
+            exp = json.load(exp_file)
+            run_name = exp['run_name']
+            parent_run_names = get_parent_run_names(exp)
+            run_name_to_file_path[run_name] = file_path
+            run_name_to_parent_run_names[run_name] = parent_run_names
+
+    return run_name_to_file_path, run_name_to_parent_run_names
+
+
+def get_parent_run_names(exp):
+    return exp.get('aggregate_run_names')
+
+
+def build_dep_graph(run_name_to_parent_run_names):
+    g = nx.DiGraph()
+
+    for run_name in run_name_to_parent_run_names.keys():
+        g.add_node(run_name)
+
+    for child_run_name, parent_run_names in \
+            run_name_to_parent_run_names.items():
+        if parent_run_names is not None:
+            for parent_run_name in parent_run_names:
+                g.add_edge(parent_run_name, child_run_name)
+
+    return g
+
+
+def submit_job(branch_name, file_path, tasks, run_name, parent_job_ids=None):
+    s3_bucket = environ.get('S3_BUCKET')
+
+    job_name = run_name.replace('/', '-')
+
+    # Make file_path be rooted at experiments/ instead of src/ since
+    # src/ is the root of the directory structure inside the container.
+    file_path = file_path[file_path.find('experiments/'):]
+
+    command = ['run_experiment.sh', s3_bucket, branch_name, file_path]
+    command.extend(tasks)
+
+    dependsOn = []
+    if parent_job_ids is not None:
+        dependsOn = [{'jobId': job_id} for job_id in parent_job_ids]
+
+    client = boto3.client('batch')
+    job_id = client.submit_job(
+        jobName=job_name,
+        jobQueue='raster-vision-experiments',
+        jobDefinition='raster-vision-experiment',
+        containerOverrides={
+            'command': command
+        },
+        dependsOn=dependsOn)['jobId']
+
+    print(
+        'Submitted job with jobName={} and jobId={}'.format(job_name, job_id))
+
+    return job_id
+
+
+def prompt_user(branch_name, experiment_path):
+    question = 'Are your experiment files pushed to the remote branch {}' \
+        .format(branch_name)
+    pushed_branch = query_yes_no(question, default='no')
+
+    want_to_run = False
+    if pushed_branch:
+        nb_jobs = len(list(glob.iglob(experiment_path)))
+        question = 'Are you sure you want to run {} jobs?'.format(nb_jobs)
+        want_to_run = query_yes_no(question, default='no')
+
+    return pushed_branch, want_to_run
+
+
+def run():
+    args = parse_args()
+    print('Branch name: {}'.format(args.branch_name))
+    print('Experiment path: {}'.format(args.experiment_path))
+    print('Tasks: {}'.format(args.tasks))
+
+    experiment_path = join(args.experiment_path, '*.json') \
+        if isdir(args.experiment_path) else args.experiment_path
+
+    pushed_branch, want_to_run = prompt_user(
+        args.branch_name, experiment_path)
+
+    if pushed_branch and want_to_run:
+        run_name_to_file_path, run_name_to_parent_run_names = \
+            read_experiment_files(experiment_path)
+        dep_graph = build_dep_graph(run_name_to_parent_run_names)
+        sorted_run_names = nx.topological_sort(dep_graph)
+
+        run_name_to_job_id = {}
+        for run_name in sorted_run_names:
+            file_path = run_name_to_file_path[run_name]
+
+            parent_run_names = run_name_to_parent_run_names[run_name]
+            parent_job_ids = None
+            if parent_run_names is not None:
+                parent_job_ids = [run_name_to_job_id[parent_run_name]
+                                  for parent_run_name in parent_run_names]
+
+            run_name_to_job_id[run_name] = submit_job(
+                args.branch_name, file_path, args.tasks, run_name,
+                parent_job_ids)
+
+
+if __name__ == '__main__':
+    run()

--- a/src/rastervision/common/models/factory.py
+++ b/src/rastervision/common/models/factory.py
@@ -1,7 +1,8 @@
 from os.path import isfile, join
 from subprocess import call
 
-from rastervision.common.settings import datasets_path, results_path, s3_bucket
+from rastervision.common.settings import datasets_path, results_path
+from rastervision.common.utils import s3_download
 
 
 class ModelFactory():
@@ -10,14 +11,7 @@ class ModelFactory():
         self.results_path = results_path
 
     def s3_download(self, run_name, file_name):
-        s3_run_path = 's3://{}/results/{}'.format(
-            s3_bucket, run_name)
-        s3_file_path = join(s3_run_path, file_name)
-
-        run_path = join(results_path, run_name)
-        print(s3_file_path)
-        print(run_path)
-        call(['aws', 's3', 'cp', s3_file_path, run_path + '/'])
+        s3_download(run_name, file_name)
 
     def make_model(self, options, generator):
         """Make a new model."""

--- a/src/rastervision/common/run.py
+++ b/src/rastervision/common/run.py
@@ -4,7 +4,7 @@ import sys
 from rastervision.common.tasks.plot_curves import PLOT_CURVES
 from rastervision.common.tasks.validation_eval import VALIDATION_EVAL
 from rastervision.common.utils import (
-    Logger, make_sync_results, _makedirs, save_json)
+    Logger, make_sync_results, _makedirs, save_json, s3_download)
 from rastervision.common.settings import results_path
 
 
@@ -65,6 +65,10 @@ class Runner():
                             .get_data_generator(self.options)
             self.model = model_factory.get_model(
                 self.run_path, self.options, self.generator, use_best=True)
+        else:
+            for run_name in self.options.aggregate_run_names:
+                s3_download(run_name, 'log.txt')
+                s3_download(run_name, 'scores.json')
 
         for task in self.tasks:
             if self.is_valid_task(task):

--- a/src/rastervision/common/utils.py
+++ b/src/rastervision/common/utils.py
@@ -12,7 +12,8 @@ import numpy as np
 import rasterio
 
 from rastervision.common.settings import (
-    s3_results_path, results_path, s3_datasets_path, datasets_path)
+    s3_results_path, results_path, s3_datasets_path, datasets_path,
+    s3_bucket)
 
 
 def _makedirs(path):
@@ -146,6 +147,15 @@ def s3_sync(src_path, dst_path):
 
 def s3_cp(src_path, dst_path):
     call(['aws', 's3', 'cp', src_path, dst_path])
+
+
+def s3_download(run_name, file_name):
+    s3_run_path = 's3://{}/results/{}'.format(
+        s3_bucket, run_name)
+    s3_file_path = join(s3_run_path, file_name)
+
+    run_path = join(results_path, run_name)
+    call(['aws', 's3', 'cp', s3_file_path, run_path + '/'])
 
 
 def download_dataset(dataset_name, file_names):


### PR DESCRIPTION
This PR re-writes the `submit_jobs` script in Python and makes it so it can handle dependencies between experiment files. For instance, it ensures that aggregate jobs are run after all individual runs are finished. It works by building a dependency graph over jobs using the information in the experiment files and then submits the jobs in the order defined by a topological sort over the graph. It tells AWS Batch which jobs depend on which using their job ids, which allows Batch to properly sequence the jobs.