### PR TITLE
Increase memory for Batch jobs

### DIFF
--- a/deployment/batch/job_def.json
+++ b/deployment/batch/job_def.json
@@ -8,7 +8,7 @@
     "containerProperties": {
         "image": "279682201306.dkr.ecr.us-east-1.amazonaws.com/raster-vision-gpu:latest",
         "vcpus": 4,
-        "memory": 2000,
+        "memory": 40000,
         "command": [
             "run_experiment.sh",
             "raster-vision",


### PR DESCRIPTION
This PR increases the amount of memory allocated to Docker containers that are being run in Batch jobs. This commit is from a long-lost branch that I forgot to merge a while ago.