### PR TITLE
Clarify crs_transformer naming

### DIFF
--- a/src/rastervision/core/crs_transformer.py
+++ b/src/rastervision/core/crs_transformer.py
@@ -2,26 +2,28 @@ from abc import ABC, abstractmethod
 
 
 class CRSTransformer(object):
-    """Converts points between CRSs for a RasterSource."""
+    """Transforms map points in some CRS into pixel coordinates.
 
-    def web_to_pixel(self, web_point):
-        """Return point in pixel coordinates.
+    Each transformer is associated with a particular RasterSource."""
+
+    def map_to_pixel(self, map_point):
+        """Transform point from map to pixel-based coordinates.
 
         Args:
-            web_point: tuple (long, lat) in WebMercator coordinates
+            map_point: (x, y) tuple in map coordinates (eg. lon/lat)
 
         Returns:
-            tuple (x, y) in pixel coordinates
+            (x, y) tuple in pixel coordinates
         """
         pass
 
-    def pixel_to_web(self, pixel_point):
-        """Return point in Web Mercator coordinates.
+    def pixel_to_map(self, pixel_point):
+        """Transform point from pixel to map-based coordinates.
 
         Args:
-            pixel_point: tuple (x, y) in pixel coordinates
+            pixel_point: (x, y) tuple in pixel coordinates
 
         Returns:
-            tuple (long, lat) in WebMercator coordinates
+            (x, y) tuple in map coordinates (eg. lon/lat)
         """
         pass

--- a/src/rastervision/crs_transformers/identity_crs_transformer.py
+++ b/src/rastervision/crs_transformers/identity_crs_transformer.py
@@ -2,8 +2,28 @@ from rastervision.core.crs_transformer import CRSTransformer
 
 
 class IdentityCRSTransformer(CRSTransformer):
-    def web_to_pixel(self, web_point):
-        return web_point
+    """Transformer for when map coordinates are already in pixel coordinates.
 
-    def pixel_to_web(self, pixel_point):
+    This is useful for non-georeferenced imagery.
+    """
+    def map_to_pixel(self, map_point):
+        """Identity function.
+
+        Args:
+            map_point: (x, y) tuple in pixel coordinates
+
+        Returns:
+            (x, y) tuple in pixel coordinates
+        """
+        return map_point
+
+    def pixel_to_map(self, pixel_point):
+        """Identity function.
+
+        Args:
+            pixel_point: (x, y) tuple in pixel coordinates
+
+        Returns:
+            (x, y) tuple in pixel coordinates
+        """
         return pixel_point

--- a/src/rastervision/crs_transformers/rasterio_crs_transformer.py
+++ b/src/rastervision/crs_transformers/rasterio_crs_transformer.py
@@ -4,19 +4,17 @@ from rastervision.core.crs_transformer import CRSTransformer
 
 
 class RasterioCRSTransformer(CRSTransformer):
-    """Transformer for a RasterioRasterSource.
+    """Transformer for a RasterioRasterSource."""
 
-    This assumes that the map coordinates are always in lon/lat format.
-    """
-
-    def __init__(self, image_dataset):
+    def __init__(self, image_dataset, map_crs='epsg:4326'):
         """Construct transformer.
 
         Args:
             image_dataset: Rasterio DatasetReader
+            map_crs: CRS code
         """
         self.image_dataset = image_dataset
-        self.map_proj = pyproj.Proj(init='epsg:4326')
+        self.map_proj = pyproj.Proj(init=map_crs)
         image_crs = image_dataset.crs['init']
         self.image_proj = pyproj.Proj(init=image_crs)
 
@@ -24,7 +22,7 @@ class RasterioCRSTransformer(CRSTransformer):
         """Transform point from map to pixel-based coordinates.
 
         Args:
-            map_point: (long, lat) tuple
+            map_point: (x, y) tuple in map coordinates
 
         Returns:
             (x, y) tuple in pixel coordinates
@@ -42,7 +40,7 @@ class RasterioCRSTransformer(CRSTransformer):
             pixel_point: (x, y) tuple in pixel coordinates
 
         Returns:
-            (lon, lat) tuple
+            (x, y) tuple in map coordinates
         """
         image_point = self.image_dataset.ul(
             int(pixel_point[1]), int(pixel_point[0]))

--- a/src/rastervision/crs_transformers/rasterio_crs_transformer.py
+++ b/src/rastervision/crs_transformers/rasterio_crs_transformer.py
@@ -4,22 +4,48 @@ from rastervision.core.crs_transformer import CRSTransformer
 
 
 class RasterioCRSTransformer(CRSTransformer):
+    """Transformer for a RasterioRasterSource.
+
+    This assumes that the map coordinates are always in lon/lat format.
+    """
+
     def __init__(self, image_dataset):
+        """Construct transformer.
+
+        Args:
+            image_dataset: Rasterio DatasetReader
+        """
         self.image_dataset = image_dataset
-        self.web_proj = pyproj.Proj(init='epsg:4326')
+        self.map_proj = pyproj.Proj(init='epsg:4326')
         image_crs = image_dataset.crs['init']
         self.image_proj = pyproj.Proj(init=image_crs)
 
-    def web_to_pixel(self, web_point):
+    def map_to_pixel(self, map_point):
+        """Transform point from map to pixel-based coordinates.
+
+        Args:
+            map_point: (long, lat) tuple
+
+        Returns:
+            (x, y) tuple in pixel coordinates
+        """
         image_point = pyproj.transform(
-            self.web_proj, self.image_proj, web_point[0], web_point[1])
+            self.map_proj, self.image_proj, map_point[0], map_point[1])
         pixel_point = self.image_dataset.index(image_point[0], image_point[1])
         pixel_point = (pixel_point[1], pixel_point[0])
         return pixel_point
 
-    def pixel_to_web(self, pixel_point):
+    def pixel_to_map(self, pixel_point):
+        """Transform point from pixel to map-based coordinates.
+
+        Args:
+            pixel_point: (x, y) tuple in pixel coordinates
+
+        Returns:
+            (lon, lat) tuple
+        """
         image_point = self.image_dataset.ul(
             int(pixel_point[1]), int(pixel_point[0]))
-        web_point = pyproj.transform(
-            self.image_proj, self.web_proj, image_point[0], image_point[1])
-        return web_point
+        map_point = pyproj.transform(
+            self.image_proj, self.map_proj, image_point[0], image_point[1])
+        return map_point

--- a/src/rastervision/label_stores/classification_geojson_file.py
+++ b/src/rastervision/label_stores/classification_geojson_file.py
@@ -22,7 +22,7 @@ def get_str_tree(geojson, crs_transformer):
     for feature in features:
         # Convert polygon to pixel coords.
         polygon = feature['geometry']['coordinates'][0]
-        polygon = [crs_transformer.web_to_pixel(p) for p in polygon]
+        polygon = [crs_transformer.map_to_pixel(p) for p in polygon]
         json_polygons.append(polygon)
 
         properties = feature.get('properties', {})

--- a/src/rastervision/labels/object_detection_labels.py
+++ b/src/rastervision/labels/object_detection_labels.py
@@ -20,7 +20,7 @@ def geojson_to_labels(geojson, crs_transformer, extent):
     for feature in features:
         # Convert polygon to pixel coords and then convert to bounding box.
         polygon = feature['geometry']['coordinates'][0]
-        polygon = [crs_transformer.web_to_pixel(p) for p in polygon]
+        polygon = [crs_transformer.map_to_pixel(p) for p in polygon]
         xmin, ymin = np.min(polygon, axis=0)
         xmax, ymax = np.max(polygon, axis=0)
         boxes.append(Box(ymin, xmin, ymax, xmax))

--- a/src/rastervision/labels/utils.py
+++ b/src/rastervision/labels/utils.py
@@ -2,7 +2,7 @@ def boxes_to_geojson(boxes, class_ids, crs_transformer, class_map, scores=None):
     features = []
     for box_ind, box in enumerate(boxes):
         polygon = box.geojson_coordinates()
-        polygon = [crs_transformer.pixel_to_web(p) for p in polygon]
+        polygon = [crs_transformer.pixel_to_map(p) for p in polygon]
 
         class_id = class_ids[box_ind]
         class_name = class_map.get_by_id(class_id).name


### PR DESCRIPTION
This PR changes `web` to `map` in crs_transformer method and variable names and adds more comments. This is to reflect the fact that map-based coordinates are not necessarily in web mercator.

Closes #294