### PR TITLE
Install OpenCV and Pandas in docker container for jupyter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,8 @@ deployment/ansible/*.retry
 *.tfvars
 *.tfstate
 *.tfstate.backup
+
+# Emacs
+\#*#
+*~
+.#*

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The goal of tagging is to infer a set of labels for each image. The following da
 | `infra`  | Execute Terraform subcommands            |
 | `test`   | Run unit tests and lint on source code |
 | `run` | Run container locally or remotely |
+| `jupyter` | Run container with juptyer notebook with mounted data and notebook directory from `RASTER_VISION_NOTEBOOK_DIR` |
 | `setup`  | Bring up the virtual machine and install dependent software on it |
 | `setup_aws_batch`  | Setup AWS Batch |
 | `submit_jobs`  | Submit jobs to AWS Batch |
@@ -84,6 +85,17 @@ You can get into the bash console for the Docker container which has Keras and T
 vagrant ssh
 vagrant@raster-vision:/vagrant$ ./scripts/update --cpu
 vagrant@raster-vision:/vagrant$ ./scripts/run --cpu
+```
+
+### Running a Jupyter Notebook instance
+
+You can run a juptyer notebook that has the data from `RASTER_VISION_DATA_DIR` mounted to `/opt/data`
+and `RASTER_VISION_NOTEBOOK_DIR` mounted to `/opt/notebooks` and set as the juptyer notebook directory.
+
+```shell
+vagrant ssh
+vagrant@raster-vision:/vagrant$ ./scripts/update --jupyter
+vagrant@raster-vision:/vagrant$ ./scripts/jupyter
 ```
 
 ### Preparing datasets

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,13 @@ SCRIPT
 
 DATA_DIR = ENV["RASTER_VISION_DATA_DIR"]
 if DATA_DIR.nil?
-  puts "You must set the environment variable: RASTER_VISION_DATA_DIR"
+  puts "ERROR: You must set the environment variable: RASTER_VISION_DATA_DIR"
   exit 1
+end
+
+NOTEBOOK_DIR = ENV["RASTER_VISION_NOTEBOOK_DIR"]
+if NOTEBOOK_DIR.nil?
+  puts "WARN: To use juptyer, You must set the environment variable: RASTER_VISION_NOTEBOOK_DIR"
 end
 
 S3_BUCKET = ENV.fetch("RASTER_VISION_BUCKET", "raster-vision")
@@ -24,6 +29,11 @@ Vagrant.configure("2") do |config|
     raster_vision.vm.hostname = "raster-vision"
     raster_vision.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
     raster_vision.vm.synced_folder DATA_DIR, "/opt/data"
+
+    # If RASTER_VISION_NOTEBOOK_DIR is set, sync it to the VM
+    if File.directory?(File.expand_path(NOTEBOOK_DIR))
+      raster_vision.vm.synced_folder NOTEBOOK_DIR, "/opt/notebooks"
+    end
 
     raster_vision.vm.network "forwarded_port", guest: 8888, host: 8888
 

--- a/scripts/jupyter
+++ b/scripts/jupyter
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
+    set -x
+fi
+
+PROJECT_ROOT="$(dirname "$(dirname "$(readlink -f "${0}")")")"
+SRC="$PROJECT_ROOT/src"
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0") (--local|--remote)
+Run the jupyter notebook in a raster-vision docker image locally
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    docker run --rm -it \
+           -v "$SRC":/opt/src \
+           -v /opt/data:/opt/data \
+           -v /opt/notebooks:/opt/notebooks \
+           -p 8888:8888 \
+           raster-vision-base \
+           jupyter notebook \
+           --ip 0.0.0.0 \
+           --port 8888 \
+           --no-browser \
+           --allow-root \
+           --notebook-dir=/opt/notebooks
+fi

--- a/scripts/jupyter
+++ b/scripts/jupyter
@@ -23,8 +23,8 @@ then
            -v /opt/data:/opt/data \
            -v /opt/notebooks:/opt/notebooks \
            -p 8888:8888 \
-           raster-vision-cpu \
-           jupyter notebook \
+           raster-vision-jupyter \
+           notebook \
            --ip 0.0.0.0 \
            --port 8888 \
            --no-browser \

--- a/scripts/update
+++ b/scripts/update
@@ -8,7 +8,7 @@ fi
 
 function usage() {
     echo -n \
-         "Usage: $(basename "$0") [--cpu|--gpu]
+         "Usage: $(basename "$0") [--cpu|--gpu|--jupyter]
 Build docker images for model training.
 If the type is not specified, it will build both cpu and gpu docker images.
 "
@@ -31,5 +31,9 @@ then
     if [ $# -eq 0 -o "${1:-}" = "--gpu" ]
     then
         docker build -t raster-vision-gpu -f src/Dockerfile-gpu src
+    fi
+    if [ $# -eq 0 -o "${1:-}" = "--jupyter" ]
+    then
+        docker build -t raster-vision-jupyter -f src/Dockerfile-jupyter src
     fi
 fi

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -32,7 +32,7 @@ USER keras
 ARG python_version=3.5.1
 
 RUN conda install -y python=${python_version} scikit-learn six h5py \
-        matplotlib pillow rasterio jupyter scikit-image && \
+        matplotlib pillow rasterio scikit-image && \
     conda clean -yt
 
 RUN pip install flake8 awscli spectral

--- a/src/Dockerfile-jupyter
+++ b/src/Dockerfile-jupyter
@@ -1,0 +1,10 @@
+FROM raster-vision-cpu
+
+ARG python_version=3.5.1
+
+RUN conda install -y python=${python_version} jupyter opencv && \
+    conda clean -yt
+
+RUN pip install pandas
+
+ENTRYPOINT ["jupyter"]


### PR DESCRIPTION
This PR makes the jupyter container its own container, that installs opencv and pandas.

Testing instructions:
- ssh into provisioned vagrant box
- `./scripts/update --jupyter`
- `./scripts/jupyter`

You will now have a notebook that has access to the pandas and cv2 packages.