### PR TITLE
Upgrade TF to 1.8

### DIFF
--- a/src/Dockerfile-cpu
+++ b/src/Dockerfile-cpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.5.0-py3
+FROM tensorflow/tensorflow:1.8.0-py3
 
 # Everything below this line is common between CPU and GPU images.
 

--- a/src/Dockerfile-gpu
+++ b/src/Dockerfile-gpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.5.0-gpu-py3
+FROM tensorflow/tensorflow:1.8.0-gpu-py3
 
 # Everything below this line is common between CPU and GPU images.
 


### PR DESCRIPTION
Upgrading to TF 1.8  seems to fix an intermittent bug in the frozen graph exporter. After this upgrade, I did notice that there are more warning messages about running out of memory, but I *think* they're benign. The GPU Docker image on ECR has this update.

Test with something like
```
#!/bin/bash

set -e

COUNT=1
while true; do
    rm -rf /opt/data/lf-dev/rv-output/raw-datasets/tiny-test/datasets/object-detection/models/default/output/saved_model/

    echo "Run number $COUNT"
    let "COUNT++"
    python /opt/tf-models/object_detection/export_inference_graph.py \
        --input_type image_tensor --pipeline_config_path /opt/data/lf-dev/rv-output/raw-datasets/tiny-test/datasets/object-detection/models/default/backend.config \
        --trained_checkpoint_prefix /opt/data/lf-dev/rv-output/raw-datasets/tiny-test/datasets/object-detection/models/default/output/train/model.ckpt-4 \
        --output_directory /opt/data/lf-dev/rv-output/raw-datasets/tiny-test/datasets/object-detection/models/default/output
done
```

Connects #285 