### PR TITLE
Added option to optionally compute channel statistics

### DIFF
--- a/src/rastervision/common/options.py
+++ b/src/rastervision/common/options.py
@@ -58,3 +58,7 @@ class Options():
                 raise ValueError(
                     '{} are not valid augment_methods'.format(
                         str(invalid_augment_methods)))
+
+        # Option for determining whether or not to compute or load channel stats;
+        # if channel stats for normalization of images are not needed, can set this to false.
+        self.requires_channel_stats = options.get('requires_channel_stats', True)


### PR DESCRIPTION
If you want to use the generators for tasks that do not need to normalize or un-normalize the images, the requirement to compute channel statistics is burdensome (having to download the correct precomputed channel statistics or the imagery). This PR gives an option that allows for the channel statics to not be computed if the tasks do not need them.