### PR TITLE
Add support for predict_scenes

### DIFF
--- a/src/rastervision/protos/chain_workflow.proto
+++ b/src/rastervision/protos/chain_workflow.proto
@@ -18,6 +18,13 @@ message ChainWorkflowConfig {
     // during training.
     repeated Scene test_scenes = 18;
 
+    // The predict_scenes are not associated with any ground truth labels and
+    // are only used for making predictions to visually inspect. These scenes
+    // should contain an id, a raster_source and a ground_truth_label_source
+    // that has a blank URI. (The ground_truth_label_source is still needed
+    // to infer the type of the prediction file that should be generated.)
+    repeated Scene predict_scenes = 20;
+
     required MachineLearning machine_learning = 3;
     required RasterTransformer raster_transformer = 5;
     required int32 chip_size = 6;


### PR DESCRIPTION
This PR adds support for a `predict_scenes` field in workflow configs. These are scenes that don't have ground truth labels and are just used for making predictions to visually inspect. As seen in the example below, you still need to specify the `ground_truth_label_store` without a URI so that the chain workflow runner knows the type of the predictions file to create (in this case `object_detection_geojson_file`).

Closes #238 

Example:
```
    "predict_scenes": [
        {
            "id": "2-13-predict",
            "raster_source": {
                "geotiff_files": {
                    "uris": [
                        "{rv_root}/processed-data/cowc-potsdam-test/2-13.tif"
                    ]
                }
            },
            "ground_truth_label_store": {
                "object_detection_geojson_file": {
                    "uri": ""
                }
            }
        }
    ]
```