### PR TITLE
Generate predictions as GeoJSON for GeoTIFFs

### DIFF
--- a/src/detection/scripts/make_mock_geotiff.py
+++ b/src/detection/scripts/make_mock_geotiff.py
@@ -1,0 +1,39 @@
+import argparse
+from os.path import splitext
+
+from scipy.ndimage import imread
+import rasterio
+from rasterio.transform import from_origin
+
+
+def make_geotiff(image_path):
+    im = imread(image_path)
+    height, width, nchannels = im.shape
+    out_path = splitext(image_path)[0] + '.tif'
+
+    transform = from_origin(
+        -75.163506, 39.952536, 0.000001, 0.000001)
+
+    with rasterio.open(out_path, 'w', driver='GTiff', height=height,
+                       transform=transform, crs='EPSG:4326',
+                       compression=rasterio.enums.Compression.none,
+                       width=width, count=nchannels, dtype=im.dtype) as dst:
+        for channel_ind in range(0, nchannels):
+            dst.write(im[:, :, channel_ind], channel_ind + 1)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--image-path')
+
+    return parser.parse_args()
+
+
+def run():
+    args = parse_args()
+    print('image_path: {}'.format(args.image_path))
+    make_geotiff(args.image_path)
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
This PR makes it so that when predictions are made on a GeoTIFF file, the output is a GeoJSON file of polygons with coordinates in the same CRS as the TIFF file. To test this, I turned the animal montage into a  GeoTIFF centered around City Hall in Philly, and then displayed the output in QGIS.

![geo_zoo](https://user-images.githubusercontent.com/1896461/29423223-ee8a9ce4-8348-11e7-888a-60f2b74f8b63.png)
