### PR TITLE
Filter predictions using mask

### DIFF
--- a/src/detection/README.md
+++ b/src/detection/README.md
@@ -49,8 +49,9 @@ You can monitor training using Tensorboard by pointing your browser at `http://<
 
 ## Making predictions on EC2
 
-After training finishes, you can make predictions for a GeoTIFF file. To do this, first upload the image to `s3://raster-vision/results/detection/predict/<tiff-id>/image.tif`.
-The `tiff-id` should be a unique id for the tiff, and should follow the same format as the `train-id`.
+After training finishes, you can make predictions for a GeoTIFF file. To do this, first upload the image to `s3://raster-vision/results/detection/predict/<predict-id>/image.tif`. If you would like to remove predictions that are contained inside a mask multi-polygon, you should also upload a GeoJSON file with the mask to
+`s3://raster-vision/results/detection/predict/<predict-id>/mask.json`.
+The `predict-id` should be a unique id for the files for which to make a prediction, and should follow the same format as the `train-id`.
 To start a prediction job, run the following command with the `checkpoint-id` set to the integer id in the filename of the latest training checkpoint file, which can be found in `s3://raster-vision/results/detection/train/<train-id>/train`.
 ```
 src/detection/scripts/batch_submit.py <branch-name> \
@@ -58,7 +59,7 @@ src/detection/scripts/batch_submit.py <branch-name> \
     --config-path /opt/src/detection/configs/ships/neg/ssd_mobilenet_v1.config \
     --train-id <train-id> \
     --checkpoint-id <checkpoint-id> \
-    --tiff-id <tiff-id> \
+    --predict-id <predict-id> \
     --dataset-id singapore_ships_chips_neg"
     --attempts 1
 ```

--- a/src/detection/scripts/filter_geojson.py
+++ b/src/detection/scripts/filter_geojson.py
@@ -1,0 +1,50 @@
+import json
+import argparse
+
+from shapely.geometry import shape
+
+
+def filter_geojson(mask_path, input_path, output_path):
+    with open(input_path) as input_file:
+        input_dict = json.load(input_file)
+
+    with open(mask_path) as mask_file:
+        mask_dict = json.load(mask_file)
+        mask_geom = shape(mask_dict['features'][0]['geometry'])
+
+    features = input_dict['features']
+    filtered_features = []
+    for feature in features:
+        geom = shape(feature['geometry'])
+
+        if not mask_geom.contains(geom):
+            filtered_features.append(feature)
+
+    output_dict = dict(input_dict)
+    output_dict['features'] = filtered_features
+
+    with open(output_path, 'w') as output_file:
+        json.dump(output_dict, output_file, indent=4)
+
+
+def parse_args():
+    description = """
+        Filter out polygons that are contained in a mask multipolygon. Input
+        and output is GeoJSON.
+    """
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument('--mask-path', help='GeoJSON file with mask')
+    parser.add_argument('--input-path',
+                        help='GeoJSON file with polygons to filter')
+    parser.add_argument('--output-path')
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    print(args)
+
+    filter_geojson(
+        args.mask_path, args.input_path, args.output_path)


### PR DESCRIPTION
This PR adds the ability to filter out predictions that are contained within a mask multi-polygon specified in a mask GeoJSON file. This is useful if we know that predictions should only be at sea or on land, for instance.