### PR TITLE
Ensure all workflow commands are valid

### DIFF
--- a/src/rastervision/utils/chain_workflow.py
+++ b/src/rastervision/utils/chain_workflow.py
@@ -271,6 +271,10 @@ def main(workflow_uri, tasks, remote, simulated_remote, branch, run):
     if len(tasks) == 0:
         tasks = ALL_TASKS
 
+    for task in tasks:
+        if not task in ALL_TASKS:
+            raise Exception("Task '{}' is not a valid task.".format(task))
+
     workflow = ChainWorkflow(workflow_uri, remote=(remote or simulated_remote))
     workflow.save_configs(tasks)
 


### PR DESCRIPTION
This PR simply scratches an itch of taking a second not knowing what happened when I have a type in a command (usually `process_training_data`). Previous behavior simply exits without comment; now it will throw an exception showing you which command you typo'd or misnamed.