### PR TITLE
Handle polygons when inferring classification grid

### DIFF
--- a/src/rastervision/label_stores/classification_geojson_file.py
+++ b/src/rastervision/label_stores/classification_geojson_file.py
@@ -1,6 +1,8 @@
 import json
 
 import numpy as np
+from shapely.strtree import STRtree
+from shapely import geometry
 
 from rastervision.labels.classification_labels import (
     ClassificationLabels)
@@ -11,31 +13,72 @@ from rastervision.label_stores.classification_label_store import (
         ClassificationLabelStore)
 
 
-def infer_labels(od_labels, extent, options):
+def get_str_tree(geojson, crs_transformer):
+    features = geojson['features']
+    json_polygons = []
+    class_ids = []
+
+    for feature in features:
+        # Convert polygon to pixel coords and then convert to bounding box.
+        polygon = feature['geometry']['coordinates'][0]
+        polygon = [crs_transformer.web_to_pixel(p) for p in polygon]
+        json_polygons.append(polygon)
+
+        properties = feature.get('properties', {})
+        class_ids.append(properties.get('class_id', 1))
+
+    # Convert polygons to shapely
+    polygons = []
+    for json_polygon, class_id in zip(json_polygons, class_ids):
+        polygon = geometry.Polygon([(p[0], p[1]) for p in json_polygon])
+        polygon.class_id = class_id
+        polygons.append(polygon)
+
+    return STRtree(polygons)
+
+
+def infer_labels(geojson, crs_transformer, extent, options):
+    """Infer the class_id for each grid cell from polygons."""
+    str_tree = get_str_tree(geojson, crs_transformer)
     labels = ClassificationLabels()
+
+    # For each cell, find intersecting polygons.
     cells = extent.get_windows(options.cell_size, options.cell_size)
     for cell in cells:
-        # Figure out which class_id to assocate with a cell.
-        cell_od_labels = \
-            od_labels.get_subwindow(cell, ioa_thresh=options.ioa_thresh)
-        cell_boxes = cell_od_labels.get_boxes()
-        cell_class_ids = cell_od_labels.get_class_ids()
+        cell_geom = geometry.Polygon(
+            [(p[0], p[1]) for p in cell.geojson_coordinates()])
+        intersecting_polygons = str_tree.query(cell_geom)
 
-        # If there are no boxes in the window, we use the
-        # background_class_id which can be set to None.
-        class_id = (None if options.background_class_id == 0
-                    else options.background_class_id)
+        intersection_over_cells = []
+        intersection_over_polygons = []
+        class_ids = []
 
-        if len(cell_class_ids) > 0:
-            # When there are boxes associated with more than one class
-            # inside the window, we need a way to pick *the* class for
-            # that window.
-            if options.pick_min_class_id:
-                class_id = min(cell_class_ids)
+        # Find polygons whose intersection with the cell is big enough.
+        for polygon in intersecting_polygons:
+            intersection = polygon.intersection(cell_geom)
+            intersection_over_cell = intersection.area / cell_geom.area
+            intersection_over_polygon = intersection.area / polygon.area
+
+            if options.use_intersection_over_cell:
+                enough_intersection = intersection_over_cell >= options.ioa_thresh
             else:
-                biggest_box_ind = np.argmax(
-                    [box.get_area() for box in cell_boxes])
-                class_id = cell_class_ids[biggest_box_ind]
+                enough_intersection = intersection_over_polygon >= options.ioa_thresh
+
+            if enough_intersection:
+                intersection_over_cells.append(intersection_over_cell)
+                intersection_over_polygons.append(intersection_over_polygon)
+                class_ids.append(polygon.class_id)
+
+        # Infer class id for cell.
+        if len(class_ids) == 0:
+            class_id = (None if options.background_class_id == 0
+                        else options.background_class_id)
+        elif options.pick_min_class_id:
+            class_id = min(class_ids)
+        else:
+            # Pick class_id of the polygon with the biggest intersection over
+            # cell.
+            class_id = class_ids[np.argmax(intersection_over_cells)]
 
         labels.set_cell(cell, class_id)
     return labels
@@ -58,14 +101,13 @@ def load_geojson(geojson, crs_transformer, extent, options):
     Args:
         options: ClassificationGeoJSONFile.Options
     """
-    # Use the ObjectDetectionLabels to parse bounding boxes out of the GeoJSON
-    # which contains polygons and infer which boxes lie within cells.
-    od_labels = ObjectDetectionLabels.from_geojson(
-        geojson, crs_transformer)
-
     if options.infer_cells:
-        labels = infer_labels(od_labels, extent, options)
+        labels = infer_labels(geojson, crs_transformer, extent, options)
     else:
+        # Use the ObjectDetectionLabels to parse bounding boxes out of the
+        # GeoJSON.
+        od_labels = ObjectDetectionLabels.from_geojson(
+            geojson, crs_transformer)
         labels = convert_labels(od_labels, extent, options)
 
     return labels

--- a/src/rastervision/protos/label_store.proto
+++ b/src/rastervision/protos/label_store.proto
@@ -8,9 +8,13 @@ message ObjectDetectionGeoJSONFile {
 
 message ClassificationGeoJSONFile {
     message Options {
-        // The minimum IOA (intersection over area) for a box to be considered
-        // inside a cell.
+        // The minimum IOA of a polygon and cell.
         optional float ioa_thresh = 1;
+
+        // If use_intersection_over_cell is true, then use the area of the
+        // cell as the denominator in the IOA. Otherwise, use the area of the
+        // polygon.
+        optional bool use_intersection_over_cell = 6;
 
         // If true, the class_id for a cell is the minimum class_id of the
         // boxes in that cell. Otherwise, pick the class_id of the box

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test-jpg.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test-jpg.json
@@ -12,6 +12,7 @@
                     "uri": "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-10.json",
                     "options": {
                         "ioa_thresh": 0.5,
+                        "use_intersection_over_cell": false,
                         "pick_min_class_id": true,
                         "background_class_id": 2,
                         "cell_size": 300,
@@ -34,6 +35,7 @@
                     "uri": "{rv_root}/processed-data/cowc-potsdam-test-jpg/2-13.json",
                     "options": {
                         "ioa_thresh": 0.5,
+                        "use_intersection_over_cell": false,
                         "pick_min_class_id": true,
                         "background_class_id": 2,
                         "cell_size": 300,

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam-test.json
@@ -14,6 +14,7 @@
                     "uri": "{rv_root}/processed-data/cowc-potsdam-test/2-10.json",
                     "options": {
                         "ioa_thresh": 0.5,
+                        "use_intersection_over_cell": false,
                         "pick_min_class_id": true,
                         "background_class_id": 2,
                         "cell_size": 300,
@@ -38,6 +39,7 @@
                     "uri": "{rv_root}/processed-data/cowc-potsdam-test/2-13.json",
                     "options": {
                         "ioa_thresh": 0.5,
+                        "use_intersection_over_cell": false,
                         "pick_min_class_id": true,
                         "background_class_id": 2,
                         "cell_size": 300,

--- a/src/rastervision/samples/workflow-configs/classification/cowc-potsdam.json
+++ b/src/rastervision/samples/workflow-configs/classification/cowc-potsdam.json
@@ -22,6 +22,7 @@
                     "uri":  "{rv_root}/processed-data/cowc-potsdam/labels/train.json",
                     "options": {
                         "ioa_thresh": 0.5,
+                        "use_intersection_over_cell": false,
                         "pick_min_class_id": true,
                         "background_class_id": 2,
                         "cell_size": 300,
@@ -46,6 +47,7 @@
                     "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_2_13_RGBIR.json",
                     "options": {
                         "ioa_thresh": 0.5,
+                        "use_intersection_over_cell": false,
                         "pick_min_class_id": true,
                         "background_class_id": 2,
                         "cell_size": 300,
@@ -68,6 +70,7 @@
                     "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_6_8_RGBIR.json",
                     "options": {
                         "ioa_thresh": 0.5,
+                        "use_intersection_over_cell": false,
                         "pick_min_class_id": true,
                         "background_class_id": 2,
                         "cell_size": 300,
@@ -90,6 +93,7 @@
                     "uri": "{rv_root}/processed-data/cowc-potsdam/labels/test/top_potsdam_3_10_RGBIR.json",
                     "options": {
                         "ioa_thresh": 0.5,
+                        "use_intersection_over_cell": false,
                         "pick_min_class_id": true,
                         "background_class_id": 2,
                         "cell_size": 300,
@@ -111,7 +115,7 @@
             {
                 "id": 2,
                 "name": "background",
-                "color": "Black"                
+                "color": "Black"
             }
         ]
     },


### PR DESCRIPTION
This PR makes it so that we infer classification cell classes by testing the intersection of polygons with each cell. Previously, we were converting polygons to bounding boxes which can lead to errors. This also adds the ability to specify how to compute the IOA between polygons and cells.

#### Testing
* Run test classification workflow
* It would be a better test if we had an example where there were non-convex polygons in the LabelStore and not just a bunch of rectangles. Hopefully I can add a unit test for this when I get back.