### PR TITLE
Use labels that cover raster source

### DIFF
--- a/src/rastervision/builders/label_store_builder.py
+++ b/src/rastervision/builders/label_store_builder.py
@@ -8,7 +8,7 @@ def build(config, crs_transformer, extent, class_map, writable=False):
     label_store_type = config.WhichOneof('label_store_type')
     if label_store_type == 'object_detection_geojson_file':
         return ObjectDetectionGeoJSONFile(
-            config.object_detection_geojson_file.uri, crs_transformer,
+            config.object_detection_geojson_file.uri, crs_transformer, extent,
             class_map, writable=writable)
     elif label_store_type == 'classification_geojson_file':
         return ClassificationGeoJSONFile(

--- a/src/rastervision/label_stores/classification_geojson_file.py
+++ b/src/rastervision/label_stores/classification_geojson_file.py
@@ -111,7 +111,7 @@ def load_geojson(geojson, crs_transformer, extent, options):
         # Use the ObjectDetectionLabels to parse bounding boxes out of the
         # GeoJSON.
         od_labels = ObjectDetectionLabels.from_geojson(
-            geojson, crs_transformer)
+            geojson, crs_transformer, extent)
         labels = convert_labels(od_labels, extent, options)
 
     return labels

--- a/src/rastervision/label_stores/object_detection_geojson_file.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file.py
@@ -12,7 +12,7 @@ class ObjectDetectionGeoJSONFile(ObjectDetectionLabelStore):
     # TODO allow null crs_transformer for when we assume that the labels
     # are already in the crs and don't need to be converted.
 
-    def __init__(self, uri, crs_transformer, class_map, writable=False):
+    def __init__(self, uri, crs_transformer, extent, class_map, writable=False):
         self.uri = uri
         self.crs_transformer = crs_transformer
         self.class_map = class_map
@@ -23,7 +23,7 @@ class ObjectDetectionGeoJSONFile(ObjectDetectionLabelStore):
             geojson = json.loads(file_to_str(uri))
             geojson = add_classes_to_geojson(geojson, class_map)
             self.labels = ObjectDetectionLabels.from_geojson(
-                geojson, crs_transformer)
+                geojson, crs_transformer, extent)
         except:
             if self.writable or not self.uri:
                 self.labels = ObjectDetectionLabels.make_empty()

--- a/src/rastervision/ml_tasks/object_detection.py
+++ b/src/rastervision/ml_tasks/object_detection.py
@@ -25,7 +25,7 @@ def save_debug_image(im, labels, class_map, output_path):
 def _make_chip_pos_windows(image_extent, label_store, options):
     chip_size = options.chip_size
     pos_windows = []
-    for box in label_store.get_all_labels().get_intersection_boxes(image_extent):
+    for box in label_store.get_all_labels().get_boxes():
         window = box.make_random_square_container(
             image_extent.get_width(), image_extent.get_height(), chip_size)
         pos_windows.append(window)
@@ -36,7 +36,7 @@ def _make_chip_pos_windows(image_extent, label_store, options):
 def _make_label_pos_windows(image_extent, label_store, options):
     label_buffer = options.object_detection_options.label_buffer
     pos_windows = []
-    for box in label_store.get_all_labels().get_intersection_boxes(image_extent):
+    for box in label_store.get_all_labels().get_boxes():
         window = box.make_buffer(label_buffer, image_extent)
         pos_windows.append(window)
 
@@ -44,7 +44,6 @@ def _make_label_pos_windows(image_extent, label_store, options):
 
 
 def make_pos_windows(image_extent, label_store, options):
-
     window_method = options.object_detection_options.window_method
 
     if window_method == 'label':
@@ -76,7 +75,6 @@ def make_neg_windows(raster_source, label_store, chip_size, nb_windows,
 
 
 class ObjectDetection(MLTask):
-
     def get_train_windows(self, scene, options):
         raster_source = scene.raster_source
         label_store = scene.ground_truth_label_store


### PR DESCRIPTION
This PR makes it so that that the labels for a scene are the subset of the labels in the label store that cover the raster source. This makes it easier to split a raster up and use the parts individually because it is no longer necessary to also have to split up the label file. This functionality was already partially implemented, but only worked for `make_training_chips` and not `predict`. The subsetting now occurs at the point where the label file is parsed which makes it apply to all the commands.

This was tested with a split version of the `cowc-potsdam-test`. 
```
{
    "train_scenes": [
        {
            "id": "2-10-crop1",
            "raster_source": {
                "geotiff_files": {
                    "uris": [
                        "{rv_root}/processed-data/cowc-potsdam-test-split/2-10-crop1.tif"
                    ]
                }
            },
            "ground_truth_label_store": {
                "object_detection_geojson_file": {
                    "uri": "{rv_root}/processed-data/cowc-potsdam-test-split/2-10.json"
                }
            }
        }
    ],
    "test_scenes": [
        {
            "id": "2-10-crop2",
            "raster_source": {
                "geotiff_files": {
                    "uris": [
                        "{rv_root}/processed-data/cowc-potsdam-test-split/2-10-crop2.tif"
                    ]
                }
            },
            "ground_truth_label_store": {
                "object_detection_geojson_file": {
                    "uri": "{rv_root}/processed-data/cowc-potsdam-test-split/2-10.json"
                }
            }
        }
    ],
```
