### PR TITLE
Fix problems with ISPRS preprocess methods

### DIFF
--- a/src/rastervision/common/data/factory.py
+++ b/src/rastervision/common/data/factory.py
@@ -66,7 +66,7 @@ class DataGeneratorFactory():
             else [args.dataset_name]
         generator_names = self.generator_names if args.generator_name == ALL \
             else [args.generator_name]
-        tasks = [PLOT, PREPROCESS] if args.task == ALL else [args.task]
+        tasks = [PREPROCESS, PLOT] if args.task == ALL else [args.task]
 
         for dataset_name in dataset_names:
             for generator_name in generator_names:

--- a/src/rastervision/semseg/data/potsdam.py
+++ b/src/rastervision/semseg/data/potsdam.py
@@ -81,6 +81,9 @@ class PotsdamImageFileGenerator(PotsdamFileGenerator):
         # Fix the depth image that is missing a column if it hasn't been
         # fixed already.
         data_path = join(datasets_path, POTSDAM)
+        proc_data_path = join(datasets_path, PROCESSED_POTSDAM)
+        _makedirs(proc_data_path)
+
         file_path = join(
             data_path,
             '1_DSM_normalisation/dsm_potsdam_03_13_normalized_lastools.jpg')
@@ -91,8 +94,15 @@ class PotsdamImageFileGenerator(PotsdamFileGenerator):
             im_fix[:, 0:-1] = im[:, :, 0]
             save_img(im_fix, file_path)
 
+        class Options():
+            def __init__(self):
+                self.active_input_inds = [0, 1, 2, 3, 4]
+                self.train_ratio = 0.8
+                self.cross_validation = None
+
+        options = Options()
         PotsdamImageFileGenerator(
-            datasets_path, [0, 1, 2, 3, 4]).write_channel_stats(data_path)
+            datasets_path, options).write_channel_stats(proc_data_path)
 
     def get_file_size(self, file_ind):
         ind0, ind1 = file_ind
@@ -171,9 +181,6 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
                 self.cross_validation = None
 
         options = Options()
-        PotsdamNumpyFileGenerator(
-            datasets_path, options).write_channel_stats(proc_data_path)
-
         generator = PotsdamImageFileGenerator(datasets_path, options)
         dataset = generator.dataset
 
@@ -210,6 +217,9 @@ class PotsdamNumpyFileGenerator(PotsdamFileGenerator):
         _preprocess(TRAIN)
         _preprocess(VALIDATION)
         _preprocess(TEST)
+
+        PotsdamNumpyFileGenerator(
+            datasets_path, options).write_channel_stats(proc_data_path)
 
     def get_file_path(self, file_ind):
         ind0, ind1 = file_ind

--- a/src/rastervision/semseg/data/vaihingen.py
+++ b/src/rastervision/semseg/data/vaihingen.py
@@ -67,8 +67,17 @@ class VaihingenImageFileGenerator(VaihingenFileGenerator):
 
     @staticmethod
     def preprocess(datasets_path):
+        proc_data_path = join(datasets_path, PROCESSED_VAIHINGEN)
+        _makedirs(proc_data_path)
+
+        class Options():
+            def __init__(self):
+                self.active_input_inds = [0, 1, 2, 3]
+                self.train_ratio = 0.8
+                self.cross_validation = None
+        options = Options()
         VaihingenImageFileGenerator(
-            datasets_path, [0, 1, 2, 3]).write_channel_stats(datasets_path)
+            datasets_path, options).write_channel_stats(proc_data_path)
 
     def get_file_size(self, file_ind):
         irrg_file_path = join(
@@ -142,10 +151,6 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
                 self.train_ratio = 0.8
                 self.cross_validation = None
         options = Options()
-
-        VaihingenNumpyFileGenerator(
-            datasets_path, options).write_channel_stats(proc_data_path)
-
         generator = VaihingenImageFileGenerator(datasets_path, options)
         dataset = generator.dataset
 
@@ -181,6 +186,9 @@ class VaihingenNumpyFileGenerator(VaihingenFileGenerator):
         _preprocess(TRAIN)
         _preprocess(VALIDATION)
         _preprocess(TEST)
+
+        VaihingenNumpyFileGenerator(
+            datasets_path, options).write_channel_stats(proc_data_path)
 
     def get_file_path(self, file_ind):
         return join(self.dataset_path, '{}.npy'.format(file_ind))


### PR DESCRIPTION
Previously, I forgot to switch to passing the options object to generator constructors in two of the
preprocess methods, so I fixed that. I also reverted to writing the channel stats at the end of the
preprocess method, since we need to ensure that the numpy files have already been generated. I also changed the order of tasks so that `preprocess` happens before `plot` when running `all`, since plotting depends on preprocessing.