### PR TITLE
Better memory management when building training data

### DIFF
--- a/src/rastervision/core/ml_backend.py
+++ b/src/rastervision/core/ml_backend.py
@@ -9,9 +9,21 @@ class MLBackend(ABC):
     """
 
     @abstractmethod
-    def convert_training_data(self, training_data, validation_data, class_map,
-                              options):
-        """Convert training data to backend-specific format and save it.
+    def per_project_data_processor(self, project, data, class_map, options):
+        """Process each project's training data
+
+        Args:
+            project: Project
+            data: TrainingData
+            class_map: ClassMap
+            options: ProcessTrainingDataConfig.Options
+        """
+        pass
+
+    @abstractmethod
+    def all_projects_dataset_processor(self, training_data, validation_data,
+                                       class_map, options):
+        """After all projects have been processed, process the resultset
 
         Args:
             training_data: TrainingData


### PR DESCRIPTION
My training set results in a 24+ GB TFRecord and given that RV currently stores all chips in memory until all Training and Evaluation datasets are process, i reliably get an OOM error. Instead, write a TFRecord for each project and after all projects are done, merge all TFRecords.

This will also allow the next step of parallel building of training datasets. It takes me 2 hours right now to build the training set...