### PR TITLE
Handle non-georeferenced data

### DIFF
--- a/src/rastervision/builders/raster_source_builder.py
+++ b/src/rastervision/builders/raster_source_builder.py
@@ -1,4 +1,5 @@
 from rastervision.raster_sources.geotiff_files import GeoTiffFiles
+from rastervision.raster_sources.image_file import ImageFile
 from rastervision.builders import raster_transformer_builder
 
 
@@ -9,3 +10,5 @@ def build(config):
     raster_source_type = config.WhichOneof('raster_source_type')
     if raster_source_type == 'geotiff_files':
         return GeoTiffFiles(raster_transformer, config.geotiff_files.uris)
+    if raster_source_type == 'image_file':
+        return ImageFile(raster_transformer, config.image_file.uri)

--- a/src/rastervision/crs_transformers/identity_crs_transformer.py
+++ b/src/rastervision/crs_transformers/identity_crs_transformer.py
@@ -1,0 +1,9 @@
+from rastervision.core.crs_transformer import CRSTransformer
+
+
+class IdentityCRSTransformer(CRSTransformer):
+    def web_to_pixel(self, web_point):
+        return web_point
+
+    def pixel_to_web(self, pixel_point):
+        return pixel_point

--- a/src/rastervision/protos/raster_source.proto
+++ b/src/rastervision/protos/raster_source.proto
@@ -8,9 +8,15 @@ message GeoTiffFiles {
     repeated string uris = 1;
 }
 
+message ImageFile {
+    required string uri = 1;
+}
+
 message RasterSource {
     required RasterTransformer raster_transformer = 1;
+
     oneof raster_source_type {
         GeoTiffFiles geotiff_files = 2;
+        ImageFile image_file = 3;
     }
 }

--- a/src/rastervision/raster_sources/geotiff_files.py
+++ b/src/rastervision/raster_sources/geotiff_files.py
@@ -1,27 +1,12 @@
 import subprocess
 import os
-import tempfile
-
-import numpy as np
 import rasterio
 
-from rastervision.core.raster_source import RasterSource
-from rastervision.core.box import Box
+from rastervision.raster_sources.rasterio_raster_source import (
+    RasterioRasterSource)
 from rastervision.crs_transformers.rasterio_crs_transformer import (
     RasterioCRSTransformer)
-from rastervision.utils.files import download_if_needed, RV_TEMP_DIR
-
-
-def load_window(image_dataset, window=None):
-    """Load a window of an image from a TIFF file.
-
-    Args:
-        window: ((row_start, row_stop), (col_start, col_stop)) or
-        ((y_min, y_max), (x_min, x_max))
-    """
-    im = np.transpose(
-        image_dataset.read(window=window), axes=[1, 2, 0])
-    return im
+from rastervision.utils.files import download_if_needed
 
 
 def build_vrt(vrt_path, image_paths):
@@ -39,34 +24,16 @@ def download_and_build_vrt(image_uris, temp_dir):
     return image_path
 
 
-class GeoTiffFiles(RasterSource):
+class GeoTiffFiles(RasterioRasterSource):
     def __init__(self, raster_transformer, uris):
-        print('Loading GeoTiffFFiles...')
         self.uris = uris
-        self.temp_dir = tempfile.TemporaryDirectory(dir=RV_TEMP_DIR)
-        self.vrt_path = download_and_build_vrt(
-            self.uris, self.temp_dir.name)
-        self.image_dataset = rasterio.open(self.vrt_path)
-
         super().__init__(raster_transformer)
+
+    def build_image_dataset(self):
+        print('Loading GeoTiffFFiles...')
+        imagery_path = download_and_build_vrt(
+            self.uris, self.temp_dir.name)
+        return rasterio.open(imagery_path)
 
     def get_crs_transformer(self):
         return RasterioCRSTransformer(self.image_dataset)
-
-    def get_extent(self):
-        return Box(
-            0, 0, self.image_dataset.height, self.image_dataset.width)
-
-    def _get_chip(self, window):
-        height = window.get_height()
-        width = window.get_width()
-        # If window is off the edge of the array, the returned image will
-        # have a shortened height and width. Therefore, we need to transform
-        # the partial chip back to full window size.
-        partial_chip = load_window(
-            self.image_dataset, window.rasterio_format())
-        chip = np.zeros((height, width, partial_chip.shape[2]), dtype=np.uint8)
-        chip[0:partial_chip.shape[0], 0:partial_chip.shape[1], :] = \
-            partial_chip
-
-        return chip

--- a/src/rastervision/raster_sources/image_file.py
+++ b/src/rastervision/raster_sources/image_file.py
@@ -1,0 +1,20 @@
+import rasterio
+
+from rastervision.raster_sources.rasterio_raster_source import (
+    RasterioRasterSource)
+from rastervision.crs_transformers.identity_crs_transformer import (
+    IdentityCRSTransformer)
+from rastervision.utils.files import download_if_needed
+
+
+class ImageFile(RasterioRasterSource):
+    def __init__(self, raster_transformer, uri):
+        self.uri = uri
+        super().__init__(raster_transformer)
+
+    def build_image_dataset(self):
+        imagery_path = download_if_needed(self.uri, self.temp_dir.name)
+        return rasterio.open(imagery_path)
+
+    def get_crs_transformer(self):
+        return IdentityCRSTransformer()

--- a/src/rastervision/raster_sources/rasterio_raster_source.py
+++ b/src/rastervision/raster_sources/rasterio_raster_source.py
@@ -1,0 +1,47 @@
+import tempfile
+
+import numpy as np
+
+from rastervision.core.raster_source import RasterSource
+from rastervision.core.box import Box
+from rastervision.utils.files import download_if_needed, RV_TEMP_DIR
+
+
+def load_window(image_dataset, window=None):
+    """Load a window of an image from a TIFF file.
+
+    Args:
+        window: ((row_start, row_stop), (col_start, col_stop)) or
+        ((y_min, y_max), (x_min, x_max))
+    """
+    im = np.transpose(
+        image_dataset.read(window=window), axes=[1, 2, 0])
+    return im
+
+
+class RasterioRasterSource(RasterSource):
+    def __init__(self, raster_transformer):
+        self.temp_dir = tempfile.TemporaryDirectory(dir=RV_TEMP_DIR)
+        self.image_dataset = self.build_image_dataset()
+        super().__init__(raster_transformer)
+
+    def build_image_dataset(self):
+        pass
+
+    def get_extent(self):
+        return Box(
+            0, 0, self.image_dataset.height, self.image_dataset.width)
+
+    def _get_chip(self, window):
+        height = window.get_height()
+        width = window.get_width()
+        # If window is off the edge of the array, the returned image will
+        # have a shortened height and width. Therefore, we need to transform
+        # the partial chip back to full window size.
+        partial_chip = load_window(
+            self.image_dataset, window.rasterio_format())
+        chip = np.zeros((height, width, partial_chip.shape[2]), dtype=np.uint8)
+        chip[0:partial_chip.shape[0], 0:partial_chip.shape[1], :] = \
+            partial_chip
+
+        return chip

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test-jpg.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test-jpg.json
@@ -3,9 +3,7 @@
         {
             "raster_source": {
                 "image_file": {
-                    "uris": [
-                        "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-10.jpg"
-                    ]
+                    "uri": "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-10.jpg"
                 }
             },
             "ground_truth_label_store": {
@@ -27,9 +25,7 @@
             "id": "2-13",
             "raster_source": {
                 "image_file": {
-                    "uris": [
-                        "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-13.jpg"
-                    ]
+                    "uri": "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-13.jpg"
                 }
             },
             "ground_truth_label_store": {

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test-jpg.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test-jpg.json
@@ -1,0 +1,94 @@
+{
+    "train_projects": [
+        {
+            "raster_source": {
+                "image_file": {
+                    "uris": [
+                        "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-10.jpg"
+                    ]
+                }
+            },
+            "ground_truth_label_store": {
+                "classification_geojson_file": {
+                    "uri": "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-10.json",
+                    "options": {
+                        "ioa_thresh": 0.5,
+                        "pick_min_class_id": true,
+                        "background_class_id": 2,
+                        "cell_size": 300,
+                        "infer_cells": true
+                    }
+                }
+            }
+        }
+    ],
+    "test_projects": [
+        {
+            "id": "2-13",
+            "raster_source": {
+                "image_file": {
+                    "uris": [
+                        "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-13.jpg"
+                    ]
+                }
+            },
+            "ground_truth_label_store": {
+                "classification_geojson_file": {
+                    "uri": "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-13.json",
+                    "options": {
+                        "ioa_thresh": 0.5,
+                        "pick_min_class_id": true,
+                        "background_class_id": 2,
+                        "cell_size": 300,
+                        "infer_cells": true
+                    }
+                }
+            }
+        }
+    ],
+    "machine_learning": {
+        "task": "CLASSIFICATION",
+        "backend": "KERAS_CLASSIFICATION",
+        "class_items": [
+            {
+                "id": 1,
+                "name": "car"
+            },
+            {
+                "id": 2,
+                "name": "background"
+            }
+        ]
+    },
+    "process_training_data_options": {
+        "classification_options": {
+        }
+    },
+    "train_options": {
+        "backend_config_uri": "{rv_root}/backend-configs/keras-classification/resnet50-test.json",
+        "sync_interval": 600
+    },
+    "predict_options": {
+        "classification_options": {
+        }
+    },
+    "eval_options": {
+    },
+    "debug": true,
+    "chip_size": 300,
+    "raster_transformer": {
+        "channel_order": [0, 1, 2]
+    },
+    "local_uri_map": {
+        "rv_root": "/opt/data/lf-dev",
+        "raw": "/opt/data/raw-data"
+    },
+    "remote_uri_map": {
+        "rv_root": "s3://raster-vision-lf-dev",
+        "raw": "s3://raster-vision-raw-data"
+    },
+    "dataset_key": "cowc-potsdam-cl-test-jpg",
+    "model_key": "resnet50",
+    "prediction_key": "test",
+    "eval_key": "default"
+}


### PR DESCRIPTION
This PR adds support for non-georeferenced data which is necessary for handling oblique imagery and some data provided by various ML contests. This is accomplished by adding`ImageFile`, a new type of `RasterSource` that is backed by a PNG or JPG file and assuming that the coordinates in the corresponding GeoJSON file are in pixel (col/row) format.

Connects #206 

#### Testing
* Retrieve the test JPG dataset from https://github.com/azavea/raster-vision-data/releases/download/v0.0.3/cowc-potsdam-test-jpg.zip
* Copy and edit the test workflow config in `cowc-potsdam-test-jpg.json`
* Run the test classification workflow for JPG data using something like
```
python -m rastervision.utils.chain_workflow \
    /opt/data/lf-dev/workflow-configs/classification/cowc-potsdam-test-jpg.json \
    --run
```
* Check that the training chips were generated correctly.
* Verify that test workflows for georeferenced object detection and classification still work correctly.  