### PR TITLE
Temporary Directory handling

### DIFF
--- a/src/rastervision/ml_backends/keras_classification.py
+++ b/src/rastervision/ml_backends/keras_classification.py
@@ -14,7 +14,7 @@ from google.protobuf import json_format
 from rastervision.core.ml_backend import MLBackend
 from rastervision.utils.files import (
     make_dir, get_local_path, upload_if_needed, download_if_needed,
-    RV_TEMP_DIR, start_sync, sync_dir, load_json_config)
+    start_sync, sync_dir, load_json_config)
 from rastervision.utils.misc import save_img
 from rastervision.labels.classification_labels import ClassificationLabels
 from rastervision.core.box import Box
@@ -22,7 +22,7 @@ from rastervision.core.box import Box
 
 class FileGroup(object):
     def __init__(self, base_uri):
-        self.temp_dir_obj = tempfile.TemporaryDirectory(dir=RV_TEMP_DIR)
+        self.temp_dir_obj = tempfile.TemporaryDirectory()
         self.temp_dir = self.temp_dir_obj.name
 
         self.base_uri = base_uri
@@ -162,7 +162,7 @@ class KerasClassification(MLBackend):
 
     def predict(self, chip, options):
         if self.model is None:
-            with tempfile.TemporaryDirectory(dir=RV_TEMP_DIR) as temp_dir:
+            with tempfile.TemporaryDirectory() as temp_dir:
                 model_path = download_if_needed(options.model_uri, temp_dir)
                 self.model = model_builder.build_from_path(model_path)
 

--- a/src/rastervision/ml_backends/tf_object_detection_api.py
+++ b/src/rastervision/ml_backends/tf_object_detection_api.py
@@ -30,7 +30,7 @@ from rastervision.labels.object_detection_labels import (
     ObjectDetectionLabels)
 from rastervision.utils.files import (
     get_local_path, upload_if_needed, make_dir, download_if_needed,
-    file_to_str, sync_dir, RV_TEMP_DIR, start_sync)
+    file_to_str, sync_dir, start_sync)
 
 TRAIN = 'train'
 VALIDATION = 'validation'
@@ -212,7 +212,7 @@ def export_inference_graph(
 
 class TrainingPackage(object):
     def __init__(self, base_uri):
-        self.temp_dir_obj = tempfile.TemporaryDirectory(dir=RV_TEMP_DIR)
+        self.temp_dir_obj = tempfile.TemporaryDirectory()
         self.temp_dir = self.temp_dir_obj.name
 
         self.base_uri = base_uri
@@ -359,7 +359,7 @@ class TFObjectDetectionAPI(MLBackend):
             if options.debug:
                 debug_zip_path = training_package.get_local_path(
                     training_package.get_debug_chips_uri(split))
-                with tempfile.TemporaryDirectory(dir=RV_TEMP_DIR) as debug_dir:
+                with tempfile.TemporaryDirectory() as debug_dir:
                     make_debug_images(record_path, class_map, debug_dir)
                     shutil.make_archive(
                         os.path.splitext(debug_zip_path)[0], 'zip', debug_dir)
@@ -382,7 +382,7 @@ class TFObjectDetectionAPI(MLBackend):
         config_path = training_package.download_config(
             options.pretrained_model_uri, options.backend_config_uri)
 
-        with tempfile.TemporaryDirectory(dir=RV_TEMP_DIR) as temp_dir:
+        with tempfile.TemporaryDirectory() as temp_dir:
             # Setup output dirs.
             output_dir = get_local_path(options.output_uri, temp_dir)
             make_dir(output_dir)
@@ -408,7 +408,7 @@ class TFObjectDetectionAPI(MLBackend):
     def predict(self, chip, options):
         # Load and memoize the detection graph and TF session.
         if self.detection_graph is None:
-            with tempfile.TemporaryDirectory(dir=RV_TEMP_DIR) as temp_dir:
+            with tempfile.TemporaryDirectory() as temp_dir:
                 model_path = download_if_needed(options.model_uri, temp_dir)
                 self.detection_graph = load_frozen_graph(model_path)
                 self.session = tf.Session(graph=self.detection_graph)

--- a/src/rastervision/ml_tasks/classification.py
+++ b/src/rastervision/ml_tasks/classification.py
@@ -8,7 +8,7 @@ from rastervision.core.ml_task import MLTask
 from rastervision.evaluations.classification_evaluation import (
     ClassificationEvaluation)
 from rastervision.utils.files import (
-    get_local_path, upload_if_needed, RV_TEMP_DIR, make_dir)
+    get_local_path, upload_if_needed, make_dir)
 
 
 def draw_debug_predict_image(project, class_map):
@@ -52,7 +52,7 @@ class Classification(MLTask):
         img = draw_debug_predict_image(project, self.class_map)
         # Saving to a jpg leads to segfault for unknown reasons.
         debug_image_uri = join(debug_dir_uri, project.id + '.png')
-        with tempfile.TemporaryDirectory(dir=RV_TEMP_DIR) as temp_dir:
+        with tempfile.TemporaryDirectory() as temp_dir:
             debug_image_path = get_local_path(debug_image_uri, temp_dir)
             make_dir(debug_image_path, use_dirname=True)
             img.save(debug_image_path)

--- a/src/rastervision/raster_sources/rasterio_raster_source.py
+++ b/src/rastervision/raster_sources/rasterio_raster_source.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from rastervision.core.raster_source import RasterSource
 from rastervision.core.box import Box
-from rastervision.utils.files import download_if_needed, RV_TEMP_DIR
+from rastervision.utils.files import download_if_needed
 
 
 def load_window(image_dataset, window=None):
@@ -21,7 +21,7 @@ def load_window(image_dataset, window=None):
 
 class RasterioRasterSource(RasterSource):
     def __init__(self, raster_transformer):
-        self.temp_dir = tempfile.TemporaryDirectory(dir=RV_TEMP_DIR)
+        self.temp_dir = tempfile.TemporaryDirectory()
         self.image_dataset = self.build_image_dataset()
         super().__init__(raster_transformer)
 


### PR DESCRIPTION
* Consider the environment when setting temporary directory. In my AWS Batch envs, I explicitly provide sufficient disk space to be provided to Docker containers.
* Given that there may be more than one RasterVision process running on a host (across docker containers or directly on the host), make sure to provision a one-off temporary directory for the process.

Eventually, we should have a unified "init" mechanism to contain the per-process environment (temp dir, s3 object)