### PR TITLE
Improve car classification and detection

### DIFF
--- a/src/rv/classification/commands/prep_train_data.py
+++ b/src/rv/classification/commands/prep_train_data.py
@@ -1,15 +1,16 @@
-from os.path import splitext, join, dirname
-from os import makedirs
+from os.path import splitext, join
 import shutil
+import glob
 
 import rasterio
 import click
+import numpy as np
 
 from rv.utils import (
     download_if_needed, make_empty_dir, get_local_path, upload_if_needed,
     load_projects, BoxDB, get_random_window_for_box, get_random_window,
     load_window, save_img, get_boxes_from_geojson,
-    print_box_stats, build_vrt)
+    print_box_stats, build_vrt, add_blank_chips)
 from rv.classification.commands.settings import (
     planet_channel_order, temp_root_dir)
 
@@ -38,11 +39,12 @@ def make_pos_chips(project_ind, image_dataset, chip_size, boxes, classes,
     return pos_count
 
 
-def make_neg_chips(project_ind, desired_neg_count, image_dataset, chip_size,
-                   boxes, classes, neg_dir, channel_order):
+def make_neg_chips(project_ind, desired_neg_count,
+                   image_dataset, chip_size, boxes, classes, neg_dir,
+                   channel_order):
     box_db = BoxDB(boxes)
     neg_count = 0
-    max_attempts = desired_neg_count * 10
+    max_attempts = desired_neg_count * 100
 
     for _ in range(max_attempts):
         # extract random window
@@ -62,11 +64,13 @@ def make_neg_chips(project_ind, desired_neg_count, image_dataset, chip_size,
             chip_im = load_window(
                 image_dataset, channel_order, window=window)
 
-            # save to disk
-            chip_fn = '{}-{}.png'.format(project_ind, neg_count)
-            chip_path = join(neg_dir, chip_fn)
-            save_img(chip_path, chip_im)
-            neg_count += 1
+            # if not a blank chip (these are in areas of the VRT with no data)
+            if np.any(chip_im != 0):
+                # save to disk
+                chip_fn = '{}-{}.png'.format(project_ind, neg_count)
+                chip_path = join(neg_dir, chip_fn)
+                save_img(chip_path, chip_im)
+                neg_count += 1
 
         if neg_count == desired_neg_count:
             break
@@ -103,10 +107,12 @@ def process_image(project_ind, image_path, annotations_path, pos_dir, neg_dir,
               help='Number of positive chips to generate per object')
 @click.option('--neg-ratio', default=1,
               help='Ratio of negative to positive chips')
+@click.option('--blank-neg-ratio', default=0.05,
+              help='Ratio of blank to non-blank negative chips')
 @click.option('--channel-order', nargs=3, type=int,
               default=planet_channel_order, help='Indices of the RGB channels')
 def prep_train_data(projects_uri, output_zip_uri, chip_size,
-                    nb_pos_sets, neg_ratio, channel_order):
+                    nb_pos_sets, neg_ratio, blank_neg_ratio, channel_order):
     """Generate training chips and label map for set of projects.
 
     Given a set of projects (each a set of images and a GeoJSON file with
@@ -142,6 +148,14 @@ def prep_train_data(projects_uri, output_zip_uri, chip_size,
         process_image(
             project_ind, vrt_path, annotations_path, pos_dir, neg_dir,
             chip_size, nb_pos_sets, neg_ratio, channel_order)
+
+    # We filter out all blank negative chips when generating them in
+    # make_neg_chips, since sometimes they dominate and are a waste of time
+    # for the model. But we still need some of them, so we add some in at the
+    # end.
+    neg_count = len(glob.glob(join(neg_dir, '*.png')))
+    blank_neg_count = max(10, int(blank_neg_ratio * neg_count))
+    add_blank_chips(blank_neg_count, chip_size, neg_dir)
 
     # Copy label map so it's included in the zip file for convenience.
     # label_map_copy_path = join(output_zip_dir, 'label-map.pbtxt')

--- a/src/rv/classification/ml/train.py
+++ b/src/rv/classification/ml/train.py
@@ -125,8 +125,8 @@ def get_train_loader(config, dataset_dir):
     transform = transforms.Compose([
         Resize((config.image_size, config.image_size)),
         transforms.RandomHorizontalFlip(),
-        # RandomVerticalFlip(),
-        # RandomRotate90(), #  seems to hurt performance due to lossy transform?
+        RandomVerticalFlip(),
+        RandomRotate90(),
         transforms.ToTensor(),
         transforms.Normalize(mean=config.mean, std=config.std),
     ])
@@ -257,11 +257,10 @@ def validate(config, val_loader, model, criterion):
                   'Prec@K {topK.val:.3f} ({topK.avg:.3f})'.format(
                    batch_ind, len(val_loader), batch_time=batch_time,
                    loss=losses, top1=top1, topK=topK))
-            # print('Confusion: {}'.format(confusion.value()))
 
     print(' * Prec@1 {top1.avg:.3f} Prec@K {topK.avg:.3f}'
           .format(top1=top1, topK=topK))
-    # print('Confusion: {}'.format(confusion.value()))
+    print('Confusion: {}'.format(confusion.value()))
 
     return top1.avg
 

--- a/src/rv/classification/ml/utils.py
+++ b/src/rv/classification/ml/utils.py
@@ -119,7 +119,13 @@ class RandomRotate90(object):
         Returns:
             PIL Image: Randomly rotated image.
         """
-        return img.rotate(90 * random.randint(0, 4))
+        rot_choices = [
+            None, Image.ROTATE_90, Image.ROTATE_180,
+            Image.ROTATE_270]
+        rot_choice = random.choice(rot_choices)
+        if rot_choice is None:
+            return img
+        return img.transpose(rot_choice)
 
 
 class Resize(object):

--- a/src/rv/detection/commands/make_train_chips.py
+++ b/src/rv/detection/commands/make_train_chips.py
@@ -13,7 +13,7 @@ from object_detection.utils import label_map_util
 from rv.utils import (
     load_window, build_vrt, make_empty_dir,
     get_boxes_from_geojson, save_img, BoxDB, print_box_stats,
-    get_random_window_for_box, get_random_window)
+    get_random_window_for_box, get_random_window, add_blank_chips)
 from rv.detection.commands.settings import (
     planet_channel_order, max_num_classes, temp_root_dir)
 
@@ -135,15 +135,18 @@ def make_neg_chips(image_dataset, chip_size, boxes, classes, chip_dir,
             chip_im = load_window(
                 image_dataset, channel_order, window=window)
 
-            # save to disk
-            chip_fn = 'neg_{}.png'.format(neg_chips_count)
-            chip_path = join(chip_dir, chip_fn)
-            save_img(chip_path, chip_im)
-            neg_chips_count += 1
+            # if not a blank chip (these are in areas of the VRT with no data)
+            if np.any(chip_im != 0):
+                # save to disk
+                chip_fn = 'neg_{}.png'.format(neg_chips_count)
+                chip_path = join(chip_dir, chip_fn)
+                save_img(chip_path, chip_im)
+                neg_chips_count += 1
 
         attempt_count += 1
 
     click.echo('Wrote {} negative chips.'.format(neg_chips_count))
+    return neg_chips_count
 
 
 def make_train_chips_for_image(image_path, json_path, chip_dir,
@@ -172,9 +175,18 @@ def make_train_chips_for_image(image_path, json_path, chip_dir,
 
     if num_neg_chips is None:
         num_neg_chips = num_pos_chips
-        max_attempts = 10 * num_neg_chips
-    make_neg_chips(image_dataset, chip_size, boxes, classes, chip_dir,
-                   num_neg_chips, max_attempts, channel_order)
+        max_attempts = 100 * num_neg_chips
+    neg_count = make_neg_chips(
+        image_dataset, chip_size, boxes, classes, chip_dir, num_neg_chips,
+        max_attempts, channel_order)
+
+    # We filter out all blank negative chips when generating them in
+    # make_neg_chips, since sometimes they dominate and are a waste of time
+    # for the model. But we still need some of them, so we add some in at the
+    # end.
+    blank_neg_ratio = 0.05
+    blank_neg_count = max(10, int(blank_neg_ratio * neg_count))
+    add_blank_chips(blank_neg_count, chip_size, chip_dir)
 
 
 def _make_train_chips(image_paths, label_path, chip_dir, chip_label_path,

--- a/src/rv/detection/commands/make_train_chips.py
+++ b/src/rv/detection/commands/make_train_chips.py
@@ -83,15 +83,14 @@ def make_pos_chips(image_dataset, chip_size, boxes, classes, chip_dir,
             chip_ymin, chip_xmin, chip_ymax, chip_xmax = chip_box
             chip_box_class_id = classes[intersecting_ind]
 
-            # if enough of the box is contained in the window, then add it to the
-            # csv.
+            # box is considered partially contained if less than
+            # 3/4 is contained.
             contained_ratio = get_contained_ratio(chip_box, chip_size)
-            # TODO make this constant an option to the script
-            enough_contained = contained_ratio > 0.5
+            considered_partial = contained_ratio < 0.75
 
             chip_ymin, chip_xmin, chip_ymax, chip_xmax = \
                 np.clip(chip_box, 0, chip_size).astype(np.int32)
-            if enough_contained or not no_partial:
+            if not (no_partial and considered_partial):
                 row = [chip_fn, chip_ymin, chip_xmin,
                        chip_ymax, chip_xmax, chip_box_class_id]
                 chip_rows.append(row)

--- a/src/rv/utils.py
+++ b/src/rv/utils.py
@@ -351,6 +351,13 @@ def print_box_stats(boxes):
         np.mean(height), np.min(height), np.max(height)))
 
 
+def add_blank_chips(blank_count, chip_size, chip_dir):
+    blank_im = np.zeros((chip_size, chip_size, 3))
+    for blank_neg_ind in range(blank_count):
+        chip_path = join(chip_dir, 'blank-{}.png'.format(blank_neg_ind))
+        save_img(chip_path, blank_im)
+
+
 def get_random_window_for_box(box, im_width, im_height, chip_size):
     """Get random window in image that contains box.
 


### PR DESCRIPTION
This PR makes some changes to improve performance on car classification and detection. 
For both tasks, I changed the channel order to match that of the dataset (from BGR to RGB), removed most of the blank negative chips so that there is effectively way more negative examples, and changed the training/test split so that the test tiles better match the statistics of the training set. For classification, I also added a rotation transform, and got around the same accuracy as before. (However, the former number wasn't very representative because most of the negative chips were blank and therefore easy.) For detection, I removed the blank negative chips (which means there are effectively way more negative chips), trained for much longer (~100k steps), changed the `--merge-thresh` to 0.5, including boxes in windows if they are more than 75% contained. This resulted in much better predictions, judging qualitatively. In the screenshot below, pink boxes are ground truth and aqua are predictions. There are few false positives and negatives, it's able to handle cars that are close together, and there aren't spurious duplicate detections.

![screen shot 2017-12-27 at 2 30 15 pm 2](https://user-images.githubusercontent.com/1896461/34391759-be8e5c30-eb15-11e7-87da-f20ab0aa89a2.png)

Closes #171 
Closes #172