### PR TITLE
Add DenseNet models and experiments

### DIFF
--- a/src/experiments/tagging/6_22_17/baseline.json
+++ b/src/experiments/tagging/6_22_17/baseline.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 32,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "lr_schedule": [[0, 0.00001], [20, 0.000001]],
+    "model_type": "baseline_resnet",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 120,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_22_17/baseline",
+    "steps_per_epoch": 600
+}

--- a/src/experiments/tagging/6_22_17/dense_0.json
+++ b/src/experiments/tagging/6_22_17/dense_0.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 8,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "init_lr": 1e-4,
+    "model_type": "densenet121",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 20,
+    "validation_steps": 480,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_22_17/dense_0",
+    "steps_per_epoch": 2400
+}

--- a/src/experiments/tagging/6_23_17/dense_1.json
+++ b/src/experiments/tagging/6_23_17/dense_1.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 8,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "lr_schedule": [[0, 0.00001], [20, 0.000001]],
+    "model_type": "densenet121",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 480,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_23_17/dense_1",
+    "steps_per_epoch": 2400
+}

--- a/src/experiments/tagging/6_26_17/dense121_3x10epochs_0.json
+++ b/src/experiments/tagging/6_26_17/dense121_3x10epochs_0.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 8,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "lr_schedule": [[0, 0.0001], [10, 0.00001],[20, 0.000001]],
+    "model_type": "densenet121",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 480,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_26_17/dense121_3x10epochs_0",
+    "steps_per_epoch": 2400
+}

--- a/src/experiments/tagging/6_26_17/dense121_3x20epochs_0.json
+++ b/src/experiments/tagging/6_26_17/dense121_3x20epochs_0.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 8,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "lr_schedule": [[0, 0.0001], [20, 0.00001],[40, 0.000001]],
+    "model_type": "densenet121",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 60,
+    "validation_steps": 480,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_26_17/dense121_3x20epochs_0",
+    "steps_per_epoch": 2400
+}

--- a/src/experiments/tagging/6_26_17/dense169_0.json
+++ b/src/experiments/tagging/6_26_17/dense169_0.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 8,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "lr_schedule": [[0, 0.00001], [20, 0.000001]],
+    "model_type": "densenet169",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 480,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_26_17/dense169_0",
+    "steps_per_epoch": 2400
+}

--- a/src/rastervision/common/models/custom_layers.py
+++ b/src/rastervision/common/models/custom_layers.py
@@ -1,0 +1,75 @@
+# flake8: noqa
+# -*- coding: utf-8 -*-
+"""
+Custom Scale Layer for Keras
+This code is based on
+https://github.com/flyyufelix/DenseNet-Keras
+"""
+
+from keras import initializers
+from keras.engine import Layer, InputSpec
+
+import keras.backend as K
+
+class Scale(Layer):
+    '''Custom Layer for DenseNet used for BatchNormalization.
+
+    Learns a set of weights and biases used for scaling the input data.
+    the output consists simply in an element-wise multiplication of the input
+    and a sum of a set of constants:
+
+        out = in * gamma + beta,
+
+    where 'gamma' and 'beta' are the weights and biases larned.
+
+    # Arguments
+        axis: integer, axis along which to normalize in mode 0. For instance,
+            if your input tensor has shape (samples, channels, rows, cols),
+            set axis to 1 to normalize per feature map (channels axis).
+        momentum: momentum in the computation of the
+            exponential average of the mean and standard deviation
+            of the data, for feature-wise normalization.
+        weights: Initialization weights.
+            List of 2 Numpy arrays, with shapes:
+            `[(input_shape,), (input_shape,)]`
+        beta_init: name of initialization function for shift parameter
+            (see [initializers](../initializers.md)), or alternatively,
+            Theano/TensorFlow function to use for weights initialization.
+            This parameter is only relevant if you don't pass a `weights` argument.
+        gamma_init: name of initialization function for scale parameter (see
+            [initializers](../initializers.md)), or alternatively,
+            Theano/TensorFlow function to use for weights initialization.
+            This parameter is only relevant if you don't pass a `weights` argument.
+    '''
+    def __init__(self, weights=None, axis=-1, momentum = 0.9, beta_init='zero', gamma_init='one', **kwargs):
+        self.momentum = momentum
+        self.axis = axis
+        self.beta_init = initializers.get(beta_init)
+        self.gamma_init = initializers.get(gamma_init)
+        self.initial_weights = weights
+        super(Scale, self).__init__(**kwargs)
+
+    def build(self, input_shape):
+        self.input_spec = [InputSpec(shape=input_shape)]
+        shape = (int(input_shape[self.axis]),)
+
+        self.gamma = K.variable(self.gamma_init(shape), name='{}_gamma'.format(self.name))
+        self.beta = K.variable(self.beta_init(shape), name='{}_beta'.format(self.name))
+        self.trainable_weights = [self.gamma, self.beta]
+
+        if self.initial_weights is not None:
+            self.set_weights(self.initial_weights)
+            del self.initial_weights
+
+    def call(self, x, mask=None):
+        input_shape = self.input_spec[0].shape
+        broadcast_shape = [1] * len(input_shape)
+        broadcast_shape[self.axis] = input_shape[self.axis]
+
+        out = K.reshape(self.gamma, broadcast_shape) * x + K.reshape(self.beta, broadcast_shape)
+        return out
+
+    def get_config(self):
+        config = {"momentum": self.momentum, "axis": self.axis}
+        base_config = super(Scale, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/src/rastervision/common/models/densenet121.py
+++ b/src/rastervision/common/models/densenet121.py
@@ -1,0 +1,201 @@
+# flake8: noqa
+# -*- coding: utf-8 -*-
+"""
+DenseNet 169 Model for Keras
+Model Schema is based on
+https://github.com/flyyufelix/DenseNet-Keras
+ImageNet Pretrained Weights
+Theano: https://drive.google.com/open?id=0Byy2AcGyEVxfMlRYb3YzV210VzQ
+TensorFlow: https://drive.google.com/open?id=0Byy2AcGyEVxfSTA4SHJVOHNuTXc
+"""
+
+from os.path import exists, join
+
+from keras.optimizers import SGD
+from keras.layers import Input, merge, ZeroPadding2D
+from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.convolutional import Convolution2D
+from keras.layers.pooling import AveragePooling2D, GlobalAveragePooling2D, MaxPooling2D
+from keras.layers.normalization import BatchNormalization
+from keras.models import Model
+import keras.backend as K
+
+from sklearn.metrics import log_loss
+
+from rastervision.common.settings import weights_path
+from rastervision.common.models.custom_layers import Scale
+from rastervision.common.utils import download_weights
+
+
+def DenseNet121(nb_dense_block=4, growth_rate=32, nb_filter=64, reduction=0.5,
+                dropout_rate=0.0, weight_decay=1e-4, weights=None,
+                classes=1000, input_shape=None, activation='softmax'):
+    '''
+    # Arguments
+        nb_dense_block: number of dense blocks to add to end
+        growth_rate: number of filters to add per dense block
+        nb_filter: initial number of filters
+        reduction: reduction factor of transition blocks.
+        dropout_rate: dropout rate
+        weight_decay: weight decay factor
+        classes: optional number of classes to classify images
+        weights_path: path to pre-trained weights
+    # Returns
+        A Keras model instance.
+    '''
+
+    compression = 1.0 - reduction
+    eps = 1.1e-5
+    global concat_axis
+    concat_axis = 3
+
+    if input_shape is None:
+        img_input = Input(shape=(224, 224, 3), name='data')
+    else:
+        img_input = Input(input_shape)
+
+    # From architecture for ImageNet (Table 1 in the paper)
+    nb_filter = 64
+    nb_layers = [6,12,24,16] # For DenseNet-121
+
+    # Initial convolution
+    x = ZeroPadding2D((3, 3), name='conv1_zeropadding')(img_input)
+    x = Convolution2D(nb_filter, 7, 7, subsample=(2, 2), name='conv1', bias=False)(x)
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name='conv1_bn')(x)
+    x = Scale(axis=concat_axis, name='conv1_scale')(x)
+    x = Activation('relu', name='relu1')(x)
+    x = ZeroPadding2D((1, 1), name='pool1_zeropadding')(x)
+    x = MaxPooling2D((3, 3), strides=(2, 2), name='pool1')(x)
+
+    # Add dense blocks
+    for block_idx in range(nb_dense_block - 1):
+        stage = block_idx+2
+        x, nb_filter = dense_block(x, stage, nb_layers[block_idx], nb_filter, growth_rate, dropout_rate=dropout_rate, weight_decay=weight_decay)
+
+        # Add transition_block
+        x = transition_block(x, stage, nb_filter, compression=compression, dropout_rate=dropout_rate, weight_decay=weight_decay)
+        nb_filter = int(nb_filter * compression)
+
+    final_stage = stage + 1
+    x, nb_filter = dense_block(x, final_stage, nb_layers[-1], nb_filter, growth_rate, dropout_rate=dropout_rate, weight_decay=weight_decay)
+
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name='conv'+str(final_stage)+'_blk_bn')(x)
+    x = Scale(axis=concat_axis, name='conv'+str(final_stage)+'_blk_scale')(x)
+    x = Activation('relu', name='relu'+str(final_stage)+'_blk')(x)
+
+    x_fc = GlobalAveragePooling2D(name='pool'+str(final_stage))(x)
+    x_fc = Dense(1000, name='fc6')(x_fc)
+    x_fc = Activation('softmax', name='prob')(x_fc)
+
+    model = Model(img_input, x_fc, name='densenet')
+
+    # load weights
+    if weights == 'imagenet':
+        path = join(weights_path, 'densenet121_weights_tf.h5')
+        if not exists(path):
+            download_weights('densenet121_weights_tf.h5')
+        model.load_weights(path, by_name=True)
+
+    # Truncate and replace softmax layer for transfer learning
+    # Cannot use model.layers.pop() since model is not of Sequential() type
+    # The method below works since pre-trained weights are stored in layers but not in the model
+    x_newfc = GlobalAveragePooling2D(name='pool'+str(final_stage))(x)
+    x_newfc = Dense(classes, name='fc6')(x_newfc)
+    x_newfc = Activation(activation, name='prob')(x_newfc)
+
+    model = Model(img_input, x_newfc)
+
+    return model
+
+
+def conv_block(x, stage, branch, nb_filter, dropout_rate=None, weight_decay=1e-4):
+    '''Apply BatchNorm, Relu, bottleneck 1x1 Conv2D, 3x3 Conv2D, and option dropout
+        # Arguments
+            x: input tensor
+            stage: index for dense block
+            branch: layer index within each dense block
+            nb_filter: number of filters
+            dropout_rate: dropout rate
+            weight_decay: weight decay factor
+    '''
+    eps = 1.1e-5
+    conv_name_base = 'conv' + str(stage) + '_' + str(branch)
+    relu_name_base = 'relu' + str(stage) + '_' + str(branch)
+
+    # 1x1 Convolution (Bottleneck layer)
+    inter_channel = nb_filter * 4
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name=conv_name_base+'_x1_bn')(x)
+    x = Scale(axis=concat_axis, name=conv_name_base+'_x1_scale')(x)
+    x = Activation('relu', name=relu_name_base+'_x1')(x)
+    x = Convolution2D(inter_channel, 1, 1, name=conv_name_base+'_x1', bias=False)(x)
+
+    if dropout_rate:
+        x = Dropout(dropout_rate)(x)
+
+    # 3x3 Convolution
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name=conv_name_base+'_x2_bn')(x)
+    x = Scale(axis=concat_axis, name=conv_name_base+'_x2_scale')(x)
+    x = Activation('relu', name=relu_name_base+'_x2')(x)
+    x = ZeroPadding2D((1, 1), name=conv_name_base+'_x2_zeropadding')(x)
+    x = Convolution2D(nb_filter, 3, 3, name=conv_name_base+'_x2', bias=False)(x)
+
+    if dropout_rate:
+        x = Dropout(dropout_rate)(x)
+
+    return x
+
+
+def transition_block(x, stage, nb_filter, compression=1.0, dropout_rate=None, weight_decay=1E-4):
+    ''' Apply BatchNorm, 1x1 Convolution, averagePooling, optional compression, dropout
+        # Arguments
+            x: input tensor
+            stage: index for dense block
+            nb_filter: number of filters
+            compression: calculated as 1 - reduction. Reduces the number of feature maps in the transition block.
+            dropout_rate: dropout rate
+            weight_decay: weight decay factor
+    '''
+
+    eps = 1.1e-5
+    conv_name_base = 'conv' + str(stage) + '_blk'
+    relu_name_base = 'relu' + str(stage) + '_blk'
+    pool_name_base = 'pool' + str(stage)
+
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name=conv_name_base+'_bn')(x)
+    x = Scale(axis=concat_axis, name=conv_name_base+'_scale')(x)
+    x = Activation('relu', name=relu_name_base)(x)
+    x = Convolution2D(int(nb_filter * compression), 1, 1, name=conv_name_base, bias=False)(x)
+
+    if dropout_rate:
+        x = Dropout(dropout_rate)(x)
+
+    x = AveragePooling2D((2, 2), strides=(2, 2), name=pool_name_base)(x)
+
+    return x
+
+
+def dense_block(x, stage, nb_layers, nb_filter, growth_rate, dropout_rate=None, weight_decay=1e-4, grow_nb_filters=True):
+    ''' Build a dense_block where the output of each conv_block is fed to subsequent ones
+        # Arguments
+            x: input tensor
+            stage: index for dense block
+            nb_layers: the number of layers of conv_block to append to the model.
+            nb_filter: number of filters
+            growth_rate: growth rate
+            dropout_rate: dropout rate
+            weight_decay: weight decay factor
+            grow_nb_filters: flag to decide to allow number of filters to grow
+    '''
+
+    eps = 1.1e-5
+    concat_feat = x
+
+    for i in range(nb_layers):
+        branch = i+1
+        x = conv_block(concat_feat, stage, branch, growth_rate, dropout_rate, weight_decay)
+        concat_feat = merge([concat_feat, x], mode='concat', concat_axis=concat_axis, name='concat_'+str(stage)+'_'+str(branch))
+
+        if grow_nb_filters:
+            nb_filter += growth_rate
+
+    return concat_feat, nb_filter

--- a/src/rastervision/common/models/densenet169.py
+++ b/src/rastervision/common/models/densenet169.py
@@ -1,0 +1,201 @@
+# flake8: noqa
+# -*- coding: utf-8 -*-
+"""
+DenseNet 169 Model for Keras
+Model Schema is based on
+https://github.com/flyyufelix/DenseNet-Keras
+ImageNet Pretrained Weights
+Theano: https://drive.google.com/open?id=0Byy2AcGyEVxfN0d3T1F1MXg0NlU
+TensorFlow: https://drive.google.com/open?id=0Byy2AcGyEVxfSEc5UC1ROUFJdmM
+"""
+
+from os.path import exists, join
+
+from keras.optimizers import SGD
+from keras.layers import Input, merge, ZeroPadding2D
+from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.convolutional import Convolution2D
+from keras.layers.pooling import AveragePooling2D, GlobalAveragePooling2D, MaxPooling2D
+from keras.layers.normalization import BatchNormalization
+from keras.models import Model
+import keras.backend as K
+
+from sklearn.metrics import log_loss
+
+from rastervision.common.settings import weights_path
+from rastervision.common.models.custom_layers import Scale
+from rastervision.common.utils import download_weights
+
+
+def DenseNet169(nb_dense_block=4, growth_rate=32, nb_filter=64, reduction=0.5,
+                dropout_rate=0.0, weight_decay=1e-4, weights=None,
+                classes=1000, input_shape=None, activation='softmax'):
+    '''
+    # Arguments
+        nb_dense_block: number of dense blocks to add to end
+        growth_rate: number of filters to add per dense block
+        nb_filter: initial number of filters
+        reduction: reduction factor of transition blocks.
+        dropout_rate: dropout rate
+        weight_decay: weight decay factor
+        classes: optional number of classes to classify images
+        weights_path: path to pre-trained weights
+    # Returns
+        A Keras model instance.
+    '''
+
+    compression = 1.0 - reduction
+    eps = 1.1e-5
+    global concat_axis
+    concat_axis = 3
+
+    if input_shape is None:
+        img_input = Input(shape=(224, 224, 3), name='data')
+    else:
+        img_input = Input(input_shape)
+
+    # From architecture for ImageNet (Table 1 in the paper)
+    nb_filter = 64
+    nb_layers = [6,12,32,32] # For DenseNet-169
+
+    # Initial convolution
+    x = ZeroPadding2D((3, 3), name='conv1_zeropadding')(img_input)
+    x = Convolution2D(nb_filter, 7, 7, subsample=(2, 2), name='conv1', bias=False)(x)
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name='conv1_bn')(x)
+    x = Scale(axis=concat_axis, name='conv1_scale')(x)
+    x = Activation('relu', name='relu1')(x)
+    x = ZeroPadding2D((1, 1), name='pool1_zeropadding')(x)
+    x = MaxPooling2D((3, 3), strides=(2, 2), name='pool1')(x)
+
+    # Add dense blocks
+    for block_idx in range(nb_dense_block - 1):
+        stage = block_idx+2
+        x, nb_filter = dense_block(x, stage, nb_layers[block_idx], nb_filter, growth_rate, dropout_rate=dropout_rate, weight_decay=weight_decay)
+
+        # Add transition_block
+        x = transition_block(x, stage, nb_filter, compression=compression, dropout_rate=dropout_rate, weight_decay=weight_decay)
+        nb_filter = int(nb_filter * compression)
+
+    final_stage = stage + 1
+    x, nb_filter = dense_block(x, final_stage, nb_layers[-1], nb_filter, growth_rate, dropout_rate=dropout_rate, weight_decay=weight_decay)
+
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name='conv'+str(final_stage)+'_blk_bn')(x)
+    x = Scale(axis=concat_axis, name='conv'+str(final_stage)+'_blk_scale')(x)
+    x = Activation('relu', name='relu'+str(final_stage)+'_blk')(x)
+
+    x_fc = GlobalAveragePooling2D(name='pool'+str(final_stage))(x)
+    x_fc = Dense(1000, name='fc6')(x_fc)
+    x_fc = Activation('softmax', name='prob')(x_fc)
+
+    model = Model(img_input, x_fc, name='densenet')
+
+    # load weights
+    if weights == 'imagenet':
+        path = join(weights_path, 'densenet169_weights_tf.h5')
+        if not exists(path):
+            download_weights('densenet169_weights_tf.h5')
+        model.load_weights(path, by_name=True)
+
+    # Truncate and replace softmax layer for transfer learning
+    # Cannot use model.layers.pop() since model is not of Sequential() type
+    # The method below works since pre-trained weights are stored in layers but not in the model
+    x_newfc = GlobalAveragePooling2D(name='pool'+str(final_stage))(x)
+    x_newfc = Dense(classes, name='fc6')(x_newfc)
+    x_newfc = Activation(activation, name='prob')(x_newfc)
+
+    model = Model(img_input, x_newfc)
+
+    return model
+
+
+def conv_block(x, stage, branch, nb_filter, dropout_rate=None, weight_decay=1e-4):
+    '''Apply BatchNorm, Relu, bottleneck 1x1 Conv2D, 3x3 Conv2D, and option dropout
+        # Arguments
+            x: input tensor
+            stage: index for dense block
+            branch: layer index within each dense block
+            nb_filter: number of filters
+            dropout_rate: dropout rate
+            weight_decay: weight decay factor
+    '''
+    eps = 1.1e-5
+    conv_name_base = 'conv' + str(stage) + '_' + str(branch)
+    relu_name_base = 'relu' + str(stage) + '_' + str(branch)
+
+    # 1x1 Convolution (Bottleneck layer)
+    inter_channel = nb_filter * 4
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name=conv_name_base+'_x1_bn')(x)
+    x = Scale(axis=concat_axis, name=conv_name_base+'_x1_scale')(x)
+    x = Activation('relu', name=relu_name_base+'_x1')(x)
+    x = Convolution2D(inter_channel, 1, 1, name=conv_name_base+'_x1', bias=False)(x)
+
+    if dropout_rate:
+        x = Dropout(dropout_rate)(x)
+
+    # 3x3 Convolution
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name=conv_name_base+'_x2_bn')(x)
+    x = Scale(axis=concat_axis, name=conv_name_base+'_x2_scale')(x)
+    x = Activation('relu', name=relu_name_base+'_x2')(x)
+    x = ZeroPadding2D((1, 1), name=conv_name_base+'_x2_zeropadding')(x)
+    x = Convolution2D(nb_filter, 3, 3, name=conv_name_base+'_x2', bias=False)(x)
+
+    if dropout_rate:
+        x = Dropout(dropout_rate)(x)
+
+    return x
+
+
+def transition_block(x, stage, nb_filter, compression=1.0, dropout_rate=None, weight_decay=1E-4):
+    ''' Apply BatchNorm, 1x1 Convolution, averagePooling, optional compression, dropout
+        # Arguments
+            x: input tensor
+            stage: index for dense block
+            nb_filter: number of filters
+            compression: calculated as 1 - reduction. Reduces the number of feature maps in the transition block.
+            dropout_rate: dropout rate
+            weight_decay: weight decay factor
+    '''
+
+    eps = 1.1e-5
+    conv_name_base = 'conv' + str(stage) + '_blk'
+    relu_name_base = 'relu' + str(stage) + '_blk'
+    pool_name_base = 'pool' + str(stage)
+
+    x = BatchNormalization(epsilon=eps, axis=concat_axis, name=conv_name_base+'_bn')(x)
+    x = Scale(axis=concat_axis, name=conv_name_base+'_scale')(x)
+    x = Activation('relu', name=relu_name_base)(x)
+    x = Convolution2D(int(nb_filter * compression), 1, 1, name=conv_name_base, bias=False)(x)
+
+    if dropout_rate:
+        x = Dropout(dropout_rate)(x)
+
+    x = AveragePooling2D((2, 2), strides=(2, 2), name=pool_name_base)(x)
+
+    return x
+
+
+def dense_block(x, stage, nb_layers, nb_filter, growth_rate, dropout_rate=None, weight_decay=1e-4, grow_nb_filters=True):
+    ''' Build a dense_block where the output of each conv_block is fed to subsequent ones
+        # Arguments
+            x: input tensor
+            stage: index for dense block
+            nb_layers: the number of layers of conv_block to append to the model.
+            nb_filter: number of filters
+            growth_rate: growth rate
+            dropout_rate: dropout rate
+            weight_decay: weight decay factor
+            grow_nb_filters: flag to decide to allow number of filters to grow
+    '''
+
+    eps = 1.1e-5
+    concat_feat = x
+
+    for i in range(nb_layers):
+        branch = i+1
+        x = conv_block(concat_feat, stage, branch, growth_rate, dropout_rate, weight_decay)
+        concat_feat = merge([concat_feat, x], mode='concat', concat_axis=concat_axis, name='concat_'+str(stage)+'_'+str(branch))
+
+        if grow_nb_filters:
+            nb_filter += growth_rate
+
+    return concat_feat, nb_filter

--- a/src/rastervision/common/settings.py
+++ b/src/rastervision/common/settings.py
@@ -4,10 +4,12 @@ from os.path import join
 data_path = '/opt/data/'
 datasets_path = join(data_path, 'datasets')
 results_path = join(data_path, 'results')
+weights_path = join(data_path, 'weights')
 
 s3_bucket = environ.get('S3_BUCKET')
 s3_datasets_path = join('s3://{}'.format(s3_bucket), 'datasets')
 s3_results_path = join('s3://{}'.format(s3_bucket), 'results')
+s3_weights_path = join('s3://{}'.format(s3_bucket), 'weights')
 
 TRAIN = 'train'
 VALIDATION = 'validation'

--- a/src/rastervision/common/utils.py
+++ b/src/rastervision/common/utils.py
@@ -13,7 +13,7 @@ import rasterio
 
 from rastervision.common.settings import (
     s3_results_path, results_path, s3_datasets_path, datasets_path,
-    s3_bucket)
+    s3_weights_path, weights_path, s3_bucket)
 
 
 def _makedirs(path):
@@ -178,6 +178,13 @@ def download_dataset(dataset_name, file_names):
 
         for file_name in file_names:
             get_file(file_name)
+
+
+def download_weights(file_name):
+    print('Downloading {}...'.format(file_name))
+    src_path = join(s3_weights_path, file_name)
+    dst_path = join(weights_path, file_name)
+    s3_cp(src_path, dst_path)
 
 
 def make_sync_results(run_name):

--- a/src/rastervision/tagging/models/factory.py
+++ b/src/rastervision/tagging/models/factory.py
@@ -1,7 +1,11 @@
 from rastervision.common.models.factory import ModelFactory
 from rastervision.common.models.resnet50 import ResNet50
+from rastervision.common.models.densenet121 import DenseNet121
+from rastervision.common.models.densenet169 import DenseNet169
 
 BASELINE_RESNET = 'baseline_resnet'
+DENSENET_121 = 'densenet121'
+DENSENET_169 = 'densenet169'
 
 
 class TaggingModelFactory(ModelFactory):
@@ -24,6 +28,18 @@ class TaggingModelFactory(ModelFactory):
                 input_shape=input_shape,
                 classes=generator.dataset.nb_tags,
                 activation='sigmoid')
+        elif model_type == DENSENET_121:
+            weights = 'imagenet' if options.use_pretraining else None
+            model = DenseNet121(weights=weights,
+                                input_shape=input_shape,
+                                classes=generator.dataset.nb_tags,
+                                activation='sigmoid')
+        elif model_type == DENSENET_169:
+            weights = 'imagenet' if options.use_pretraining else None
+            model = DenseNet169(weights=weights,
+                                input_shape=input_shape,
+                                classes=generator.dataset.nb_tags,
+                                activation='sigmoid')
         else:
             raise ValueError('{} is not a valid model_type'.format(model_type))
 


### PR DESCRIPTION
This PR adds the densenet121 and densenet169 models to the project. Both models support pretraining with imagenet weights. Additionally, this includes a series of experiments that were used to investigate the relative performances of the different architectures with variable learning rate schedules.

The link to the imagenet weights can be found at the top level comment of each model. These models use a tensorflow backend so choose the weights accordingly. They must be accessible by the Docker container via the file path `/opt/data/weights/`.