### PR TITLE
Support eval for classification and run full workflow

### DIFF
--- a/src/keras_classification/commands/train.py
+++ b/src/keras_classification/commands/train.py
@@ -1,6 +1,6 @@
 import click
 
-from keras_classification.utils.files import load_json_config
+from keras_classification.utils import load_json_config
 from keras_classification.builders import trainer_builder, model_builder
 from keras_classification.protos.pipeline_pb2 import PipelineConfig
 

--- a/src/keras_classification/core/trainer.py
+++ b/src/keras_classification/core/trainer.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import keras
 from keras.preprocessing.image import ImageDataGenerator
 
-from keras_classification.utils.files import make_dir
+from keras_classification.utils import make_dir
 
 
 def get_nb_images(image_dir):
@@ -83,8 +83,10 @@ class Trainer(object):
         loss_function = 'categorical_crossentropy'
         metrics = ['accuracy']
         initial_epoch = self.get_initial_epoch()
-        steps_per_epoch = self.nb_training_samples
-        validation_steps = self.nb_validation_samples
+        steps_per_epoch = int(
+            self.nb_training_samples / self.options.batch_size)
+        validation_steps = int(
+            self.nb_validation_samples / self.options.batch_size)
 
         # Useful for testing
         if self.options.short_epoch:

--- a/src/keras_classification/core/trainer.py
+++ b/src/keras_classification/core/trainer.py
@@ -85,6 +85,12 @@ class Trainer(object):
         initial_epoch = self.get_initial_epoch()
         steps_per_epoch = self.nb_training_samples
         validation_steps = self.nb_validation_samples
+
+        # Useful for testing
+        if self.options.short_epoch:
+            steps_per_epoch = 1
+            validation_steps = 1
+
         callbacks = self.make_callbacks()
 
         self.model.compile(self.optimizer, loss_function, metrics=metrics)

--- a/src/keras_classification/protos/trainer.proto
+++ b/src/keras_classification/protos/trainer.proto
@@ -13,6 +13,7 @@ message Trainer {
         required int32 input_size = 6;
         required string output_dir = 7;
         repeated string class_names = 8;
+        required bool short_epoch = 9 [default=false];
     }
 
     required Optimizer optimizer = 1;

--- a/src/keras_classification/samples/pipeline.json
+++ b/src/keras_classification/samples/pipeline.json
@@ -17,7 +17,8 @@
             "batch_size": 1,
             "input_size": 300,
             "output_dir": "/opt/data/lf-dev/rv-output/datasets/cowc-potsdam-cl-test/models/resnet50/output",
-            "class_names": ["car", "background"]
+            "class_names": ["car", "background"],
+            "short_epoch": true
         }
     }
 }

--- a/src/keras_classification/utils.py
+++ b/src/keras_classification/utils.py
@@ -28,3 +28,10 @@ def make_dir(path, check_empty=False, force_empty=False, use_dirname=False):
     if check_empty and not is_empty:
         raise ValueError(
             '{} needs to be an empty directory!'.format(directory))
+
+
+def predict(batch, model):
+    # Apply same transform to input as when training.
+    # TODO be able to configure this transform and the one in the
+    # training generator.
+    return model.predict(batch / 255.0)

--- a/src/rastervision/core/evaluation.py
+++ b/src/rastervision/core/evaluation.py
@@ -1,16 +1,58 @@
 from abc import ABC, abstractmethod
+import json
+
+from rastervision.utils.files import str_to_file
 
 
 class Evaluation(ABC):
     """An evaluation of the predictions for a set of projects."""
 
-    @abstractmethod
+    def __init__(self):
+        self.clear()
+
     def clear(self):
         """Clear the Evaluation."""
-        pass
+        self.class_to_eval_item = {}
+        self.avg_item = None
+
+    def get_by_id(self, class_id):
+        return self.class_to_eval_item[class_id]
+
+    def to_json(self):
+        json_rep = []
+        for eval_item in self.class_to_eval_item.values():
+            json_rep.append(eval_item.to_json())
+        json_rep.append(self.avg_item.to_json())
+        return json_rep
+
+    def save(self, output_uri):
+        """Save this Evaluation to a file.
+
+        Args:
+            output_uri: string URI for the file to write.
+        """
+        json_str = json.dumps(self.to_json(), indent=4)
+        str_to_file(json_str, output_uri)
+
+    def merge(self, evaluation):
+        """Merge Evaluation for another Project into this one.
+
+        This is useful for computing the average metrics of a set of projects.
+        The results of the averaging are stored in this Evaluation.
+
+        Args:
+            evaluation: Evaluation to merge into this one
+        """
+        if len(self.class_to_eval_item) == 0:
+            self.class_to_eval_item = evaluation.class_to_eval_item
+        else:
+            for class_id, other_eval_item in evaluation.class_to_eval_item.items():
+                self.get_by_id(class_id).merge(other_eval_item)
+
+        self.compute_avg()
 
     @abstractmethod
-    def compute(ground_truth_label_store, prediction_label_store):
+    def compute(self, ground_truth_label_store, prediction_label_store):
         """Compute metrics for a single project.
 
         Args:
@@ -22,22 +64,6 @@ class Evaluation(ABC):
         pass
 
     @abstractmethod
-    def merge(self, evaluation):
-        """Merge Evaluation for another Project into this one.
-
-        This is useful for computing the average metrics of a set of projects.
-        The results of the averaging are stored in this Evaluation.
-
-        Args:
-            evaluation: Evaluation to merge into this one
-        """
-        pass
-
-    @abstractmethod
-    def save(self, output_uri):
-        """Save this Evaluation to a file.
-
-        Args:
-            output_uri: string URI for the file to write.
-        """
+    def compute_avg(self):
+        """Compute average metrics over classes."""
         pass

--- a/src/rastervision/core/evaluation_item.py
+++ b/src/rastervision/core/evaluation_item.py
@@ -1,0 +1,30 @@
+class EvaluationItem(object):
+    """Evaluation metrics for a single class."""
+    def __init__(self, precision, recall, f1, gt_count=None,
+                 class_id=None, class_name=None):
+        self.precision = precision
+        self.recall = recall
+        self.f1 = f1
+
+        self.gt_count = gt_count
+        self.class_id = class_id
+        self.class_name = class_name
+
+    def merge(self, other):
+        total_gt_count = self.gt_count + other.gt_count
+        self_ratio = 0
+        other_ratio = 0
+        if total_gt_count > 0:
+            self_ratio = self.gt_count / total_gt_count
+            other_ratio = other.gt_count / total_gt_count
+
+        def avg(self_val, other_val):
+            return self_ratio * self_val + other_ratio * other_val
+
+        self.precision = avg(self.precision, other.precision)
+        self.recall = avg(self.recall, other.recall)
+        self.f1 = avg(self.f1, other.f1)
+        self.gt_count = total_gt_count
+
+    def to_json(self):
+        return self.__dict__

--- a/src/rastervision/evaluation_items/classification_evaluation_item.py
+++ b/src/rastervision/evaluation_items/classification_evaluation_item.py
@@ -1,0 +1,5 @@
+from rastervision.core.evaluation_item import EvaluationItem
+
+
+class ClassificationEvaluationItem(EvaluationItem):
+    pass

--- a/src/rastervision/evaluation_items/object_detection_evaluation_item.py
+++ b/src/rastervision/evaluation_items/object_detection_evaluation_item.py
@@ -1,0 +1,22 @@
+from rastervision.core.evaluation_item import EvaluationItem
+
+
+class ObjectDetectionEvaluationItem(EvaluationItem):
+    def __init__(self, precision, recall, f1, count_error, gt_count=None,
+                 class_id=None, class_name=None):
+        super().__init__(
+            precision, recall, f1, gt_count=gt_count, class_id=class_id,
+            class_name=class_name)
+        self.count_error = count_error
+
+    def merge(self, other):
+        super().merge(other)
+
+        total_gt_count = self.gt_count + other.gt_count
+        self_ratio = self.gt_count / total_gt_count
+        other_ratio = other.gt_count / total_gt_count
+
+        def avg(self_val, other_val):
+            return self_ratio * self_val + other_ratio * other_val
+
+        self.count_error = avg(self.count_error, other.count_error)

--- a/src/rastervision/evaluations/classification_evaluation.py
+++ b/src/rastervision/evaluations/classification_evaluation.py
@@ -1,15 +1,58 @@
+import numpy as np
+from sklearn import metrics
+
 from rastervision.core.evaluation import Evaluation
+from rastervision.evaluation_items.classification_evaluation_item import (
+    ClassificationEvaluationItem)
+
+
+def compute_eval_items(gt_labels, pred_labels, class_map):
+    nb_classes = len(class_map)
+    class_to_eval_item = {}
+
+    gt_class_ids = []
+    pred_class_ids = []
+
+    gt_cells = gt_labels.get_cells()
+    for gt_cell in gt_cells:
+        gt_class_id = gt_labels.get_cell_class_id(gt_cell)
+        pred_class_id = pred_labels.get_cell_class_id(gt_cell)
+
+        if gt_class_id is not None and pred_class_id is not None:
+            gt_class_ids.append(gt_class_id)
+            pred_class_ids.append(pred_class_id)
+
+    # Add 1 because class_ids start at 1.
+    sklabels = np.arange(1 + nb_classes)
+    precision, recall, f1, support = metrics.precision_recall_fscore_support(
+        gt_class_ids, pred_class_ids, labels=sklabels, warn_for=())
+
+    for class_map_item in class_map.get_items():
+        class_id = class_map_item.id
+        class_name = class_map_item.name
+
+        eval_item = ClassificationEvaluationItem(
+            float(precision[class_id]), float(recall[class_id]),
+            float(f1[class_id]), gt_count=float(support[class_id]),
+            class_id=class_id, class_name=class_name)
+        class_to_eval_item[class_id] = eval_item
+
+    return class_to_eval_item
 
 
 class ClassificationEvaluation(Evaluation):
-    def clear(self):
-        pass
+    def compute(self, class_map, ground_truth_label_store,
+                prediction_label_store):
+        gt_labels = ground_truth_label_store.get_all_labels()
+        pred_labels = prediction_label_store.get_all_labels()
 
-    def compute(ground_truth_label_store, prediction_label_store):
-        pass
+        self.class_to_eval_item = compute_eval_items(
+            gt_labels, pred_labels, class_map)
 
-    def merge(self, evaluation):
-        pass
+        self.compute_avg()
 
-    def save(self, output_uri):
-        pass
+    def compute_avg(self):
+        self.avg_item = ClassificationEvaluationItem(
+            0, 0, 0, gt_count=0, class_name='average')
+        for eval_item in self.class_to_eval_item.values():
+            self.avg_item.merge(eval_item)

--- a/src/rastervision/evaluations/object_detection_evaluation.py
+++ b/src/rastervision/evaluations/object_detection_evaluation.py
@@ -4,36 +4,8 @@ from object_detection.utils import object_detection_evaluation
 
 from rastervision.core.evaluation import Evaluation
 from rastervision.utils.files import str_to_file
-
-
-class EvaluationItem(object):
-    def __init__(self, precision, recall, f1, count_error,
-                 gt_count=None, class_id=None, class_name=None):
-        self.precision = precision
-        self.recall = recall
-        self.f1 = f1
-        self.count_error = count_error
-
-        self.gt_count = gt_count
-        self.class_id = class_id
-        self.class_name = class_name
-
-    def merge(self, other):
-        total_gt_count = self.gt_count + other.gt_count
-        self_ratio = self.gt_count / total_gt_count
-        other_ratio = other.gt_count / total_gt_count
-
-        def avg(self_val, other_val):
-            return self_ratio * self_val + other_ratio * other_val
-
-        self.precision = avg(self.precision, other.precision)
-        self.recall = avg(self.recall, other.recall)
-        self.f1 = avg(self.f1, other.f1)
-        self.count_error = avg(self.count_error, other.count_error)
-        self.gt_count = total_gt_count
-
-    def to_json(self):
-        return self.__dict__
+from rastervision.evaluation_items.object_detection_evaluation_item import (
+    ObjectDetectionEvaluationItem)
 
 
 def compute_od_eval(ground_truth_labels, prediction_labels):
@@ -71,7 +43,7 @@ def parse_od_eval(od_eval, class_map):
         count_error = pred_count - gt_count
         norm_count_error = count_error / gt_count
 
-        eval_item = EvaluationItem(
+        eval_item = ObjectDetectionEvaluationItem(
             precision, recall, f1, norm_count_error, gt_count=gt_count,
             class_id=class_id, class_name=class_name)
         class_to_eval_item[class_id] = eval_item
@@ -80,16 +52,6 @@ def parse_od_eval(od_eval, class_map):
 
 
 class ObjectDetectionEvaluation(Evaluation):
-    def __init__(self):
-        self.clear()
-
-    def clear(self):
-        self.class_to_eval_item = {}
-        self.avg_item = None
-
-    def get_by_id(self, class_id):
-        return self.class_to_eval_item[class_id]
-
     def compute(self, class_map, ground_truth_label_store,
                 prediction_label_store):
         gt_labels = ground_truth_label_store.get_all_labels()
@@ -101,27 +63,7 @@ class ObjectDetectionEvaluation(Evaluation):
         self.compute_avg()
 
     def compute_avg(self):
-        self.avg_item = EvaluationItem(0, 0, 0, 0, gt_count=0,
-                                       class_name='average')
+        self.avg_item = ObjectDetectionEvaluationItem(
+            0, 0, 0, 0, gt_count=0, class_name='average')
         for eval_item in self.class_to_eval_item.values():
             self.avg_item.merge(eval_item)
-
-    def merge(self, evaluation):
-        if len(self.class_to_eval_item) == 0:
-            self.class_to_eval_item = evaluation.class_to_eval_item
-        else:
-            for class_id, other_eval_item in evaluation.class_to_eval_item.items():
-                self.get_by_id(class_id).merge(other_eval_item)
-
-        self.compute_avg()
-
-    def to_json(self):
-        json_rep = []
-        for eval_item in self.class_to_eval_item.values():
-            json_rep.append(eval_item.to_json())
-        json_rep.append(self.avg_item.to_json())
-        return json_rep
-
-    def save(self, output_uri):
-        json_str = json.dumps(self.to_json(), indent=4)
-        str_to_file(json_str, output_uri)

--- a/src/rastervision/ml_backends/keras_classification.py
+++ b/src/rastervision/ml_backends/keras_classification.py
@@ -8,6 +8,7 @@ import numpy as np
 from keras_classification.commands.train import _train
 from keras_classification.protos.pipeline_pb2 import PipelineConfig
 from keras_classification.builders import model_builder
+from keras_classification.utils import predict
 from google.protobuf import json_format
 
 from rastervision.core.ml_backend import MLBackend
@@ -163,10 +164,11 @@ class KerasClassification(MLBackend):
         # Make a batch of size 1. This won't be needed once we refactor
         # the predict method to take batches of chips.
         batch = np.expand_dims(chip, axis=0)
-        probs = self.model.predict(batch)
+        probs = predict(batch, self.model)
+        # Add 1 to class_id since they start at 1.
         class_id = int(np.argmax(probs[0]) + 1)
 
-        # Make labels with a single dummy cell.
+        # Make labels with a single dummy cell. 
         labels = ClassificationLabels()
         dummy_cell = Box(0, 0, 0, 0)
         labels.set_cell(dummy_cell, class_id)

--- a/src/rastervision/ml_backends/keras_classification.py
+++ b/src/rastervision/ml_backends/keras_classification.py
@@ -83,13 +83,14 @@ class ModelFiles(FileGroup):
         config = load_json_config(backend_config_uri, PipelineConfig())
 
         # Update config using local paths.
+        config.trainer.options.output_dir = self.get_local_path(self.base_uri)
         config.model.model_path = self.get_local_path(self.model_uri)
+
         config.trainer.options.training_data_dir = \
             dataset_files.get_local_path(dataset_files.training_uri)
         config.trainer.options.validation_data_dir = \
             dataset_files.get_local_path(dataset_files.validation_uri)
-        config.trainer.options.output_dir = \
-            dataset_files.get_local_path(self.base_uri)
+
         del config.trainer.options.class_names[:]
         config.trainer.options.class_names.extend(
             class_map.get_class_names())
@@ -149,6 +150,7 @@ class KerasClassification(MLBackend):
         start_sync(model_files.base_dir, options.output_uri,
                    sync_interval=options.sync_interval)
         _train(backend_config_path)
+
         if urlparse(options.output_uri).scheme == 's3':
             sync_dir(model_files.base_dir, options.output_uri, delete=True)
 

--- a/src/rastervision/ml_tasks/classification.py
+++ b/src/rastervision/ml_tasks/classification.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from rastervision.core.ml_task import MLTask
 from rastervision.evaluations.classification_evaluation import (
     ClassificationEvaluation)
@@ -8,7 +10,12 @@ class Classification(MLTask):
         extent = project.raster_source.get_extent()
         chip_size = options.chip_size
         stride = chip_size
-        return extent.get_windows(chip_size, stride)
+        windows = []
+        for window in extent.get_windows(chip_size, stride):
+            chip = project.raster_source.get_chip(window)
+            if np.sum(chip.ravel()) > 0:
+                windows.append(window)
+        return windows
 
     def get_train_labels(self, window, project, options):
         return project.ground_truth_label_store.get_labels(window)

--- a/src/rastervision/ml_tasks/classification.py
+++ b/src/rastervision/ml_tasks/classification.py
@@ -1,4 +1,6 @@
 from rastervision.core.ml_task import MLTask
+from rastervision.evaluations.classification_evaluation import (
+    ClassificationEvaluation)
 
 
 class Classification(MLTask):
@@ -17,4 +19,4 @@ class Classification(MLTask):
         return extent.get_windows(chip_size, stride)
 
     def get_evaluation(self):
-        pass
+        return ClassificationEvaluation()

--- a/src/rastervision/samples/backend-configs/keras-classification/resnet50-test.json
+++ b/src/rastervision/samples/backend-configs/keras-classification/resnet50-test.json
@@ -17,7 +17,8 @@
             "batch_size": 1,
             "input_size": 300,
             "output_dir": "",
-            "class_names": ["car", "background"]
+            "class_names": ["car", "background"],
+            "short_epoch": true
         }
     }
 }

--- a/src/rastervision/samples/backend-configs/keras-classification/resnet50.json
+++ b/src/rastervision/samples/backend-configs/keras-classification/resnet50.json
@@ -14,7 +14,7 @@
             "training_data_dir": "",
             "validation_data_dir": "",
             "nb_epochs": 20,
-            "batch_size": 64,
+            "batch_size": 8,
             "input_size": 300,
             "output_dir": "",
             "class_names": ["car", "background"]

--- a/src/rastervision/samples/backend-configs/keras-classification/resnet50.json
+++ b/src/rastervision/samples/backend-configs/keras-classification/resnet50.json
@@ -13,8 +13,8 @@
         "options": {
             "training_data_dir": "",
             "validation_data_dir": "",
-            "nb_epochs": 1,
-            "batch_size": 1,
+            "nb_epochs": 20,
+            "batch_size": 64,
             "input_size": 300,
             "output_dir": "",
             "class_names": ["car", "background"]

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test.json
@@ -24,7 +24,7 @@
     ],
     "test_projects": [
         {
-            "id": "2_13",
+            "id": "2-13",
             "raster_source": {
                 "geotiff_files": {
                     "uris": [

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam.json
@@ -1,0 +1,147 @@
+{
+    "train_projects": [
+        {
+            "raster_source": {
+                "geotiff_files": {
+                    "uris": [
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif",
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif",
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif",
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_2_14_RGBIR.tif",
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif",
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_3_13_RGBIR.tif",
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif",
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif",
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif",
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif"
+                    ]
+                }
+            },
+            "ground_truth_label_store": {
+                "classification_geojson_file": {
+                    "uri":  "{rv_root}/processed-data/cowc-potsdam/labels/train.json",
+                    "options": {
+                        "ioa_thresh": 0.5,
+                        "pick_min_class_id": true,
+                        "background_class_id": 2,
+                        "cell_size": 300,
+                        "infer_cells": true
+                    }
+                }
+            }
+        }
+    ],
+    "test_projects": [
+        {
+            "id": "2-13",
+            "raster_source": {
+                "geotiff_files": {
+                    "uris": [
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_2_13_RGBIR.tif"
+                    ]
+                }
+            },
+            "ground_truth_label_store": {
+                "classification_geojson_file": {
+                    "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_2_13_RGBIR.json",
+                    "options": {
+                        "ioa_thresh": 0.5,
+                        "pick_min_class_id": true,
+                        "background_class_id": 2,
+                        "cell_size": 300,
+                        "infer_cells": true
+                    }
+                }
+            }
+        },
+        {
+            "id": "6-8",
+            "raster_source": {
+                "geotiff_files": {
+                    "uris": [
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_6_8_RGBIR.tif"
+                    ]
+                }
+            },
+            "ground_truth_label_store": {
+                "classification_geojson_file": {
+                    "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_6_8_RGBIR.json",
+                    "options": {
+                        "ioa_thresh": 0.5,
+                        "pick_min_class_id": true,
+                        "background_class_id": 2,
+                        "cell_size": 300,
+                        "infer_cells": true
+                    }
+                }
+            }
+        },
+        {
+            "id": "3-10",
+            "raster_source": {
+                "geotiff_files": {
+                    "uris": [
+                        "{raw}/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif"
+                    ]
+                }
+            },
+            "ground_truth_label_store": {
+                "classification_geojson_file": {
+                    "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_3_10_RGBIR.json",
+                    "options": {
+                        "ioa_thresh": 0.5,
+                        "pick_min_class_id": true,
+                        "background_class_id": 2,
+                        "cell_size": 300,
+                        "infer_cells": true
+                    }
+                }
+            }
+        }
+    ],
+    "machine_learning": {
+        "task": "CLASSIFICATION",
+        "backend": "KERAS_CLASSIFICATION",
+        "class_items": [
+            {
+                "id": 1,
+                "name": "car"
+            },
+            {
+                "id": 2,
+                "name": "background"
+            }
+        ]
+    },
+    "process_training_data_options": {
+        "classification_options": {
+        }
+    },
+    "train_options": {
+        "backend_config_uri": "{rv_root}/backend-configs/keras-classification/resnet50.json",
+        "sync_interval": 600
+    },
+    "predict_options": {
+        "classification_options": {
+        }
+    },
+    "eval_options": {
+    },
+    "debug": true,
+    "chip_size": 300,
+    "raster_transformer": {
+        "channel_order": [0, 1, 2]
+    },
+    "local_uri_map": {
+        "rv_root": "/opt/data/lf-dev",
+        "raw": "/opt/data/raw-data"
+    },
+    "remote_uri_map": {
+        "rv_root": "s3://raster-vision-lf-dev",
+        "raw": "s3://raster-vision-raw-data"
+    },
+    "dataset_key": "cowc-potsdam-cl",
+    "model_key": "resnet50",
+    "prediction_key": "test",
+    "eval_key": "default"
+}

--- a/src/rastervision/utils/chain_workflow.py
+++ b/src/rastervision/utils/chain_workflow.py
@@ -262,13 +262,14 @@ class ChainWorkflow(object):
 @click.argument('workflow_uri')
 @click.argument('tasks', nargs=-1)
 @click.option('--remote', is_flag=True)
+@click.option('--simulated-remote', is_flag=True)
 @click.option('--branch', default='develop')
 @click.option('--run', is_flag=True)
-def main(workflow_uri, tasks, remote, branch, run):
+def main(workflow_uri, tasks, remote, simulated_remote, branch, run):
     if len(tasks) == 0:
         tasks = ALL_TASKS
 
-    workflow = ChainWorkflow(workflow_uri, remote=remote)
+    workflow = ChainWorkflow(workflow_uri, remote=(remote or simulated_remote))
     workflow.save_configs(tasks)
 
     if run:


### PR DESCRIPTION
This PR adds support for the eval command for classification, adds a full workflow for training a classification model on cowc-potsdam, and fixes bugs that were discovered when running the full workflow.

Connects #205 

#### Testing
* Run the test workflow with the following and make sure it doesn't crash.
```
python -m rastervision.utils.chain_workflow \
    /opt/data/lf-dev/workflow-configs/classification/cowc-potsdam-test.json \
    --run
```
* Swap in the model I trained using the full workflow which is at https://github.com/azavea/raster-vision-data/releases/download/v0.0.2/cowc-potsdam-classification-model.zip, and then run the `predict` and `eval` steps again for the test workflow. The predictions viewed in QGIS (filter GeoJSON so `class_id=1`) should look like this
![test-tetris](https://user-images.githubusercontent.com/1896461/38177025-8a3a5392-35c7-11e8-8b5b-4828decefdba.png)
* Run the full workflow remotely using the following. This will take a long time, so you probably want to skip this and just check the results on S3.  The average F1 score was 0.97.
```
python -m rastervision.utils.chain_workflow \
    /opt/data/lf-dev/workflow-configs/classification/cowc-potsdam.json \
    --run --remote --branch lf/cleval
```

Here are the predictions on the full test file 2-13.
![tetris](https://user-images.githubusercontent.com/1896461/38176536-d33c2696-35be-11e8-96af-363cb9aab673.png)