### PR TITLE
Expand learning rate manipulation options

### DIFF
--- a/src/experiments/tagging/7_7_17/baseline_cyclic_1.json
+++ b/src/experiments/tagging/7_7_17/baseline_cyclic_1.json
@@ -1,0 +1,24 @@
+{
+    "batch_size": 32,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "model_type": "baseline_resnet",
+    "train_ratio": 0.8,
+    "cyclic_lr": {
+      "base_lr": 1e-6,
+      "max_lr": 1e-4,
+      "step_size": 2000,
+      "cycle_mode": "triangular"
+    },
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 120,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/7_7_17/baseline_cyclic_1",
+    "steps_per_epoch": 600
+}

--- a/src/rastervision/common/options.py
+++ b/src/rastervision/common/options.py
@@ -58,3 +58,21 @@ class Options():
                 raise ValueError(
                     '{} are not valid augment_methods'.format(
                         str(invalid_augment_methods)))
+        # decay options
+        decay_set = False
+        self.lr_step_decay = options.get('lr_step_decay')
+        if self.lr_step_decay is not None:
+            decay_set = True
+        self.lr_epoch_decay = options.get('lr_epoch_decay')
+        if self.lr_epoch_decay is not None:
+            if decay_set:
+                raise ValueError('Cannot set more than one decay option.')
+            decay_set = True
+        self.cyclic_lr = options.get('cyclic_lr')
+        if self.cyclic_lr is not None:
+            if decay_set:
+                raise ValueError('Cannot set more than one decay option.')
+            self.base_lr = options['cyclic_lr']['base_lr']
+            self.max_lr = options['cyclic_lr']['max_lr']
+            self.step_size = options['cyclic_lr']['step_size']
+            self.cycle_mode = options['cyclic_lr']['cycle_mode']

--- a/src/rastervision/common/tasks/cyclic_lr.py
+++ b/src/rastervision/common/tasks/cyclic_lr.py
@@ -1,0 +1,136 @@
+# flake8: noqa
+"""
+Cyclic Learning Rates for Keras
+Callback Schema is based on
+https://github.com/bckenstler/CLR
+"""
+from keras.callbacks import *
+
+class CyclicLR(Callback):
+    """This callback implements a cyclical learning rate policy (CLR).
+    The method cycles the learning rate between two boundaries with
+    some constant frequency, as detailed in this paper (https://arxiv.org/abs/1506.01186).
+    The amplitute of the cycle can be scaled on a per-iteration or
+    per-cycle basis.
+    This class has three built-in policies, as put forth in the paper.
+    "triangular":
+        A basic triangular cycle w/ no amplitude scaling.
+    "triangular2":
+        A basic triangular cycle that scales initial amplitude by half each cycle.
+    "exp_range":
+        A cycle that scales initial amplitude by gamma**(cycle iterations) at each
+        cycle iteration.
+    For more detail, please see paper.
+
+    # Example
+        ```python
+            clr = CyclicLR(base_lr=0.001, max_lr=0.006,
+                                step_size=2000., mode='triangular')
+            model.fit(X_train, Y_train, callbacks=[clr])
+        ```
+
+    Class also supports custom scaling functions:
+        ```python
+            clr_fn = lambda x: 0.5*(1+np.sin(x*np.pi/2.))
+            clr = CyclicLR(base_lr=0.001, max_lr=0.006,
+                                step_size=2000., scale_fn=clr_fn,
+                                scale_mode='cycle')
+            model.fit(X_train, Y_train, callbacks=[clr])
+        ```
+    # Arguments
+        base_lr: initial learning rate which is the
+            lower boundary in the cycle.
+        max_lr: upper boundary in the cycle. Functionally,
+            it defines the cycle amplitude (max_lr - base_lr).
+            The lr at any cycle is the sum of base_lr
+            and some scaling of the amplitude; therefore
+            max_lr may not actually be reached depending on
+            scaling function.
+        step_size: number of training iterations per
+            half cycle. Authors suggest setting step_size
+            2-8 x training iterations in epoch.
+        mode: one of {triangular, triangular2, exp_range}.
+            Default 'triangular'.
+            Values correspond to policies detailed above.
+            If scale_fn is not None, this argument is ignored.
+        gamma: constant in 'exp_range' scaling function:
+            gamma**(cycle iterations)
+        scale_fn: Custom scaling policy defined by a single
+            argument lambda function, where
+            0 <= scale_fn(x) <= 1 for all x >= 0.
+            mode paramater is ignored
+        scale_mode: {'cycle', 'iterations'}.
+            Defines whether scale_fn is evaluated on
+            cycle number or cycle iterations (training
+            iterations since start of cycle). Default is 'cycle'.
+    """
+
+    def __init__(self, base_lr=0.001, max_lr=0.006, step_size=2000., mode='triangular',
+                 gamma=1., scale_fn=None, scale_mode='cycle'):
+        super(CyclicLR, self).__init__()
+
+        self.base_lr = base_lr
+        self.max_lr = max_lr
+        self.step_size = step_size
+        self.mode = mode
+        self.gamma = gamma
+        if scale_fn == None:
+            if self.mode == 'triangular':
+                self.scale_fn = lambda x: 1.
+                self.scale_mode = 'cycle'
+            elif self.mode == 'triangular2':
+                self.scale_fn = lambda x: 1/(2.**(x-1))
+                self.scale_mode = 'cycle'
+            elif self.mode == 'exp_range':
+                self.scale_fn = lambda x: gamma**(x)
+                self.scale_mode = 'iterations'
+        else:
+            self.scale_fn = scale_fn
+            self.scale_mode = scale_mode
+        self.clr_iterations = 0.
+        self.trn_iterations = 0.
+        self.history = {}
+
+        self._reset()
+
+    def _reset(self, new_base_lr=None, new_max_lr=None,
+               new_step_size=None):
+        """Resets cycle iterations.
+        Optional boundary/step size adjustment.
+        """
+        if new_base_lr != None:
+            self.base_lr = new_base_lr
+        if new_max_lr != None:
+            self.max_lr = new_max_lr
+        if new_step_size != None:
+            self.step_size = new_step_size
+        self.clr_iterations = 0.
+
+    def clr(self):
+        cycle = np.floor(1+self.clr_iterations/(2*self.step_size))
+        x = np.abs(self.clr_iterations/self.step_size - 2*cycle + 1)
+        if self.scale_mode == 'cycle':
+            return self.base_lr + (self.max_lr-self.base_lr)*np.maximum(0, (1-x))*self.scale_fn(cycle)
+        else:
+            return self.base_lr + (self.max_lr-self.base_lr)*np.maximum(0, (1-x))*self.scale_fn(self.clr_iterations)
+
+    def on_train_begin(self, logs={}):
+        logs = logs or {}
+
+        if self.clr_iterations == 0:
+            K.set_value(self.model.optimizer.lr, self.base_lr)
+        else:
+            K.set_value(self.model.optimizer.lr, self.clr())
+
+    def on_batch_end(self, epoch, logs=None):
+
+        logs = logs or {}
+        self.trn_iterations += 1
+        self.clr_iterations += 1
+        K.set_value(self.model.optimizer.lr, self.clr())
+
+        self.history.setdefault('lr', []).append(K.get_value(self.model.optimizer.lr))
+        self.history.setdefault('iterations', []).append(self.trn_iterations)
+
+        for k, v in logs.items():
+            self.history.setdefault(k, []).append(v)


### PR DESCRIPTION
This PR adds several new ways to modify the learning rate throughout the training process.

One of these methods is a cyclic learning rate. For usage, you must specify a subset of four options for `cyclic_lr`, which are `base_lr`, `max_lr`, `step_size` and `cycle_mode`.  These parameters do not have defaults and must all be specified in order to use this functionality. More details on this implementation of cyclic learning rates can be found [here](https://github.com/bckenstler/CLR).

Usage example in an experiment file:

```
"cyclic_lr": { 
      "base_lr": 1e-6, 
      "max_lr": 1e-4, 
      "step_size": 2000, 
      "cycle_mode": "triangular" 
}, 
```

Also, this PR introduces two options for decaying the learning rate as the model trains. You may now give a decay value for optimizers with this parameter using the option `decay`. If you would prefer that the learning rate decay by some factor after each epoch, give the factor instead as `epoch_decay`.

Note that these decay options are mutually exclusive and a maximum of one decay option may be set per experiment.