### PR TITLE
Changes to normalization procedures

### DIFF
--- a/src/rastervision/semseg/data/potsdam.py
+++ b/src/rastervision/semseg/data/potsdam.py
@@ -74,6 +74,7 @@ class PotsdamImageFileGenerator(PotsdamFileGenerator):
     def __init__(self, datasets_path, active_input_inds,
                  train_ratio=0.8, cross_validation=None):
         self.dataset_path = join(datasets_path, POTSDAM)
+        self.name = "potsdam_image"
         super().__init__(active_input_inds, train_ratio, cross_validation)
 
     @staticmethod
@@ -90,6 +91,9 @@ class PotsdamImageFileGenerator(PotsdamFileGenerator):
             im_fix = np.zeros((6000, 6000), dtype=np.uint8)
             im_fix[:, 0:-1] = im[:, :, 0]
             save_img(im_fix, file_path)
+
+        PotsdamImageFileGenerator(
+            datasets_path, [0, 1, 2, 3, 4]).write_channel_stats(data_path)
 
     def get_file_size(self, file_ind):
         ind0, ind1 = file_ind
@@ -153,6 +157,7 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
         self.raw_dataset_path = join(datasets_path, POTSDAM)
         self.dataset_path = join(datasets_path, PROCESSED_POTSDAM)
         self.download_dataset(['processed_potsdam.zip'])
+        self.name = "potsdam_numpy"
 
         super().__init__(active_input_inds, train_ratio, cross_validation)
 
@@ -198,6 +203,9 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
         _preprocess(TRAIN)
         _preprocess(VALIDATION)
         _preprocess(TEST)
+
+        PotsdamNumpyFileGenerator(
+            datasets_path, [0, 1, 2, 3, 4]).write_channel_stats(proc_data_path)
 
     def get_file_path(self, file_ind):
         ind0, ind1 = file_ind

--- a/src/rastervision/semseg/data/test/test_batch_norms.py
+++ b/src/rastervision/semseg/data/test/test_batch_norms.py
@@ -1,0 +1,28 @@
+import numpy as np
+import unittest
+
+from rastervision.semseg.data.potsdam import (PotsdamNumpyFileGenerator,
+                                              PotsdamImageFileGenerator)
+from rastervision.common.settings import datasets_path
+
+
+class NormalizationTestCase(unittest.TestCase):
+    def test_numpy_potsdam_batch(self):
+        generator = PotsdamNumpyFileGenerator(datasets_path, [0, 1, 2, 3, 4])
+        means, stds = generator.compute_channel_stats(100, True)
+
+        # passes when mean = 0 with an error of +/- 0.3 and stds = 1 +/- 0.3.
+        self.assertTrue((np.absolute(means) < 0.3).all())
+        self.assertTrue((stds > 0.3).all() and (stds < 1.3).all())
+
+    def test_image_potsdam_batch(self):
+        generator = PotsdamImageFileGenerator(datasets_path, [0, 1, 2, 3, 4])
+        means, stds = generator.compute_channel_stats(100, True)
+
+        # passes when mean = 0 and stds = 1 with an error of +/- 0.3.
+        self.assertTrue((np.absolute(means) < 0.3).all())
+        self.assertTrue((stds > 0.7).all() and (stds < 1.3).all())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/rastervision/semseg/data/vaihingen.py
+++ b/src/rastervision/semseg/data/vaihingen.py
@@ -63,11 +63,13 @@ class VaihingenImageFileGenerator(VaihingenFileGenerator):
     def __init__(self, datasets_path, active_input_inds,
                  train_ratio=0.8, cross_validation=None):
         self.dataset_path = join(datasets_path, VAIHINGEN)
+        self.name = "vaihingen_image"
         super().__init__(active_input_inds, train_ratio, cross_validation)
 
     @staticmethod
     def preprocess(datasets_path):
-        pass
+        VaihingenImageFileGenerator(
+            datasets_path, [0, 1, 2, 3]).write_channel_stats(datasets_path)
 
     def get_file_size(self, file_ind):
         irrg_file_path = join(
@@ -128,6 +130,7 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
         self.raw_dataset_path = join(datasets_path, VAIHINGEN)
         self.dataset_path = join(datasets_path, PROCESSED_VAIHINGEN)
         self.download_dataset(['processed_vaihingen.zip'])
+        self.name = "vaihingen_numpy"
         super().__init__(active_input_inds, train_ratio, cross_validation)
 
     @staticmethod
@@ -171,6 +174,9 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
         _preprocess(TRAIN)
         _preprocess(VALIDATION)
         _preprocess(TEST)
+
+        VaihingenNumpyFileGenerator(
+            datasets_path, [0, 1, 2, 3]).write_channel_stats(proc_data_path)
 
     def get_file_path(self, file_ind):
         return join(self.dataset_path, '{}.npy'.format(file_ind))


### PR DESCRIPTION
We decided to add the ability to calculate the normalization parameters during the preprocessing stage on a sample size of 1000 images and then save the mean and standard deviations to a json file. Once stored, these values are read for future runs. This helps reduce randomness between instantiations of image generators.

You can test the functionality of the parameter saving feature on any image generator by plotting and checking the debug plots or preprocessing the data and checking the json file. For example, the command `python -m rastervision.semseg.data.factory isprs/potsdam numpy preprocess` may be used to store the parameters for the `PotsdamNumpyImageGenerator`. Additionally, unittests were added to ensure consistent normalization behavior. Using the command `python -m rastervision.semseg.data.test.test_batch_norms` while in the Vagrant environment will run this test.