### PR TITLE
Add zoom data transform

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -25,7 +25,6 @@ then
             -e "S3_BUCKET=$S3_BUCKET" \
             -v "$SRC":/opt/src \
             -v /opt/data:/opt/data \
-            -p 8888:8888 \
             raster-vision-cpu "${@:2}"
     elif [ "${1:-}" = "--gpu" ]
     then

--- a/src/experiments/tagging/7_13_17/densenet_zoom.json
+++ b/src/experiments/tagging/7_13_17/densenet_zoom.json
@@ -1,0 +1,19 @@
+{
+    "batch_size": 8,
+    "git_commit": "c4fcd0",
+    "problem_type": "tagging",
+    "dataset_name": "planet_kaggle",
+    "generator_name": "jpg",
+    "active_input_inds": [0, 1, 2],
+    "use_pretraining": true,
+    "optimizer": "adam",
+    "lr_schedule": [[0, 0.0001], [10, 0.00001],[20, 0.000001]],
+    "model_type": "densenet121",
+    "train_ratio": 0.8,
+    "nb_eval_plot_samples": 100,
+    "epochs": 30,
+    "validation_steps": 480,
+    "augment_methods": ["hflip", "vflip", "rotate90", "zoom"],
+    "run_name": "tagging/7_13_17/densenet_zoom",
+    "steps_per_epoch": 2400
+}

--- a/src/rastervision/tagging/data/factory.py
+++ b/src/rastervision/tagging/data/factory.py
@@ -2,7 +2,7 @@ from os.path import join
 
 from rastervision.common.data.factory import DataGeneratorFactory
 from rastervision.common.utils import _makedirs
-from rastervision.common.data.generators import HFLIP, VFLIP, ROTATE, TRANSLATE
+from rastervision.common.data.generators import HFLIP, VFLIP, ROTATE, TRANSLATE, ZOOM
 
 from rastervision.tagging.data.planet_kaggle import (
     PLANET_KAGGLE, TIFF, JPG, PlanetKaggleTiffFileGenerator,
@@ -38,6 +38,8 @@ class TaggingDataGeneratorFactory(DataGeneratorFactory):
                 self.train_ratio = 0.8
                 self.cross_validation = None
                 self.augment_methods = [HFLIP, VFLIP, ROTATE, TRANSLATE]
+                self.active_tags = None
+                self.active_tags_prob = None
 
         options = Options()
         generator = self.get_data_generator(options)


### PR DESCRIPTION
This adds `zoom` as a transform for augmenting training data. This transform randomly zooms in and out in the range +-15%. I ran an experiment adding this transform to our best single model setup and got 0.92852 on the LB, which is a less than an experiment without the transform.