### PR TITLE
Add Jupyter and experiments for investigating tiffs and jpegs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure("2") do |config|
     raster_vision.vm.synced_folder DATA_DIR, "/opt/data"
 
     # If RASTER_VISION_NOTEBOOK_DIR is set, sync it to the VM
-    if File.directory?(File.expand_path(NOTEBOOK_DIR))
+    if NOTEBOOK_DIR and File.directory?(File.expand_path(NOTEBOOK_DIR))
       raster_vision.vm.synced_folder NOTEBOOK_DIR, "/opt/notebooks"
     end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,13 @@ SCRIPT
 
 DATA_DIR = ENV["RASTER_VISION_DATA_DIR"]
 if DATA_DIR.nil?
-  puts "You must set the environment variable: RASTER_VISION_DATA_DIR"
+  puts "ERROR: You must set the environment variable: RASTER_VISION_DATA_DIR"
   exit 1
+end
+
+NOTEBOOK_DIR = ENV["RASTER_VISION_NOTEBOOK_DIR"]
+if NOTEBOOK_DIR.nil?
+  puts "WARN: To use juptyer, You must set the environment variable: RASTER_VISION_NOTEBOOK_DIR"
 end
 
 S3_BUCKET = ENV.fetch("RASTER_VISION_BUCKET", "raster-vision")
@@ -24,6 +29,11 @@ Vagrant.configure("2") do |config|
     raster_vision.vm.hostname = "raster-vision"
     raster_vision.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
     raster_vision.vm.synced_folder DATA_DIR, "/opt/data"
+
+    # If RASTER_VISION_NOTEBOOK_DIR is set, sync it to the VM
+    if File.directory?(File.expand_path(NOTEBOOK_DIR))
+      raster_vision.vm.synced_folder NOTEBOOK_DIR, "/opt/notebooks"
+    end
 
     raster_vision.vm.network "forwarded_port", guest: 8888, host: 8888
 

--- a/scripts/jupyter
+++ b/scripts/jupyter
@@ -23,7 +23,7 @@ then
            -v /opt/data:/opt/data \
            -v /opt/notebooks:/opt/notebooks \
            -p 8888:8888 \
-           raster-vision-base \
+           raster-vision-cpu \
            jupyter notebook \
            --ip 0.0.0.0 \
            --port 8888 \

--- a/scripts/jupyter
+++ b/scripts/jupyter
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
+    set -x
+fi
+
+PROJECT_ROOT="$(dirname "$(dirname "$(readlink -f "${0}")")")"
+SRC="$PROJECT_ROOT/src"
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0") (--local|--remote)
+Run the jupyter notebook in a raster-vision docker image locally
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    docker run --rm -it \
+           -v "$SRC":/opt/src \
+           -v /opt/data:/opt/data \
+           -v /opt/notebooks:/opt/notebooks \
+           -p 8888:8888 \
+           raster-vision-base \
+           jupyter notebook \
+           --ip 0.0.0.0 \
+           --port 8888 \
+           --no-browser \
+           --allow-root \
+           --notebook-dir=/opt/notebooks
+fi

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -35,7 +35,7 @@ RUN conda install -y python=${python_version} scikit-learn six h5py \
         matplotlib pillow rasterio jupyter scikit-image && \
     conda clean -yt
 
-RUN pip install flake8 awscli
+RUN pip install flake8 awscli spectral
 
 WORKDIR /opt/src
 ENV PYTHONPATH=/opt/src/:$PYTHONPATH

--- a/src/experiments/tagging/6_20_17/IRRGtiff_0.json
+++ b/src/experiments/tagging/6_20_17/IRRGtiff_0.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 32,
+    "git_commit": "95f4e9",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "tiff",
+    "active_input_inds": [3, 0, 1],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "init_lr": 1e-4,
+    "model_type": "baseline_resnet",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 240,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_20_17/IRRGtiff_0",
+    "steps_per_epoch": 400
+}

--- a/src/experiments/tagging/6_20_17/RGBjpg_0.json
+++ b/src/experiments/tagging/6_20_17/RGBjpg_0.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 32,
+    "git_commit": "95f4e9",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "init_lr": 1e-4,
+    "model_type": "baseline_resnet",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 240,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_20_17/RGBjpg_0",
+    "steps_per_epoch": 400
+}

--- a/src/experiments/tagging/6_20_17/RGBtiff_0.json
+++ b/src/experiments/tagging/6_20_17/RGBtiff_0.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 32,
+    "git_commit": "95f4e9",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "tiff",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "init_lr": 1e-4,
+    "model_type": "baseline_resnet",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 240,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_20_17/RGBtiff_0",
+    "steps_per_epoch": 400
+}

--- a/src/rastervision/tagging/data/planet_kaggle.py
+++ b/src/rastervision/tagging/data/planet_kaggle.py
@@ -282,9 +282,9 @@ class PlanetKaggleFileGenerator(FileGenerator):
 class PlanetKaggleTiffFileGenerator(PlanetKaggleFileGenerator):
     def __init__(self, datasets_path, options):
         self.dev_dir = 'train-tif-v2'
-        self.test_dir = 'test-tif-v2'
+        self.test_dir = 'test-tif-v3'
         self.file_names = [
-            'train-tif-v2.zip', 'test-tif-v2.zip', 'train_v2.csv.zip',
+            'train-tif-v2.zip', 'test-tif-v3.zip', 'train_v2.csv.zip',
             'planet_kaggle_tiff_channel_stats.json']
         self.file_extension = 'tif'
         self.dataset = TiffDataset()


### PR DESCRIPTION
In order to better understand the difference in performance on the tif versus jpg versions of the Planet Kaggle dataset, this PR adds the ability to use Jupyter notebooks while in the vagrant environment. This also includes several experiments for image performance comparisons and a change to the test-tif path to the new files that now correctly match with the test-jpg files.

You can run Jupyter while in the vagrantbox by using the command `./scripts/jupyter`. Similar to the datasets, this functionality requires that the file path to your local notebooks folder be stored in a global variable under `RASTER_VISION_NOTEBOOK_DIR` in `~/.bash.rc`. The notebooks path in the Docker is at `opt/notebooks`. Note that Jupyter cannot be run concurrently with `./scripts/run --cpu` as both docker contains require the same port. 