### PR TITLE
Travis: Use only 7 characters of commit hash for deploy

### DIFF
--- a/.travis/deploy
+++ b/.travis/deploy
@@ -5,8 +5,10 @@ if [ "$QUAY_USERNAME" != "" -a "$QUAY_PASSWORD" != "" ]; then
     if [ -z "${TRAVIS_TAG}" ]; then
         if [ "$TRAVIS_BRANCH" == "develop" ]; then
             echo "INFO: Push to develop branch, publishing commit and latest tags";
+            # Only use the first 7 characters of the commit hash
+            COMMIT=${TRAVIS_COMMIT:0:7}
             .travis/build "BUILD_ALL" && \
-                .travis/publish "$TRAVIS_COMMIT" "TRUE";
+                .travis/publish "$COMMIT" "TRUE";
         else
             echo "INFO: non-tag branch is not 'develop', skipping publish";
         fi


### PR DESCRIPTION
In what is hopefully the last PR for a while in the sequence of #215, #265 and #267, this change will only use 7 characters from the commit hash as a docker tag suffix.