### PR TITLE
Allow specification of object detection scripts

### DIFF
--- a/src/rastervision/protos/train.proto
+++ b/src/rastervision/protos/train.proto
@@ -5,6 +5,18 @@ package rv.protos;
 import "rastervision/protos/machine_learning.proto";
 
 message TrainConfig {
+
+    message ObjectDetectionOptions {
+        // path to Object Detection's train.py script
+        optional string train_py = 1 [default="/opt/src/tf/object_detection/train.py"];
+
+        // path to Object Detection's eval.py script
+        optional string eval_py = 2 [default="/opt/src/tf/object_detection/eval.py"];
+
+        // path to Object Detection's export_inference_graph.py script
+        optional string export_py = 3 [default="/opt/src/tf/object_detection/export_inference_graph.py"];
+    }
+
     message Options {
         // URI for a separate training configuration that is specific to an ML
         // backend.
@@ -21,6 +33,11 @@ message TrainConfig {
 
         // How often to sync output of training to the cloud (in seconds).
         optional int32 sync_interval = 5 [default=600];
+
+        oneof ml_options_type {
+            ObjectDetectionOptions object_detection_options = 6;
+        }
+
     }
 
     required MachineLearning machine_learning = 1;


### PR DESCRIPTION
This adds support for calling externally placed tensorflow models, specifically object detection

Example...

```
...
    "train_options": {
        "pretrained_model_uri": "{rv_root}/pretrained-models/tf-object-detection-api/faster_rcnn_inception_v2_coco_2018_01_28.tar.gz",
        "backend_config_uri": "{rv_root}/backend-configs/tf-object-detection-api/faster_rcnn_inception_v2_coco.config",
        "sync_interval": 600,
        "object_detection_options": {
            "train_py": "/opt/tf_models/research/object_detection/train.py",
            "eval_py": "/opt/tf_models/research/object_detection/eval.py",
            "export_py": "/opt/tf_models/research/object_detection/export_inference_graph.py"
        }
    },
...
```