### PR TITLE
Add support for projects with just raster files, no annotations

### DIFF
--- a/src/rastervision/core/ml_task.py
+++ b/src/rastervision/core/ml_task.py
@@ -92,10 +92,11 @@ class MLTask():
                 (that is disjoint from train_projects)
             options: ProcessTrainingDataConfig.Options
         """
-        def _process_training_data(projects):
+        def _process_training_data(projects, type_):
             training_data = TrainingData()
             for project in projects:
-                print('Making training chips for project', end='', flush=True)
+                print('Making {} chips for project'.format(type_),
+                    end='', flush=True)
                 windows = self.get_train_windows(project, options)
                 for window in windows:
                     chip = project.raster_source.get_chip(window)
@@ -108,8 +109,10 @@ class MLTask():
                 # running out of disk space
             return training_data
 
-        training_data = _process_training_data(train_projects)
-        validation_data = _process_training_data(validation_projects)
+        # TODO: parallel processing!
+        training_data = _process_training_data(train_projects, 'training')
+        validation_data = _process_training_data(
+            validation_projects, 'validation')
         self.backend.convert_training_data(
             training_data, validation_data, self.class_map, options)
 

--- a/src/rastervision/label_stores/object_detection_geojson_file.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file.py
@@ -20,7 +20,7 @@ class ObjectDetectionGeoJSONFile(ObjectDetectionLabelStore):
             self.labels = ObjectDetectionLabels.from_geojson(
                 geojson, crs_transformer)
         except:
-            if writable:
+            if self.writable or not self.uri:
                 self.labels = ObjectDetectionLabels.make_empty()
             else:
                 raise ValueError('Could not open {}'.format(uri))

--- a/src/rastervision/ml_tasks/object_detection.py
+++ b/src/rastervision/ml_tasks/object_detection.py
@@ -59,6 +59,7 @@ class ObjectDetection(MLTask):
         # Make positive windows which contain labels.
         pos_windows = make_pos_windows(
             raster_source.get_extent(), label_store, options.chip_size)
+        nb_pos_windows = len(pos_windows)
 
         # Make negative windows which do not contain labels.
         # Generate randow windows and save the ones that don't contain

--- a/src/rastervision/ml_tasks/object_detection.py
+++ b/src/rastervision/ml_tasks/object_detection.py
@@ -65,8 +65,11 @@ class ObjectDetection(MLTask):
         # any labels. It may take many attempts to generate a single
         # negative window, and could get into an infinite loop in some cases,
         # so we cap the number of attempts.
-        nb_neg_windows = \
-            int(options.object_detection_options.neg_ratio * len(pos_windows))
+        if nb_pos_windows:
+            nb_neg_windows = round(
+                options.object_detection_options.neg_ratio * nb_pos_windows)
+        else:
+            nb_neg_windows = 100 # just make some
         max_attempts = 100 * nb_neg_windows
         neg_windows = make_neg_windows(
             raster_source, label_store, options.chip_size,

--- a/src/rastervision/utils/chain_workflow.py
+++ b/src/rastervision/utils/chain_workflow.py
@@ -98,12 +98,16 @@ class ChainWorkflow(object):
         self.update_projects()
 
     def update_projects(self):
-        for project in self.workflow.train_projects:
+        for idx, project in enumerate(self.workflow.train_projects):
+            if len(project.id) < 1:
+                project.id = 'train-{}'.format(idx)
             # Set raster_tranformer for raster_sources
             project.raster_source.raster_transformer.MergeFrom(
                 self.workflow.raster_transformer)
 
-        for project in self.workflow.test_projects:
+        for idx, project in enumerate(self.workflow.test_projects):
+            if len(project.id) < 1:
+                project.id = 'eval-{}'.format(idx)
             project.raster_source.raster_transformer.MergeFrom(
                 self.workflow.raster_transformer)
 


### PR DESCRIPTION
Depending on the training data, it really isn't feasible to build sufficient negative data for training. Instead, allow configs to pass in rasters to be used as negative data...

```
...
{
    "raster_source": {
        "geotiff_files": {
            "uris": ["s3://aws-naip/ca/2012/1m/rgbir/39122/m_3912232_sw_10_1_20120705.tif"]
        }
    },
    "ground_truth_label_store": {
        "object_detection_geojson_file": {}
    }
}
```
I'm kind of concerned with the verbosity for essentially an empty `ground_truth_label_store` but minimal changes needed to support the end goal...