### PR TITLE
Generate debug prediction plots for classification

### DIFF
--- a/src/keras_classification/core/trainer.py
+++ b/src/keras_classification/core/trainer.py
@@ -35,7 +35,7 @@ class Trainer(object):
         self.training_gen = self.make_data_generator(
             options.training_data_dir)
         self.validation_gen = self.make_data_generator(
-            options.validation_data_dir)
+            options.validation_data_dir, validation_mode=True)
 
         self.nb_training_samples = get_nb_images(
             options.training_data_dir)
@@ -64,11 +64,16 @@ class Trainer(object):
 
         return initial_epoch
 
-    def make_data_generator(self, image_folder_dir):
-        generator = ImageDataGenerator(
-            rescale=1./255,
-            horizontal_flip=True,
-            vertical_flip=True)
+    def make_data_generator(self, image_folder_dir, validation_mode=False):
+        # Don't apply randomized data transforms if in validation mode.
+        # This will make the validation scores more comparable between epochs.
+        if validation_mode:
+            generator = ImageDataGenerator(rescale=1./255)
+        else:
+            generator = ImageDataGenerator(
+                rescale=1./255,
+                horizontal_flip=True,
+                vertical_flip=True)
 
         generator = generator.flow_from_directory(
             image_folder_dir,

--- a/src/rastervision/builders/ml_task_builder.py
+++ b/src/rastervision/builders/ml_task_builder.py
@@ -9,7 +9,7 @@ from rastervision.core.class_map import ClassItem, ClassMap
 def build(config):
     class_items = []
     for item_config in config.class_items:
-        item = ClassItem(item_config.id, item_config.name)
+        item = ClassItem(item_config.id, item_config.name, item_config.color)
         class_items.append(item)
     class_map = ClassMap(class_items)
 

--- a/src/rastervision/builders/project_builder.py
+++ b/src/rastervision/builders/project_builder.py
@@ -23,6 +23,7 @@ def build(config):
             writable=True)
 
     return Project(
+        id=config.id,
         raster_source=raster_source,
         ground_truth_label_store=ground_truth_label_store,
         prediction_label_store=prediction_label_store)

--- a/src/rastervision/core/box.py
+++ b/src/rastervision/core/box.py
@@ -114,6 +114,11 @@ class Box():
         """Return new square Box."""
         return Box(ymin, xmin, ymin+size, xmin+size)
 
+    def make_eroded(self, erosion_size):
+        """Return new Box whose sides are eroded by erosion_size."""
+        return Box(self.ymin + erosion_size, self.xmin + erosion_size,
+                   self.ymax - erosion_size, self.xmax - erosion_size)
+
     def get_windows(self, chip_size, stride):
         height = self.get_height()
         width = self.get_width()

--- a/src/rastervision/core/class_map.py
+++ b/src/rastervision/core/class_map.py
@@ -16,10 +16,6 @@ class ClassItem(object):
         """
         self.id = id
         self.name = name
-        if not color:
-            color = (random.randint(0, 255),
-                     random.randint(0, 255),
-                     random.randint(0, 255))
         self.color = color
 
 
@@ -55,6 +51,12 @@ class ClassMap(object):
 
     def __len__(self):
         return len(self.get_items())
+
+    def has_all_colors(self):
+        for item in self.get_items():
+            if not item.color:
+                return False
+        return True
 
     def get_category_index(self):
         """Get the corresponding category_index used by TF Object Detection."""

--- a/src/rastervision/core/class_map.py
+++ b/src/rastervision/core/class_map.py
@@ -1,15 +1,26 @@
+import random
+
+
 class ClassItem(object):
     """A class id and associated data."""
 
-    def __init__(self, id, name):
+    def __init__(self, id, name, color=None):
         """Construct a new ClassItem.
+
+        Color is picked randomly if it is a null value.
 
         Args:
             id: (int) class id
             name: (string) name of the class
+            color: (string) Pillow color code
         """
         self.id = id
         self.name = name
+        if not color:
+            color = (random.randint(0, 255),
+                     random.randint(0, 255),
+                     random.randint(0, 255))
+        self.color = color
 
 
 class ClassMap(object):

--- a/src/rastervision/core/ml_task.py
+++ b/src/rastervision/core/ml_task.py
@@ -70,6 +70,14 @@ class MLTask():
         """
         pass
 
+    @abstractmethod
+    def save_debug_predict_image(self, project, debug_dir_uri):
+        """Save a debug image of predictions.
+
+        This writes to debug_dir_uri/<project.id>.jpg.
+        """
+        pass
+
     def process_training_data(self, train_projects, validation_projects,
                               options):
         """Process training data.
@@ -140,6 +148,10 @@ class MLTask():
 
             label_store.post_process(options)
             label_store.save(self.class_map)
+
+            if (options.debug and options.debug_uri and
+                    self.class_map.has_all_colors()):
+                self.save_debug_predict_image(project, options.debug_uri)
 
     def eval(self, projects, options):
         """Evaluate predictions against ground truth in projects.

--- a/src/rastervision/core/project.py
+++ b/src/rastervision/core/project.py
@@ -1,16 +1,18 @@
 class Project():
     """The raster data and labels associated with an area of interest."""
 
-    def __init__(self, raster_source=None,
+    def __init__(self, id=None, raster_source=None,
                 ground_truth_label_store=None,
                 prediction_label_store=None):
         """Construct a new Project.
 
         Args:
+            id: optional string
             raster_source: optional RasterSource
             ground_truth_label_store: optional LabelStore
             prediction_label_store: optional LabelStore
         """
+        self.id = id
         self.raster_source = raster_source
         self.ground_truth_label_store = ground_truth_label_store
         self.prediction_label_store = prediction_label_store

--- a/src/rastervision/core/raster_source.py
+++ b/src/rastervision/core/raster_source.py
@@ -54,3 +54,10 @@ class RasterSource(ABC):
     def get_crs_transformer(self):
         """Return the associated CRSTransformer."""
         pass
+
+    def get_image_array(self):
+        """Return entire image array.
+
+        Not safe to call on very large RasterSources.
+        """
+        return self.get_chip(self.get_extent())

--- a/src/rastervision/ml_backends/keras_classification.py
+++ b/src/rastervision/ml_backends/keras_classification.py
@@ -86,6 +86,7 @@ class ModelFiles(FileGroup):
         # Update config using local paths.
         config.trainer.options.output_dir = self.get_local_path(self.base_uri)
         config.model.model_path = self.get_local_path(self.model_uri)
+        config.model.nb_classes = len(class_map)
 
         config.trainer.options.training_data_dir = \
             dataset_files.get_local_path(dataset_files.training_uri)

--- a/src/rastervision/ml_backends/keras_classification.py
+++ b/src/rastervision/ml_backends/keras_classification.py
@@ -149,6 +149,10 @@ class KerasClassification(MLBackend):
         backend_config_path = model_files.download_backend_config(
             options.backend_config_uri, dataset_files, class_map)
 
+        # Get output from potential previous run so we can resume training.
+        if urlparse(options.output_uri).scheme == 's3':
+            sync_dir(options.output_uri, model_files.base_dir)
+
         start_sync(model_files.base_dir, options.output_uri,
                    sync_interval=options.sync_interval)
         _train(backend_config_path)
@@ -169,7 +173,7 @@ class KerasClassification(MLBackend):
         # Add 1 to class_id since they start at 1.
         class_id = int(np.argmax(probs[0]) + 1)
 
-        # Make labels with a single dummy cell. 
+        # Make labels with a single dummy cell.
         labels = ClassificationLabels()
         dummy_cell = Box(0, 0, 0, 0)
         labels.set_cell(dummy_cell, class_id)

--- a/src/rastervision/ml_tasks/object_detection.py
+++ b/src/rastervision/ml_tasks/object_detection.py
@@ -85,3 +85,7 @@ class ObjectDetection(MLTask):
 
     def get_evaluation(self):
         return ObjectDetectionEvaluation()
+
+    def save_debug_predict_image(self, project, debug_dir_uri):
+        # TODO implement this
+        pass

--- a/src/rastervision/protos/machine_learning.proto
+++ b/src/rastervision/protos/machine_learning.proto
@@ -19,6 +19,7 @@ message MachineLearning {
         // A label (ie. car) its id.
         required int32 id = 1;
         required string name = 2;
+        optional string color = 3;
     }
 
     required Task task = 1;

--- a/src/rastervision/protos/predict.proto
+++ b/src/rastervision/protos/predict.proto
@@ -32,6 +32,9 @@ message PredictConfig {
         optional int32 chip_size = 3;
 
         optional bool debug = 4 [default=true];
+        // Root of dir to write debug files to.
+        optional string debug_uri = 7;
+
         oneof ml_options_type {
             ObjectDetectionOptions object_detection_options = 5;
             ClassificationOptions classification_options = 6;

--- a/src/rastervision/samples/backend-configs/keras-classification/resnet50-test.json
+++ b/src/rastervision/samples/backend-configs/keras-classification/resnet50-test.json
@@ -1,7 +1,6 @@
 {
     "model": {
         "input_size": 300,
-        "nb_classes": 2,
         "type": "RESNET50",
         "model_path": ""
     },

--- a/src/rastervision/samples/backend-configs/keras-classification/resnet50.json
+++ b/src/rastervision/samples/backend-configs/keras-classification/resnet50.json
@@ -1,7 +1,6 @@
 {
     "model": {
         "input_size": 300,
-        "nb_classes": 2,
         "type": "RESNET50",
         "model_path": ""
     },

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test-jpg.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test-jpg.json
@@ -1,6 +1,7 @@
 {
     "train_projects": [
         {
+            "id": "2-10",
             "raster_source": {
                 "image_file": {
                     "uri": "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-10.jpg"
@@ -48,11 +49,13 @@
         "class_items": [
             {
                 "id": 1,
-                "name": "car"
+                "name": "car",
+                "color": "Red"
             },
             {
                 "id": 2,
-                "name": "background"
+                "name": "background",
+                "color": "Black"
             }
         ]
     },

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test.json
@@ -1,6 +1,7 @@
 {
     "train_projects": [
         {
+            "id": "2-10",
             "raster_source": {
                 "geotiff_files": {
                     "uris": [
@@ -52,11 +53,13 @@
         "class_items": [
             {
                 "id": 1,
-                "name": "car"
+                "name": "car",
+                "color": "Red"
             },
             {
                 "id": 2,
-                "name": "background"
+                "name": "background",
+                "color": "Black"
             }
         ]
     },

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam.json
@@ -105,11 +105,13 @@
         "class_items": [
             {
                 "id": 1,
-                "name": "car"
+                "name": "car",
+                "color": "Red"
             },
             {
                 "id": 2,
-                "name": "background"
+                "name": "background",
+                "color": "Black"                
             }
         ]
     },

--- a/src/rastervision/utils/chain_workflow.py
+++ b/src/rastervision/utils/chain_workflow.py
@@ -175,6 +175,8 @@ class ChainWorkflow(object):
         config.projects.MergeFrom(self.workflow.test_projects)
         config.options.MergeFrom(self.workflow.predict_options)
         config.options.debug = self.workflow.debug
+        config.options.debug_uri = join(
+            self.path_generator.prediction_output_uri, 'debug')
         config.options.chip_size = self.workflow.chip_size
         config.options.model_uri = join(
             self.path_generator.train_output_uri, 'model')


### PR DESCRIPTION
This PR adds the ability to generate prediction plots for classification and makes some other small improvements. The color of each cell is determined by the `color` field for each class in the class map. If any classes don't have a color specified, then the debug plot is not generated. Currently, this is left unimplemented for object detection but shouldn't cause any problems for it.

#### Testing
* Run test classification workflow
* A debug plot should be in in `predictions/test/output/debug/2-13.png` that looks like this:
![2-13](https://user-images.githubusercontent.com/1896461/38272003-fdba0ec2-3755-11e8-9e9f-07394e46aea0.png)

