### PR TITLE
Support models that predict subset of tags

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -11,7 +11,7 @@ SRC="$PROJECT_ROOT/src"
 
 function usage() {
     echo -n \
-         "Usage: $(basename "$0") (--local|--remote)
+         "Usage: $(basename "$0") (--cpu|--gpu)
 Run raster-vision docker image either locally or on an AWS GPU-enabled
 EC2 instance. All arguments except the first are passed to 'docker run'.
 "

--- a/src/experiments/tagging/tests/agg_concat_test/generate_experiments.py
+++ b/src/experiments/tagging/tests/agg_concat_test/generate_experiments.py
@@ -1,0 +1,58 @@
+from os.path import join
+from copy import deepcopy
+
+from rastervision.experiment_generator import (
+    ExperimentGenerator, get_parent_dir)
+from rastervision.tagging.data.planet_kaggle import Dataset
+
+
+class TestExperimentGenerator(ExperimentGenerator):
+    def generate_experiments(self):
+        base_exp = {
+            'batch_size': 1,
+            'problem_type': 'tagging',
+            'dataset_name': 'planet_kaggle',
+            'generator_name': 'jpg',
+            'active_input_inds': [0, 1, 2],
+            'use_pretraining': True,
+            'optimizer': 'adam',
+            'init_lr': 1e-3,
+            'model_type': 'baseline_resnet',
+            'train_ratio': 0.8,
+            'epochs': 2,
+            'nb_eval_samples': 10,
+            'nb_eval_plot_samples': 3,
+            'validation_steps': 1,
+            'run_name': 'tagging/tests/agg_concat_test',
+            'steps_per_epoch': 2,
+            'augment_methods': ['hflip', 'vflip', 'rotate', 'translate'],
+            'rare_sample_prob': 0.5
+        }
+
+        dataset = Dataset()
+        active_tags_list = [
+            dataset.atmos_tags, dataset.rare_tags, dataset.common_tags]
+
+        exps = []
+        exp_count = 0
+        for active_tags in active_tags_list:
+            exp = deepcopy(base_exp)
+            exp['active_tags'] = active_tags
+            exp['run_name'] = join(exp['run_name'], str(exp_count))
+            exps.append(exp)
+            exp_count += 1
+
+        agg_exp = deepcopy(base_exp)
+        agg_exp['run_name'] = join(base_exp['run_name'], str(exp_count))
+        agg_exp['aggregate_run_names'] = [exp['run_name'] for exp in exps]
+        agg_exp['aggregate_type'] = 'agg_concat'
+        agg_exp['active_tags'] = dataset.all_tags
+        exps.append(agg_exp)
+        exp_count += 1
+
+        return exps
+
+
+if __name__ == '__main__':
+    path = get_parent_dir(__file__)
+    gen = TestExperimentGenerator().run(path)

--- a/src/experiments/tagging/tests/agg_concat_test/generate_experiments.py
+++ b/src/experiments/tagging/tests/agg_concat_test/generate_experiments.py
@@ -26,7 +26,7 @@ class TestExperimentGenerator(ExperimentGenerator):
             'run_name': 'tagging/tests/agg_concat_test',
             'steps_per_epoch': 2,
             'augment_methods': ['hflip', 'vflip', 'rotate', 'translate'],
-            'rare_sample_prob': 0.5
+            'active_tags_prob': 0.75
         }
 
         dataset = Dataset()

--- a/src/experiments/tagging/tests/quick_test/generate_experiments.py
+++ b/src/experiments/tagging/tests/quick_test/generate_experiments.py
@@ -39,14 +39,10 @@ class TestExperimentGenerator(ExperimentGenerator):
             exps.append(exp)
             exp_count += 1
 
-        agg_exp = {
-            'problem_type': base_exp['problem_type'],
-            'run_name': join(base_exp['run_name'], str(exp_count)),
-            'aggregate_run_names': [exp['run_name'] for exp in exps],
-            'aggregate_type': 'agg_ensemble',
-            'nb_eval_samples': base_exp['nb_eval_samples'],
-            'batch_size': base_exp['batch_size']
-        }
+        agg_exp = deepcopy(base_exp)
+        agg_exp['run_name'] = join(base_exp['run_name'], str(exp_count))
+        agg_exp['aggregate_run_names'] = [exp['run_name'] for exp in exps]
+        agg_exp['aggregate_type'] = 'agg_ensemble'
         exps.append(agg_exp)
         exp_count += 1
 

--- a/src/rastervision/common/options.py
+++ b/src/rastervision/common/options.py
@@ -3,7 +3,7 @@ from rastervision.common.data.generators import (
 
 AGG_SUMMARY = 'agg_summary'
 AGG_ENSEMBLE = 'agg_ensemble'
-
+AGG_CONCAT = 'agg_concat'
 
 class Options():
     """Represents the options used to control an experimental run."""
@@ -22,38 +22,37 @@ class Options():
         # Controls how many samples to plot as part of validation_eval
         self.nb_eval_plot_samples = options.get('nb_eval_plot_samples')
 
-        if self.aggregate_type is None:
-            self.train_stages = options.get('train_stages')
-            if self.train_stages is not None:
-                options.update(self.train_stages[0])
+        self.train_stages = options.get('train_stages')
+        if self.train_stages is not None:
+            options.update(self.train_stages[0])
 
-            self.model_type = options['model_type']
-            self.dataset_name = options['dataset_name']
-            self.generator_name = options['generator_name']
-            self.epochs = options['epochs']
-            self.steps_per_epoch = options['steps_per_epoch']
-            self.validation_steps = options['validation_steps']
-            self.active_input_inds = options['active_input_inds']
+        self.model_type = options['model_type']
+        self.dataset_name = options['dataset_name']
+        self.generator_name = options['generator_name']
+        self.epochs = options['epochs']
+        self.steps_per_epoch = options['steps_per_epoch']
+        self.validation_steps = options['validation_steps']
+        self.active_input_inds = options['active_input_inds']
 
-            # Optional options
-            self.git_commit = options.get('git_commit')
-            # Size of the imgs used as input to the network
-            # [nb_rows, nb_cols]
-            self.target_size = options.get('target_size', (256, 256))
-            self.optimizer = options.get('optimizer', 'adam')
-            self.init_lr = options.get('init_lr', 1e-3)
-            self.patience = options.get('patience')
-            self.lr_schedule = options.get('lr_schedule')
-            self.train_ratio = options.get('train_ratio')
-            self.cross_validation = options.get('cross_validation')
-            self.delta_model_checkpoint = options.get(
-                'delta_model_checkpoint', None)
-            self.augment_methods = options.get(
-                'augment_methods', safe_augment_methods)
-            if self.augment_methods is not None:
-                invalid_augment_methods = \
-                    set(self.augment_methods) - set(all_augment_methods)
-                if invalid_augment_methods:
-                    raise ValueError(
-                        '{} are not valid augment_methods'.format(
-                            str(invalid_augment_methods)))
+        # Optional options
+        self.git_commit = options.get('git_commit')
+        # Size of the imgs used as input to the network
+        # [nb_rows, nb_cols]
+        self.target_size = options.get('target_size', (256, 256))
+        self.optimizer = options.get('optimizer', 'adam')
+        self.init_lr = options.get('init_lr', 1e-3)
+        self.patience = options.get('patience')
+        self.lr_schedule = options.get('lr_schedule')
+        self.train_ratio = options.get('train_ratio')
+        self.cross_validation = options.get('cross_validation')
+        self.delta_model_checkpoint = options.get(
+            'delta_model_checkpoint', None)
+        self.augment_methods = options.get(
+            'augment_methods', safe_augment_methods)
+        if self.augment_methods is not None:
+            invalid_augment_methods = \
+                set(self.augment_methods) - set(all_augment_methods)
+            if invalid_augment_methods:
+                raise ValueError(
+                    '{} are not valid augment_methods'.format(
+                        str(invalid_augment_methods)))

--- a/src/rastervision/semseg/options.py
+++ b/src/rastervision/semseg/options.py
@@ -15,39 +15,38 @@ class SemsegOptions(Options):
     def __init__(self, options):
         super().__init__(options)
 
-        if self.aggregate_type is None:
-            if (self.augment_methods is not None and
-                (ROTATE in self.augment_methods or
-                 TRANSLATE in self.augment_methods)):
-                raise ValueError('Cannot use rotate or translate with semseg.')
+        if (self.augment_methods is not None and
+            (ROTATE in self.augment_methods or
+             TRANSLATE in self.augment_methods)):
+            raise ValueError('Cannot use rotate or translate with semseg.')
 
-            self.nb_videos = options.get('nb_videos')
+        self.nb_videos = options.get('nb_videos')
 
-            if self.model_type == CONV_LOGISTIC:
-                self.kernel_size = options['kernel_size']
-            elif self.model_type == FC_DENSENET:
-                self.growth_rate = options['growth_rate']
-                self.drop_prob = options['drop_prob']
-                self.weight_decay = options['weight_decay']
-                self.down_blocks = options['down_blocks']
-                self.up_blocks = options['up_blocks']
-            elif self.model_type in [FCN_RESNET, DUAL_FCN_RESNET]:
-                self.use_pretraining = options['use_pretraining']
-                self.freeze_base = options['freeze_base']
+        if self.model_type == CONV_LOGISTIC:
+            self.kernel_size = options['kernel_size']
+        elif self.model_type == FC_DENSENET:
+            self.growth_rate = options['growth_rate']
+            self.drop_prob = options['drop_prob']
+            self.weight_decay = options['weight_decay']
+            self.down_blocks = options['down_blocks']
+            self.up_blocks = options['up_blocks']
+        elif self.model_type in [FCN_RESNET, DUAL_FCN_RESNET]:
+            self.use_pretraining = options['use_pretraining']
+            self.freeze_base = options['freeze_base']
 
-            if self.model_type == DUAL_FCN_RESNET:
-                self.dual_active_input_inds = options['dual_active_input_inds']
-            elif self.model_type in [CONCAT_ENSEMBLE, AVG_ENSEMBLE]:
-                # Names of the runs that should be combined together into an
-                # ensemble. The outputs of each model will be concatenated
-                # together and used as the input to this model.
-                self.ensemble_run_names = options['ensemble_run_names']
+        if self.model_type == DUAL_FCN_RESNET:
+            self.dual_active_input_inds = options['dual_active_input_inds']
+        elif self.model_type in [CONCAT_ENSEMBLE, AVG_ENSEMBLE]:
+            # Names of the runs that should be combined together into an
+            # ensemble. The outputs of each model will be concatenated
+            # together and used as the input to this model.
+            self.ensemble_run_names = options['ensemble_run_names']
 
-            default_eval_target_size = (2000, 2000) \
-                if self.dataset_name == POTSDAM else None
+        default_eval_target_size = (2000, 2000) \
+            if self.dataset_name == POTSDAM else None
 
-            # Size of the imgs evaluated at each iteration in validation_eval.
-            # This should evenly divide the size of the original image.
-            # None means to use the size of the original image.
-            self.eval_target_size = options.get(
-                'eval_target_size', default_eval_target_size)
+        # Size of the imgs evaluated at each iteration in validation_eval.
+        # This should evenly divide the size of the original image.
+        # None means to use the size of the original image.
+        self.eval_target_size = options.get(
+            'eval_target_size', default_eval_target_size)

--- a/src/rastervision/tagging/data/factory.py
+++ b/src/rastervision/tagging/data/factory.py
@@ -39,6 +39,8 @@ class TaggingDataGeneratorFactory(DataGeneratorFactory):
                 self.cross_validation = None
                 self.augment_methods = [HFLIP, VFLIP, ROTATE, TRANSLATE]
                 self.rare_sample_prob = 0.5
+                # TODO remove
+                self.active_tags = ['primary', 'clear']
 
         options = Options()
         generator = self.get_data_generator(options)

--- a/src/rastervision/tagging/data/factory.py
+++ b/src/rastervision/tagging/data/factory.py
@@ -38,9 +38,6 @@ class TaggingDataGeneratorFactory(DataGeneratorFactory):
                 self.train_ratio = 0.8
                 self.cross_validation = None
                 self.augment_methods = [HFLIP, VFLIP, ROTATE, TRANSLATE]
-                self.rare_sample_prob = 0.5
-                # TODO remove
-                self.active_tags = ['primary', 'clear']
 
         options = Options()
         generator = self.get_data_generator(options)

--- a/src/rastervision/tagging/data/planet_kaggle.py
+++ b/src/rastervision/tagging/data/planet_kaggle.py
@@ -221,10 +221,15 @@ class PlanetKaggleFileGenerator(FileGenerator):
         self.dev_file_inds = self.generate_file_inds(self.dev_path)
         self.test_file_inds = self.generate_file_inds(self.test_path)
 
-        tags_path = join(self.dataset_path, 'train_v2.csv')
-        self.tag_store = TagStore(tags_path)
-
+        self.active_tags = options.active_tags
+        self.active_tags = options.active_tags \
+            if options.active_tags is not None else self.dataset.all_tags
         self.rare_sample_prob = options.rare_sample_prob
+
+        tags_path = join(self.dataset_path, 'train_v2.csv')
+        self.tag_store = TagStore(
+            tags_path=tags_path, active_tags=self.active_tags)
+
         super().__init__(options)
 
     def compute_train_probs(self):
@@ -237,10 +242,9 @@ class PlanetKaggleFileGenerator(FileGenerator):
     def preprocess(datasets_path):
         dataset_path = join(datasets_path, PLANET_KAGGLE)
         tags_path = join(dataset_path, 'train_v2.csv')
-        dataset = Dataset()
-        tag_store = TagStore(tags_path)
+        tag_store = TagStore(tags_path=tags_path)
         counts_path = join(dataset_path, 'tag_counts.json')
-        save_json(tag_store.get_tag_counts(dataset.all_tags), counts_path)
+        save_json(tag_store.get_tag_counts(), counts_path)
 
     def generate_file_inds(self, path):
         paths = sorted(
@@ -336,6 +340,7 @@ class PlanetKaggleTiffFileGenerator(PlanetKaggleFileGenerator):
                 self.train_ratio = 0.8
                 self.cross_validation = None
                 self.rare_sample_prob = None
+                self.active_tags = None
 
         options = Options()
         PlanetKaggleTiffFileGenerator(
@@ -375,6 +380,7 @@ class PlanetKaggleJpgFileGenerator(PlanetKaggleFileGenerator):
                 self.train_ratio = 0.8
                 self.cross_validation = None
                 self.rare_sample_prob = None
+                self.active_tags = None
 
         options = Options()
         PlanetKaggleJpgFileGenerator(

--- a/src/rastervision/tagging/data/planet_kaggle.py
+++ b/src/rastervision/tagging/data/planet_kaggle.py
@@ -50,7 +50,7 @@ class Dataset():
             self.agriculture, self.bare_ground, self.cultivation,
             self.habitation, self.primary, self.road, self.water]
         self.rare_tags = [
-            self.artisinal_mine, self.blooming, self.blow_down, self.blooming,
+            self.artisinal_mine, self.blooming, self.blow_down,
             self.conventional_mine, self.selective_logging, self.slash_burn]
 
         self.red_ind = 0

--- a/src/rastervision/tagging/data/test/test_tag_store.py
+++ b/src/rastervision/tagging/data/test/test_tag_store.py
@@ -66,11 +66,11 @@ class TagStoreTestCase(unittest.TestCase):
 
     def test_compute_train_probs(self):
         ind3 = 'ind3'
-        self.tag_store.add_csv_row((ind3, 'artisinal_mine'))
-        rare_sample_prob = 0.5
+        self.tag_store.add_csv_row((ind3, 'blooming'))
+        active_tags_prob = 0.5
         sample_probs = \
             self.tag_store.compute_sample_probs(
-                [self.ind1, self.ind2, ind3], rare_sample_prob)
+                [self.ind1, self.ind2, ind3], active_tags_prob)
         self.assertTrue(np.array_equal(sample_probs, [0.25, 0.25, 0.5]))
 
 

--- a/src/rastervision/tagging/data/test/test_tag_store.py
+++ b/src/rastervision/tagging/data/test/test_tag_store.py
@@ -7,13 +7,17 @@ from rastervision.tagging.data.planet_kaggle import TagStore, Dataset
 
 class TagStoreTestCase(unittest.TestCase):
     def setUp(self):
-        self.tag_store = TagStore()
         self.dataset = Dataset()
+        self.active_tags = [
+            self.dataset.bare_ground, self.dataset.partly_cloudy,
+            self.dataset.artisinal_mine]
+        self.tag_store = TagStore(active_tags=self.active_tags)
+
         self.str_tags = [self.dataset.bare_ground, self.dataset.partly_cloudy]
-        self.binary_tags = np.zeros((self.dataset.nb_tags,))
+        self.binary_tags = np.zeros((len(self.active_tags),))
         self.binary_tags[[
-            self.dataset.get_tag_ind(self.dataset.bare_ground),
-            self.dataset.get_tag_ind(self.dataset.partly_cloudy)]] = 1
+            self.tag_store.get_tag_ind(self.dataset.bare_ground),
+            self.tag_store.get_tag_ind(self.dataset.partly_cloudy)]] = 1
 
         self.ind1 = 'ind1'
         self.ind2 = 'ind2'
@@ -21,8 +25,12 @@ class TagStoreTestCase(unittest.TestCase):
         self.tag_store.add_csv_row((self.ind2, 'bare_ground'))
 
     def test_strs_to_binary(self):
+        # Should ignore blooming because it's not in active_tags.
+        str_tags = [
+            self.dataset.bare_ground, self.dataset.partly_cloudy,
+            self.dataset.blooming]
         self.assertTrue(np.array_equal(
-            self.tag_store.strs_to_binary(self.str_tags),
+            self.tag_store.strs_to_binary(str_tags),
             self.binary_tags))
 
     def test_binary_to_str(self):
@@ -31,15 +39,15 @@ class TagStoreTestCase(unittest.TestCase):
             self.str_tags)
 
     def test_get_tag_array(self):
-        tag_array = self.tag_store.get_tag_array([self.ind2, self.ind1])
-        ind2_tags = self.tag_store.binary_to_strs(tag_array[0, :])
-        ind1_tags = self.tag_store.binary_to_strs(tag_array[1, :])
-        self.assertEqual(set(ind2_tags), set(['bare_ground']))
+        tag_array = self.tag_store.get_tag_array([self.ind1, self.ind2])
+        ind1_tags = self.tag_store.binary_to_strs(tag_array[0, :])
+        ind2_tags = self.tag_store.binary_to_strs(tag_array[1, :])
         self.assertEqual(set(ind1_tags), set(['bare_ground', 'partly_cloudy']))
+        self.assertEqual(set(ind2_tags), set(['bare_ground']))
 
     def test_get_tag_counts(self):
-        tag_counts = self.tag_store.get_tag_counts(self.dataset.all_tags)
-        self.assertEqual(len(tag_counts), self.dataset.nb_tags)
+        tag_counts = self.tag_store.get_tag_counts()
+        self.assertEqual(len(tag_counts), len(self.active_tags))
         self.assertEqual(tag_counts['bare_ground'], 2)
         self.assertEqual(tag_counts['partly_cloudy'], 1)
         count_sum = sum(tag_counts.values())
@@ -49,11 +57,11 @@ class TagStoreTestCase(unittest.TestCase):
         y_true = self.tag_store.strs_to_binary(
             [self.dataset.bare_ground, self.dataset.partly_cloudy])
         y_pred = self.tag_store.strs_to_binary(
-            [self.dataset.bare_ground, self.dataset.cultivation])
+            [self.dataset.bare_ground, self.dataset.artisinal_mine])
 
         add_pred_tags, remove_pred_tags = \
             self.tag_store.get_tag_diff(y_true, y_pred)
-        self.assertEqual(add_pred_tags, [self.dataset.cultivation])
+        self.assertEqual(add_pred_tags, [self.dataset.artisinal_mine])
         self.assertEqual(remove_pred_tags, [self.dataset.partly_cloudy])
 
     def test_compute_train_probs(self):

--- a/src/rastervision/tagging/models/factory.py
+++ b/src/rastervision/tagging/models/factory.py
@@ -26,7 +26,7 @@ class TaggingModelFactory(ModelFactory):
             model = ResNet50(
                 include_top=True, weights=weights,
                 input_shape=input_shape,
-                classes=generator.dataset.nb_tags,
+                classes=len(generator.active_tags),
                 activation='sigmoid')
         elif model_type == DENSENET_121:
             weights = 'imagenet' if options.use_pretraining else None

--- a/src/rastervision/tagging/options.py
+++ b/src/rastervision/tagging/options.py
@@ -8,4 +8,4 @@ class TaggingOptions(Options):
         self.active_tags = options.get('active_tags')
         self.use_pretraining = options.get('use_pretraining', False)
         self.target_size = None
-        self.rare_sample_prob = options.get('rare_sample_prob')
+        self.active_tags_prob = options.get('active_tags_prob')

--- a/src/rastervision/tagging/options.py
+++ b/src/rastervision/tagging/options.py
@@ -5,8 +5,7 @@ class TaggingOptions(Options):
     def __init__(self, options):
         super().__init__(options)
 
-        if self.aggregate_type is None:
-            self.use_pretraining = options.get('use_pretraining', False)
-            self.target_size = None
-            self.rare_sample_prob = options.get('rare_sample_prob')
-            self.active_tags = options.get('active_tags')
+        self.active_tags = options.get('active_tags')
+        self.use_pretraining = options.get('use_pretraining', False)
+        self.target_size = None
+        self.rare_sample_prob = options.get('rare_sample_prob')

--- a/src/rastervision/tagging/options.py
+++ b/src/rastervision/tagging/options.py
@@ -9,3 +9,4 @@ class TaggingOptions(Options):
             self.use_pretraining = options.get('use_pretraining', False)
             self.target_size = None
             self.rare_sample_prob = options.get('rare_sample_prob')
+            self.active_tags = options.get('active_tags')

--- a/src/rastervision/tagging/run.py
+++ b/src/rastervision/tagging/run.py
@@ -3,7 +3,8 @@ from rastervision.common.tasks.plot_curves import plot_curves, PLOT_CURVES
 from rastervision.common.tasks.train_model import TRAIN_MODEL
 from rastervision.common.tasks.aggregate_scores import aggregate_scores
 from rastervision.common.run import Runner
-from rastervision.common.options import AGG_SUMMARY, AGG_ENSEMBLE
+from rastervision.common.options import (
+    AGG_SUMMARY, AGG_ENSEMBLE, AGG_CONCAT)
 
 from rastervision.tagging.data.factory import TaggingDataGeneratorFactory
 from rastervision.tagging.options import TaggingOptions
@@ -12,7 +13,7 @@ from rastervision.tagging.tasks.train_model import TaggingTrainModel
 from rastervision.tagging.tasks.predict import (
     TRAIN_PROBS, TRAIN_PREDICT, VALIDATION_PROBS, VALIDATION_PREDICT,
     TEST_PROBS, TEST_PREDICT, compute_ensemble_probs, compute_probs,
-    compute_preds)
+    compute_preds, compute_concat_probs)
 from rastervision.tagging.tasks.validation_eval import (
     VALIDATION_EVAL, validation_eval)
 from rastervision.tagging.tasks.train_thresholds import (
@@ -43,10 +44,14 @@ class TaggingRunner(Runner):
                     self.generator, self.model)
                 train_model.train_model()
         elif task == PLOT_CURVES:
-            plot_curves(self.options)
+            if aggregate_type in [None, AGG_SUMMARY]:
+                plot_curves(self.options)
         elif task == TRAIN_PROBS:
             if aggregate_type == AGG_ENSEMBLE:
                 compute_ensemble_probs(
+                    self.run_path, self.options, self.generator, TRAIN)
+            elif aggregate_type == AGG_CONCAT:
+                compute_concat_probs(
                     self.run_path, self.options, self.generator, TRAIN)
             elif aggregate_type is None:
                 compute_probs(self.run_path, self.model, self.options,
@@ -55,6 +60,9 @@ class TaggingRunner(Runner):
             if aggregate_type == AGG_ENSEMBLE:
                 compute_ensemble_probs(
                     self.run_path, self.options, self.generator, VALIDATION)
+            elif aggregate_type == AGG_CONCAT:
+                compute_concat_probs(
+                    self.run_path, self.options, self.generator, VALIDATION)
             elif aggregate_type is None:
                 compute_probs(self.run_path, self.model, self.options,
                               self.generator, VALIDATION)
@@ -62,23 +70,26 @@ class TaggingRunner(Runner):
             if aggregate_type == AGG_ENSEMBLE:
                 compute_ensemble_probs(
                     self.run_path, self.options, self.generator, TEST)
+            elif aggregate_type == AGG_CONCAT:
+                compute_concat_probs(
+                    self.run_path, self.options, self.generator, TEST)
             elif aggregate_type is None:
                 compute_probs(self.run_path, self.model, self.options,
                               self.generator, TEST)
         elif task == TRAIN_THRESHOLDS:
-            if aggregate_type in [None, AGG_ENSEMBLE]:
+            if aggregate_type in [None, AGG_ENSEMBLE, AGG_CONCAT]:
                 train_thresholds(
                     self.run_path, self.options, self.generator)
         elif task == TRAIN_PREDICT:
-            if aggregate_type in [None, AGG_ENSEMBLE]:
+            if aggregate_type in [None, AGG_ENSEMBLE, AGG_CONCAT]:
                 compute_preds(
                     self.run_path, self.options, self.generator, TRAIN)
         elif task == VALIDATION_PREDICT:
-            if aggregate_type in [None, AGG_ENSEMBLE]:
+            if aggregate_type in [None, AGG_ENSEMBLE, AGG_CONCAT]:
                 compute_preds(self.run_path, self.options,
                               self.generator, VALIDATION)
         elif task == TEST_PREDICT:
-            if aggregate_type in [None, AGG_ENSEMBLE]:
+            if aggregate_type in [None, AGG_ENSEMBLE, AGG_CONCAT]:
                 compute_preds(
                     self.run_path, self.options, self.generator, TEST)
         elif task == VALIDATION_EVAL:

--- a/src/rastervision/tagging/tasks/predict.py
+++ b/src/rastervision/tagging/tasks/predict.py
@@ -1,8 +1,10 @@
 from os.path import join
+import json
 
 import numpy as np
 
 from rastervision.common.settings import results_path
+from rastervision.common.options import AGG_CONCAT, AGG_ENSEMBLE
 
 from rastervision.tagging.data.planet_kaggle import TagStore
 from rastervision.tagging.tasks.utils import compute_prediction
@@ -17,13 +19,53 @@ VALIDATION_PREDICT = 'validation_predict'
 TEST_PREDICT = 'test_predict'
 
 
+def get_probs_fn(split):
+    return '{}_probs.npy'.format(split)
+
+
+def get_preds_fn(split):
+    return '{}_preds.csv'.format(split)
+
+
+def compute_concat_probs(run_path, options, generator, split):
+    probs_path = join(run_path, get_probs_fn(split))
+
+    y_probs_list = []
+    active_tags_list = []
+
+    for run_name in options.aggregate_run_names:
+        run_probs_path = join(
+            results_path, run_name, get_probs_fn(split))
+        options_path = join(
+            results_path, run_name, 'options.json')
+
+        with open(options_path) as options_file:
+            # TODO check that active_tags are disjoint
+            options_dict = json.load(options_file)
+            active_tags = options_dict.get(
+                'active_tags', generator.dataset.all_tags)
+            active_tags_list.append(active_tags)
+            y_probs_list.append(np.load(run_probs_path))
+
+    nb_samples = y_probs_list[0].shape[0]
+    nb_active_tags = sum(map(lambda x: len(x), active_tags_list))
+    concat_y_probs = np.zeros((nb_samples, nb_active_tags))
+    print(concat_y_probs.shape)
+    for y_probs, active_tags in zip(y_probs_list, active_tags_list):
+        for tag_ind, active_tag in enumerate(active_tags):
+            concat_tag_ind = generator.tag_store.get_tag_ind(active_tag)
+            concat_y_probs[:, concat_tag_ind] = y_probs[:, tag_ind]
+
+    np.save(probs_path, concat_y_probs)
+
+
 def compute_ensemble_probs(run_path, options, generator, split):
-    probs_path = join(run_path, '{}_probs.npy'.format(split))
+    probs_path = join(run_path, get_probs_fn(split))
     y_probs = []
 
     for run_name in options.aggregate_run_names:
         run_probs_path = join(
-            results_path, run_name, '{}_probs.npy'.format(split))
+            results_path, run_name, get_probs_fn(split))
         y_probs.append(np.expand_dims(np.load(run_probs_path), axis=2))
 
     y_probs = np.concatenate(y_probs, axis=2)
@@ -36,7 +78,7 @@ def compute_ensemble_probs(run_path, options, generator, split):
 
 
 def compute_probs(run_path, model, options, generator, split):
-    probs_path = join(run_path, '{}_probs.npy'.format(split))
+    probs_path = join(run_path, get_probs_fn(split))
     y_probs = []
 
     batch_size = options.batch_size
@@ -60,10 +102,10 @@ def compute_probs(run_path, model, options, generator, split):
 
 
 def compute_preds(run_path, options, generator, split):
-    probs_path = join(run_path, '{}_probs.npy'.format(split))
+    probs_path = join(run_path, get_probs_fn(split))
     y_probs = np.load(probs_path)
 
-    predictions_path = join(run_path, '{}_preds.csv'.format(split))
+    predictions_path = join(run_path, get_preds_fn(split))
     thresholds = load_thresholds(run_path)
     tag_store = TagStore(active_tags=options.active_tags)
     file_inds = generator.get_file_inds(split)

--- a/src/rastervision/tagging/tasks/predict.py
+++ b/src/rastervision/tagging/tasks/predict.py
@@ -65,12 +65,13 @@ def compute_preds(run_path, options, generator, split):
 
     predictions_path = join(run_path, '{}_preds.csv'.format(split))
     thresholds = load_thresholds(run_path)
-    tag_store = TagStore()
+    tag_store = TagStore(active_tags=options.active_tags)
     file_inds = generator.get_file_inds(split)
 
     for sample_ind in range(y_probs.shape[0]):
         y_pred = compute_prediction(
-            y_probs[sample_ind, :], generator.dataset, thresholds)
+            y_probs[sample_ind, :], generator.dataset, generator.tag_store,
+            thresholds)
         file_ind = file_inds[sample_ind]
         tag_store.add_tags(file_ind, y_pred)
 

--- a/src/rastervision/tagging/tasks/predict.py
+++ b/src/rastervision/tagging/tasks/predict.py
@@ -50,7 +50,6 @@ def compute_concat_probs(run_path, options, generator, split):
     nb_samples = y_probs_list[0].shape[0]
     nb_active_tags = sum(map(lambda x: len(x), active_tags_list))
     concat_y_probs = np.zeros((nb_samples, nb_active_tags))
-    print(concat_y_probs.shape)
     for y_probs, active_tags in zip(y_probs_list, active_tags_list):
         for tag_ind, active_tag in enumerate(active_tags):
             concat_tag_ind = generator.tag_store.get_tag_ind(active_tag)

--- a/src/rastervision/tagging/tasks/test/test_predict.py
+++ b/src/rastervision/tagging/tasks/test/test_predict.py
@@ -2,44 +2,47 @@ import unittest
 
 import numpy as np
 
-from rastervision.tagging.data.planet_kaggle import Dataset
+from rastervision.tagging.data.planet_kaggle import Dataset, TagStore
 from rastervision.tagging.tasks.predict import compute_prediction
 
 
 class PredictTestCase(unittest.TestCase):
     def setUp(self):
         self.dataset = Dataset()
+        self.tag_store = TagStore(active_tags=self.dataset.all_tags)
+        self.nb_tags = len(self.tag_store.active_tags)
 
     def test_compute_predictions1(self):
-        y_probs = np.zeros((self.dataset.nb_tags,))
-        haze_ind = self.dataset.get_tag_ind(self.dataset.haze)
-        road_ind = self.dataset.get_tag_ind(self.dataset.road)
+        y_probs = np.zeros((self.nb_tags,))
+        haze_ind = self.tag_store.get_tag_ind(self.dataset.haze)
+        road_ind = self.tag_store.get_tag_ind(self.dataset.road)
         y_probs[haze_ind] = 0.5
         y_probs[road_ind] = 0.7
 
-        thresholds = np.zeros((self.dataset.nb_tags,))
+        thresholds = np.zeros((self.nb_tags,))
         thresholds[haze_ind] = 0.4
         thresholds[road_ind] = 0.6
 
-        y_pred = compute_prediction(y_probs, self.dataset, thresholds)
-        y = np.zeros((self.dataset.nb_tags,))
+        y_pred = compute_prediction(
+            y_probs, self.dataset, self.tag_store, thresholds)
+        y = np.zeros((self.nb_tags,))
         y[[haze_ind, road_ind]] = 1
-
         self.assertTrue(np.array_equal(y_pred, y))
 
     def test_compute_predictions2(self):
-        y_probs = np.zeros((self.dataset.nb_tags,))
-        haze_ind = self.dataset.get_tag_ind(self.dataset.haze)
-        road_ind = self.dataset.get_tag_ind(self.dataset.road)
+        y_probs = np.zeros((self.nb_tags,))
+        haze_ind = self.tag_store.get_tag_ind(self.dataset.haze)
+        road_ind = self.tag_store.get_tag_ind(self.dataset.road)
         y_probs[haze_ind] = 0.1
         y_probs[road_ind] = 0.1
 
-        thresholds = np.zeros((self.dataset.nb_tags,))
+        thresholds = np.zeros((self.nb_tags,))
         thresholds[haze_ind] = 0.2
         thresholds[road_ind] = 0.2
 
-        y_pred = compute_prediction(y_probs, self.dataset, thresholds)
-        y = np.zeros((self.dataset.nb_tags,))
+        y_pred = compute_prediction(
+            y_probs, self.dataset, self.tag_store, thresholds)
+        y = np.zeros((self.nb_tags,))
         y[[haze_ind]] = 1
 
         self.assertTrue(np.array_equal(y_pred, y))

--- a/src/rastervision/tagging/tasks/train_thresholds.py
+++ b/src/rastervision/tagging/tasks/train_thresholds.py
@@ -57,8 +57,8 @@ def train_thresholds(run_path, options, generator):
     # I'm commenting this out and setting thresholds to a default of 0.2 to
     # maintain the previous performance.
 
-    # y_true, y_probs = get_model_output(
-    #    run_path, generator, options.nb_eval_samples)
+    y_true, y_probs = get_model_output(
+        run_path, generator, options.nb_eval_samples)
     # thresholds = optimize_thresholds(y_true, y_probs)
-    thresholds = 0.2 * np.ones((len(generator.dataset.all_tags),))
+    thresholds = 0.2 * np.ones((len(generator.tag_store.active_tags),))
     save_thresholds(run_path, thresholds)

--- a/src/rastervision/tagging/tasks/utils.py
+++ b/src/rastervision/tagging/tasks/utils.py
@@ -1,19 +1,20 @@
 import numpy as np
 
 
-def compute_prediction(y_probs, dataset, thresholds):
-    atmos_inds = [dataset.get_tag_ind(tag)
-                  for tag in dataset.atmos_tags]
-
+def compute_prediction(y_probs, dataset, tag_store, thresholds):
     y_pred = (y_probs > thresholds).astype(np.float32)
 
-    # TODO remove this post-processing step once our model
-    # enforces the constraint that there is at least one atmospheric
-    # tag.
-    if np.sum(y_pred[atmos_inds]) == 0:
-        max_ind = np.argmax(y_probs[atmos_inds])
-        max_tag = dataset.atmos_tags[max_ind]
-        max_ind = dataset.get_tag_ind(max_tag)
-        y_pred[max_ind] = 1
+    if tag_store.active_tags == dataset.all_tags:
+        atmos_inds = [tag_store.get_tag_ind(tag)
+                      for tag in dataset.atmos_tags]
+
+        # TODO remove this post-processing step once our model
+        # enforces the constraint that there is at least one atmospheric
+        # tag.
+        if np.sum(y_pred[atmos_inds]) == 0:
+            max_ind = np.argmax(y_probs[atmos_inds])
+            max_tag = dataset.atmos_tags[max_ind]
+            max_ind = tag_store.get_tag_ind(max_tag)
+            y_pred[max_ind] = 1
 
     return y_pred


### PR DESCRIPTION
This PR makes it so we can train models that predict a subset of the tags (represented by `active_tags` in the options file). This way, we can train a separate model for the rare, common, and atmospheric tags on the Planet Kaggle dataset, allowing us to us to tailor the training regime to each subset. This also adds an `agg_concat` `aggregate_job_type` which concatenates the probabilities from each individual (tag subset) run into a single probability file over all tags. This also adds support for oversampling samples which contain the `active_tags` via `active_tags_prob`.