### PR TITLE
Add attempts as argument to submit_jobs script

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ In order to run experiments on GPUs and in parallel, we use AWS EC2. There are t
 The latest Docker image should be stored in ECR so that it can be downloaded onto EC2 instances. To build and publish the container, run `./scripts/cipublish`.
 
 ### Submit jobs to AWS Batch
-To setup the AWS Batch stack, which should only be done once per AWS account, run `./scripts/setup_aws_batch`. To submit a set of jobs to Batch, use the `submit_jobs` script. The syntax for invoking it is `./scripts/submit_jobs <branch_name> <experiment_path> <space separated list of tasks>`. The `branch_name` should be the name of the branch with the code to run, `experiment_path` should be a directory full of experiment json files rooted at `src/experiments` (or a single json file), and the list of tasks should contain the task you want to run. For example, you could run
+To setup the AWS Batch stack, which should only be done once per AWS account, run `./scripts/setup_aws_batch`. To submit a set of jobs to Batch, use the `submit_jobs` script. The syntax for invoking it is `./scripts/submit_jobs <branch_name> <experiment_path> <space separated list of tasks> --attempts <# of attempts>`. The `branch_name` should be the name of the branch with the code to run, `experiment_path` should be a directory full of experiment json files rooted at `src/experiments` (or a single json file), and the list of tasks should contain the task you want to run. By default, the job will be attempted five times. If you are testing a job to see if it might fail, you should run it with `--attempts 1` so that it won't be retried if it fails. For example, you could run
 ```shell
 ./scripts/submit_jobs lf/batch src/experiments/tests/generator/experiments train_model validation_eval
 ```

--- a/scripts/submit_jobs
+++ b/scripts/submit_jobs
@@ -45,19 +45,6 @@ def query_yes_no(question, default="yes"):
                              "(or 'y' or 'n').\n")
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('branch_name', help='Branch with code to run on AWS')
-    parser.add_argument(
-        'experiment_path',
-        help='Directory with experiment files rooted at src/experiments/...')
-    parser.add_argument(
-        'tasks', nargs='*',
-        help='Space-delimited list of tasks to run on AWS. ' +
-             'Can be empty to run all tasks.')
-    return parser.parse_args()
-
-
 def read_experiment_files(path):
     run_name_to_file_path = {}
     run_name_to_parent_run_names = {}
@@ -92,7 +79,8 @@ def build_dep_graph(run_name_to_parent_run_names):
     return g
 
 
-def submit_job(branch_name, file_path, tasks, run_name, parent_job_ids=None):
+def submit_job(branch_name, file_path, tasks, run_name,
+               attempts, parent_job_ids=None):
     s3_bucket = environ.get('S3_BUCKET')
 
     job_name = run_name.replace('/', '-')
@@ -109,6 +97,7 @@ def submit_job(branch_name, file_path, tasks, run_name, parent_job_ids=None):
         dependsOn = [{'jobId': job_id} for job_id in parent_job_ids]
 
     client = boto3.client('batch')
+
     job_id = client.submit_job(
         jobName=job_name,
         jobQueue='raster-vision-experiments',
@@ -116,7 +105,10 @@ def submit_job(branch_name, file_path, tasks, run_name, parent_job_ids=None):
         containerOverrides={
             'command': command
         },
-        dependsOn=dependsOn)['jobId']
+        dependsOn=dependsOn,
+        retryStrategy={
+            'attempts': attempts
+        })['jobId']
 
     print(
         'Submitted job with jobName={} and jobId={}'.format(job_name, job_id))
@@ -138,11 +130,27 @@ def prompt_user(branch_name, experiment_path):
     return pushed_branch, want_to_run
 
 
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('branch_name', help='Branch with code to run on AWS')
+    parser.add_argument(
+        'experiment_path',
+        help='Directory with experiment files rooted at src/experiments/...')
+    parser.add_argument(
+        'tasks', nargs='*',
+        help='Space-delimited list of tasks to run on AWS. ' +
+             'Can be empty to run all tasks.')
+    parser.add_argument(
+        '--attempts', type=int, default=5, help='Number of times to retry job')
+    return parser.parse_args()
+
+
 def run():
     args = parse_args()
     print('Branch name: {}'.format(args.branch_name))
     print('Experiment path: {}'.format(args.experiment_path))
     print('Tasks: {}'.format(args.tasks))
+    print('Number of attempts: {}'.format(args.attempts))
 
     experiment_path = join(args.experiment_path, '*.json') \
         if isdir(args.experiment_path) else args.experiment_path
@@ -168,7 +176,7 @@ def run():
 
             run_name_to_job_id[run_name] = submit_job(
                 args.branch_name, file_path, args.tasks, run_name,
-                parent_job_ids)
+                args.attempts, parent_job_ids)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds an optional `attempts` argument to the `submit_jobs` script. By default, the job will be attempted five times in order to deal with spot instances that get outbid. However, if you are running a job to see if it might fail, you should set the attempts to one.