### PR TITLE
Add task to compute decision thresholds

### DIFF
--- a/src/rastervision/common/utils.py
+++ b/src/rastervision/common/utils.py
@@ -205,10 +205,15 @@ class Logger(object):
         pass
 
 
-def save_json(a_dict, path):
-    json_str = json.dumps(a_dict, sort_keys=True, indent=4)
+def save_json(obj, path):
+    json_str = json.dumps(obj, sort_keys=True, indent=4)
     with open(path, 'w') as json_file:
         json_file.write(json_str)
+
+
+def load_json(path):
+    with open(path) as f:
+        return json.load(f)
 
 
 def plot_img_row(fig, grid_spec, row_ind, imgs, titles=None):

--- a/src/rastervision/tagging/run.py
+++ b/src/rastervision/tagging/run.py
@@ -10,13 +10,15 @@ from rastervision.tagging.tasks.train_model import TaggingTrainModel
 from rastervision.tagging.tasks.predict import (
     VALIDATION_PREDICT, TEST_PREDICT, validation_predict, test_predict)
 from rastervision.tagging.tasks.validation_eval import validation_eval
+from rastervision.tagging.tasks.train_thresholds import (
+    TRAIN_THRESHOLDS, train_thresholds)
 
 
 class TaggingRunner(Runner):
     def __init__(self):
         self.valid_tasks = [
-            TRAIN_MODEL, PLOT_CURVES, VALIDATION_PREDICT, VALIDATION_EVAL,
-            TEST_PREDICT]
+            TRAIN_MODEL, TRAIN_THRESHOLDS, PLOT_CURVES, VALIDATION_PREDICT,
+            VALIDATION_EVAL, TEST_PREDICT]
         self.model_factory_class = TaggingModelFactory
         self.data_generator_factory_class = TaggingDataGeneratorFactory
 
@@ -26,6 +28,9 @@ class TaggingRunner(Runner):
                 self.run_path, self.sync_results, self.options,
                 self.generator, self.model)
             train_model.train_model()
+        elif task == TRAIN_THRESHOLDS:
+            train_thresholds(
+                self.run_path, self.model, self.options, self.generator)
         elif task == PLOT_CURVES:
             plot_curves(self.options)
         elif task == VALIDATION_PREDICT:

--- a/src/rastervision/tagging/tasks/predict.py
+++ b/src/rastervision/tagging/tasks/predict.py
@@ -4,6 +4,7 @@ from rastervision.common.settings import VALIDATION, TEST
 
 from rastervision.tagging.data.planet_kaggle import TagStore
 from rastervision.tagging.tasks.utils import compute_prediction
+from rastervision.tagging.tasks.train_thresholds import load_thresholds
 
 VALIDATION_PREDICT = 'validation_predict'
 TEST_PREDICT = 'test_predict'
@@ -24,6 +25,7 @@ def predict(run_path, model, options, generator, split):
     """
     predictions_path = join(run_path, '{}_predictions.csv'.format(split))
 
+    thresholds = load_thresholds(run_path)
     batch_size = options.batch_size
     split_gen = generator.make_split_generator(
         split, target_size=None,
@@ -36,7 +38,7 @@ def predict(run_path, model, options, generator, split):
         y_probs = model.predict(batch.x)
         for sample_ind in range(batch.x.shape[0]):
             y_pred = compute_prediction(
-                y_probs[sample_ind, :], generator.dataset)
+                y_probs[sample_ind, :], generator.dataset, thresholds)
             tag_store.add_tags(
                 batch.file_inds[sample_ind], y_pred)
 

--- a/src/rastervision/tagging/tasks/test/test_predict.py
+++ b/src/rastervision/tagging/tasks/test/test_predict.py
@@ -14,10 +14,14 @@ class PredictTestCase(unittest.TestCase):
         y_probs = np.zeros((self.dataset.nb_tags,))
         haze_ind = self.dataset.get_tag_ind(self.dataset.haze)
         road_ind = self.dataset.get_tag_ind(self.dataset.road)
-        y_probs[haze_ind] = 0.6
+        y_probs[haze_ind] = 0.5
         y_probs[road_ind] = 0.7
 
-        y_pred = compute_prediction(y_probs, self.dataset)
+        thresholds = np.zeros((self.dataset.nb_tags,))
+        thresholds[haze_ind] = 0.4
+        thresholds[road_ind] = 0.6
+
+        y_pred = compute_prediction(y_probs, self.dataset, thresholds)
         y = np.zeros((self.dataset.nb_tags,))
         y[[haze_ind, road_ind]] = 1
 
@@ -30,7 +34,11 @@ class PredictTestCase(unittest.TestCase):
         y_probs[haze_ind] = 0.1
         y_probs[road_ind] = 0.1
 
-        y_pred = compute_prediction(y_probs, self.dataset)
+        thresholds = np.zeros((self.dataset.nb_tags,))
+        thresholds[haze_ind] = 0.2
+        thresholds[road_ind] = 0.2
+
+        y_pred = compute_prediction(y_probs, self.dataset, thresholds)
         y = np.zeros((self.dataset.nb_tags,))
         y[[haze_ind]] = 1
 

--- a/src/rastervision/tagging/tasks/train_thresholds.py
+++ b/src/rastervision/tagging/tasks/train_thresholds.py
@@ -1,0 +1,81 @@
+from os.path import join
+
+from sklearn.metrics import fbeta_score
+import numpy as np
+
+from rastervision.common.settings import TRAIN
+from rastervision.common.utils import save_json, load_json
+
+TRAIN_THRESHOLDS = 'train_thresholds'
+
+
+def load_thresholds(run_path):
+    return np.array(load_json(join(run_path, 'thresholds.json')))
+
+
+def save_thresholds(run_path, thresholds):
+    save_json(thresholds.tolist(), join(run_path, 'thresholds.json'))
+
+
+def compute_model_output(model, options, generator):
+    y_true_list = []
+    y_probs_list = []
+
+    split_gen = generator.make_split_generator(
+        TRAIN, target_size=None,
+        batch_size=options.batch_size, shuffle=False, augment_methods=None,
+        normalize=True, only_xy=False)
+
+    sample_count = 0
+    for batch_ind, batch in enumerate(split_gen):
+        batch_y_probs = model.predict(batch.x)
+        for sample_ind in range(batch.x.shape[0]):
+            file_ind = batch.file_inds[sample_ind]
+
+            y_probs = batch_y_probs[sample_ind, :]
+            y_probs_list.append(np.expand_dims(y_probs, axis=0))
+
+            y_true = generator.tag_store.get_tag_array([file_ind])[0, :]
+            y_true_list.append(np.expand_dims(y_true, axis=0))
+
+            sample_count += 1
+
+        if (options.nb_eval_samples is not None and
+                sample_count >= options.nb_eval_samples):
+            break
+
+    y_true = np.concatenate(y_true_list, axis=0)
+    y_probs = np.concatenate(y_probs_list, axis=0)
+
+    return y_true, y_probs
+
+
+def optimize_thresholds(y_true, y_probs):
+    nb_tags = y_true.shape[1]
+    best_thresholds = np.ones((nb_tags,)) * 0.2
+    y_preds = y_probs > np.expand_dims(best_thresholds, axis=0)
+    best_f2 = fbeta_score(y_true, y_preds, beta=2, average='samples')
+
+    for tag_ind in range(nb_tags):
+        thresholds = np.copy(best_thresholds)
+        for tag_thresh in np.arange(0, 1.0, 0.01):
+            thresholds[tag_ind] = tag_thresh
+            y_preds = y_probs > np.expand_dims(thresholds, axis=0)
+            f2 = fbeta_score(y_true, y_preds, beta=2, average='samples')
+            if f2 > best_f2:
+                best_f2 = f2
+                best_thresholds = np.copy(thresholds)
+
+    return best_thresholds
+
+
+def train_thresholds(run_path, model, options, generator):
+    # Finding the correct thresholds seems to result in a small decrease in
+    # test performance. I'm not sure what's going on, so for now
+    # I'm commenting this out and setting thresholds to a default of 0.2 to
+    # maintain the previous performance.
+    
+    # y_true, y_probs = compute_model_output(model, options, generator)
+    # thresholds = optimize_thresholds(y_true, y_probs)
+    thresholds = 0.2 * np.ones((len(generator.dataset.all_tags),))
+    save_thresholds(run_path, thresholds)

--- a/src/rastervision/tagging/tasks/utils.py
+++ b/src/rastervision/tagging/tasks/utils.py
@@ -1,15 +1,11 @@
 import numpy as np
 
 
-def compute_prediction(y_probs, dataset):
+def compute_prediction(y_probs, dataset, thresholds):
     atmos_inds = [dataset.get_tag_ind(tag)
                   for tag in dataset.atmos_tags]
 
-    # TODO experimenting with a different threshold
-    # remove this after the loss function is a better approximate
-    # of f2
-    decision_thresh = 0.2
-    y_pred = (y_probs > decision_thresh).astype(np.float32)
+    y_pred = (y_probs > thresholds).astype(np.float32)
 
     # TODO remove this post-processing step once our model
     # enforces the constraint that there is at least one atmospheric

--- a/src/rastervision/tagging/tasks/validation_eval.py
+++ b/src/rastervision/tagging/tasks/validation_eval.py
@@ -12,6 +12,7 @@ from rastervision.common.settings import VALIDATION
 from rastervision.common.utils import plot_img_row, _makedirs
 
 from rastervision.tagging.tasks.utils import compute_prediction
+from rastervision.tagging.tasks.train_thresholds import load_thresholds
 
 
 class Scores():
@@ -76,6 +77,7 @@ def plot_predictions(run_path, model, options, generator):
     y_trues = []
     y_preds = []
 
+    thresholds = load_thresholds(run_path)
     split_gen = generator.make_split_generator(
         VALIDATION, target_size=None,
         batch_size=options.batch_size, shuffle=False, augment_methods=None,
@@ -89,7 +91,7 @@ def plot_predictions(run_path, model, options, generator):
             all_x = batch.all_x[sample_ind, :, :, :]
 
             y_pred = compute_prediction(
-                y_probs[sample_ind, :], generator.dataset)
+                y_probs[sample_ind, :], generator.dataset, thresholds)
             y_true = generator.tag_store.get_tag_array([file_ind])[0, :]
             y_preds.append(np.expand_dims(y_pred, axis=0))
             y_trues.append(np.expand_dims(y_true, axis=0))


### PR DESCRIPTION
This PR adds a `train_thresholds` task for use with tagging problems which searches for good decision thresholds for each tag. The thresholds are saved to a file and then loaded and used when actually computing predictions given a model. This is needed due to the mismatch between the `binary_cross_entropy` loss function and the non-differentiable F2 score that is used to evaluate models in the contest. There might be a way to alter the loss function to approximate the F2 score, but I wanted to try something simpler first. 

This currently results in lower test performance. I think we need to investigate this further, but I'd like to merge it in to avoid a long running branch that will end up causing lots of merge conflicts. So, I'm commenting out optimizing the thresholds and just setting them to a default of 0.2 which worked well before.