### PR TITLE
Improve chip generation

### DIFF
--- a/src/detection/README.md
+++ b/src/detection/README.md
@@ -6,28 +6,26 @@ This guide shows how to train a model on a tiny dataset containing ships, and th
 
 ## Data Prep
 
-First, download the raw ships data from  `s3://raster-vision/datasets/detection/singapore_ships.zip` to `/opt/data/datasets/detection/singapore_ships.zip` and unzip it.
+First, download the raw ships data from  `s3://raster-vision/datasets/detection/singapore_ships.zip` to `/opt/data/datasets/detection/singapore_ships.zip` and unzip it. Then, split
+the files into two directories, `train` and `test`. I used all images except `1.tif` and `3.tif` for the training set.
 
-In order to train a model, you must convert a GeoTIFF and GeoJSON file with annotations into training chips and a CSV file representing bounding boxes in the chips' frame of reference. To do this for the first file in the dataset, run this:
+In order to train a model, you must convert a set of GeoTIFF and GeoJSON file with annotations into training chips and a CSV file representing bounding boxes in the chips' frame of reference.
 
 ```
 python scripts/tiff_chipper.py \
-    --tiff-path /opt/data/datasets/detection/singapore_ships/0.tif \
-    --json-path /opt/data/datasets/detection/singapore_ships/0.geojson \
-    --output-dir /opt/data/datasets/detection/singapore_ships_chips_tiny \
-    --chip-size 300 --debug
+    --input-dir /opt/data/datasets/detection/singapore_ships/train/ \
+    --output-dir /opt/data/datasets/detection/singapore_ships_chips_neg \
+    --chip-size 300 --num-neg-chips 50 --max-attempts 500
 ```
 
-Create a `label_map.pbtxt` file in the `singapore_ships_chips_tiny` directory. It should have a single entry with `id=1` and `name=Ships`. An example of this kind of file can be found in `pet_label_map.pbtxt`. Then, convert the output to TFRecord format, which is the required format for the TF Object Detection API. The files will be placed in the `singapore_ships_chips_tiny` directory
+Create a `label_map.pbtxt` file in the `singapore_ships_chips_neg` directory. It should have a single entry with `id=1` and `name=Ships`. An example of this kind of file can be found in `pet_label_map.pbtxt`. Then, convert the output to TFRecord format, which is the required format for the TF Object Detection API. The files will be placed in the `singapore_ships_chips_neg` directory, which will include a directory of debug plots if the `--debug` flag is used.
 
 ```
 python scripts/create_tf_record.py \
-    --data-dir /opt/data/datasets/detection/singapore_ships_chips_tiny \
-    --label-map-path /opt/data/datasets/detection/singapore_ships_chips_tiny/label_map.pbtxt \
-    --output-dir /opt/data/datasets/detection/singapore_ships_chips_tiny
+    --debug --data-dir /opt/data/datasets/detection/singapore_ships_chips_neg
 ```
 
-When this is done, zip the `singapore_ships_chips_tiny` folder into `singapore_ships_chips_tiny.zip` and upload to S3 inside `s3://raster-vision/datasets/detection`.
+When this is done, zip the `singapore_ships_chips_neg` folder into `singapore_ships_chips_neg.zip` and upload to S3 inside `s3://raster-vision/datasets/detection`.
 
 ## Training a model on EC2
 
@@ -36,32 +34,36 @@ Once this file is committed to a branch (with name denoted by `branch-name`) and
 ```
 src/detection/scripts/batch_submit.py  <branch-name> \
     "/opt/src/detection/scripts/train_ec2.sh \
-    --config-path /opt/src/detection/configs/ships/ssd_mobilenet_v1.config \
-    --train-id ships1 \
-    --dataset-id singapore_ships_chips_tiny \
+    --config-path /opt/src/detection/configs/ships/neg/ssd_mobilenet_v1.config \
+    --train-id <train-id> \
+    --dataset-id singapore_ships_chips_neg \
     --model-id ssd_mobilenet_v1_coco_11_06_2017"
+    --attempts 1
 ```
 
 This requires that there is a model checkpoint file (for using a pre-trained model) at `s3://raster-vision/datasets/detection/ssd_mobilenet_v1_coco_11_06_2017.zip`. This file can be downloaded from the website for the TF Object Detection API.
+The `train-id` should be a unique name prefixed with your initials and a forward slash, for instance `lhf/ships0`. It is used to generate the path to the files for a training run.
 
-Every 10 minutes, model checkpoints are synced to the S3 bucket under `results/detection/train/ships1`, since `ships1` is the `train_id`.
+Every 10 minutes, model checkpoints are synced to the S3 bucket under `results/detection/train/<train-id>`.
 You can monitor training using Tensorboard by pointing your browser at `http://<ec2 instance ip>:6006`. It may take a few minutes before results show up. When you are done training the model (ie. after the total loss flattens out), you need to kill the Batch job since it's running in an infinite loop. If this script fails due to instance shutdown and is run again, it should pick up where it left off using saved checkpoints.
 
 ## Making predictions on EC2
 
-After training finishes, you can make predictions for a GeoTIFF file. To do this, first upload the image to `s3://raster-vision/results/detection/predict/ships_2/image.tif`.
-To start a prediction job, run the following command with the `checkpoint-id` set to the id in the filename of the latest training checkpoint file, which can be found in `s3://raster-vision/results/detection/ships1/train/train`.
+After training finishes, you can make predictions for a GeoTIFF file. To do this, first upload the image to `s3://raster-vision/results/detection/predict/<tiff-id>/image.tif`.
+The `tiff-id` should be a unique id for the tiff, and should follow the same format as the `train-id`.
+To start a prediction job, run the following command with the `checkpoint-id` set to the integer id in the filename of the latest training checkpoint file, which can be found in `s3://raster-vision/results/detection/train/<train-id>/train`.
 ```
 src/detection/scripts/batch_submit.py <branch-name> \
     "/opt/src/detection/scripts/predict_ec2.sh \
-    --config-path /opt/src/detection/configs/ships/ssd_mobilenet_v1.config \
-    --train-id ships1 \
-    --checkpoint-id 64336 \
-    --tiff-id ships_2 \
-    --dataset-id singapore_ships_chips_tiny"
+    --config-path /opt/src/detection/configs/ships/neg/ssd_mobilenet_v1.config \
+    --train-id <train-id> \
+    --checkpoint-id <checkpoint-id> \
+    --tiff-id <tiff-id> \
+    --dataset-id singapore_ships_chips_neg"
+    --attempts 1
 ```
 
-You may want to run this with the `--cpu` flag to `batch_submit.py`, since the speedup from the GPU might be negligible. When this is finished running, there should be a GeoJSON file with predictions at `s3://raster-vision/results/detection/predict/ships_2/output/predictions.geojson`.
+You may want to run this locally, since the speedup from the GPU might be negligible. When this is finished running, there should be a GeoJSON file with predictions at `s3://raster-vision/results/detection/predict/ships_2/output/predictions.geojson`.
 
 ## Debugging
 

--- a/src/detection/configs/ships/neg/ssd_mobilenet_v1.config
+++ b/src/detection/configs/ships/neg/ssd_mobilenet_v1.config
@@ -169,9 +169,9 @@ train_config: {
 
 train_input_reader: {
   tf_record_input_reader {
-    input_path: "/opt/data/datasets/detection/singapore_ships_chips/train.record"
+    input_path: "/opt/data/datasets/detection/singapore_ships_chips_neg/train.record"
   }
-  label_map_path: "/opt/data/datasets/detection/singapore_ships_chips/label_map.pbtxt"
+  label_map_path: "/opt/data/datasets/detection/singapore_ships_chips_neg/label_map.pbtxt"
 }
 
 eval_config: {
@@ -180,9 +180,9 @@ eval_config: {
 
 eval_input_reader: {
   tf_record_input_reader {
-    input_path: "/opt/data/datasets/detection/singapore_ships_chips/val.record"
+    input_path: "/opt/data/datasets/detection/singapore_ships_chips_neg/val.record"
   }
-  label_map_path: "/opt/data/datasets/detection/singapore_ships_chips/label_map.pbtxt"
+  label_map_path: "/opt/data/datasets/detection/singapore_ships_chips_neg/label_map.pbtxt"
   shuffle: false
   num_readers: 1
 }

--- a/src/detection/scripts/aggregate_predictions.py
+++ b/src/detection/scripts/aggregate_predictions.py
@@ -285,7 +285,7 @@ def aggregate_predictions(image_path, window_info_path, predictions_path,
     save_geojson(agg_predictions_path, boxes, classes, scores, im_size,
                  category_index, image_dataset=image_dataset)
 
-    plot_path = join(output_dir, 'predictions.jpg')
+    plot_path = join(output_dir, 'predictions.png')
     plot_predictions(plot_path, im, category_index, boxes, scores, classes)
 
 

--- a/src/detection/scripts/aggregate_predictions.py
+++ b/src/detection/scripts/aggregate_predictions.py
@@ -15,7 +15,7 @@ from object_detection.utils import label_map_util
 from object_detection.utils import visualization_utils as vis_util
 
 from utils import load_tiff
-from settings import max_num_classes
+from settings import max_num_classes, line_thickness
 
 
 def compute_agg_predictions(window_offsets, window_size, im_size, predictions):
@@ -40,6 +40,7 @@ def compute_agg_predictions(window_offsets, window_size, im_size, predictions):
             box[2] += y  # ymax
             box[3] += x  # xmax
 
+            # Coordinates are floats between 0 and 1.
             box[0] /= im_size[1]
             box[1] /= im_size[0]
             box[2] /= im_size[1]
@@ -67,7 +68,7 @@ def plot_predictions(plot_path, im, category_index, boxes, scores, classes):
         np.squeeze(scores),
         category_index,
         use_normalized_coordinates=True,
-        line_thickness=4)
+        line_thickness=line_thickness)
 
     imsave(plot_path, norm_im)
 

--- a/src/detection/scripts/create_tf_record.py
+++ b/src/detection/scripts/create_tf_record.py
@@ -38,13 +38,13 @@ def create_tf_example(image_dir, image_file_name, boxes, category_index,
                       debug_dir):
     image_path = os.path.join(image_dir, image_file_name)
     with tf.gfile.GFile(image_path, 'rb') as fid:
-        encoded_jpg = fid.read()
-    encoded_jpg_io = io.BytesIO(encoded_jpg)
-    image = PIL.Image.open(encoded_jpg_io)
+        encoded_png = fid.read()
+    encoded_png_io = io.BytesIO(encoded_png)
+    image = PIL.Image.open(encoded_png_io)
 
     width, height = image.size
     filename = image_file_name
-    encoded_image_data = encoded_jpg
+    encoded_image_data = encoded_png
     image_format = image.format.lower().encode('utf8')
 
     xmins = []

--- a/src/detection/scripts/create_tf_record.py
+++ b/src/detection/scripts/create_tf_record.py
@@ -11,10 +11,11 @@ import tensorflow as tf
 from object_detection.utils import dataset_util
 from object_detection.utils import label_map_util
 
-from settings import max_num_classes
+from settings import max_num_classes, line_thickness
 
 
 def create_tf_example(image_dir, image_file_name, boxes, category_index):
+        use_normalized_coordinates=True, line_thickness=line_thickness)
     image_path = os.path.join(image_dir, image_file_name)
     with tf.gfile.GFile(image_path, 'rb') as fid:
         encoded_jpg = fid.read()

--- a/src/detection/scripts/create_tf_record.py
+++ b/src/detection/scripts/create_tf_record.py
@@ -4,18 +4,38 @@ import os
 import io
 from collections import OrderedDict
 import argparse
+from os.path import join, basename
+from os import makedirs
+import glob
+import random
 
 import PIL.Image
 import tensorflow as tf
+from scipy.misc import imread, imsave
+import numpy as np
 
-from object_detection.utils import dataset_util
-from object_detection.utils import label_map_util
+from object_detection.utils import (
+    dataset_util, label_map_util, visualization_utils as vis_util)
 
 from settings import max_num_classes, line_thickness
 
+random.seed(12345)
 
-def create_tf_example(image_dir, image_file_name, boxes, category_index):
+
+def make_debug_plot(debug_image_path, image_path, xmins, xmaxs, ymins, ymaxs,
+                    classes, category_index):
+    im = imread(image_path)
+    boxes = np.array(list(zip(ymins, xmins, ymaxs, xmaxs)))
+    scores = np.array([1.0] * len(classes))
+
+    vis_util.visualize_boxes_and_labels_on_image_array(
+        im, boxes, classes, scores, category_index,
         use_normalized_coordinates=True, line_thickness=line_thickness)
+    imsave(debug_image_path, im)
+
+
+def create_tf_example(image_dir, image_file_name, boxes, category_index,
+                      debug_dir):
     image_path = os.path.join(image_dir, image_file_name)
     with tf.gfile.GFile(image_path, 'rb') as fid:
         encoded_jpg = fid.read()
@@ -33,15 +53,22 @@ def create_tf_example(image_dir, image_file_name, boxes, category_index):
     ymaxs = []
     classes_text = []
     classes = []
-    for box in boxes:
-        xmins.append(box.xmin / width)
-        xmaxs.append(box.xmax / width)
-        ymins.append(box.ymin / height)
-        ymaxs.append(box.ymax / height)
-        class_id = int(box.class_id)
-        classes_text.append(
-            category_index[class_id]['name'].encode('utf8'))
-        classes.append(class_id)
+    if boxes is not None:
+        for box in boxes:
+            xmins.append(box.xmin / width)
+            xmaxs.append(box.xmax / width)
+            ymins.append(box.ymin / height)
+            ymaxs.append(box.ymax / height)
+            class_id = int(box.class_id)
+            classes_text.append(
+                category_index[class_id]['name'].encode('utf8'))
+            classes.append(class_id)
+
+    if debug_dir is not None:
+        debug_image_path = join(debug_dir, image_file_name)
+        make_debug_plot(
+            debug_image_path, image_path, xmins, xmaxs, ymins, ymaxs, classes,
+            category_index)
 
     tf_example = tf.train.Example(features=tf.train.Features(feature={
         'image/height': dataset_util.int64_feature(height),
@@ -62,14 +89,14 @@ def create_tf_example(image_dir, image_file_name, boxes, category_index):
 
 
 def create_tf_record(output_path, category_index, annotations,
-                     image_dir, image_file_names):
+                     image_dir, image_file_names, debug_dir):
     writer = tf.python_io.TFRecordWriter(output_path)
     for idx, image_file_name in enumerate(image_file_names):
         if idx % 100 == 0:
             logging.info('On image %d of %d', idx, len(image_file_names))
         tf_example = create_tf_example(
-            image_dir, image_file_name, annotations[image_file_name],
-            category_index)
+            image_dir, image_file_name, annotations.get(image_file_name),
+            category_index, debug_dir)
         writer.write(tf_example.SerializeToString())
     writer.close()
 
@@ -97,7 +124,8 @@ def read_annotations(annotations_path):
     return annotations
 
 
-def create_tf_records(data_dir, output_dir, label_map_path):
+def create_tf_records(data_dir, debug):
+    label_map_path = join(data_dir, 'label_map.pbtxt')
     label_map = label_map_util.load_labelmap(label_map_path)
     categories = label_map_util.convert_label_map_to_categories(
         label_map, max_num_classes=max_num_classes, use_display_name=True)
@@ -105,10 +133,12 @@ def create_tf_records(data_dir, output_dir, label_map_path):
 
     logging.info('Reading from dataset.')
     image_dir = os.path.join(data_dir, 'images')
+    image_paths = glob.glob(join(image_dir, '*.png'))
+    image_file_names = [basename(path) for path in image_paths]
+    random.shuffle(image_file_names)
     annotations_path = os.path.join(data_dir, 'annotations.csv')
     annotations = read_annotations(annotations_path)
 
-    image_file_names = list(annotations.keys())
     num_examples = len(image_file_names)
     train_ratio = 0.7
     num_train = int(train_ratio * num_examples)
@@ -117,13 +147,18 @@ def create_tf_records(data_dir, output_dir, label_map_path):
     logging.info('%d training and %d validation examples.',
                  len(train_file_names), len(val_file_names))
 
-    train_output_path = os.path.join(output_dir, 'train.record')
-    val_output_path = os.path.join(output_dir, 'val.record')
+    train_output_path = os.path.join(data_dir, 'train.record')
+    val_output_path = os.path.join(data_dir, 'val.record')
+
+    debug_dir = None
+    if debug is not None:
+        debug_dir = join(data_dir, 'debug')
+        makedirs(debug_dir, exist_ok=True)
 
     create_tf_record(train_output_path, category_index, annotations,
-                     image_dir, train_file_names)
+                     image_dir, train_file_names, debug_dir)
     create_tf_record(val_output_path, category_index, annotations,
-                     image_dir, val_file_names)
+                     image_dir, val_file_names, debug_dir)
 
 
 def parse_args():
@@ -133,8 +168,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description=description)
 
     parser.add_argument('--data-dir')
-    parser.add_argument('--output-dir')
-    parser.add_argument('--label-map-path')
+    parser.add_argument('--debug', dest='debug', action='store_true')
 
     return parser.parse_args()
 
@@ -143,5 +177,4 @@ if __name__ == '__main__':
     args = parse_args()
     print(args)
 
-    create_tf_records(
-        args.data_dir, args.output_dir, args.label_map_path)
+    create_tf_records(args.data_dir, args.debug)

--- a/src/detection/scripts/make_windows.py
+++ b/src/detection/scripts/make_windows.py
@@ -41,7 +41,7 @@ def make_windows(image_path, output_dir, window_size):
                 break
 
             window = pad_im[i:i+window_size, j:j+window_size, :]
-            window_file_name = '{}_{}.jpg'.format(i, j)
+            window_file_name = '{}_{}.png'.format(i, j)
             window_path = join(images_dir, window_file_name)
             imsave(window_path, window)
 

--- a/src/detection/scripts/predict.py
+++ b/src/detection/scripts/predict.py
@@ -77,7 +77,7 @@ def predict(frozen_graph_path, label_map_path, input_dir,
         label_map, max_num_classes=max_num_classes, use_display_name=True)
     category_index = label_map_util.create_category_index(categories)
 
-    image_paths = glob.glob(os.path.join(input_dir, '*.jpg'))
+    image_paths = glob.glob(os.path.join(input_dir, '*.png'))
     predictions = {}
     predictions_path = os.path.join(
         output_dir, 'predictions.json')

--- a/src/detection/scripts/predict.py
+++ b/src/detection/scripts/predict.py
@@ -15,7 +15,7 @@ from scipy.misc import imsave
 from object_detection.utils import label_map_util
 from object_detection.utils import visualization_utils as vis_util
 
-from settings import max_num_classes, min_score_threshold
+from settings import max_num_classes, min_score_threshold, line_thickness
 
 image_size = (12, 8)
 
@@ -99,7 +99,7 @@ def predict(frozen_graph_path, label_map_path, input_dir,
                     np.squeeze(scores),
                     category_index,
                     use_normalized_coordinates=True,
-                    line_thickness=4)
+                    line_thickness=line_thickness)
 
                 out_image_path = os.path.join(
                     output_images_dir, os.path.basename(image_path))

--- a/src/detection/scripts/predict_ec2.sh
+++ b/src/detection/scripts/predict_ec2.sh
@@ -42,7 +42,7 @@ echo "TIFF_ID         = ${TIFF_ID}"
 echo "DATASET_ID      = ${DATASET_ID}"
 echo "LOCAL           = ${LOCAL}"
 
-set -x
+set -e -x
 cd /opt/src/detection
 
 S3_DATASETS=s3://raster-vision/datasets/detection

--- a/src/detection/scripts/settings.py
+++ b/src/detection/scripts/settings.py
@@ -1,2 +1,3 @@
 max_num_classes = 100
 min_score_threshold = 0.5
+line_thickness = 2

--- a/src/detection/scripts/tiff_chipper.py
+++ b/src/detection/scripts/tiff_chipper.py
@@ -118,7 +118,7 @@ def make_pos_chips(image_id, image_dataset, chip_size,
             continue
 
         # extract random window around anchor_box.
-        chip_fn = '{}_{}.jpg'.format(image_id, chip_ind)
+        chip_fn = '{}_{}.png'.format(image_id, chip_ind)
         rand_x, rand_y = get_random_window_for_box(
             anchor_box, image_dataset.width, image_dataset.height, chip_size)
         window = ((rand_y, rand_y + chip_size), (rand_x, rand_x + chip_size))
@@ -194,7 +194,7 @@ def make_neg_chips(image_id, image_dataset, chip_size,
             chip_im = chip_im[:, :, [2, 1, 0]]
 
             # save to disk
-            chip_fn = '{}_neg_{}.jpg'.format(image_id, neg_chips_count)
+            chip_fn = '{}_neg_{}.png'.format(image_id, neg_chips_count)
             chip_path = join(output_image_dir, chip_fn)
             imsave(chip_path, chip_im)
 

--- a/src/detection/scripts/tiff_chipper.py
+++ b/src/detection/scripts/tiff_chipper.py
@@ -58,22 +58,6 @@ def print_box_stats(boxes):
           np.mean(height), np.min(height), np.max(height)))
 
 
-def make_debug_plot(output_debug_dir, boxes, box_ind, im):
-    # draw rectangle representing box
-    debug_im = np.copy(im)
-
-    for box in boxes:
-        xmin, ymin, xmax, ymax = box
-        debug_im[ymin:ymax+1, xmin, :] = 0
-        debug_im[ymin:ymax+1, xmax, :] = 0
-        debug_im[ymin, xmin:xmax+1, :] = 0
-        debug_im[ymax, xmin:xmax+1, :] = 0
-
-    debug_path = join(
-        output_debug_dir, '{}.jpg'.format(box_ind))
-    imsave(debug_path, debug_im)
-
-
 def write_chips_csv(csv_path, chip_rows, append_csv=False):
     mode = 'a' if append_csv else 'w'
     with open(csv_path, mode) as csv_file:

--- a/src/detection/scripts/train_ec2.sh
+++ b/src/detection/scripts/train_ec2.sh
@@ -37,7 +37,7 @@ echo "DATASET_ID      = ${DATASET_ID}"
 echo "MODEL_ID        = ${MODEL_ID}"
 echo "LOCAL           = ${LOCAL}"
 
-set -x
+set -e -x
 cd /opt/src/detection
 
 S3_DATASETS=s3://raster-vision/datasets/detection


### PR DESCRIPTION
This PR improves chip generation among some other things. The ultimate goal was to improve predictions on ship data.

I added the ability to generate chips from multiple TIFFs in order to have a bigger dataset, and left out two TIFFs from the training set (image 1 and 3) for a test set. These two images are of different locations than in the training set. Before, we were training on image 0 and testing on image 2, which were both of the same scene, just at different times, so it was kind of cheating.

Connects #110

I also added the ability to generate negative chips that have no objects. I realized that many of the chips fed into the model when making predictions have no objects in them, yet all the training chips have at least one object. So, by adding negative chips to the training set, the model might be better at avoiding false positives in regions with no ships, such as on land or in the middle of the ocean. 

Connects #111 

Here are predictions for file 3 (which is of a scene not in the training set) made with models trained without and with negative chips. There are way fewer false positives when training with negative chips. I updated the readme to use the dataset with negative chips since it seems to work better. There are still a lot of false negative on ships that are docked, but I think we will need more of these in the training data, if we want to do well on them. 

Without negative chips
![ships_3](https://user-images.githubusercontent.com/1896461/29988299-9abd4456-8f3a-11e7-8792-a07e99f3e6d3.png)

With negative chips
![ships_3_neg_training_later](https://user-images.githubusercontent.com/1896461/29989409-b9d69512-8f40-11e7-87d9-81207096132a.png)

The predictions for file 3 can be found in `s3://raster-vision/results/detection/predict/lhf_ships3` and were created by running 
```
src/detection/scripts/batch_submit.py lf/neg-chips \
    "/opt/src/detection/scripts/predict_ec2.sh \
    --config-path /opt/src/detection/configs/ships/neg/ssd_mobilenet_v1.config \
    --train-id lhf_ships_neg0 \
    --checkpoint-id 45016 \
    --tiff-id lhf_ships3 \
    --dataset-id singapore_ships_chips_neg" \
    --attempts 1 --cpu
```