### PR TITLE
Generate separate files for each augmention

### DIFF
--- a/src/experiments/tagging/7_13_17/almost_flying_blind_1.json
+++ b/src/experiments/tagging/7_13_17/almost_flying_blind_1.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 8,
+    "git_commit": "176ef3",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "lr_schedule": [[0, 0.0001], [15, 0.00001]],
+    "model_type": "densenet121",
+    "train_ratio": 0.8, 
+    "nb_eval_plot_samples": 100,
+    "epochs": 20,
+    "validation_steps": 480,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/7_13_17/almost_flying_blind_1",
+    "steps_per_epoch": 2400
+}

--- a/src/experiments/tagging/7_16_17/densenet/0.json
+++ b/src/experiments/tagging/7_16_17/densenet/0.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 15,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "densenet121",
+    "momentum": null,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": false,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/densenet/0",
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_16_17/densenet/1.json
+++ b/src/experiments/tagging/7_16_17/densenet/1.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 15,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "densenet121",
+    "momentum": null,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": false,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/densenet/1",
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_16_17/densenet/2.json
+++ b/src/experiments/tagging/7_16_17/densenet/2.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 15,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "densenet121",
+    "momentum": null,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": false,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/densenet/2",
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_16_17/densenet/3.json
+++ b/src/experiments/tagging/7_16_17/densenet/3.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 15,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "densenet121",
+    "momentum": null,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": false,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/densenet/3",
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_16_17/densenet/4.json
+++ b/src/experiments/tagging/7_16_17/densenet/4.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 15,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "densenet121",
+    "momentum": null,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": false,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/densenet/4",
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_16_17/resnet/0.json
+++ b/src/experiments/tagging/7_16_17/resnet/0.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 32,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 20,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": "7f79ca",
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.01000
+        ],
+        [
+            10,
+            0.00100
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "baseline_resnet",
+    "momentum": 0.90000,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": true,
+    "optimizer": "sgd",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/resnet/0",
+    "steps_per_epoch": 600,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_16_17/resnet/1.json
+++ b/src/experiments/tagging/7_16_17/resnet/1.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 32,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 20,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": "7f79ca",
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.01000
+        ],
+        [
+            10,
+            0.00100
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "baseline_resnet",
+    "momentum": 0.90000,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": true,
+    "optimizer": "sgd",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/resnet/1",
+    "steps_per_epoch": 600,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_16_17/resnet/2.json
+++ b/src/experiments/tagging/7_16_17/resnet/2.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 32,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 20,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": "7f79ca",
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.01000
+        ],
+        [
+            10,
+            0.00100
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "baseline_resnet",
+    "momentum": 0.90000,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": true,
+    "optimizer": "sgd",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/resnet/2",
+    "steps_per_epoch": 600,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_16_17/resnet/3.json
+++ b/src/experiments/tagging/7_16_17/resnet/3.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 32,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 20,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": "7f79ca",
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.01000
+        ],
+        [
+            10,
+            0.00100
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "baseline_resnet",
+    "momentum": 0.90000,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": true,
+    "optimizer": "sgd",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/resnet/3",
+    "steps_per_epoch": 600,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_16_17/resnet/4.json
+++ b/src/experiments/tagging/7_16_17/resnet/4.json
@@ -1,0 +1,60 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 32,
+    "cross_validation": null,
+    "cyclic_lr": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 20,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "git_commit": "7f79ca",
+    "init_lr": 0.00100,
+    "loss_function": "binary_crossentropy",
+    "lr_epoch_decay": 0.00000,
+    "lr_schedule": [
+        [
+            0,
+            0.01000
+        ],
+        [
+            10,
+            0.00100
+        ]
+    ],
+    "lr_step_decay": 0.00000,
+    "metrics": [
+        "binary_accuracy"
+    ],
+    "model_type": "baseline_resnet",
+    "momentum": 0.90000,
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "nesterov": true,
+    "optimizer": "sgd",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_16_17/resnet/4",
+    "steps_per_epoch": 600,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.99000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "validation_steps": 8
+}

--- a/src/experiments/tagging/7_7_17/baseline_cyclic_1200steps.json
+++ b/src/experiments/tagging/7_7_17/baseline_cyclic_1200steps.json
@@ -1,0 +1,24 @@
+{
+    "batch_size": 32,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "model_type": "baseline_resnet",
+    "train_ratio": 0.8,
+    "cyclic_lr": {
+      "base_lr": 1e-6,
+      "max_lr": 1e-4,
+      "step_size": 1200,
+      "cycle_mode": "triangular"
+    },
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 120,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/7_7_17/baseline_cyclic_1200steps",
+    "steps_per_epoch": 600
+}

--- a/src/experiments/tagging/7_7_17/baseline_cyclic_1200steps.json
+++ b/src/experiments/tagging/7_7_17/baseline_cyclic_1200steps.json
@@ -18,6 +18,9 @@
     "nb_eval_plot_samples": 100,
     "epochs": 30,
     "validation_steps": 120,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
     "augment_methods": ["hflip", "vflip", "rotate90"],
     "run_name": "tagging/7_7_17/baseline_cyclic_1200steps",
     "steps_per_epoch": 600

--- a/src/experiments/tagging/7_7_17/baseline_cyclic_2.json
+++ b/src/experiments/tagging/7_7_17/baseline_cyclic_2.json
@@ -1,0 +1,24 @@
+{
+    "batch_size": 32,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "model_type": "baseline_resnet",
+    "train_ratio": 0.8,
+    "cyclic_lr": {
+      "base_lr": 1e-5,
+      "max_lr": 1e-3,
+      "step_size": 2000,
+      "cycle_mode": "triangular"
+    },
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 120,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/7_7_17/baseline_cyclic_2",
+    "steps_per_epoch": 600
+}

--- a/src/experiments/tagging/7_7_17/baseline_cyclic_2.json
+++ b/src/experiments/tagging/7_7_17/baseline_cyclic_2.json
@@ -18,6 +18,9 @@
     "nb_eval_plot_samples": 100,
     "epochs": 30,
     "validation_steps": 120,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
     "augment_methods": ["hflip", "vflip", "rotate90"],
     "run_name": "tagging/7_7_17/baseline_cyclic_2",
     "steps_per_epoch": 600

--- a/src/experiments/tagging/7_7_17/baseline_cyclic_2400steps.json
+++ b/src/experiments/tagging/7_7_17/baseline_cyclic_2400steps.json
@@ -18,6 +18,9 @@
     "nb_eval_plot_samples": 100,
     "epochs": 30,
     "validation_steps": 120,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
     "augment_methods": ["hflip", "vflip", "rotate90"],
     "run_name": "tagging/7_7_17/baseline_cyclic_2400steps",
     "steps_per_epoch": 600

--- a/src/experiments/tagging/7_7_17/baseline_cyclic_2400steps.json
+++ b/src/experiments/tagging/7_7_17/baseline_cyclic_2400steps.json
@@ -1,0 +1,24 @@
+{
+    "batch_size": 32,
+    "git_commit": "059350",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "model_type": "baseline_resnet",
+    "train_ratio": 0.8,
+    "cyclic_lr": {
+      "base_lr": 1e-6,
+      "max_lr": 1e-4,
+      "step_size": 2400,
+      "cycle_mode": "triangular"
+    },
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 120,
+    "augment_methods": ["hflip", "vflip", "rotate90"],
+    "run_name": "tagging/7_7_17/baseline_cyclic_2400steps",
+    "steps_per_epoch": 600
+}

--- a/src/experiments/tagging/7_7_17/baseline_cyclic_2400steps.json
+++ b/src/experiments/tagging/7_7_17/baseline_cyclic_2400steps.json
@@ -22,6 +22,6 @@
     "val_augmentation": true,
     "test_augmentation": true,
     "augment_methods": ["hflip", "vflip", "rotate90"],
-    "run_name": "tagging/7_7_17/baseline_cyclic_2400steps",
+    "run_name": "tagging/7_10_17/cyclic_2400steps",
     "steps_per_epoch": 600
 }

--- a/src/experiments/tagging/7_7_17/jpg_ensemble_0/0.json
+++ b/src/experiments/tagging/7_7_17/jpg_ensemble_0/0.json
@@ -1,0 +1,56 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 30,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ],
+        [
+            20,
+            0.00000
+        ]
+    ],
+    "model_type": "densenet121",
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_7_17/jpg_ensemble_0/0",
+    "seed": 0,
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.80000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "val_ind": 0,
+    "validation_steps": 480
+}

--- a/src/experiments/tagging/7_7_17/jpg_ensemble_0/1.json
+++ b/src/experiments/tagging/7_7_17/jpg_ensemble_0/1.json
@@ -1,0 +1,56 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 30,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ],
+        [
+            20,
+            0.00000
+        ]
+    ],
+    "model_type": "densenet121",
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_7_17/jpg_ensemble_0/1",
+    "seed": 0,
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.80000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "val_ind": 1,
+    "validation_steps": 480
+}

--- a/src/experiments/tagging/7_7_17/jpg_ensemble_0/2.json
+++ b/src/experiments/tagging/7_7_17/jpg_ensemble_0/2.json
@@ -1,0 +1,56 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 30,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ],
+        [
+            20,
+            0.00000
+        ]
+    ],
+    "model_type": "densenet121",
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_7_17/jpg_ensemble_0/2",
+    "seed": 0,
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.80000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "val_ind": 2,
+    "validation_steps": 480
+}

--- a/src/experiments/tagging/7_7_17/jpg_ensemble_0/3.json
+++ b/src/experiments/tagging/7_7_17/jpg_ensemble_0/3.json
@@ -1,0 +1,56 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 30,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ],
+        [
+            20,
+            0.00000
+        ]
+    ],
+    "model_type": "densenet121",
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_7_17/jpg_ensemble_0/3",
+    "seed": 0,
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.80000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "val_ind": 3,
+    "validation_steps": 480
+}

--- a/src/experiments/tagging/7_7_17/jpg_ensemble_0/4.json
+++ b/src/experiments/tagging/7_7_17/jpg_ensemble_0/4.json
@@ -1,0 +1,56 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "active_tags": null,
+    "active_tags_prob": null,
+    "aggregate_run_names": null,
+    "aggregate_type": null,
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate90"
+    ],
+    "batch_size": 8,
+    "cross_validation": null,
+    "dataset_name": "planet_kaggle",
+    "delta_model_checkpoint": null,
+    "epochs": 30,
+    "generator_name": "jpg",
+    "git_commit": null,
+    "init_lr": 0.00100,
+    "lr_schedule": [
+        [
+            0,
+            0.00010
+        ],
+        [
+            10,
+            0.00001
+        ],
+        [
+            20,
+            0.00000
+        ]
+    ],
+    "model_type": "densenet121",
+    "nb_eval_plot_samples": 100,
+    "nb_eval_samples": null,
+    "optimizer": "adam",
+    "patience": null,
+    "problem_type": "tagging",
+    "run_name": "tagging/7_7_17/jpg_ensemble_0/4",
+    "seed": 0,
+    "steps_per_epoch": 2400,
+    "target_size": null,
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "train_ratio": 0.80000,
+    "train_stages": null,
+    "use_pretraining": true,
+    "val_ind": 4,
+    "validation_steps": 480
+}

--- a/src/experiments/tagging/tests/quick_test/experiments/more_preds.json
+++ b/src/experiments/tagging/tests/quick_test/experiments/more_preds.json
@@ -1,0 +1,33 @@
+{
+    "active_input_inds": [
+        0,
+        1,
+        2
+    ],
+    "augment_methods": [
+        "hflip",
+        "vflip",
+        "rotate",
+        "translate"
+    ],
+    "batch_size": 1,
+    "dataset_name": "planet_kaggle",
+    "epochs": 2,
+    "freeze_base": false,
+    "generator_name": "jpg",
+    "init_lr": 0.001,
+    "model_type": "baseline_resnet",
+    "nb_eval_plot_samples": 3,
+    "nb_eval_samples": 10,
+    "optimizer": "adam",
+    "problem_type": "tagging",
+    "rare_sample_prob": 0.5,
+    "run_name": "tagging/tests/quick_test/more_preds",
+    "train_augmentation": true,
+    "val_augmentation": true,
+    "test_augmentation": true,
+    "steps_per_epoch": 2,
+    "train_ratio": 0.8,
+    "use_pretraining": true,
+    "validation_steps": 1
+}

--- a/src/rastervision/common/options.py
+++ b/src/rastervision/common/options.py
@@ -46,7 +46,9 @@ class Options():
         self.lr_schedule = options.get('lr_schedule')
         self.train_ratio = options.get('train_ratio')
         self.cross_validation = options.get('cross_validation')
-        self.test_augmentation = options.get('test_augmentation', True)
+        self.train_augmentation = options.get('train_augmentation', False)
+        self.val_augmentation = options.get('val_augmentation', False)
+        self.test_augmentation = options.get('test_augmentation', False)
         self.delta_model_checkpoint = options.get(
             'delta_model_checkpoint', None)
         self.augment_methods = options.get(

--- a/src/rastervision/tagging/tasks/predict.py
+++ b/src/rastervision/tagging/tasks/predict.py
@@ -18,6 +18,8 @@ TRAIN_PREDICT = 'train_predict'
 VALIDATION_PREDICT = 'validation_predict'
 TEST_PREDICT = 'test_predict'
 
+NUM_AUG = 6
+
 
 def get_probs_fn(split):
     return '{}_probs.npy'.format(split)
@@ -25,6 +27,9 @@ def get_probs_fn(split):
 
 def get_preds_fn(split):
     return '{}_preds.csv'.format(split)
+
+def get_aug_probs_fn(split, aug_ind):
+    return str(aug_ind) + '_' + get_probs_fn(split)
 
 
 def compute_concat_probs(run_path, options, generator, split):
@@ -77,22 +82,21 @@ def compute_ensemble_probs(run_path, options, generator, split):
 
 
 def compute_probs(run_path, model, options, generator, split):
-    probs_path = join(run_path, get_probs_fn(split))
-    y_probs = []
-
     batch_size = options.batch_size
     split_gen = generator.make_split_generator(
         split, target_size=None,
         batch_size=batch_size, shuffle=False, augment_methods=None,
         normalize=True, only_xy=False)
 
-    for batch_ind, batch in enumerate(split_gen):
-        # Performing safe augmentations on images one by one, predicting
-        # probs and taking average, if calculating test probabilities
-        if split == TEST and options.test_augmentation:
+    # Performing safe augmentations on images one by one, predicting
+    # probs and taking average, if calculating test probabilities
+    if split == TEST and options.test_augmentation:
+        y_probs = [[] for i in range(NUM_AUG)]
+        for batch_ind, batch in enumerate(split_gen):
             for img_ind in range(batch.x.shape[0]):
                 img = batch.x[img_ind, :, :, :]
                 aug_batch = []
+
                 for rotation in range(4):
                     rot_img = np.rot90(img, rotation)
                     aug_batch.append(np.expand_dims(rot_img, axis=0))
@@ -101,40 +105,78 @@ def compute_probs(run_path, model, options, generator, split):
                 flip_img = np.fliplr(img)
                 aug_batch.append(np.expand_dims(flip_img, axis=0))
                 aug_batch = np.concatenate(aug_batch, axis=0)
+                aug_probs = model.predict(aug_batch)
 
-                aug_probs = np.mean(model.predict(aug_batch), axis=0,
-                                    keepdims=True)
+                for aug_ind in range(NUM_AUG):
+                    y_probs[aug_ind].append(aug_probs[aug_ind])
 
-                y_probs.append(aug_probs)
-        # Otherwise, predicting probs on unaugmented images by batch
-        else:
+            if (options.nb_eval_samples is not None and
+                    batch_ind * options.batch_size >= options.nb_eval_samples):
+                break
+
+        for aug_ind in range(NUM_AUG):
+            y_probs[aug_ind] = np.concatenate([y_probs[aug_ind]])
+            if options.nb_eval_samples is not None:
+                y_probs[aug_ind] = y_probs[aug_ind][0:options.nb_eval_samples]
+            probs_path = join(run_path, get_aug_probs_fn(split, aug_ind))
+            np.save(probs_path, y_probs[aug_ind])
+    # Otherwise, predicting probs on unaugmented images by batch
+    else:
+        y_probs = []
+        for batch_ind, batch in enumerate(split_gen):
             y_probs.append(model.predict(batch.x))
 
-        if (options.nb_eval_samples is not None and
-                batch_ind * options.batch_size >= options.nb_eval_samples):
-            break
+            if (options.nb_eval_samples is not None and
+                    batch_ind * options.batch_size >= options.nb_eval_samples):
+                break
 
-    y_probs = np.concatenate(y_probs, axis=0)
-    if options.nb_eval_samples is not None:
-        y_probs = y_probs[0:options.nb_eval_samples, :]
+        y_probs = np.concatenate(y_probs, axis=0)
 
-    np.save(probs_path, y_probs)
+        if options.nb_eval_samples is not None:
+            y_probs = y_probs[0:options.nb_eval_samples, :]
+
+        probs_path = join(run_path, get_probs_fn(split))
+        np.save(probs_path, y_probs)
 
 
 def compute_preds(run_path, options, generator, split):
-    probs_path = join(run_path, get_probs_fn(split))
-    y_probs = np.load(probs_path)
-
-    predictions_path = join(run_path, get_preds_fn(split))
     thresholds = load_thresholds(run_path, options.loss_function)
-    tag_store = TagStore(active_tags=options.active_tags)
-    file_inds = generator.get_file_inds(split)
 
-    for sample_ind in range(y_probs.shape[0]):
-        y_pred = compute_prediction(
-            y_probs[sample_ind, :], generator.dataset, generator.tag_store,
-            thresholds)
-        file_ind = file_inds[sample_ind]
-        tag_store.add_tags(file_ind, y_pred)
+    if split == TEST and options.test_augmentation:
+        tag_stores = []
+        file_inds = generator.get_file_inds(split)
 
-    tag_store.save(predictions_path)
+        y_probs = []
+        for aug_ind in range(NUM_AUG):
+            tag_store = TagStore(active_tags=options.active_tags)
+            tag_stores.append(tag_store)
+
+        for aug_ind in range(NUM_AUG):
+            probs_path = join(run_path, get_aug_probs_fn(split, aug_ind))
+            y_probs = np.load(probs_path)
+
+            for sample_ind in range(y_probs.shape[0]):
+                y_pred = compute_prediction(
+                    y_probs[sample_ind, :], generator.dataset,
+                    generator.tag_store, thresholds)
+                file_ind = file_inds[sample_ind]
+                tag_stores[aug_ind].add_tags(file_ind, y_pred)
+
+            predictions_path = join(run_path, str(aug_ind) + '_' +
+                                    get_preds_fn(split))
+            tag_stores[aug_ind].save(predictions_path)
+    else:
+        probs_path = join(run_path, get_probs_fn(split))
+        y_probs = np.load(probs_path)
+        predictions_path = join(run_path, get_preds_fn(split))
+        tag_store = TagStore(active_tags=options.active_tags)
+        file_inds = generator.get_file_inds(split)
+
+        for sample_ind in range(y_probs.shape[0]):
+            y_pred = compute_prediction(
+                y_probs[sample_ind, :], generator.dataset, generator.tag_store,
+                thresholds)
+            file_ind = file_inds[sample_ind]
+            tag_store.add_tags(file_ind, y_pred)
+
+        tag_store.save(predictions_path)


### PR DESCRIPTION
In the interest of generating more diversity and being able to better manipulate augmented predictions, we wanted to have the probabilities and predictions obtained from augmented images accessible at all times. This PR creates a probability and prediction file for each separate image augmentation during test time. There is no longer a single `test_preds.csv` prediction file, but six separate prediction files that may be combined or used separately in submission.

Note that the numbers of filenames do consistently correspond with an image augmentation. Files beginning with 0-3 are the results from rotations and files beginning with 4 and 5 are flipped images.