### PR TITLE
Handle unbalanced datasets by oversampling

### DIFF
--- a/src/experiments/tagging/tests/quick_test/generate_experiments.py
+++ b/src/experiments/tagging/tests/quick_test/generate_experiments.py
@@ -24,7 +24,8 @@ class TestExperimentGenerator(ExperimentGenerator):
             'validation_steps': 1,
             'run_name': 'tagging/tests/quick_test',
             'steps_per_epoch': 2,
-            'augment_methods': ['hflip', 'vflip', 'rotate', 'translate']
+            'augment_methods': ['hflip', 'vflip', 'rotate', 'translate'],
+            'rare_sample_prob': 0.5
         }
 
         init_lrs = [1e-3, 1e-4]

--- a/src/rastervision/common/data/factory.py
+++ b/src/rastervision/common/data/factory.py
@@ -34,8 +34,7 @@ class DataGeneratorFactory():
         data_generator_class = \
             self.get_class(options.dataset_name, options.generator_name)
         return data_generator_class(
-            self.datasets_path, options.active_input_inds, options.train_ratio,
-            options.cross_validation)
+            self.datasets_path, options)
 
     def preprocess(self, dataset_name, generator_name):
         data_generator_class = \

--- a/src/rastervision/common/data/generators.py
+++ b/src/rastervision/common/data/generators.py
@@ -63,10 +63,10 @@ class FileGenerator(Generator):
     A generic data generator that creates batches from files. It can read
     windows of data from disk without loading the entire file into memory.
     """
-    def __init__(self, active_input_inds, train_ratio, cross_validation):
-        self.active_input_inds = active_input_inds
-        self.train_ratio = train_ratio
-        self.cross_validation = cross_validation
+    def __init__(self, options):
+        self.active_input_inds = options.active_input_inds
+        self.train_ratio = options.train_ratio
+        self.cross_validation = options.cross_validation
 
         if self.train_ratio is not None:
             nb_train_inds = \
@@ -77,7 +77,7 @@ class FileGenerator(Generator):
         if self.cross_validation is not None:
             self.process_cross_validation()
 
-        self.train_weights = self.compute_train_weights()
+        self.train_probs = self.compute_train_probs()
 
         # If a dataset's normalized parameters have already been
         # calculated, load its json file. Otherwise, calculate parameters
@@ -92,7 +92,7 @@ class FileGenerator(Generator):
         else:
             self.channel_stats = self.compute_channel_stats(100, False)
 
-    def compute_train_weights(self):
+    def compute_train_probs(self):
         return None
 
     def calibrate_image(self, normalized_image):
@@ -284,7 +284,7 @@ class FileGenerator(Generator):
                              augment_methods=None,
                              normalize=False, only_xy=True):
         file_inds = self.get_file_inds(split)
-        sample_probs = self.train_weights if split == TRAIN else None
+        sample_probs = self.train_probs if split == TRAIN else None
         img_batch_gen = self.make_img_batch_generator(
             file_inds, target_size, batch_size, shuffle, sample_probs)
 

--- a/src/rastervision/common/models/factory.py
+++ b/src/rastervision/common/models/factory.py
@@ -1,5 +1,4 @@
 from os.path import isfile, join
-from subprocess import call
 
 from rastervision.common.settings import datasets_path, results_path
 from rastervision.common.utils import s3_download

--- a/src/rastervision/semseg/data/factory.py
+++ b/src/rastervision/semseg/data/factory.py
@@ -54,7 +54,8 @@ class SemsegDataGeneratorFactory(DataGeneratorFactory):
 
         gen = generator.make_split_generator(
             split, target_size=(400, 400), batch_size=batch_size, shuffle=True,
-            augment_methods=options.augment_methods, normalize=True, only_xy=False)
+            augment_methods=options.augment_methods, normalize=True,
+            only_xy=False)
 
         for batch_ind in range(nb_batches):
             batch = next(gen)

--- a/src/rastervision/semseg/data/isprs.py
+++ b/src/rastervision/semseg/data/isprs.py
@@ -144,8 +144,8 @@ class IsprsDataset():
 
 
 class IsprsFileGenerator(FileGenerator):
-    def __init__(self, active_input_inds, train_ratio, cross_validation):
-        super().__init__(active_input_inds, train_ratio, cross_validation)
+    def __init__(self, options):
+        super().__init__(options)
 
     def plot_sample(self, file_path, x, y):
         fig = plt.figure()

--- a/src/rastervision/semseg/data/potsdam.py
+++ b/src/rastervision/semseg/data/potsdam.py
@@ -45,7 +45,7 @@ class PotsdamFileGenerator(IsprsFileGenerator):
     A data generator for the Potsdam dataset that creates batches from
     files on disk.
     """
-    def __init__(self, active_input_inds, train_ratio, cross_validation):
+    def __init__(self, options):
         self.dataset = PotsdamDataset()
 
         # The first 24 indices correspond to the training set,
@@ -63,7 +63,7 @@ class PotsdamFileGenerator(IsprsFileGenerator):
             (5, 13), (5, 14), (5, 15), (6, 13), (6, 14), (6, 15), (7, 13)
         ]
 
-        super().__init__(active_input_inds, train_ratio, cross_validation)
+        super().__init__(options)
 
 
 class PotsdamImageFileGenerator(PotsdamFileGenerator):
@@ -71,11 +71,10 @@ class PotsdamImageFileGenerator(PotsdamFileGenerator):
     A data generator for the Potsdam dataset that creates batches from
     the original TIFF and JPG files.
     """
-    def __init__(self, datasets_path, active_input_inds,
-                 train_ratio=0.8, cross_validation=None):
+    def __init__(self, datasets_path, options):
         self.dataset_path = join(datasets_path, POTSDAM)
         self.name = "potsdam_image"
-        super().__init__(active_input_inds, train_ratio, cross_validation)
+        super().__init__(options)
 
     @staticmethod
     def preprocess(datasets_path):
@@ -152,22 +151,27 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
     A data generator for the Potsdam dataset that creates batches from
     numpy array files. This is about 20x faster than reading the raw files.
     """
-    def __init__(self, datasets_path, active_input_inds,
-                 train_ratio=0.8, cross_validation=None):
+    def __init__(self, datasets_path, options):
         self.raw_dataset_path = join(datasets_path, POTSDAM)
         self.dataset_path = join(datasets_path, PROCESSED_POTSDAM)
         self.download_dataset(['processed_potsdam.zip'])
         self.name = "potsdam_numpy"
 
-        super().__init__(active_input_inds, train_ratio, cross_validation)
+        super().__init__(options)
 
     @staticmethod
     def preprocess(datasets_path):
         proc_data_path = join(datasets_path, PROCESSED_POTSDAM)
         _makedirs(proc_data_path)
 
-        generator = PotsdamImageFileGenerator(
-            datasets_path, [0, 1, 2, 3, 4])
+        class Options():
+            def __init__(self):
+                self.active_input_inds = [0, 1, 2, 3, 4]
+                self.train_ratio = 0.8
+                self.cross_validation = None
+
+        options = Options()
+        generator = PotsdamImageFileGenerator(datasets_path, options)
         dataset = generator.dataset
 
         def _preprocess(split):

--- a/src/rastervision/semseg/data/potsdam.py
+++ b/src/rastervision/semseg/data/potsdam.py
@@ -171,6 +171,9 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
                 self.cross_validation = None
 
         options = Options()
+        PotsdamNumpyFileGenerator(
+            datasets_path, options).write_channel_stats(proc_data_path)
+
         generator = PotsdamImageFileGenerator(datasets_path, options)
         dataset = generator.dataset
 
@@ -207,9 +210,6 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
         _preprocess(TRAIN)
         _preprocess(VALIDATION)
         _preprocess(TEST)
-
-        PotsdamNumpyFileGenerator(
-            datasets_path, [0, 1, 2, 3, 4]).write_channel_stats(proc_data_path)
 
     def get_file_path(self, file_ind):
         ind0, ind1 = file_ind

--- a/src/rastervision/semseg/data/vaihingen.py
+++ b/src/rastervision/semseg/data/vaihingen.py
@@ -43,7 +43,7 @@ class VaihingenFileGenerator(IsprsFileGenerator):
     A data generator for the Vaihingen dataset that creates batches from
     files on disk.
     """
-    def __init__(self, active_input_inds, train_ratio, cross_validation):
+    def __init__(self, options):
         self.dataset = VaihingenDataset()
 
         self.dev_file_inds = [
@@ -52,7 +52,7 @@ class VaihingenFileGenerator(IsprsFileGenerator):
         self.test_file_inds = [
             2, 4, 6, 8, 10, 12, 14, 16, 20, 22, 24, 27, 29, 31, 33, 35, 38]
 
-        super().__init__(active_input_inds, train_ratio, cross_validation)
+        super().__init__(options)
 
 
 class VaihingenImageFileGenerator(VaihingenFileGenerator):
@@ -60,11 +60,10 @@ class VaihingenImageFileGenerator(VaihingenFileGenerator):
     A data generator for the Vaihingen dataset that creates batches from
     the original TIFF and JPG files.
     """
-    def __init__(self, datasets_path, active_input_inds,
-                 train_ratio=0.8, cross_validation=None):
+    def __init__(self, datasets_path, options):
         self.dataset_path = join(datasets_path, VAIHINGEN)
         self.name = "vaihingen_image"
-        super().__init__(active_input_inds, train_ratio, cross_validation)
+        super().__init__(options)
 
     @staticmethod
     def preprocess(datasets_path):
@@ -125,21 +124,26 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
     A data generator for the Vaihingen dataset that creates batches from
     numpy array files. This is about 20x faster than reading the raw files.
     """
-    def __init__(self, datasets_path, active_input_inds,
-                 train_ratio=0.8, cross_validation=None):
+    def __init__(self, datasets_path, options):
         self.raw_dataset_path = join(datasets_path, VAIHINGEN)
         self.dataset_path = join(datasets_path, PROCESSED_VAIHINGEN)
         self.download_dataset(['processed_vaihingen.zip'])
         self.name = "vaihingen_numpy"
-        super().__init__(active_input_inds, train_ratio, cross_validation)
+        super().__init__(options)
 
     @staticmethod
     def preprocess(datasets_path):
         proc_data_path = join(datasets_path, PROCESSED_VAIHINGEN)
         _makedirs(proc_data_path)
 
-        generator = VaihingenImageFileGenerator(
-            datasets_path, [0, 1, 2, 3])
+        class Options():
+            def __init__(self):
+                self.active_input_inds = [0, 1, 2, 3]
+                self.train_ratio = 0.8
+                self.cross_validation = None
+        options = Options()
+
+        generator = VaihingenImageFileGenerator(datasets_path, options)
         dataset = generator.dataset
 
         def _preprocess(split):

--- a/src/rastervision/semseg/data/vaihingen.py
+++ b/src/rastervision/semseg/data/vaihingen.py
@@ -143,6 +143,9 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
                 self.cross_validation = None
         options = Options()
 
+        VaihingenNumpyFileGenerator(
+            datasets_path, options).write_channel_stats(proc_data_path)
+
         generator = VaihingenImageFileGenerator(datasets_path, options)
         dataset = generator.dataset
 
@@ -178,9 +181,6 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
         _preprocess(TRAIN)
         _preprocess(VALIDATION)
         _preprocess(TEST)
-
-        VaihingenNumpyFileGenerator(
-            datasets_path, [0, 1, 2, 3]).write_channel_stats(proc_data_path)
 
     def get_file_path(self, file_ind):
         return join(self.dataset_path, '{}.npy'.format(file_ind))

--- a/src/rastervision/tagging/data/factory.py
+++ b/src/rastervision/tagging/data/factory.py
@@ -38,6 +38,7 @@ class TaggingDataGeneratorFactory(DataGeneratorFactory):
                 self.train_ratio = 0.8
                 self.cross_validation = None
                 self.augment_methods = [HFLIP, VFLIP, ROTATE, TRANSLATE]
+                self.rare_sample_prob = 0.5
 
         options = Options()
         generator = self.get_data_generator(options)

--- a/src/rastervision/tagging/data/factory.py
+++ b/src/rastervision/tagging/data/factory.py
@@ -50,7 +50,8 @@ class TaggingDataGeneratorFactory(DataGeneratorFactory):
 
         gen = generator.make_split_generator(
             split, batch_size=batch_size, shuffle=True,
-            augment_methods=options.augment_methods, normalize=True, only_xy=False)
+            augment_methods=options.augment_methods, normalize=True,
+            only_xy=False)
 
         for batch_ind in range(nb_batches):
             batch = next(gen)

--- a/src/rastervision/tagging/data/planet_kaggle.py
+++ b/src/rastervision/tagging/data/planet_kaggle.py
@@ -9,7 +9,7 @@ mpl.use('Agg') # NOQA
 import matplotlib.pyplot as plt
 
 from rastervision.common.utils import (
-    save_json, compute_ndvi, plot_img_row, download_dataset)
+    save_json, compute_ndvi, plot_img_row, download_dataset, _makedirs)
 from rastervision.common.data.generators import FileGenerator, Batch
 
 PLANET_KAGGLE = 'planet_kaggle'
@@ -284,9 +284,11 @@ class PlanetKaggleTiffFileGenerator(PlanetKaggleFileGenerator):
         self.dev_dir = 'train-tif-v2'
         self.test_dir = 'test-tif-v2'
         self.zip_file_names = [
-            'train-tif-v2.zip', 'test-tif-v2.zip', 'train_v2.csv.zip']
+            'train-tif-v2.zip', 'test-tif-v2.zip', 'train_v2.csv.zip',
+            'planet_kaggle_tiff_channel_stats.json']
         self.file_extension = 'tif'
         self.dataset = TiffDataset()
+        self.name = 'planet_kaggle_tiff'
 
         super().__init__(datasets_path, options)
 
@@ -297,15 +299,35 @@ class PlanetKaggleTiffFileGenerator(PlanetKaggleFileGenerator):
             img = np.dstack([r, g, b, nir])
             return img
 
+    @staticmethod
+    def preprocess(datasets_path):
+        PlanetKaggleFileGenerator.preprocess(datasets_path)
+
+        proc_data_path = join(datasets_path, PLANET_KAGGLE)
+        _makedirs(proc_data_path)
+
+        class Options():
+            def __init__(self):
+                self.active_input_inds = [0, 1, 2, 3]
+                self.train_ratio = 0.8
+                self.cross_validation = None
+                self.rare_sample_prob = None
+
+        options = Options()
+        PlanetKaggleTiffFileGenerator(
+            datasets_path, options).write_channel_stats(proc_data_path)
+
 
 class PlanetKaggleJpgFileGenerator(PlanetKaggleFileGenerator):
     def __init__(self, datasets_path, options):
         self.dev_dir = 'train-jpg'
         self.test_dir = 'test-jpg'
         self.zip_file_names = [
-            'train-jpg.zip', 'test-jpg.zip', 'train_v2.csv.zip']
+            'train-jpg.zip', 'test-jpg.zip', 'train_v2.csv.zip',
+            'planet_kaggle_jpg_channel_stats.json']
         self.file_extension = 'jpg'
         self.dataset = JpgDataset()
+        self.name = 'planet_kaggle_jpg'
 
         super().__init__(datasets_path, options)
 
@@ -315,3 +337,21 @@ class PlanetKaggleJpgFileGenerator(PlanetKaggleFileGenerator):
             r, g, b = src.read(window=window)
             img = np.dstack([r, g, b])
             return img
+
+    @staticmethod
+    def preprocess(datasets_path):
+        PlanetKaggleFileGenerator.preprocess(datasets_path)
+
+        proc_data_path = join(datasets_path, PLANET_KAGGLE)
+        _makedirs(proc_data_path)
+
+        class Options():
+            def __init__(self):
+                self.active_input_inds = [0, 1, 2]
+                self.train_ratio = 0.8
+                self.cross_validation = None
+                self.rare_sample_prob = None
+
+        options = Options()
+        PlanetKaggleJpgFileGenerator(
+            datasets_path, options).write_channel_stats(proc_data_path)

--- a/src/rastervision/tagging/data/test/test_tag_store.py
+++ b/src/rastervision/tagging/data/test/test_tag_store.py
@@ -56,6 +56,13 @@ class TagStoreTestCase(unittest.TestCase):
         self.assertEqual(add_pred_tags, [self.dataset.cultivation])
         self.assertEqual(remove_pred_tags, [self.dataset.partly_cloudy])
 
+    def test_compute_train_probs(self):
+        ind3 = 'ind3'
+        self.tag_store.add_csv_row((ind3, 'artisinal_mine'))
+        sample_probs = \
+            self.tag_store.compute_sample_probs([self.ind1, self.ind2, ind3])
+        self.assertTrue(np.array_equal(sample_probs, [0.25, 0.25, 0.5]))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rastervision/tagging/data/test/test_tag_store.py
+++ b/src/rastervision/tagging/data/test/test_tag_store.py
@@ -59,8 +59,10 @@ class TagStoreTestCase(unittest.TestCase):
     def test_compute_train_probs(self):
         ind3 = 'ind3'
         self.tag_store.add_csv_row((ind3, 'artisinal_mine'))
+        rare_sample_prob = 0.5
         sample_probs = \
-            self.tag_store.compute_sample_probs([self.ind1, self.ind2, ind3])
+            self.tag_store.compute_sample_probs(
+                [self.ind1, self.ind2, ind3], rare_sample_prob)
         self.assertTrue(np.array_equal(sample_probs, [0.25, 0.25, 0.5]))
 
 

--- a/src/rastervision/tagging/options.py
+++ b/src/rastervision/tagging/options.py
@@ -8,3 +8,4 @@ class TaggingOptions(Options):
         if self.aggregate_run_names is None:
             self.use_pretraining = options.get('use_pretraining', False)
             self.target_size = None
+            self.rare_sample_prob = options.get('rare_sample_prob')

--- a/src/rastervision/tagging/tasks/predict.py
+++ b/src/rastervision/tagging/tasks/predict.py
@@ -1,7 +1,5 @@
 from os.path import join
 
-import numpy as np
-
 from rastervision.common.settings import VALIDATION, TEST
 
 from rastervision.tagging.data.planet_kaggle import TagStore

--- a/src/rastervision/tagging/tasks/validation_eval.py
+++ b/src/rastervision/tagging/tasks/validation_eval.py
@@ -1,4 +1,4 @@
-from os.path import join, isfile
+from os.path import join
 import json
 
 from sklearn.metrics import fbeta_score


### PR DESCRIPTION
This PR makes it so that the list of training file indices is associated with a probability distribution over indices. This distribution is then used to resample the data when generating minibatches. In the Planet Kaggle dataset, there are some labels that appear rarely. In order to get the network to see samples with rare labels more often, we assign a higher probability to them so that they are picked half of the time, on average.