### PR TITLE
Pin dependencies to minor versions

### DIFF
--- a/src/scripts/install_deps
+++ b/src/scripts/install_deps
@@ -2,8 +2,8 @@
 set -ex
 
 apt-get update
-apt-get install -y wget=1.17.1-1ubuntu1.4 git=1:2.7.4-0ubuntu1.3 \
-    python-protobuf=2.6.1-1.3 python3-tk=3.5.1-1
+apt-get install -y wget=1.* git=1:2.* \
+    python-protobuf=2.* python3-tk=3.*
 
 # Install protoc
 wget -O /tmp/protoc3.zip https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip
@@ -14,17 +14,17 @@ rm -R /tmp/protoc3
 rm /tmp/protoc3.zip
 
 # Install Python deps
-pip install keras==2.1.6 flake8==3.5.0 awscli==1.15.26 lxml==4.2.1 \
-    shapely==1.6.4 boto3==1.6.0 pyproj==1.9.5.1 imageio==2.3.0 \
-    scikit-learn==0.19.1 six==1.11.0 h5py==2.7.1 matplotlib==2.1.2 \
-    pillow==5.0.0 click==6.7 npstreams==1.4.0
+pip install keras==2.1.* flake8==3.5.* awscli==1.15.* lxml==4.2.* \
+    shapely==1.6.* boto3==1.6.* pyproj==1.9.5.* imageio==2.3.* \
+    scikit-learn==0.19.* six==1.11.* h5py==2.7.* matplotlib==2.1.* \
+    pillow==5.0.* click==6.* npstreams==1.4.*
 
 # Install Rasterio
 add-apt-repository ppa:ubuntugis/ppa
 apt-get update
-apt-get install -y python-numpy=1:1.11.0-1ubuntu1 gdal-bin=2.1.3+dfsg-1~xenial2 \
-    libgdal-dev=2.1.3+dfsg-1~xenial2
-pip install rasterio==0.36.0
+apt-get install -y python-numpy=1:1.11.* gdal-bin=2.1.* \
+    libgdal-dev=2.1.*
+pip install rasterio==0.36.*
 
 # Install TF Object Detection API in /opt/tf-models
 mkdir -p /opt/tf-models/temp/
@@ -39,5 +39,5 @@ mv models/research/slim/ ../slim
 cd ..
 rm -R temp
 protoc object_detection/protos/*.proto --python_out=.
-pip install cython==0.28.2
-pip install pycocotools==2.0.0
+pip install cython==0.28.*
+pip install pycocotools==2.0.*

--- a/src/scripts/install_deps
+++ b/src/scripts/install_deps
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 apt-get update
 apt-get install -y wget=1.17.1-1ubuntu1.4 git=1:2.7.4-0ubuntu1.3 \


### PR DESCRIPTION
# Overview

Use wildcard notation to pin all dependencies to a minor version. This ensures that patch updates don't break builds. Additionally, enable `pipefail` behavior on `src/scripts/install_deps` so that any failed dependency installation fails the build. This ensures that the images we push up to quay have built properly.

# Testing
- See Travis build checks
- Apply the following diff, then run `.travis/build`. Ensure that the build exits with an error.
```diff
diff --git a/src/scripts/install_deps b/src/scripts/install_deps
index d6901b0..621d283 100755
--- a/src/scripts/install_deps
+++ b/src/scripts/install_deps
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 
+exit 1
+
 apt-get update
 apt-get install -y wget=1.* git=1:2.* \
     python-protobuf=2.* python3-tk=3.*
```

# Notes
I'm open to unpinning `git` and `wget` versions, but I imagine `python-protobuf` and `python3-tk` need to stay pinned.