### PR TITLE
Add CPU environment for Batch

### DIFF
--- a/deployment/batch/compute_environment_cpu.json
+++ b/deployment/batch/compute_environment_cpu.json
@@ -1,0 +1,34 @@
+{
+    "computeEnvironmentName": "raster-vision-cpu",
+    "type": "MANAGED",
+    "state": "ENABLED",
+    "computeResources": {
+        "type": "SPOT",
+        "minvCpus": 0,
+        "maxvCpus": 50,
+        "desiredvCpus": 0,
+        "instanceTypes": [
+            "c4.large",
+            "c4.xlarge",
+            "c4.2xlarge",
+            "c4.4xlarge",
+            "c4.8xlarge"
+        ],
+        "subnets": [
+            "subnet-e121d7cd",
+            "subnet-b2f915e8",
+            "subnet-804804bc",
+            "subnet-173c9c5f",
+            "subnet-7f16321a"
+        ],
+        "spotIamFleetRole": "arn:aws:iam::279682201306:role/aws-ec2-spot-fleet-role",
+        "securityGroupIds": [
+            "sg-4c00d332"
+        ],
+        "imageId": "ami-d09fd7c6",
+        "bidPercentage": 50,
+        "instanceRole": "arn:aws:iam::279682201306:instance-profile/raster-vision-instance-profile",
+        "ec2KeyPair": "raster-vision"
+    },
+    "serviceRole": "arn:aws:iam::279682201306:role/service-role/AWSBatchServiceRole"
+}

--- a/deployment/batch/compute_environment_gpu.json
+++ b/deployment/batch/compute_environment_gpu.json
@@ -1,11 +1,11 @@
 {
-    "computeEnvironmentName": "raster-vision-p2",
+    "computeEnvironmentName": "raster-vision-gpu",
     "type": "MANAGED",
     "state": "ENABLED",
     "computeResources": {
         "type": "SPOT",
         "minvCpus": 0,
-        "maxvCpus": 400,
+        "maxvCpus": 200,
         "desiredvCpus": 0,
         "instanceTypes": [
             "p2.xlarge"

--- a/deployment/batch/job_def_cpu.json
+++ b/deployment/batch/job_def_cpu.json
@@ -1,0 +1,60 @@
+{
+    "jobDefinitionName": "raster-vision-cpu",
+    "type": "container",
+    "parameters": {},
+    "retryStrategy": {
+        "attempts": 1
+    },
+    "containerProperties": {
+        "image": "279682201306.dkr.ecr.us-east-1.amazonaws.com/raster-vision-cpu:latest",
+        "vcpus": 1,
+        "memory": 3500,
+        "command": [
+            "run_experiment.sh",
+            "raster-vision",
+            "lf/batch",
+            "experiments/tests/semseg/potsdam_quick_test.json",
+            "validation_eval"
+        ],
+        "volumes": [
+            {
+                "host": {
+                    "sourcePath": "/usr"
+                },
+                "name": "usr"
+            },
+            {
+                "host": {
+                    "sourcePath": "/lib"
+                },
+                "name": "lib"
+            },
+            {
+                "host": {
+                    "sourcePath": "/home/ec2-user"
+                },
+                "name": "home"
+            }
+        ],
+        "mountPoints": [
+            {
+                "containerPath": "/hostusr",
+                "readOnly": false,
+                "sourceVolume": "usr"
+            },
+            {
+                "containerPath": "/hostlib",
+                "readOnly": false,
+                "sourceVolume": "lib"
+            },
+            {
+                "containerPath": "/opt/data",
+                "readOnly": false,
+                "sourceVolume": "home"
+            }
+        ],
+        "readonlyRootFilesystem": false,
+        "privileged": true,
+        "ulimits": []
+    }
+}

--- a/deployment/batch/job_def_gpu.json
+++ b/deployment/batch/job_def_gpu.json
@@ -1,5 +1,5 @@
 {
-    "jobDefinitionName": "raster-vision-experiment",
+    "jobDefinitionName": "raster-vision-gpu",
     "type": "container",
     "parameters": {},
     "retryStrategy": {

--- a/deployment/batch/job_queue_cpu.json
+++ b/deployment/batch/job_queue_cpu.json
@@ -1,11 +1,11 @@
 {
-  "jobQueueName": "raster-vision-experiments",
+  "jobQueueName": "raster-vision-cpu",
   "state": "ENABLED",
   "priority": 1,
   "computeEnvironmentOrder": [
     {
       "order": 1,
-      "computeEnvironment": "raster-vision-p2"
+      "computeEnvironment": "raster-vision-cpu"
     }
   ]
 }

--- a/deployment/batch/job_queue_gpu.json
+++ b/deployment/batch/job_queue_gpu.json
@@ -1,0 +1,11 @@
+{
+  "jobQueueName": "raster-vision-gpu",
+  "state": "ENABLED",
+  "priority": 1,
+  "computeEnvironmentOrder": [
+    {
+      "order": 1,
+      "computeEnvironment": "raster-vision-gpu"
+    }
+  ]
+}

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -21,9 +21,12 @@ then
     then
         usage
     else
-        $PROJECT_ROOT/scripts/update --gpu
+        $PROJECT_ROOT/scripts/update
         `aws ecr get-login --region us-east-1`
         docker tag raster-vision-gpu:latest 279682201306.dkr.ecr.us-east-1.amazonaws.com/raster-vision-gpu:latest
         docker push 279682201306.dkr.ecr.us-east-1.amazonaws.com/raster-vision-gpu:latest
+
+        docker tag raster-vision-gpu:latest 279682201306.dkr.ecr.us-east-1.amazonaws.com/raster-vision-cpu:latest
+        docker push 279682201306.dkr.ecr.us-east-1.amazonaws.com/raster-vision-cpu:latest
     fi
 fi

--- a/scripts/setup_aws_batch
+++ b/scripts/setup_aws_batch
@@ -17,6 +17,15 @@ should only be done once per AWS account.
 PROJECT_ROOT="$(dirname "$(dirname "$(readlink -f "${0}")")")"
 BATCH_CONFIG=$PROJECT_ROOT/deployment/batch
 
-aws batch create-compute-environment --cli-input-json file://$BATCH_CONFIG/compute_environment.json
-aws batch create-job-queue --cli-input-json file://$BATCH_CONFIG/job_queue.json
-aws batch register-job-definition --cli-input-json file://$BATCH_CONFIG/job_def.json
+aws batch create-compute-environment --cli-input-json file://$BATCH_CONFIG/compute_environment_gpu.json
+aws batch create-compute-environment --cli-input-json file://$BATCH_CONFIG/compute_environment_cpu.json
+echo 'Waiting 10s...'
+sleep 10s
+
+aws batch create-job-queue --cli-input-json file://$BATCH_CONFIG/job_queue_gpu.json
+aws batch create-job-queue --cli-input-json file://$BATCH_CONFIG/job_queue_cpu.json
+echo 'Waiting 10s...'
+sleep 10s
+
+aws batch register-job-definition --cli-input-json file://$BATCH_CONFIG/job_def_gpu.json
+aws batch register-job-definition --cli-input-json file://$BATCH_CONFIG/job_def_cpu.json

--- a/scripts/submit_jobs
+++ b/scripts/submit_jobs
@@ -80,7 +80,7 @@ def build_dep_graph(run_name_to_parent_run_names):
 
 
 def submit_job(branch_name, file_path, tasks, run_name,
-               attempts, parent_job_ids=None):
+               attempts, parent_job_ids=None, cpu=False):
     s3_bucket = environ.get('S3_BUCKET')
 
     job_name = run_name.replace('/', '-')
@@ -98,10 +98,15 @@ def submit_job(branch_name, file_path, tasks, run_name,
 
     client = boto3.client('batch')
 
+    job_queue = 'raster-vision-cpu' if cpu else \
+        'raster-vision-gpu'
+    job_definition = 'raster-vision-cpu' if cpu else \
+        'raster-vision-gpu'
+
     job_id = client.submit_job(
         jobName=job_name,
-        jobQueue='raster-vision-experiments',
-        jobDefinition='raster-vision-experiment',
+        jobQueue=job_queue,
+        jobDefinition=job_definition,
         containerOverrides={
             'command': command
         },
@@ -141,6 +146,8 @@ def parse_args():
              'Can be empty to run all tasks.')
     parser.add_argument(
         '--attempts', type=int, default=5, help='Number of times to retry job')
+    parser.add_argument(
+        '--cpu', dest='cpu', action='store_true', help='Use CPU EC2 instances')
     return parser.parse_args()
 
 
@@ -150,6 +157,7 @@ def run():
     print('Experiment path: {}'.format(args.experiment_path))
     print('Tasks: {}'.format(args.tasks))
     print('Number of attempts: {}'.format(args.attempts))
+    print('Using {}'.format('CPU' if args.cpu else 'GPU'))
 
     experiment_path = join(args.experiment_path, '*.json') \
         if isdir(args.experiment_path) else args.experiment_path
@@ -166,7 +174,7 @@ def run():
                 run_name = exp['run_name']
                 submit_job(
                     args.branch_name, experiment_path, args.tasks, run_name,
-                    args.attempts)
+                    args.attempts, cpu=args.cpu)
         else:
             # If directory of files, then build dependency graph and run
             # them in the right order, feeding the parent job ids to batch.
@@ -187,7 +195,7 @@ def run():
 
                 run_name_to_job_id[run_name] = submit_job(
                     args.branch_name, file_path, args.tasks, run_name,
-                    args.attempts, parent_job_ids)
+                    args.attempts, parent_job_ids, cpu=args.cpu)
 
 
 if __name__ == '__main__':

--- a/src/Dockerfile-cpu
+++ b/src/Dockerfile-cpu
@@ -8,4 +8,5 @@ ARG architecture=cpu
 RUN pip install https://storage.googleapis.com/tensorflow/linux/${architecture}/tensorflow-${tensorflow_version}-linux_x86_64.whl && \
     pip install git+git://github.com/fchollet/keras.git@7c6463da6f972ffaa466b0f55d06b760a98caf8e
 
+COPY run_experiment.sh /usr/local/bin/
 CMD ["bash"]

--- a/src/rastervision/tagging/tasks/utils.py
+++ b/src/rastervision/tagging/tasks/utils.py
@@ -2,19 +2,4 @@ import numpy as np
 
 
 def compute_prediction(y_probs, dataset, tag_store, thresholds):
-    y_pred = (y_probs > thresholds).astype(np.float32)
-
-    if tag_store.active_tags == dataset.all_tags:
-        atmos_inds = [tag_store.get_tag_ind(tag)
-                      for tag in dataset.atmos_tags]
-
-        # TODO remove this post-processing step once our model
-        # enforces the constraint that there is at least one atmospheric
-        # tag.
-        if np.sum(y_pred[atmos_inds]) == 0:
-            max_ind = np.argmax(y_probs[atmos_inds])
-            max_tag = dataset.atmos_tags[max_ind]
-            max_ind = tag_store.get_tag_ind(max_tag)
-            y_pred[max_ind] = 1
-
-    return y_pred
+    return (y_probs > thresholds).astype(np.float32)


### PR DESCRIPTION
This PR adds a CPU compute environment, queue and job def for Batch, and lets you submit jobs to it using a new --cpu flag. This should be useful for training random forests and for tasks that don't benefit from a GPU. For example:
```
./scripts/submit_jobs lf/cpu-env src/experiments/tagging/tests/quick_test/experiments/0.json --cpu --attempts 1
```