### PR TITLE
Restore Debug Chips

### DIFF
--- a/src/rastervision/labels/object_detection_labels.py
+++ b/src/rastervision/labels/object_detection_labels.py
@@ -55,7 +55,7 @@ class ObjectDetectionLabels(Labels):
         # We need to ensure that there is always a scores field so that the
         # concatenate method will work with empty labels objects.
         if scores is None:
-            scores = np.zeros(class_ids.shape)
+            scores = np.ones(class_ids.shape)
         self.boxlist.add_field('scores', scores)
 
     @staticmethod


### PR DESCRIPTION
This recovers the behavior that existed prior to https://github.com/azavea/raster-vision/commit/f7b279a6fcca0fce1d1ab84d5937ca33c1782408 (c.f. the behavior of [`save_debug_image`](https://github.com/jamesmcclain/raster-vision/blob/develop/src/rastervision/ml_tasks/object_detection.py#L15-L16) when `'scores'` is `None` [which was the case in the tutorial prior to the diff listed below]).

```diff
         # This field name actually needs to be 'classes' to be able to use
         # certain utility functions in the TF Object Detection API.
         self.boxlist.add_field('classes', class_ids)
-        if scores is not None:
-            self.boxlist.add_field('scores', scores)
+        # We need to ensure that there is always a scores field so that the
+        # concatenate method will work with empty labels objects.
+        if scores is None:
+            scores = np.zeros(class_ids.shape)
+        self.boxlist.add_field('scores', scores)
 
     @staticmethod
     def from_boxlist(boxlist):
```

Connects https://github.com/azavea/raster-vision/issues/319