### PR TITLE
Perform safe augmentations to test images during prediction

### DIFF
--- a/src/experiments/tagging/6_30_17/rerun_best-test_aug.json
+++ b/src/experiments/tagging/6_30_17/rerun_best-test_aug.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 8,
+    "git_commit": "176ef3",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "lr_schedule": [[0, 0.0001], [10, 0.00001],[20, 0.000001]],
+    "model_type": "densenet121",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 480,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/6_30_17/rerun_best-test_aug",
+    "steps_per_epoch": 2400
+}

--- a/src/rastervision/common/options.py
+++ b/src/rastervision/common/options.py
@@ -5,6 +5,7 @@ AGG_SUMMARY = 'agg_summary'
 AGG_ENSEMBLE = 'agg_ensemble'
 AGG_CONCAT = 'agg_concat'
 
+
 class Options():
     """Represents the options used to control an experimental run."""
 
@@ -45,6 +46,7 @@ class Options():
         self.lr_schedule = options.get('lr_schedule')
         self.train_ratio = options.get('train_ratio')
         self.cross_validation = options.get('cross_validation')
+        self.test_augmentation = options.get('test_augmentation', True)
         self.delta_model_checkpoint = options.get(
             'delta_model_checkpoint', None)
         self.augment_methods = options.get(

--- a/src/rastervision/common/run.py
+++ b/src/rastervision/common/run.py
@@ -61,7 +61,7 @@ class Runner():
 
         self.model = None
         self.generator = self.data_generator_factory_class() \
-                        .get_data_generator(self.options)
+                             .get_data_generator(self.options)
 
         if self.options.aggregate_type is None:
             self.model = self.model_factory.get_model(


### PR DESCRIPTION
This PR add the ability to perform a series of safe augmentations to each test image we want to predict label probabilities for. The augmentations are 90 degree rotations, vertical and horizontal flipping. We submit each augmented image to be predicted on by a trained model, take the resulting predictions of each augmented image and averages the probabilities for a more accurate final prediction. This is done during `compute_probs` only during the testing split. For probability calculations during training and validation, we still submit images for prediction only once.

Test-time augmentation is performed by default, however you may choose to perform only simple single predictions for an experiment by adding the line `"test_augmentation": false,` in the experiment file.