### PR TITLE
Add boto3 to jupyter notebook

### DIFF
--- a/scripts/jupyter
+++ b/scripts/jupyter
@@ -19,6 +19,8 @@ Run the jupyter notebook in a raster-vision docker image locally
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
     docker run --rm -it \
+           -e "AWS_PROFILE=$AWS_PROFILE" \
+           -v "$HOME/.aws":/root/.aws \
            -v "$SRC":/opt/src \
            -v /opt/data:/opt/data \
            -v /opt/notebooks:/opt/notebooks \

--- a/src/Dockerfile-jupyter
+++ b/src/Dockerfile-jupyter
@@ -5,6 +5,6 @@ ARG python_version=3.5.1
 RUN conda install -y python=${python_version} jupyter opencv && \
     conda clean -yt
 
-RUN pip install pandas
+RUN pip install pandas boto3==1.4.4
 
 ENTRYPOINT ["jupyter"]


### PR DESCRIPTION
Adds boto3 to the jupyter docker container, and carries through credentials, so that we can write notebooks that pull from the raster-vision bucket.