### PR TITLE
Handle process_training_data for classification

### DIFF
--- a/src/rv2/builders/label_source_builder.py
+++ b/src/rv2/builders/label_source_builder.py
@@ -1,10 +1,16 @@
-from rv2.label_sources.geojson_file import GeoJSONFile
+from rv2.label_sources.object_detection_geojson_file import (
+    ObjectDetectionGeoJSONFile)
+from rv2.label_sources.classification_geojson_file import (
+    ClassificationGeoJSONFile)
 
 
-def build(config, crs_transformer, writable=False):
-    # I wish crs_transformer wasn't required, but I don't see an easy way
-    # around it right now.
+def build(config, crs_transformer, extent, writable=False):
     label_source_type = config.WhichOneof('label_source_type')
-    if label_source_type == 'geojson_file':
-        return GeoJSONFile(
-            config.geojson_file.uri, crs_transformer, writable=writable)
+    if label_source_type == 'object_detection_geojson_file':
+        return ObjectDetectionGeoJSONFile(
+            config.object_detection_geojson_file.uri, crs_transformer,
+            writable=writable)
+    elif label_source_type == 'classification_geojson_file':
+        return ClassificationGeoJSONFile(
+            config.classification_geojson_file.uri, crs_transformer, extent,
+            config.classification_geojson_file.options, writable=writable)

--- a/src/rv2/builders/project_builder.py
+++ b/src/rv2/builders/project_builder.py
@@ -9,16 +9,17 @@ def build(config):
     prediction_label_source = None
 
     raster_source = raster_source_builder.build(config.raster_source)
+    extent = raster_source.get_extent()
     crs_transformer = raster_source.get_crs_transformer()
 
     if config.HasField('ground_truth_label_source'):
         ground_truth_label_source = label_source_builder.build(
-            config.ground_truth_label_source, crs_transformer,
+            config.ground_truth_label_source, crs_transformer, extent,
             writable=False)
 
     if config.HasField('prediction_label_source'):
         prediction_label_source = label_source_builder.build(
-            config.prediction_label_source, crs_transformer,
+            config.prediction_label_source, crs_transformer, extent,
             writable=True)
 
     return Project(

--- a/src/rv2/core/box.py
+++ b/src/rv2/core/box.py
@@ -30,6 +30,10 @@ class Box():
         """Return width of Box."""
         return self.xmax - self.xmin
 
+    def get_area(self):
+        """Return area of Box."""
+        return self.get_height() * self.get_width()
+
     def rasterio_format(self):
         """Return Box in Rasterio format."""
         return ((self.ymin, self.ymax), (self.xmin, self.xmax))

--- a/src/rv2/core/class_map.py
+++ b/src/rv2/core/class_map.py
@@ -37,6 +37,10 @@ class ClassMap(object):
         """Return list of ClassItems."""
         return self.class_item_map.values()
 
+    def get_class_names(self):
+        """Return list of class names."""
+        return [item.name for item in self.class_item_map.values()]
+
     def __len__(self):
         return len(self.get_items())
 

--- a/src/rv2/core/labels.py
+++ b/src/rv2/core/labels.py
@@ -2,12 +2,13 @@ from abc import ABC, abstractmethod
 
 
 class Labels(ABC):
-    '''A set of spatially referenced labels.
+    """A set of spatially referenced labels for a chip or RasterSource.
 
     A set of labels predicted by a model or provided by human labelers for the
-    sake of training. Every label is associated with a spatial location. For
-    object detection, a label is a bounding box surrounding an object and the
-    associated class. For classification, a label is a bounding box
-    representing a chip within a spatial grid) and the associated class.
-    '''
+    sake of training. Every label is associated with a spatial location and a
+    class. For object detection, a label is a bounding box surrounding an
+    object and the associated class. For classification, a label is a bounding
+    box representing a cell/chip within a spatial grid and its class.
+    For segmentation, a label is a pixel and its class.
+    """
     pass

--- a/src/rv2/core/ml_task.py
+++ b/src/rv2/core/ml_task.py
@@ -72,7 +72,7 @@ class MLTask():
 
     def process_training_data(self, train_projects, validation_projects,
                               options):
-        """Make training data.
+        """Process training data.
 
         Convert Projects with a ground_truth_label_source into training
         chips in MLBackend-specific format, and write to URI specified in

--- a/src/rv2/label_sources/classification_geojson_file.py
+++ b/src/rv2/label_sources/classification_geojson_file.py
@@ -1,0 +1,85 @@
+import json
+
+import numpy as np
+
+from rv2.labels.classification_labels import (
+    ClassificationLabels)
+from rv2.labels.object_detection_labels import ObjectDetectionLabels
+from rv2.utils.files import file_to_str
+from rv2.label_sources.classification_label_source import (
+        ClassificationLabelSource)
+
+
+def load_geojson(geojson, crs_transformer, extent, options):
+    """Construct ClassificationLabels from GeoJSON.
+
+    Args:
+        options: ClassificationGeoJSONFile.Options
+    """
+    labels = ClassificationLabels()
+    # Use the ObjectDetectionLabels to parse bounding boxes out of the GeoJSON
+    # which contains polygons and infer which boxes lie within cells.
+    od_labels = ObjectDetectionLabels.from_geojson(
+        geojson, crs_transformer)
+
+    cells = extent.get_windows(options.cell_size, options.cell_size)
+    for cell in cells:
+        # Figure out which class_id to assocate with a cell.
+        cell_od_labels = \
+            od_labels.get_subwindow(cell, ioa_thresh=options.ioa_thresh)
+        cell_boxes = cell_od_labels.get_boxes()
+        cell_class_ids = cell_od_labels.get_class_ids()
+
+        # If there are no boxes in the window, we use the
+        # background_class_id which can be set to None.
+        class_id = (None if options.background_class_id == 0
+                    else options.background_class_id)
+
+        if len(cell_class_ids) > 0:
+            # When there are boxes associated with more than one class
+            # inside the window, we need a way to pick *the* class for
+            # that window.
+            if options.pick_min_class_id:
+                class_id = min(cell_class_ids)
+            else:
+                biggest_box_ind = np.argmax(
+                    [box.get_area() for box in cell_boxes])
+                class_id = cell_class_ids[biggest_box_ind]
+
+        labels.set_cell(cell, class_id)
+
+    return labels
+
+
+class ClassificationGeoJSONFile(ClassificationLabelSource):
+    """A GeoJSON file with classification labels in it.
+
+    Ideally the GeoJSON file contains a square for each cell in the grid. But
+    in reality, it can be difficult to label imagery in such an exhaustive way.
+    So, this can also handle GeoJSON files with non-overlapping polygons that
+    do not necessarily cover the entire extent. It infers the grid of cells
+    and associated class_ids using the extent and options.
+
+    Args:
+        options: ClassificationGeoJSONFile.Options
+    """
+    def __init__(self, uri, crs_transformer, extent, options, writable=False):
+        self.uri = uri
+        self.crs_transformer = crs_transformer
+        self.writable = writable
+
+        self.set_grid(extent, options.cell_size)
+
+        try:
+            geojson = json.loads(file_to_str(uri))
+            self.labels = load_geojson(
+                geojson, crs_transformer, extent, options)
+        except:
+            if writable:
+                self.labels = ClassificationLabels()
+            else:
+                raise ValueError('Could not open {}'.format(uri))
+
+    def save(self, class_map):
+        # Not implemented yet.
+        pass

--- a/src/rv2/label_sources/classification_label_source.py
+++ b/src/rv2/label_sources/classification_label_source.py
@@ -1,21 +1,50 @@
 from rv2.core.label_source import LabelSource
+from rv2.labels.classification_labels import ClassificationLabels
 
 
 class ClassificationLabelSource(LabelSource):
+    """Represents source of a spatial grid of cells associated with classes."""
+
+    def set_grid(self, extent, cell_size):
+        """Set parameters implicitly defining the spatial grid."""
+        self.extent = extent
+        self.cell_size = cell_size
+
+    def is_valid_cell(self, box):
+        """Returns True if box corresponds to a grid cell."""
+        return (box.ymin % self.cell_size == 0 and
+                box.ymin < self.extent.get_height() and
+                box.xmin % self.cell_size == 0 and
+                box.xmin < self.extent.get_width())
+
     def get_labels(self, window):
-        pass
+        """Get the labels for a window.
+
+        Args:
+            window: (Box)
+
+        Returns:
+            ClassificationLabels object containing a single cell.
+
+        Raises:
+            ValueError: window is not valid grid cell.
+        """
+        if not self.is_valid_cell(window):
+            raise ValueError('window needs to be valid grid cell')
+        class_id = self.labels.get_cell_class_id(window)
+        labels = ClassificationLabels()
+        labels.set_cell(window, class_id)
+        return labels
 
     def get_all_labels(self):
-        pass
+        return self.labels
 
     def extend(self, window, labels):
+        # Not implemented yet.
         pass
 
     def post_process(self):
         pass
 
-    def save(self, class_map):
-        pass
-
     def clear(self):
-        pass
+        self.labels = ClassificationLabels()

--- a/src/rv2/label_sources/object_detection_geojson_file.py
+++ b/src/rv2/label_sources/object_detection_geojson_file.py
@@ -7,7 +7,7 @@ from rv2.label_sources.object_detection_label_source import (
         ObjectDetectionLabelSource)
 
 
-class GeoJSONFile(ObjectDetectionLabelSource):
+class ObjectDetectionGeoJSONFile(ObjectDetectionLabelSource):
     # TODO allow null crs_transformer for when we assume that the labels
     # are already in the crs and don't need to be converted.
     def __init__(self, uri, crs_transformer, writable=False):

--- a/src/rv2/label_sources/object_detection_label_source.py
+++ b/src/rv2/label_sources/object_detection_label_source.py
@@ -5,7 +5,7 @@ from rv2.labels.object_detection_labels import (
 
 class ObjectDetectionLabelSource(LabelSource):
     def get_labels(self, window, ioa_thresh=1.0):
-        return self.labels.get_subset(
+        return self.labels.get_subwindow(
             window, ioa_thresh=ioa_thresh)
 
     def get_all_labels(self):

--- a/src/rv2/labels/classification_labels.py
+++ b/src/rv2/labels/classification_labels.py
@@ -1,9 +1,33 @@
+import numpy as np
+
 from rv2.core.labels import Labels
 
 
 class ClassificationLabels(Labels):
+    """Represents a spatial grid of cells associated with classes."""
     def __init__(self):
-        self.box_to_class_id = {}
+        # Mapping from Box tuple to int. This is a sparse representation of
+        # the grid.
+        self.cell_to_class_id = {}
 
-    def append(self, box, class_id):
-        self.box_to_class_id[box.tuple_format()] = class_id
+    def get_class_id(self):
+        """Get the class_id of the lone cell.
+
+        Raises ValueError when there is more than one cell.
+        """
+        if len(self.cell_to_class_id) != 1:
+            raise ValueError(
+                'Needs to represent a single cell to get the class_id')
+        else:
+            return list(self.cell_to_class_id.values())[0]
+
+    def set_cell(self, cell, class_id):
+        """Set cell and its class_id.
+
+        Args:
+            cell: (Box)
+        """
+        self.cell_to_class_id[cell.tuple_format()] = class_id
+
+    def get_cell_class_id(self, cell):
+        return self.cell_to_class_id.get(cell.tuple_format())

--- a/src/rv2/labels/object_detection_labels.py
+++ b/src/rv2/labels/object_detection_labels.py
@@ -81,6 +81,8 @@ def inverse_change_coordinate_frame(boxlist, window):
 class ObjectDetectionLabels(Labels):
     def __init__(self, npboxes, class_ids, scores=None):
         self.boxlist = BoxList(npboxes)
+        # This field name actually needs to be 'classes' to be able to use
+        # certain utility functions in the TF Object Detection API.
         self.boxlist.add_field('classes', class_ids)
         if scores is not None:
             self.boxlist.add_field('scores', scores)
@@ -103,7 +105,7 @@ class ObjectDetectionLabels(Labels):
         scores = np.empty((0,))
         return ObjectDetectionLabels(npboxes, labels, scores)
 
-    def get_subset(self, window, ioa_thresh=1.0):
+    def get_subwindow(self, window, ioa_thresh=1.0):
         window_npbox = window.npbox_format()
         window_boxlist = BoxList(np.expand_dims(window_npbox, axis=0))
         boxlist = prune_non_overlapping_boxes(

--- a/src/rv2/ml_backends/keras_classification.py
+++ b/src/rv2/ml_backends/keras_classification.py
@@ -1,10 +1,82 @@
+from os.path import join
+import tempfile
+import shutil
+
 from rv2.core.ml_backend import MLBackend
+from rv2.utils.files import (
+    make_dir, get_local_path, upload_if_needed, download_if_needed,
+    RV_TEMP_DIR)
+from rv2.utils.misc import save_img
+
+
+class TrainingPackage(object):
+    """Represents paths for training data and associated utilities."""
+    def __init__(self, base_uri):
+        self.temp_dir_obj = tempfile.TemporaryDirectory(dir=RV_TEMP_DIR)
+        self.temp_dir = self.temp_dir_obj.name
+
+        self.base_uri = base_uri
+        self.base_dir = self.get_local_path(base_uri)
+        make_dir(self.base_dir, check_empty=True)
+
+        self.training_uri = join(base_uri, 'training')
+        make_dir(self.get_local_path(self.training_uri))
+        self.training_zip_uri = join(base_uri, 'training.zip')
+
+        self.validation_uri = join(base_uri, 'validation')
+        make_dir(self.get_local_path(self.validation_uri))
+        self.validation_zip_uri = join(base_uri, 'validation.zip')
+
+    def get_local_path(self, uri):
+        return get_local_path(uri, self.temp_dir)
+
+    def upload_if_needed(self, uri):
+        upload_if_needed(self.get_local_path(uri), uri)
+
+    def download_if_needed(self, uri):
+        return download_if_needed(uri, self.temp_dir)
+
+    def download(self):
+        pass
+
+    def upload(self):
+        self.upload_if_needed(self.training_zip_uri)
+        self.upload_if_needed(self.validation_zip_uri)
 
 
 class KerasClassification(MLBackend):
     def convert_training_data(self, training_data, validation_data, class_map,
                               options):
-        pass
+        """Convert training data to ImageFolder format.
+
+        For each dataset, there is a directory for each class_name with chips
+        of that class.
+        """
+        training_package = TrainingPackage(options.output_uri)
+        training_dir = training_package.get_local_path(
+            training_package.training_uri)
+        validation_dir = training_package.get_local_path(
+            training_package.validation_uri)
+
+        def convert_dataset(dataset, output_dir):
+            for class_name in class_map.get_class_names():
+                class_dir = join(output_dir, class_name)
+                make_dir(class_dir)
+
+            for chip_ind, (chip, labels) in enumerate(dataset):
+                class_id = labels.get_class_id()
+                # If a chip is not associated with a class, don't
+                # use it in training data.
+                if class_id is not None:
+                    class_name = class_map.get_by_id(class_id).name
+                    chip_path = join(
+                        output_dir, class_name, str(chip_ind) + '.png')
+                    save_img(chip, chip_path)
+            shutil.make_archive(output_dir, 'zip', output_dir)
+
+        convert_dataset(training_data, training_dir)
+        convert_dataset(validation_data, validation_dir)
+        training_package.upload()
 
     def train(self, options):
         pass

--- a/src/rv2/ml_tasks/classification.py
+++ b/src/rv2/ml_tasks/classification.py
@@ -3,10 +3,10 @@ from rv2.core.ml_task import MLTask
 
 class Classification(MLTask):
     def get_train_windows(self, project, options):
-        imagery_extent = project.raster_source.get_extent()
+        extent = project.raster_source.get_extent()
         chip_size = options.chip_size
         stride = chip_size
-        return imagery_extent.get_windows(chip_size, stride)
+        return extent.get_windows(chip_size, stride)
 
     def get_train_labels(self, window, project, options):
         return project.ground_truth_label_source.get_labels(window)

--- a/src/rv2/protos/label_source.proto
+++ b/src/rv2/protos/label_source.proto
@@ -2,12 +2,38 @@ syntax = "proto2";
 
 package rv.protos;
 
-message GeoJSONFile {
+message ObjectDetectionGeoJSONFile {
     required string uri = 1;
+}
+
+message ClassificationGeoJSONFile {
+    message Options {
+        // The minimum IOA (intersection over area) for a box to be considered
+        // inside a cell.
+        optional float ioa_thresh = 1;
+
+        // If true, the class_id for a cell is the minimum class_id of the
+        // boxes in that cell. Otherwise, pick the class_id of the box
+        // covering the greatest area.
+        optional bool pick_min_class_id = 2;
+
+        // Optional class_id to use as the background class; ie. the one that
+        // is used when a window contains no boxes. If not set, empty windows
+        // have None set as their class_id.
+        optional int32 background_class_id = 3;
+
+        // Height and width of each cell (in pixels) in the spatial grid that
+        // is laid over the raster.
+        required int32 cell_size = 4;
+    }
+
+    required string uri = 1;
+    required Options options = 2;
 }
 
 message LabelSource {
     oneof label_source_type {
-        GeoJSONFile geojson_file = 1;
+        ObjectDetectionGeoJSONFile object_detection_geojson_file = 1;
+        ClassificationGeoJSONFile classification_geojson_file = 2;
     }
 }

--- a/src/rv2/samples/workflow-configs/classification/cowc-potsdam-test.json
+++ b/src/rv2/samples/workflow-configs/classification/cowc-potsdam-test.json
@@ -4,13 +4,19 @@
             "raster_source": {
                 "geotiff_files": {
                     "uris": [
-                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif"
+                        "{rv_root}/processed-data/cowc-potsdam-test/2-10.tif"
                     ]
                 }
             },
             "ground_truth_label_source": {
-                "geojson_file": {
-                    "uri": "{rv_root}/processed-data/cowc-potsdam/labels/train/top_potsdam_2_10_RGBIR.json"
+                "classification_geojson_file": {
+                    "uri": "{rv_root}/processed-data/cowc-potsdam-test/2-10.json",
+                    "options": {
+                        "ioa_thresh": 0.5,
+                        "pick_min_class_id": true,
+                        "background_class_id": 2,
+                        "cell_size": 300
+                    }
                 }
             }
         }
@@ -21,13 +27,19 @@
             "raster_source": {
                 "geotiff_files": {
                     "uris": [
-                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_2_13_RGBIR.tif"
+                        "{rv_root}/processed-data/cowc-potsdam-test/2-13.tif"
                     ]
                 }
             },
             "ground_truth_label_source": {
-                "geojson_file": {
-                    "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_2_13_RGBIR.json"
+                "classification_geojson_file": {
+                    "uri": "{rv_root}/processed-data/cowc-potsdam-test/2-13.json",
+                    "options": {
+                        "ioa_thresh": 0.5,
+                        "pick_min_class_id": true,
+                        "background_class_id": 2,
+                        "cell_size": 300
+                    }
                 }
             }
         }
@@ -39,6 +51,10 @@
             {
                 "id": 1,
                 "name": "car"
+            },
+            {
+                "id": 2,
+                "name": "background"
             }
         ]
     },
@@ -48,7 +64,7 @@
     },
     "train_options": {
         "pretrained_model_uri": "{rv_root}/pretrained-models/tf-object-detection-api/ssd_mobilenet_v1_coco_2017_11_17.tar.gz",
-        "backend_config_uri": "{rv_root}/backend-configs/tf-object-detection-api/mobilenet-short.config",
+        "backend_config_uri": "{rv_root}/backend-configs/tf-object-detection-api/mobilenet-test.config",
         "sync_interval": 600
     },
     "predict_options": {
@@ -70,7 +86,7 @@
         "rv_root": "s3://raster-vision-lf-dev",
         "raw": "s3://raster-vision-raw-data"
     },
-    "dataset_key": "cowc-potsdam-test",
+    "dataset_key": "cowc-potsdam-cl-test",
     "model_key": "mobilenet",
     "prediction_key": "test",
     "eval_key": "default"

--- a/src/rv2/samples/workflow-configs/object-detection/cowc-potsdam-test.json
+++ b/src/rv2/samples/workflow-configs/object-detection/cowc-potsdam-test.json
@@ -10,7 +10,7 @@
                 }
             },
             "ground_truth_label_source": {
-                "geojson_file": {
+                "object_detection_geojson_file": {
                     "uri": "{rv_root}/processed-data/cowc-potsdam-test/2-10.json"
                 }
             }
@@ -27,7 +27,7 @@
                 }
             },
             "ground_truth_label_source": {
-                "geojson_file": {
+                "object_detection_geojson_file": {
                     "uri": "{rv_root}/processed-data/cowc-potsdam-test/2-13.json"
                 }
             }

--- a/src/rv2/samples/workflow-configs/object-detection/cowc-potsdam.json
+++ b/src/rv2/samples/workflow-configs/object-detection/cowc-potsdam.json
@@ -18,7 +18,7 @@
                 }
             },
             "ground_truth_label_source": {
-                "geojson_file": {
+                "object_detection_geojson_file": {
                     "uri": "{rv_root}/processed-data/cowc-potsdam/labels/train.json"
                 }
             }
@@ -35,7 +35,7 @@
                 }
             },
             "ground_truth_label_source": {
-                "geojson_file": {
+                "object_detection_geojson_file": {
                     "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_2_13_RGBIR.json"
                 }
             }
@@ -50,7 +50,7 @@
                 }
             },
             "ground_truth_label_source": {
-                "geojson_file": {
+                "object_detection_geojson_file": {
                     "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_6_8_RGBIR.json"
                 }
             }
@@ -65,7 +65,7 @@
                 }
             },
             "ground_truth_label_source": {
-                "geojson_file": {
+                "object_detection_geojson_file": {
                     "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_3_10_RGBIR.json"
                 }
             }

--- a/src/rv2/utils/chain_workflow.py
+++ b/src/rv2/utils/chain_workflow.py
@@ -10,7 +10,8 @@ from rv2.protos.predict_pb2 import PredictConfig
 from rv2.protos.eval_pb2 import EvalConfig
 from rv2.protos.label_source_pb2 import (
     LabelSource as LabelSourceConfig,
-    GeoJSONFile as GeoJSONFileConfig)
+    ObjectDetectionGeoJSONFile as ObjectDetectionGeoJSONFileConfig,
+    ClassificationGeoJSONFile as ClassificationGeoJSONFileConfig)
 
 from rv2.utils.files import (
     load_json_config, save_json_config, file_to_str, str_to_file)
@@ -114,12 +115,18 @@ class ChainWorkflow(object):
         label_source = project.ground_truth_label_source
         label_source_type = label_source.WhichOneof(
             'label_source_type')
-        if label_source_type == 'geojson_file':
-            prediction_uri = join(
-                self.path_generator.prediction_output_uri,
-                '{}.json'.format(project.id))
-            geojson_file = GeoJSONFileConfig(uri=prediction_uri)
-            return LabelSourceConfig(geojson_file=geojson_file)
+        prediction_uri = join(
+            self.path_generator.prediction_output_uri,
+            '{}.json'.format(project.id))
+
+        if label_source_type == 'object_detection_geojson_file':
+            geojson_file = ObjectDetectionGeoJSONFileConfig(uri=prediction_uri)
+            return LabelSourceConfig(
+                object_detection_geojson_file=geojson_file)
+        elif label_source_type == 'classification_geojson_file':
+            geojson_file = ClassificationGeoJSONFileConfig(uri=prediction_uri)
+            return LabelSourceConfig(
+                classification_geojson_file=geojson_file)
         else:
             raise ValueError(
                 'Not sure how to generate label source config for type {}'


### PR DESCRIPTION
This PR adds `ClassificationGeoJSONFile` and related classes for classification and support for running the `process_training_data` command. It also includes a sample workflow using the cowc-potsdam dataset.

This represents classification data using a spatial grid where a class (or None) is associated with each grid cell. We do not assume the GeoJSON file contains a grid though. Instead, we infer the grid from whatever polygons are in the file along with options (that are part of the LabelSource config) that determine how to infer the values of the grid cells.

#### Testing
* Run the test object detection workflow to make sure it didn't break.
* Run the test classification workflow using something like
```
python -m rv2.utils.chain_workflow \
     /opt/data/lf-dev/workflow-configs/classification/cowc-potsdam-test.json \
     process_training_data     --run
```
* Check the output. There should be `background` and `car` folders containing chips exemplifying those classes.

Connects #205 