### PR TITLE
Exit on failed travis commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,4 @@ script:
    - .travis/build
 
 after_success:
-   - if [ -n "$TRAVIS_TAG" -a "$QUAY_USERNAME" != "" -a "$QUAY_PASSWORD" != ""]; then
-       .travis/build "BUILD_ALL" && \
-         .travis/publish $TRAVIS_TAG "FALSE";
-     elif [ "$TRAVIS_PULL_REQUEST" == "false" -a "$QUAY_USERNAME" != "" -a "$QUAY_PASSWORD" != "" ]; then
-       .travis/build "BUILD_ALL" && \
-         .travis/publish $COMMIT "TRUE";
-     fi
+   - .travis/after_success

--- a/.travis/after_success
+++ b/.travis/after_success
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+if [ "$QUAY_USERNAME" != "" -a "$QUAY_PASSWORD" != "" ]; then
+    if [ -n "$TRAVIS_TAG"]; then
+        .travis/build "BUILD_ALL" && \
+            .travis/publish $TRAVIS_TAG "FALSE";
+    elif [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+        .travis/build "BUILD_ALL" && \
+            .travis/publish $COMMIT "TRUE";
+    fi
+fi

--- a/.travis/build
+++ b/.travis/build
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 source .travis/env
 

--- a/.travis/env
+++ b/.travis/env
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 FAMILY=quay.io/azavea
 

--- a/.travis/publish
+++ b/.travis/publish
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 source .travis/env
 


### PR DESCRIPTION
I noticed after https://github.com/azavea/raster-vision/pull/215 that there was a travis [failure to push the images up](https://travis-ci.org/azavea/raster-vision/builds/382979908#L1789)

![screenshot from 2018-05-25 10-41-42](https://user-images.githubusercontent.com/898060/40550524-53caeab8-6008-11e8-8a5a-8dbe35a1e8c3.png)

and there weren't updated images in quay
![screenshot from 2018-05-25 10-42-10](https://user-images.githubusercontent.com/898060/40550538-5c5a75c2-6008-11e8-8c15-9f3c09febc6a.png)

I don't know the exact problem, but exiting on a failed command should help debug potentially