### PR TITLE
Exit train_ec2.sh when tensorboard quits

### DIFF
--- a/src/detection/scripts/train_ec2.sh
+++ b/src/detection/scripts/train_ec2.sh
@@ -53,7 +53,7 @@ cd /opt/src/detection
 
 # sync results of previous run just in case it crashed in the middle of running
 if [ "$LOCAL" = false ] ; then
-    rm -R ${LOCAL_TRAIN}/${TRAIN_ID}
+    rm -Rf ${LOCAL_TRAIN}/${TRAIN_ID}
     aws s3 sync ${S3_TRAIN}/${TRAIN_ID} ${LOCAL_TRAIN}/${TRAIN_ID}
 
     # download pre-trained model (to use as starting point) and unzip

--- a/src/detection/scripts/train_ec2.sh
+++ b/src/detection/scripts/train_ec2.sh
@@ -76,6 +76,10 @@ fi
 
 mkdir -p ${LOCAL_TRAIN}/${TRAIN_ID}
 
+# kill child processes when this exits
+# https://stackoverflow.com/questions/360201/how-do-i-kill-background-processes-jobs-when-my-shell-script-exits
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
 python models/object_detection/train.py \
     --logtostderr \
     --pipeline_config_path=${CONFIG_PATH} \
@@ -89,7 +93,3 @@ python models/object_detection/eval.py \
 
 # monitor results using tensorboard app
 tensorboard --logdir=${LOCAL_TRAIN}/${TRAIN_ID}
-
-# kill child processes when this exits
-# https://stackoverflow.com/questions/360201/how-do-i-kill-background-processes-jobs-when-my-shell-script-exits
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT


### PR DESCRIPTION
Move the bash signal traps in `train_ec2.sh` so that the script kills all background processes when `tensorboard` exits or the container recieves a `SIGTERM`/`SIGINT` signal.

Fixes #107.

# Testing
- Start a training job using `batch_submit.py`, then cancel it through the console.
```bash
src/detection/scripts/batch_submit.py  feature/tnation/batch-job-termination     "/opt/src/detection/scripts/train_ec2.sh \
    --config-path /opt/src/detection/configs/ships/neg/ssd_mobilenet_v1.config \
    --train-id tnation/ships2 \
    --dataset-id singapore_ships_chips_neg \
    --model-id ssd_mobilenet_v1_coco_11_06_2017"   --attempts=2
```

- See [cancelled Batch Job output](https://console.aws.amazon.com/batch/home?region=us-east-1#/jobs/queue/arn:aws:batch:us-east-1:279682201306:job-queue~2Fraster-vision-gpu/state/FAILED/job/1270a9e6-fc6a-413e-95ae-6998436407a4/queue/arn:aws:batch:us-east-1:279682201306:job-queue~2Fraster-vision-gpu/state/FAILED)

 