### PR TITLE
Add Travis CI build; publish containers to quay.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+
+language:
+   - python
+
+services:
+   - docker
+
+env:
+   global:
+      - CLEAN_TRAVIS_TAG=${TRAVIS_TAG/[[:space:]]/}
+      - COMMIT=${CLEAN_TRAVIS_TAG:-${TRAVIS_COMMIT:0:7}}
+
+script:
+   - .travis/build
+
+after_success:
+   - if [ -n "$TRAVIS_TAG" ]; then
+       .travis/build "BUILD_ALL" && \
+         .travis/publish $TRAVIS_TAG "FALSE";
+     elif [ "$TRAVIS_PULL_REQUEST" == "false" -a "$QUAY_USERNAME" != "" -a "$QUAY_PASSWORD" != "" ]; then
+       .travis/build "BUILD_ALL" && \
+         .travis/publish $COMMIT "TRUE";
+     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
    - .travis/build
 
 after_success:
-   - if [ -n "$TRAVIS_TAG" ]; then
+   - if [ -n "$TRAVIS_TAG" -a "$QUAY_USERNAME" != "" -a "$QUAY_PASSWORD" != ""]; then
        .travis/build "BUILD_ALL" && \
          .travis/publish $TRAVIS_TAG "FALSE";
      elif [ "$TRAVIS_PULL_REQUEST" == "false" -a "$QUAY_USERNAME" != "" -a "$QUAY_PASSWORD" != "" ]; then

--- a/.travis/build
+++ b/.travis/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source .travis/env
+
+docker build -t ${CPU_IMAGE} -f src/Dockerfile-cpu src;
+
+if [ "${1}" == "BUILD_ALL" ]; then
+   docker build -t ${GPU_IMAGE} -f src/Dockerfile-gpu src;
+fi

--- a/.travis/env
+++ b/.travis/env
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+FAMILY=quay.io/azavea
+
+CPU_IMAGE=raster-vision-cpu
+GPU_IMAGE=raster-vision-gpu
+
+CPU_TAG=${FAMILY}/raster-vision:cpu
+GPU_TAG=${FAMILY}/raster-vision:gpu

--- a/.travis/publish
+++ b/.travis/publish
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source .travis/env
+
+TAG_SUFFIX=${1}
+IS_LATEST=${2}
+
+docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
+
+function tag_and_push() {
+    docker tag ${CPU_IMAGE} "${CPU_TAG}-${1}";
+    docker tag ${GPU_IMAGE} "${GPU_TAG}-${1}";
+
+    docker push "${CPU_TAG}-${1}"
+    docker push "${GPU_TAG}-${1}"
+}
+
+tag_and_push ${TAG_SUFFIX}
+
+if [ "$IS_LATEST" == "TRUE" ]; then
+    tag_and_push "latest"
+fi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Join the chat at https://gitter.im/azavea/raster-vision](https://badges.gitter.im/azavea/raster-vision.svg)](https://gitter.im/azavea/raster-vision?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Docker Repository on Quay](https://quay.io/repository/azavea/raster-vision/status "Docker Repository on Quay")](https://quay.io/repository/azavea/raster-vision)
 
 *Note: this project is under development and may be difficult to use at the moment.*
 
@@ -31,6 +32,17 @@ You can find more information and talk to developers (let us know what you're wo
 
 In the past, we developed prototypes for semantic segmentation and tagging in this repo, which were discussed in our [segmentation ](https://www.azavea.com/blog/2017/05/30/deep-learning-on-aerial-imagery/), and [tagging](https://www.azavea.com/blog/2018/01/03/amazon-deep-learning/) blog posts. This implementation has been removed from the `develop` branch and is unsupported, but can still be found at [this tag](https://github.com/azavea/raster-vision/releases/tag/old-semseg-tagging).
 Similarly, an outdated prototype of object detection can be found at [this tag](https://github.com/azavea/raster-vision/releases/tag/old-object-detection) under the `rv` module.
+
+### Docker images
+
+Raster Vision is publishing docker images to [quay.io](https://quay.io/repository/azavea/raster-vision).
+The tag for the `raster-vision` image determines what type of image it is:
+- The `cpu-*` tags are for running the CPU containers.
+- The `gpu-*` tags are for running the GPU containers.
+
+We publish a new tag per commit to `develop`, which is tagged with the commit message.
+To use the latest version, pull the `latest` suffix, e.g. `raster-vision:gpu-latest`.
+Git tags are also published, with the github tag name as the docker tag suffix.
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The tag for the `raster-vision` image determines what type of image it is:
 - The `cpu-*` tags are for running the CPU containers.
 - The `gpu-*` tags are for running the GPU containers.
 
-We publish a new tag per commit to `develop`, which is tagged with the commit message.
+We publish a new tag per merge into `develop`, which is tagged with the first 7 characters of the commit hash.
 To use the latest version, pull the `latest` suffix, e.g. `raster-vision:gpu-latest`.
 Git tags are also published, with the github tag name as the docker tag suffix.
 

--- a/scripts/jupyter
+++ b/scripts/jupyter
@@ -18,17 +18,35 @@ Run the jupyter notebook in a raster-vision docker image locally
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
-    docker run --rm -it \
-           -e "AWS_PROFILE=$AWS_PROFILE" \
-           -v "$HOME/.aws":/root/.aws \
-           -v "$SRC":/opt/src \
-           -v ${RASTER_VISION_DATA_DIR}:/opt/data \
-           -p 8888:8888 \
-           raster-vision-cpu \
-           /run_jupyter.sh \
-           --ip 0.0.0.0 \
-           --port 8888 \
-           --no-browser \
-           --allow-root \
-           --notebook-dir=/opt/src
+    if [ -n ${RASTER_VISION_NOTEBOOK_DIR} ]; then
+        NOTEBOOK_DIR=$RASTER_VISION_NOTEBOOK_DIR
+        docker run --rm -it \
+               -e "AWS_PROFILE=$AWS_PROFILE" \
+               -v "$HOME/.aws":/root/.aws \
+               -v "$SRC":/opt/src \
+               -v ${RASTER_VISION_DATA_DIR}:/opt/data \
+               -v ${RASTER_VISION_NOTEBOOK_DIR}:/opt/notebooks \
+               -p 8888:8888 \
+               raster-vision-cpu \
+               /run_jupyter.sh \
+               --ip 0.0.0.0 \
+               --port 8888 \
+               --no-browser \
+               --allow-root \
+               --notebook-dir=/opt/notebooks;
+    else
+        docker run --rm -it \
+               -e "AWS_PROFILE=$AWS_PROFILE" \
+               -v "$HOME/.aws":/root/.aws \
+               -v "$SRC":/opt/src \
+               -v ${RASTER_VISION_DATA_DIR}:/opt/data \
+               -p 8888:8888 \
+               raster-vision-cpu \
+               /run_jupyter.sh \
+               --ip 0.0.0.0 \
+               --port 8888 \
+               --no-browser \
+               --allow-root \
+               --notebook-dir=/opt/src;
+    fi
 fi

--- a/scripts/jupyter
+++ b/scripts/jupyter
@@ -19,7 +19,6 @@ Run the jupyter notebook in a raster-vision docker image locally
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
     if [ -n ${RASTER_VISION_NOTEBOOK_DIR} ]; then
-        NOTEBOOK_DIR=$RASTER_VISION_NOTEBOOK_DIR
         docker run --rm -it \
                -e "AWS_PROFILE=$AWS_PROFILE" \
                -v "$HOME/.aws":/root/.aws \


### PR DESCRIPTION
Builds and publishes containers to quay.io via Travis.

Changes to Dockerfiles are to prevent conda from using a progress bar, which blows up Travis logs.

TODO:
- [x] Build containers for all branches; publish only on develop
- [x] Document the tag format of the docker repo