### PR TITLE
Create ensembles via aggregate job 

### DIFF
--- a/scripts/submit_jobs
+++ b/scripts/submit_jobs
@@ -116,14 +116,13 @@ def submit_job(branch_name, file_path, tasks, run_name,
     return job_id
 
 
-def prompt_user(branch_name, experiment_path):
+def prompt_user(branch_name, experiment_path, nb_jobs):
     question = 'Are your experiment files pushed to the remote branch {}' \
         .format(branch_name)
     pushed_branch = query_yes_no(question, default='no')
 
     want_to_run = False
     if pushed_branch:
-        nb_jobs = len(list(glob.iglob(experiment_path)))
         question = 'Are you sure you want to run {} jobs?'.format(nb_jobs)
         want_to_run = query_yes_no(question, default='no')
 
@@ -154,29 +153,41 @@ def run():
 
     experiment_path = join(args.experiment_path, '*.json') \
         if isdir(args.experiment_path) else args.experiment_path
+    experiment_paths = list(glob.iglob(experiment_path))
+    nb_jobs = len(experiment_paths)
 
     pushed_branch, want_to_run = prompt_user(
-        args.branch_name, experiment_path)
+        args.branch_name, experiment_path, nb_jobs)
 
     if pushed_branch and want_to_run:
-        run_name_to_file_path, run_name_to_parent_run_names = \
-            read_experiment_files(experiment_path)
-        dep_graph = build_dep_graph(run_name_to_parent_run_names)
-        sorted_run_names = nx.topological_sort(dep_graph)
+        if nb_jobs == 1:
+            with open(experiment_path, 'r') as exp_file:
+                exp = json.load(exp_file)
+                run_name = exp['run_name']
+                submit_job(
+                    args.branch_name, experiment_path, args.tasks, run_name,
+                    args.attempts)
+        else:
+            # If directory of files, then build dependency graph and run
+            # them in the right order, feeding the parent job ids to batch.
+            run_name_to_file_path, run_name_to_parent_run_names = \
+                read_experiment_files(experiment_path)
+            dep_graph = build_dep_graph(run_name_to_parent_run_names)
+            sorted_run_names = nx.topological_sort(dep_graph)
 
-        run_name_to_job_id = {}
-        for run_name in sorted_run_names:
-            file_path = run_name_to_file_path[run_name]
+            run_name_to_job_id = {}
+            for run_name in sorted_run_names:
+                file_path = run_name_to_file_path[run_name]
 
-            parent_run_names = run_name_to_parent_run_names[run_name]
-            parent_job_ids = None
-            if parent_run_names is not None:
-                parent_job_ids = [run_name_to_job_id[parent_run_name]
-                                  for parent_run_name in parent_run_names]
+                parent_run_names = run_name_to_parent_run_names[run_name]
+                parent_job_ids = None
+                if parent_run_names is not None:
+                    parent_job_ids = [run_name_to_job_id[parent_run_name]
+                                      for parent_run_name in parent_run_names]
 
-            run_name_to_job_id[run_name] = submit_job(
-                args.branch_name, file_path, args.tasks, run_name,
-                args.attempts, parent_job_ids)
+                run_name_to_job_id[run_name] = submit_job(
+                    args.branch_name, file_path, args.tasks, run_name,
+                    args.attempts, parent_job_ids)
 
 
 if __name__ == '__main__':

--- a/src/experiments/semseg/tests/quick_test/generate_experiments.py
+++ b/src/experiments/semseg/tests/quick_test/generate_experiments.py
@@ -43,7 +43,10 @@ class TestExperimentGenerator(ExperimentGenerator):
         agg_exp = {
             'problem_type': base_exp['problem_type'],
             'run_name': join(base_exp['run_name'], str(exp_count)),
-            'aggregate_run_names': [exp['run_name'] for exp in exps]
+            'aggregate_run_names': [exp['run_name'] for exp in exps],
+            'aggregate_type': 'agg_summary',
+            'nb_eval_samples': base_exp['nb_eval_samples'],
+            'batch_size': base_exp['batch_size']
         }
         exps.append(agg_exp)
         exp_count += 1

--- a/src/experiments/tagging/tests/quick_test/generate_experiments.py
+++ b/src/experiments/tagging/tests/quick_test/generate_experiments.py
@@ -42,7 +42,10 @@ class TestExperimentGenerator(ExperimentGenerator):
         agg_exp = {
             'problem_type': base_exp['problem_type'],
             'run_name': join(base_exp['run_name'], str(exp_count)),
-            'aggregate_run_names': [exp['run_name'] for exp in exps]
+            'aggregate_run_names': [exp['run_name'] for exp in exps],
+            'aggregate_type': 'agg_ensemble',
+            'nb_eval_samples': base_exp['nb_eval_samples'],
+            'batch_size': base_exp['batch_size']
         }
         exps.append(agg_exp)
         exp_count += 1

--- a/src/rastervision/common/options.py
+++ b/src/rastervision/common/options.py
@@ -1,6 +1,9 @@
 from rastervision.common.data.generators import (
     all_augment_methods, safe_augment_methods)
 
+AGG_SUMMARY = 'agg_summary'
+AGG_ENSEMBLE = 'agg_ensemble'
+
 
 class Options():
     """Represents the options used to control an experimental run."""
@@ -8,9 +11,18 @@ class Options():
     def __init__(self, options):
         self.problem_type = options['problem_type']
         self.run_name = options['run_name']
+        self.aggregate_type = options.get('aggregate_type')
         self.aggregate_run_names = options.get('aggregate_run_names')
+        self.batch_size = options.get('batch_size', 32)
 
-        if self.aggregate_run_names is None:
+        # Controls how many samples to use in eval tasks.
+        # Setting this to a low value can be useful when testing
+        # the code, since it will save time.
+        self.nb_eval_samples = options.get('nb_eval_samples')
+        # Controls how many samples to plot as part of validation_eval
+        self.nb_eval_plot_samples = options.get('nb_eval_plot_samples')
+
+        if self.aggregate_type is None:
             self.train_stages = options.get('train_stages')
             if self.train_stages is not None:
                 options.update(self.train_stages[0])
@@ -18,7 +30,6 @@ class Options():
             self.model_type = options['model_type']
             self.dataset_name = options['dataset_name']
             self.generator_name = options['generator_name']
-            self.batch_size = options['batch_size']
             self.epochs = options['epochs']
             self.steps_per_epoch = options['steps_per_epoch']
             self.validation_steps = options['validation_steps']
@@ -46,11 +57,3 @@ class Options():
                     raise ValueError(
                         '{} are not valid augment_methods'.format(
                             str(invalid_augment_methods)))
-
-            # Controls how many samples to use in validation_eval, test_predict
-            # and validation_predict.
-            # Setting this to a low value can be useful when testing
-            # the code, since it will save time.
-            self.nb_eval_samples = options.get('nb_eval_samples')
-            # Controls how many samples to plot as part of validation_eval
-            self.nb_eval_plot_samples = options.get('nb_eval_plot_samples')

--- a/src/rastervision/common/tasks/validation_eval.py
+++ b/src/rastervision/common/tasks/validation_eval.py
@@ -1,1 +1,0 @@
-VALIDATION_EVAL = 'validation_eval'

--- a/src/rastervision/run.py
+++ b/src/rastervision/run.py
@@ -5,8 +5,6 @@ run. Example usage: `python run.py options.json train_model`
 import argparse
 import json
 
-from rastervision.options import make_options
-
 from rastervision.semseg.settings import SEMSEG
 from rastervision.semseg.run import SemsegRunner
 
@@ -30,17 +28,15 @@ def run_tasks():
     """
     args = parse_args()
     with open(args.file_path) as options_file:
-        options_dict = json.load(options_file)
-        options = make_options(options_dict)
-        if options.problem_type == SEMSEG:
+        problem_type = json.load(options_file)['problem_type']
+        if problem_type == SEMSEG:
             runner = SemsegRunner()
-            runner.run_tasks(options, args.tasks)
-        elif options.problem_type == TAGGING:
+        elif problem_type == TAGGING:
             runner = TaggingRunner()
-            runner.run_tasks(options, args.tasks)
         else:
             raise ValueError('{} is not a valid problem_type'.format(
-                options.problem_type))
+                problem_type))
+        runner.run_tasks(args.file_path, args.tasks)
 
 
 if __name__ == '__main__':

--- a/src/rastervision/semseg/options.py
+++ b/src/rastervision/semseg/options.py
@@ -15,7 +15,7 @@ class SemsegOptions(Options):
     def __init__(self, options):
         super().__init__(options)
 
-        if self.aggregate_run_names is None:
+        if self.aggregate_type is None:
             if (self.augment_methods is not None and
                 (ROTATE in self.augment_methods or
                  TRANSLATE in self.augment_methods)):

--- a/src/rastervision/semseg/run.py
+++ b/src/rastervision/semseg/run.py
@@ -1,13 +1,15 @@
 from rastervision.common.tasks.plot_curves import plot_curves, PLOT_CURVES
 from rastervision.common.tasks.train_model import TRAIN_MODEL
 from rastervision.common.tasks.aggregate_scores import aggregate_scores
-from rastervision.common.tasks.validation_eval import VALIDATION_EVAL
 from rastervision.common.run import Runner
+from rastervision.common.options import AGG_SUMMARY
 
+from rastervision.semseg.options import SemsegOptions
 from rastervision.semseg.data.factory import SemsegDataGeneratorFactory
 from rastervision.semseg.models.factory import SemsegModelFactory
 from rastervision.semseg.tasks.train_model import SemsegTrainModel
-from rastervision.semseg.tasks.validation_eval import validation_eval
+from rastervision.semseg.tasks.validation_eval import (
+    validation_eval, VALIDATION_EVAL)
 from rastervision.semseg.tasks.predict import (
     validation_predict, test_predict, VALIDATION_PREDICT, TEST_PREDICT)
 from rastervision.semseg.tasks.make_videos import MAKE_VIDEOS, make_videos
@@ -21,43 +23,51 @@ class SemsegRunner(Runner):
 
         self.model_factory_class = SemsegModelFactory
         self.data_generator_factory_class = SemsegDataGeneratorFactory
+        self.options_class = SemsegOptions
+        self.agg_file_names = [
+            'log.txt', 'options.json', 'scores.json']
 
     def run_task(self, task):
+        aggregate_type = self.options.aggregate_type
         if task == TRAIN_MODEL:
-            train_model = SemsegTrainModel(
-                self.run_path, self.sync_results, self.options, self.generator,
-                self.model)
-            train_model.train_model()
+            if aggregate_type is None:
+                train_model = SemsegTrainModel(
+                    self.run_path, self.sync_results, self.options,
+                    self.generator, self.model)
+                train_model.train_model()
 
-            if self.options.train_stages:
-                for stage in self.options.train_stages[1:]:
-                    for key, value in stage.items():
-                        if key == 'epochs':
-                            self.options.epochs += value
-                        else:
-                            setattr(self.options, key, value)
+                if self.options.train_stages:
+                    for stage in self.options.train_stages[1:]:
+                        for key, value in stage.items():
+                            if key == 'epochs':
+                                self.options.epochs += value
+                            else:
+                                setattr(self.options, key, value)
 
-                    self.model = self.model_factory.get_model(
-                        self.run_path, self.options, self.generator,
-                        use_best=False)
-                    train_model = SemsegTrainModel(
-                        self.run_path, self.sync_results, self.options,
-                        self.generator, self.model)
-                    train_model.train_model()
+                        self.model = self.model_factory.get_model(
+                            self.run_path, self.options, self.generator,
+                            use_best=False)
+                        train_model = SemsegTrainModel(
+                            self.run_path, self.sync_results, self.options,
+                            self.generator, self.model)
+                        train_model.train_model()
         elif task == PLOT_CURVES:
             plot_curves(self.options)
         elif task == VALIDATION_EVAL:
-            if self.options.aggregate_run_names is None:
-                validation_eval(
-                    self.run_path, self.model, self.options, self.generator)
-            else:
+            if aggregate_type == AGG_SUMMARY:
                 best_score_key = 'avg_accuracy'
                 aggregate_scores(self.options, best_score_key)
+            else:
+                validation_eval(
+                    self.run_path, self.model, self.options, self.generator)
         elif task == TEST_PREDICT:
-            test_predict(
-                self.run_path, self.model, self.options, self.generator)
+            if aggregate_type is None:
+                test_predict(
+                    self.run_path, self.model, self.options, self.generator)
         elif task == VALIDATION_PREDICT:
-            validation_predict(
-                self.run_path, self.model, self.options, self.generator)
+            if aggregate_type is None:
+                validation_predict(
+                    self.run_path, self.model, self.options, self.generator)
         elif task == MAKE_VIDEOS:
-            make_videos(self.run_path, self.options, self.generator)
+            if aggregate_type is None:
+                make_videos(self.run_path, self.options, self.generator)

--- a/src/rastervision/semseg/tasks/validation_eval.py
+++ b/src/rastervision/semseg/tasks/validation_eval.py
@@ -10,6 +10,8 @@ from rastervision.common.settings import VALIDATION
 from rastervision.semseg.tasks.utils import (
     predict_x, make_prediction_img, plot_prediction)
 
+VALIDATION_EVAL = 'validation_eval'
+
 
 class Scores():
     """A set of scores for the performance of a model on a dataset."""

--- a/src/rastervision/tagging/data/planet_kaggle.py
+++ b/src/rastervision/tagging/data/planet_kaggle.py
@@ -221,7 +221,9 @@ class PlanetKaggleFileGenerator(FileGenerator):
         save_json(tag_store.get_tag_counts(dataset.all_tags), counts_path)
 
     def generate_file_inds(self, path):
-        paths = glob.glob(join(path, '*.{}'.format(self.file_extension)))
+        paths = sorted(
+            glob.glob(join(path, '*.{}'.format(self.file_extension))))
+
         file_inds = []
         for path in paths:
             file_ind = splitext(basename(path))[0]

--- a/src/rastervision/tagging/options.py
+++ b/src/rastervision/tagging/options.py
@@ -5,7 +5,7 @@ class TaggingOptions(Options):
     def __init__(self, options):
         super().__init__(options)
 
-        if self.aggregate_run_names is None:
+        if self.aggregate_type is None:
             self.use_pretraining = options.get('use_pretraining', False)
             self.target_size = None
             self.rare_sample_prob = options.get('rare_sample_prob')

--- a/src/rastervision/tagging/run.py
+++ b/src/rastervision/tagging/run.py
@@ -1,15 +1,20 @@
+from rastervision.common.settings import TRAIN, VALIDATION, TEST
 from rastervision.common.tasks.plot_curves import plot_curves, PLOT_CURVES
 from rastervision.common.tasks.train_model import TRAIN_MODEL
-from rastervision.common.tasks.validation_eval import VALIDATION_EVAL
 from rastervision.common.tasks.aggregate_scores import aggregate_scores
 from rastervision.common.run import Runner
+from rastervision.common.options import AGG_SUMMARY, AGG_ENSEMBLE
 
 from rastervision.tagging.data.factory import TaggingDataGeneratorFactory
+from rastervision.tagging.options import TaggingOptions
 from rastervision.tagging.models.factory import TaggingModelFactory
 from rastervision.tagging.tasks.train_model import TaggingTrainModel
 from rastervision.tagging.tasks.predict import (
-    VALIDATION_PREDICT, TEST_PREDICT, validation_predict, test_predict)
-from rastervision.tagging.tasks.validation_eval import validation_eval
+    TRAIN_PROBS, TRAIN_PREDICT, VALIDATION_PROBS, VALIDATION_PREDICT,
+    TEST_PROBS, TEST_PREDICT, compute_ensemble_probs, compute_probs,
+    compute_preds)
+from rastervision.tagging.tasks.validation_eval import (
+    VALIDATION_EVAL, validation_eval)
 from rastervision.tagging.tasks.train_thresholds import (
     TRAIN_THRESHOLDS, train_thresholds)
 
@@ -17,32 +22,69 @@ from rastervision.tagging.tasks.train_thresholds import (
 class TaggingRunner(Runner):
     def __init__(self):
         self.valid_tasks = [
-            TRAIN_MODEL, TRAIN_THRESHOLDS, PLOT_CURVES, VALIDATION_PREDICT,
-            VALIDATION_EVAL, TEST_PREDICT]
+            TRAIN_MODEL, PLOT_CURVES,
+            TRAIN_PROBS, VALIDATION_PROBS, TEST_PROBS,
+            TRAIN_THRESHOLDS,
+            TRAIN_PREDICT, VALIDATION_PREDICT, TEST_PREDICT,
+            VALIDATION_EVAL]
         self.model_factory_class = TaggingModelFactory
         self.data_generator_factory_class = TaggingDataGeneratorFactory
+        self.options_class = TaggingOptions
+        self.agg_file_names = [
+            'log.txt', 'options.json', 'scores.json', 'train_probs.npy',
+            'test_probs.npy', 'validation_probs.npy']
 
     def run_task(self, task):
+        aggregate_type = self.options.aggregate_type
         if task == TRAIN_MODEL:
-            train_model = TaggingTrainModel(
-                self.run_path, self.sync_results, self.options,
-                self.generator, self.model)
-            train_model.train_model()
-        elif task == TRAIN_THRESHOLDS:
-            train_thresholds(
-                self.run_path, self.model, self.options, self.generator)
+            if aggregate_type is None:
+                train_model = TaggingTrainModel(
+                    self.run_path, self.sync_results, self.options,
+                    self.generator, self.model)
+                train_model.train_model()
         elif task == PLOT_CURVES:
             plot_curves(self.options)
+        elif task == TRAIN_PROBS:
+            if aggregate_type == AGG_ENSEMBLE:
+                compute_ensemble_probs(
+                    self.run_path, self.options, self.generator, TRAIN)
+            elif aggregate_type is None:
+                compute_probs(self.run_path, self.model, self.options,
+                              self.generator, TRAIN)
+        elif task == VALIDATION_PROBS:
+            if aggregate_type == AGG_ENSEMBLE:
+                compute_ensemble_probs(
+                    self.run_path, self.options, self.generator, VALIDATION)
+            elif aggregate_type is None:
+                compute_probs(self.run_path, self.model, self.options,
+                              self.generator, VALIDATION)
+        elif task == TEST_PROBS:
+            if aggregate_type == AGG_ENSEMBLE:
+                compute_ensemble_probs(
+                    self.run_path, self.options, self.generator, TEST)
+            elif aggregate_type is None:
+                compute_probs(self.run_path, self.model, self.options,
+                              self.generator, TEST)
+        elif task == TRAIN_THRESHOLDS:
+            if aggregate_type in [None, AGG_ENSEMBLE]:
+                train_thresholds(
+                    self.run_path, self.options, self.generator)
+        elif task == TRAIN_PREDICT:
+            if aggregate_type in [None, AGG_ENSEMBLE]:
+                compute_preds(
+                    self.run_path, self.options, self.generator, TRAIN)
         elif task == VALIDATION_PREDICT:
-            validation_predict(
-                self.run_path, self.model, self.options, self.generator)
+            if aggregate_type in [None, AGG_ENSEMBLE]:
+                compute_preds(self.run_path, self.options,
+                              self.generator, VALIDATION)
+        elif task == TEST_PREDICT:
+            if aggregate_type in [None, AGG_ENSEMBLE]:
+                compute_preds(
+                    self.run_path, self.options, self.generator, TEST)
         elif task == VALIDATION_EVAL:
-            if self.options.aggregate_run_names is None:
-                validation_eval(
-                    self.run_path, self.model, self.options, self.generator)
-            else:
+            if aggregate_type == AGG_SUMMARY:
                 best_score_key = 'f2'
                 aggregate_scores(self.options, best_score_key)
-        elif task == TEST_PREDICT:
-            test_predict(
-                self.run_path, self.model, self.options, self.generator)
+            else:
+                validation_eval(
+                    self.run_path, self.options, self.generator)

--- a/src/rastervision/tagging/tasks/predict.py
+++ b/src/rastervision/tagging/tasks/predict.py
@@ -1,57 +1,77 @@
 from os.path import join
 
-from rastervision.common.settings import VALIDATION, TEST
+import numpy as np
+
+from rastervision.common.settings import results_path
 
 from rastervision.tagging.data.planet_kaggle import TagStore
 from rastervision.tagging.tasks.utils import compute_prediction
 from rastervision.tagging.tasks.train_thresholds import load_thresholds
 
+TRAIN_PROBS = 'train_probs'
+VALIDATION_PROBS = 'validation_probs'
+TEST_PROBS = 'test_probs'
+
+TRAIN_PREDICT = 'train_predict'
 VALIDATION_PREDICT = 'validation_predict'
 TEST_PREDICT = 'test_predict'
 
 
-def predict(run_path, model, options, generator, split):
-    """Generate predictions for split data.
+def compute_ensemble_probs(run_path, options, generator, split):
+    probs_path = join(run_path, '{}_probs.npy'.format(split))
+    y_probs = []
 
-    For each image in a split, create a prediction, add it to the TagStore,
-    and then save the TagStore to a csv file.
+    for run_name in options.aggregate_run_names:
+        run_probs_path = join(
+            results_path, run_name, '{}_probs.npy'.format(split))
+        y_probs.append(np.expand_dims(np.load(run_probs_path), axis=2))
 
-    # Arguments
-        run_path: the path to the files for a run
-        model: a Keras model that has been trained
-        options: RunOptions object that specifies the run
-        generator: a Generator object to generate the test data
-        split: name of the split eg. validation
-    """
-    predictions_path = join(run_path, '{}_predictions.csv'.format(split))
+    y_probs = np.concatenate(y_probs, axis=2)
+    y_probs = np.mean(y_probs, axis=2)
 
-    thresholds = load_thresholds(run_path)
+    if options.nb_eval_samples is not None:
+        y_probs = y_probs[0:options.nb_eval_samples, :]
+
+    np.save(probs_path, y_probs)
+
+
+def compute_probs(run_path, model, options, generator, split):
+    probs_path = join(run_path, '{}_probs.npy'.format(split))
+    y_probs = []
+
     batch_size = options.batch_size
     split_gen = generator.make_split_generator(
         split, target_size=None,
         batch_size=batch_size, shuffle=False, augment_methods=None,
         normalize=True, only_xy=False)
 
-    tag_store = TagStore()
-
     for batch_ind, batch in enumerate(split_gen):
-        y_probs = model.predict(batch.x)
-        for sample_ind in range(batch.x.shape[0]):
-            y_pred = compute_prediction(
-                y_probs[sample_ind, :], generator.dataset, thresholds)
-            tag_store.add_tags(
-                batch.file_inds[sample_ind], y_pred)
+        y_probs.append(model.predict(batch.x))
 
         if (options.nb_eval_samples is not None and
                 batch_ind * options.batch_size >= options.nb_eval_samples):
             break
 
+    y_probs = np.concatenate(y_probs, axis=0)
+    if options.nb_eval_samples is not None:
+        y_probs = y_probs[0:options.nb_eval_samples, :]
+
+    np.save(probs_path, y_probs)
+
+
+def compute_preds(run_path, options, generator, split):
+    probs_path = join(run_path, '{}_probs.npy'.format(split))
+    y_probs = np.load(probs_path)
+
+    predictions_path = join(run_path, '{}_preds.csv'.format(split))
+    thresholds = load_thresholds(run_path)
+    tag_store = TagStore()
+    file_inds = generator.get_file_inds(split)
+
+    for sample_ind in range(y_probs.shape[0]):
+        y_pred = compute_prediction(
+            y_probs[sample_ind, :], generator.dataset, thresholds)
+        file_ind = file_inds[sample_ind]
+        tag_store.add_tags(file_ind, y_pred)
+
     tag_store.save(predictions_path)
-
-
-def validation_predict(run_path, model, options, generator):
-    predict(run_path, model, options, generator, VALIDATION)
-
-
-def test_predict(run_path, model, options, generator):
-    predict(run_path, model, options, generator, TEST)

--- a/src/rastervision/tagging/tasks/validation_eval.py
+++ b/src/rastervision/tagging/tasks/validation_eval.py
@@ -11,8 +11,9 @@ import matplotlib.pyplot as plt
 from rastervision.common.settings import VALIDATION
 from rastervision.common.utils import plot_img_row, _makedirs
 
-from rastervision.tagging.tasks.utils import compute_prediction
-from rastervision.tagging.tasks.train_thresholds import load_thresholds
+from rastervision.tagging.data.planet_kaggle import TagStore
+
+VALIDATION_EVAL = 'validation_eval'
 
 
 class Scores():
@@ -70,54 +71,64 @@ def plot_prediction(generator, all_x, y_true, y_pred,
     plt.close(fig)
 
 
-def plot_predictions(run_path, model, options, generator):
+def plot_predictions(run_path, options, generator):
+    validation_pred_path = join(run_path, 'validation_preds.csv')
+
     validation_plot_path = join(run_path, 'validation_plots')
     _makedirs(validation_plot_path)
 
-    y_trues = []
-    y_preds = []
-
-    thresholds = load_thresholds(run_path)
+    validation_pred_tag_store = TagStore(validation_pred_path)
     split_gen = generator.make_split_generator(
         VALIDATION, target_size=None,
         batch_size=options.batch_size, shuffle=False, augment_methods=None,
         normalize=True, only_xy=False)
 
     sample_count = 0
+    plot_sample_count = 0
+    y_trues = []
+    y_preds = []
     for batch_ind, batch in enumerate(split_gen):
-        y_probs = model.predict(batch.x)
         for sample_ind in range(batch.x.shape[0]):
             file_ind = batch.file_inds[sample_ind]
             all_x = batch.all_x[sample_ind, :, :, :]
 
-            y_pred = compute_prediction(
-                y_probs[sample_ind, :], generator.dataset, thresholds)
-            y_true = generator.tag_store.get_tag_array([file_ind])[0, :]
-            y_preds.append(np.expand_dims(y_pred, axis=0))
-            y_trues.append(np.expand_dims(y_true, axis=0))
+            y_true = generator.tag_store.get_tag_array([file_ind])
+            y_trues.append(y_true)
+            y_pred = validation_pred_tag_store.get_tag_array([file_ind])
+            y_preds.append(y_pred)
 
-            if (options.nb_eval_plot_samples is not None and
-                    sample_count < options.nb_eval_plot_samples):
-                is_mistake = not np.array_equal(y_true, y_pred)
+            if (options.nb_eval_plot_samples is None or
+                    plot_sample_count < options.nb_eval_plot_samples):
+                is_mistake = not np.array_equal(y_true[-1], y_pred[-1])
                 if is_mistake:
+                    plot_sample_count += 1
                     plot_path = join(
                         validation_plot_path, '{}_debug.png'.format(file_ind))
                     plot_prediction(
-                        generator, all_x, y_true, y_pred, plot_path)
+                        generator, all_x, y_true[0, :], y_pred[0, :],
+                        plot_path)
 
             sample_count += 1
+
+            if (options.nb_eval_samples is not None and
+                    sample_count >= options.nb_eval_samples):
+                break
 
         if (options.nb_eval_samples is not None and
                 sample_count >= options.nb_eval_samples):
             break
 
-    y_trues = np.concatenate(y_trues, axis=0)
-    y_preds = np.concatenate(y_preds, axis=0)
-    return y_trues, y_preds
+    y_true = np.concatenate(y_trues, axis=0)
+    y_pred = np.concatenate(y_preds, axis=0)
+    if options.nb_eval_samples is not None:
+        y_true = y_true[0:options.nb_eval_samples, :]
+        y_pred = y_pred[0:options.nb_eval_samples, :]
+
+    return y_true, y_pred
 
 
-def validation_eval(run_path, model, options, generator):
-    y_true, y_pred = plot_predictions(run_path, model, options, generator)
+def validation_eval(run_path, options, generator):
+    y_true, y_pred = plot_predictions(run_path, options, generator)
 
     scores = Scores(y_true, y_pred, generator.dataset.all_tags)
     scores_path = join(run_path, 'scores.json')


### PR DESCRIPTION
This PR adds an `aggregate_type` option which specifies the type of aggregate job. The old functionality is now handle by `agg_summary`, and a new `agg_ensemble` type was added which averages the probabilities (stored in files) generated by a set of previous runs. Once these probability files have been generated, the other eval tasks including `train_thresholds`, `validation_eval`, and `test_predict` use them instead of having to run the model over the data again, as was done previously. This PR also fixes a bug in `scripts/submit_jobs`.