### PR TITLE
Make it so training script exits after number of steps

### DIFF
--- a/src/config-samples/detection/train/mobilenet.config
+++ b/src/config-samples/detection/train/mobilenet.config
@@ -141,6 +141,7 @@ model {
 
 train_config: {
   batch_size: 8
+  num_steps: 40000 # Set to 0 for an indefinite number of steps
   optimizer {
     rms_prop_optimizer: {
       learning_rate: {

--- a/src/rv/detection/commands/predict_array.py
+++ b/src/rv/detection/commands/predict_array.py
@@ -14,6 +14,7 @@ from rv.detection.commands.predict import _predict
 @click.argument('inference_graph_uri')
 @click.argument('label_map_uri')
 @click.argument('projects_uri')
+@click.argument('output_dir_uri')
 @click.option('--mask-uri', default=None,
               help='URI for mask GeoJSON file to use as filter for detections')
 @click.option('--channel-order', nargs=3, type=int,
@@ -21,13 +22,13 @@ from rv.detection.commands.predict import _predict
 @click.option('--chip-size', default=300)
 @click.option('--score-thresh', default=0.5,
               help='Score threshold of predictions to keep')
-@click.option('--merge-thresh', default=0.05,
+@click.option('--merge-thresh', default=0.5,
               help='IOU threshold for merging predictions')
 @click.option('--save-temp', is_flag=True)
 def predict_array(inference_graph_uri, label_map_uri, projects_uri,
-                  mask_uri, channel_order, chip_size, score_thresh,
-                  merge_thresh, save_temp):
-    job_index = int(os.environ['AWS_BATCH_JOB_ARRAY_INDEX'])
+                  output_dir_uri, mask_uri, channel_order, chip_size,
+                  score_thresh, merge_thresh, save_temp):
+    job_ind = int(os.environ['AWS_BATCH_JOB_ARRAY_INDEX'])
 
     prefix = temp_root_dir
     temp_dir = os.path.join(prefix, 'predict-array') if save_temp else None
@@ -35,20 +36,30 @@ def predict_array(inference_graph_uri, label_map_uri, projects_uri,
         projects_path = download_if_needed(projects_uri, temp_dir)
         with open(projects_path, 'r') as projects_file:
             projects = json.load(projects_file)
-            if job_index >= len(projects):
-                raise ValueError(
-                    'There are {} projects and job_index is {}!'.format(
-                        len(projects), job_index))
-            project = projects[job_index]
-            image_uris = project['images']
-            output_uri = project['annotations']
+
+            def get_image_coords():
+                image_ind = 0
+                for project_ind, project in enumerate(projects):
+                    for project_image_ind, image_uri in enumerate(project['images']):
+                        if job_ind == image_ind:
+                            return project_ind, project_image_ind
+                        image_ind += 1
+
+            # Run predict for single image and generate ouput_uri based on
+            # the index of the image within the project.
+            project_ind, project_image_ind = get_image_coords()
+            project = projects[project_ind]
+            image_uri = project['images'][project_image_ind]
+            image_uris = [image_uri]
+            output_uri = os.path.join(
+                output_dir_uri, project['id'],
+                '{}.json'.format(project_image_ind))
             output_debug_uri = None
 
             _predict(inference_graph_uri, label_map_uri, image_uris,
                      output_uri, output_debug_uri, mask_uri,
                      channel_order, chip_size, score_thresh, merge_thresh,
                      save_temp)
-
 
 
 if __name__ == '__main__':

--- a/src/workflows/detection/parallel_predict.py
+++ b/src/workflows/detection/parallel_predict.py
@@ -1,0 +1,65 @@
+import json
+import os
+import click
+
+from rv.utils.files import (
+    download_if_needed, MyTemporaryDirectory)
+from rv.utils.batch import _batch_submit
+from rv.detection.commands.settings import temp_root_dir
+
+
+def make_predict_array_cmd(inference_graph_uri, label_map_uri, projects_uri,
+                           output_dir_uri):
+    return 'python -m rv.detection.run predict_array {} {} {} {}'.format(
+        inference_graph_uri, label_map_uri, projects_uri, output_dir_uri)
+
+
+def make_merge_predictions_cmd(projects_uri, output_dir_uri):
+    return 'python -m rv.detection.run merge_predictions {} {}'.format(
+        projects_uri, output_dir_uri)
+
+
+def get_nb_images(projects):
+    nb_images = 0
+    for project in projects:
+        nb_images += len(project['images'])
+    return nb_images
+
+
+@click.command()
+@click.argument('projects_uri')
+@click.argument('label_map_uri')
+@click.argument('inference_graph_uri')
+@click.argument('output_dir_uri')
+@click.option('--branch-name', default='develop')
+@click.option('--attempts', default=1)
+@click.option('--cpu', is_flag=True)
+def parallel_predict(projects_uri, label_map_uri, inference_graph_uri,
+                     output_dir_uri,
+                     branch_name, attempts, cpu):
+    prefix = temp_root_dir
+    temp_dir = os.path.join(prefix, 'parallel-predict')
+    with MyTemporaryDirectory(temp_dir, prefix) as temp_dir:
+        # Load projects and count number of images
+        projects_path = download_if_needed(projects_uri, temp_dir)
+        projects = json.load(open(projects_path))
+        nb_images = get_nb_images(projects)
+
+        # Submit an array job with nb_images elements.
+        command = make_predict_array_cmd(
+            inference_graph_uri, label_map_uri, projects_uri, output_dir_uri)
+        '''
+        predict_job_id = _batch_submit(
+            branch_name, command, attempts=attempts, cpu=cpu,
+            array_size=nb_images)
+        '''
+        # Submit a dependent merge_predictions job.
+        command = make_merge_predictions_cmd(
+            projects_uri, output_dir_uri)
+        _batch_submit(
+            branch_name, command, attempts=attempts, cpu=cpu)
+            #parent_job_ids=[predict_job_id])
+
+
+if __name__ == '__main__':
+    parallel_predict()


### PR DESCRIPTION
This PR makes it so that the training script will exit after a certain number of training steps. This is accomplished by waiting for the training process to exit, and then killing the monitoring processes and then exporting and uploading the inference graph. If `num_steps` is set to zero, then current behavior is captured, where it trains indefinitely until the Batch job is cancelled.