### PR TITLE
Add code formatter, style tests, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+### Checklist
+
+- [ ] Ran scripts/format_code and commited any changes
+- [ ] Documentation updated if needed
+- [ ] PR has a name that won't get you publicly shamed for vagueness
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+## Testing Instructions
+
+* How to test this PR
+* Prefer bulleted description
+* Start after checking out this branch
+* Include any setup required, such as rebuilding the Docker image.
+* Include test case, and expected output if not captured by automated tests.
+
+Closes #XXX

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
    - .travis/build
    - docker run --rm -it raster-vision-cpu /opt/src/scripts/unit_tests
    - docker run --rm -it raster-vision-cpu /opt/src/scripts/integration_tests.py
+   - docker run --rm -it raster-vision-cpu /opt/src/scripts/style_tests
 
 deploy:
    - provider: script

--- a/src/keras_classification/builders/model_builder.py
+++ b/src/keras_classification/builders/model_builder.py
@@ -15,15 +15,15 @@ def build(model_options):
         return build_from_path(model_options.model_path)
 
     nb_channels = 3
-    input_shape = (model_options.input_size,
-                   model_options.input_size,
+    input_shape = (model_options.input_size, model_options.input_size,
                    nb_channels)
     activation = 'softmax'
     weights = 'imagenet'
 
     if model_options.type == Model.Type.Value('RESNET50'):
         model = ResNet50(
-            include_top=True, weights=weights,
+            include_top=True,
+            weights=weights,
             input_shape=input_shape,
             classes=model_options.nb_classes,
             activation=activation)

--- a/src/keras_classification/builders/optimizer_builder.py
+++ b/src/keras_classification/builders/optimizer_builder.py
@@ -7,8 +7,7 @@ def build(optimizer_options):
     if optimizer_options.type == Optimizer.Type.Value('ADAM'):
         optimizer = keras.optimizers.Adam(lr=optimizer_options.init_lr)
     else:
-        raise ValueError(
-            (Optimizer.Type.Name(optimizer_options.type) +
-             ' is not a valid optimizer type'))
+        raise ValueError((Optimizer.Type.Name(optimizer_options.type) +
+                          ' is not a valid optimizer type'))
 
     return optimizer

--- a/src/keras_classification/core/trainer.py
+++ b/src/keras_classification/core/trainer.py
@@ -32,15 +32,12 @@ class Trainer(object):
         self.log_path = os.path.join(options.output_dir, 'log.csv')
         make_dir(self.log_path, use_dirname=True)
 
-        self.training_gen = self.make_data_generator(
-            options.training_data_dir)
+        self.training_gen = self.make_data_generator(options.training_data_dir)
         self.validation_gen = self.make_data_generator(
             options.validation_data_dir, validation_mode=True)
 
-        self.nb_training_samples = get_nb_images(
-            options.training_data_dir)
-        self.nb_validation_samples = get_nb_images(
-            options.validation_data_dir)
+        self.nb_training_samples = get_nb_images(options.training_data_dir)
+        self.nb_validation_samples = get_nb_images(options.validation_data_dir)
 
     def make_callbacks(self):
         model_checkpoint = keras.callbacks.ModelCheckpoint(
@@ -52,6 +49,7 @@ class Trainer(object):
         if self.options.lr_schedule:
             lr_schedule = sorted(
                 self.options.lr_schedule, key=lambda x: x.epoch, reverse=True)
+
             def schedule(curr_epoch):
                 for lr_schedule_item in lr_schedule:
                     if curr_epoch >= lr_schedule_item.epoch:
@@ -81,12 +79,10 @@ class Trainer(object):
         # Don't apply randomized data transforms if in validation mode.
         # This will make the validation scores more comparable between epochs.
         if validation_mode:
-            generator = ImageDataGenerator(rescale=1./255)
+            generator = ImageDataGenerator(rescale=1. / 255)
         else:
             generator = ImageDataGenerator(
-                rescale=1./255,
-                horizontal_flip=True,
-                vertical_flip=True)
+                rescale=1. / 255, horizontal_flip=True, vertical_flip=True)
 
         generator = generator.flow_from_directory(
             image_folder_dir,

--- a/src/keras_classification/models/resnet50.py
+++ b/src/keras_classification/models/resnet50.py
@@ -31,7 +31,6 @@ from keras.utils.data_utils import get_file
 from keras.applications.imagenet_utils import (
     decode_predictions, preprocess_input, _obtain_input_shape)
 
-
 WEIGHTS_PATH = 'https://github.com/fchollet/deep-learning-models/releases/download/v0.2/resnet50_weights_tf_dim_ordering_tf_kernels.h5'
 WEIGHTS_PATH_NO_TOP = 'https://github.com/fchollet/deep-learning-models/releases/download/v0.2/resnet50_weights_tf_dim_ordering_tf_kernels_notop.h5'
 
@@ -54,14 +53,14 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
         bn_axis = 1
     conv_name_base = 'res' + str(stage) + block + '_branch'
     bn_name_base = 'bn' + str(stage) + block + '_branch'
-    act_name = 'act' + str(stage)+ block
+    act_name = 'act' + str(stage) + block
 
     x = Conv2D(filters1, (1, 1), name=conv_name_base + '2a')(input_tensor)
     x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2a')(x)
     x = Activation('relu')(x)
 
-    x = Conv2D(filters2, kernel_size,
-               padding='same', name=conv_name_base + '2b')(x)
+    x = Conv2D(
+        filters2, kernel_size, padding='same', name=conv_name_base + '2b')(x)
     x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2b')(x)
     x = Activation('relu')(x)
 
@@ -73,7 +72,12 @@ def identity_block(input_tensor, kernel_size, filters, stage, block):
     return x
 
 
-def conv_block(input_tensor, kernel_size, filters, stage, block, strides=(2, 2)):
+def conv_block(input_tensor,
+               kernel_size,
+               filters,
+               stage,
+               block,
+               strides=(2, 2)):
     """conv_block is the block that has a conv layer at shortcut
     # Arguments
         input_tensor: input tensor
@@ -95,31 +99,38 @@ def conv_block(input_tensor, kernel_size, filters, stage, block, strides=(2, 2))
     bn_name_base = 'bn' + str(stage) + block + '_branch'
     act_name = 'act' + str(stage) + block
 
-    x = Conv2D(filters1, (1, 1), strides=strides,
-               name=conv_name_base + '2a')(input_tensor)
+    x = Conv2D(
+        filters1, (1, 1), strides=strides,
+        name=conv_name_base + '2a')(input_tensor)
     x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2a')(x)
     x = Activation('relu')(x)
 
-    x = Conv2D(filters2, kernel_size, padding='same',
-               name=conv_name_base + '2b')(x)
+    x = Conv2D(
+        filters2, kernel_size, padding='same', name=conv_name_base + '2b')(x)
     x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2b')(x)
     x = Activation('relu')(x)
 
     x = Conv2D(filters3, (1, 1), name=conv_name_base + '2c')(x)
     x = BatchNormalization(axis=bn_axis, name=bn_name_base + '2c')(x)
 
-    shortcut = Conv2D(filters3, (1, 1), strides=strides,
-                      name=conv_name_base + '1')(input_tensor)
-    shortcut = BatchNormalization(axis=bn_axis, name=bn_name_base + '1')(shortcut)
+    shortcut = Conv2D(
+        filters3, (1, 1), strides=strides,
+        name=conv_name_base + '1')(input_tensor)
+    shortcut = BatchNormalization(
+        axis=bn_axis, name=bn_name_base + '1')(shortcut)
 
     x = layers.add([x, shortcut])
     x = Activation('relu', name=act_name)(x)
     return x
 
 
-def ResNet50(include_top=True, weights='imagenet',
-             input_tensor=None, input_shape=None,
-             pooling=None, classes=1000, activation='softmax'):
+def ResNet50(include_top=True,
+             weights='imagenet',
+             input_tensor=None,
+             input_shape=None,
+             pooling=None,
+             classes=1000,
+             activation='softmax'):
     """Instantiates the ResNet50 architecture.
     Optionally loads weights pre-trained
     on ImageNet.
@@ -217,10 +228,11 @@ def ResNet50(include_top=True, weights='imagenet',
 
     # load weights
     if weights == 'imagenet':
-        weights_path = get_file('resnet50_weights_tf_dim_ordering_tf_kernels_notop.h5',
-                                WEIGHTS_PATH_NO_TOP,
-                                cache_subdir='models',
-                                md5_hash='a268eb855778b3df3c7506639542a6af')
+        weights_path = get_file(
+            'resnet50_weights_tf_dim_ordering_tf_kernels_notop.h5',
+            WEIGHTS_PATH_NO_TOP,
+            cache_subdir='models',
+            md5_hash='a268eb855778b3df3c7506639542a6af')
         model.load_weights(weights_path, by_name=True)
 
     return model

--- a/src/keras_classification/utils.py
+++ b/src/keras_classification/utils.py
@@ -1,4 +1,3 @@
-from urllib.parse import urlparse
 import os
 import shutil
 

--- a/src/rastervision/builders/eval_builder.py
+++ b/src/rastervision/builders/eval_builder.py
@@ -1,5 +1,4 @@
-from rastervision.builders import (
-    scene_builder, ml_task_builder)
+from rastervision.builders import (scene_builder, ml_task_builder)
 from rastervision.utils import files
 from rastervision.commands.eval import Eval
 from rastervision.protos.eval_pb2 import EvalConfig
@@ -11,8 +10,11 @@ def build(config):
 
     ml_task = ml_task_builder.build(config.machine_learning)
     class_map = ml_task.get_class_map()
-    scenes = [scene_builder.build(scene_config, class_map, predictions_readable=True)
-              for scene_config in config.scenes]
+    scenes = [
+        scene_builder.build(
+            scene_config, class_map, predictions_readable=True)
+        for scene_config in config.scenes
+    ]
     options = config.options
 
     return Eval(scenes, ml_task, options)

--- a/src/rastervision/builders/label_store_builder.py
+++ b/src/rastervision/builders/label_store_builder.py
@@ -4,15 +4,27 @@ from rastervision.label_stores.classification_geojson_file import (
     ClassificationGeoJSONFile)
 
 
-def build(config, crs_transformer, extent, class_map, readable=True,
+def build(config,
+          crs_transformer,
+          extent,
+          class_map,
+          readable=True,
           writable=False):
     label_store_type = config.WhichOneof('label_store_type')
     if label_store_type == 'object_detection_geojson_file':
         return ObjectDetectionGeoJSONFile(
-            config.object_detection_geojson_file.uri, crs_transformer,
-            class_map, extent=extent, readable=readable, writable=writable)
+            config.object_detection_geojson_file.uri,
+            crs_transformer,
+            class_map,
+            extent=extent,
+            readable=readable,
+            writable=writable)
     elif label_store_type == 'classification_geojson_file':
         return ClassificationGeoJSONFile(
-            config.classification_geojson_file.uri, crs_transformer,
-            config.classification_geojson_file.options, class_map,
-            extent, readable=readable, writable=writable)
+            config.classification_geojson_file.uri,
+            crs_transformer,
+            config.classification_geojson_file.options,
+            class_map,
+            extent,
+            readable=readable,
+            writable=writable)

--- a/src/rastervision/builders/make_training_chips_builder.py
+++ b/src/rastervision/builders/make_training_chips_builder.py
@@ -1,5 +1,4 @@
-from rastervision.builders import (
-    scene_builder, ml_task_builder)
+from rastervision.builders import (scene_builder, ml_task_builder)
 from rastervision.utils import files
 from rastervision.commands.make_training_chips import MakeTrainingChips
 from rastervision.protos.make_training_chips_pb2 import MakeTrainingChipsConfig
@@ -11,11 +10,14 @@ def build(config):
 
     ml_task = ml_task_builder.build(config.machine_learning)
     class_map = ml_task.get_class_map()
-    train_scenes = [scene_builder.build(scene_config, class_map)
-                    for scene_config in config.train_scenes]
-    validation_scenes = [scene_builder.build(scene_config, class_map)
-                         for scene_config in config.validation_scenes]
+    train_scenes = [
+        scene_builder.build(scene_config, class_map)
+        for scene_config in config.train_scenes
+    ]
+    validation_scenes = [
+        scene_builder.build(scene_config, class_map)
+        for scene_config in config.validation_scenes
+    ]
     options = config.options
 
-    return MakeTrainingChips(train_scenes, validation_scenes, ml_task,
-                             options)
+    return MakeTrainingChips(train_scenes, validation_scenes, ml_task, options)

--- a/src/rastervision/builders/ml_task_builder.py
+++ b/src/rastervision/builders/ml_task_builder.py
@@ -1,4 +1,5 @@
-from rastervision.ml_backends.tf_object_detection_api import TFObjectDetectionAPI
+from rastervision.ml_backends.tf_object_detection_api import (
+    TFObjectDetectionAPI)
 from rastervision.ml_tasks.object_detection import ObjectDetection
 from rastervision.ml_backends.keras_classification import KerasClassification
 from rastervision.ml_tasks.classification import Classification

--- a/src/rastervision/builders/predict_builder.py
+++ b/src/rastervision/builders/predict_builder.py
@@ -1,5 +1,4 @@
-from rastervision.builders import (
-    scene_builder, ml_task_builder)
+from rastervision.builders import (scene_builder, ml_task_builder)
 from rastervision.utils import files
 from rastervision.commands.predict import Predict
 from rastervision.protos.predict_pb2 import PredictConfig
@@ -11,8 +10,10 @@ def build(config):
 
     ml_task = ml_task_builder.build(config.machine_learning)
     class_map = ml_task.get_class_map()
-    scenes = [scene_builder.build(scene_config, class_map)
-              for scene_config in config.scenes]
+    scenes = [
+        scene_builder.build(scene_config, class_map)
+        for scene_config in config.scenes
+    ]
     options = config.options
 
     return Predict(scenes, ml_task, options)

--- a/src/rastervision/builders/scene_builder.py
+++ b/src/rastervision/builders/scene_builder.py
@@ -14,13 +14,21 @@ def build(config, class_map, predictions_readable=False):
 
     if config.HasField('ground_truth_label_store'):
         ground_truth_label_store = label_store_builder.build(
-            config.ground_truth_label_store, crs_transformer, extent,
-            class_map, readable=True, writable=False)
+            config.ground_truth_label_store,
+            crs_transformer,
+            extent,
+            class_map,
+            readable=True,
+            writable=False)
 
     if config.HasField('prediction_label_store'):
         prediction_label_store = label_store_builder.build(
-            config.prediction_label_store, crs_transformer, extent,
-            class_map, readable=predictions_readable, writable=True)
+            config.prediction_label_store,
+            crs_transformer,
+            extent,
+            class_map,
+            readable=predictions_readable,
+            writable=True)
 
     return Scene(
         id=config.id,

--- a/src/rastervision/commands/eval.py
+++ b/src/rastervision/commands/eval.py
@@ -2,7 +2,6 @@ from rastervision.core.command import Command
 
 
 class Eval(Command):
-
     def __init__(self, scenes, ml_task, options):
         self.scenes = scenes
         self.ml_task = ml_task

--- a/src/rastervision/commands/make_training_chips.py
+++ b/src/rastervision/commands/make_training_chips.py
@@ -2,14 +2,12 @@ from rastervision.core.command import Command
 
 
 class MakeTrainingChips(Command):
-
-    def __init__(self, train_scenes, validation_scenes, ml_task,
-                 options):
+    def __init__(self, train_scenes, validation_scenes, ml_task, options):
         self.train_scenes = train_scenes
         self.validation_scenes = validation_scenes
         self.ml_task = ml_task
         self.options = options
 
     def run(self):
-        self.ml_task.make_training_chips(
-            self.train_scenes, self.validation_scenes, self.options)
+        self.ml_task.make_training_chips(self.train_scenes,
+                                         self.validation_scenes, self.options)

--- a/src/rastervision/commands/predict.py
+++ b/src/rastervision/commands/predict.py
@@ -2,7 +2,6 @@ from rastervision.core.command import Command
 
 
 class Predict(Command):
-
     def __init__(self, scenes, ml_task, options):
         self.scenes = scenes
         self.ml_task = ml_task

--- a/src/rastervision/contrib/cowc/prepare_potsdam.py
+++ b/src/rastervision/contrib/cowc/prepare_potsdam.py
@@ -11,8 +11,7 @@ from object_detection.utils.np_box_list import BoxList
 from rv.utils import save_geojson, make_empty_dir
 
 
-def png_to_geojson(geotiff_path, label_png_path, output_path,
-                   object_half_len):
+def png_to_geojson(geotiff_path, label_png_path, output_path, object_half_len):
     """Convert COWC PNG labels to GeoJSON format.
 
     In the COWC dataset, the center position of cars is represented as
@@ -34,14 +33,14 @@ def png_to_geojson(geotiff_path, label_png_path, output_path,
     point_inds = point_inds.astype(np.int)
 
     # Turn points into squares and ensure edges aren't outside the array
-    y_min = np.clip(
-        point_inds[:, 0:1] - object_half_len, 0, image_dataset.height)
-    x_min = np.clip(
-        point_inds[:, 1:2] - object_half_len, 0, image_dataset.width)
-    y_max = np.clip(
-        point_inds[:, 0:1] + object_half_len, 0, image_dataset.height)
-    x_max = np.clip(
-        point_inds[:, 1:2] + object_half_len, 0, image_dataset.width)
+    y_min = np.clip(point_inds[:, 0:1] - object_half_len, 0,
+                    image_dataset.height)
+    x_min = np.clip(point_inds[:, 1:2] - object_half_len, 0,
+                    image_dataset.width)
+    y_max = np.clip(point_inds[:, 0:1] + object_half_len, 0,
+                    image_dataset.height)
+    x_max = np.clip(point_inds[:, 1:2] + object_half_len, 0,
+                    image_dataset.width)
 
     # Write to GeoJSON
     boxes = np.hstack([y_min, x_min, y_max, x_max]).astype(np.float)
@@ -55,20 +54,22 @@ def png_to_geojson(geotiff_path, label_png_path, output_path,
 @click.argument('label_png_dir')
 @click.argument('output_dir')
 @click.option('--object-half-len', default=50)
-def prepare_potsdam(geotiff_dir, label_png_dir, output_dir,
-                    object_half_len):
-    label_paths = glob.glob(os.path.join(
-        label_png_dir, 'top_potsdam_*_RGB_Annotated_Cars.png'))
+def prepare_potsdam(geotiff_dir, label_png_dir, output_dir, object_half_len):
+    label_paths = glob.glob(
+        os.path.join(label_png_dir, 'top_potsdam_*_RGB_Annotated_Cars.png'))
     make_empty_dir(output_dir)
 
     for label_path in label_paths:
         geotiff_base = os.path.basename(label_path)[0:-19]
         geotiff_path = os.path.join(geotiff_dir, geotiff_base + 'IR.tif')
         output_path = os.path.join(output_dir, geotiff_base + 'IR.json')
-        boxlist = png_to_geojson(geotiff_path, label_path, output_path,
-                                 object_half_len=object_half_len)
-        print('Saved {} with {} boxes.'.format(
-            output_path, boxlist.num_boxes()))
+        boxlist = png_to_geojson(
+            geotiff_path,
+            label_path,
+            output_path,
+            object_half_len=object_half_len)
+        print('Saved {} with {} boxes.'.format(output_path,
+                                               boxlist.num_boxes()))
 
 
 if __name__ == '__main__':

--- a/src/rastervision/contrib/cowc/resample_geotiffs.py
+++ b/src/rastervision/contrib/cowc/resample_geotiffs.py
@@ -10,8 +10,8 @@ from rv.utils import make_empty_dir
 @click.command()
 @click.argument('input_dir')
 @click.argument('output_dir')
-@click.option('--resolution', default=0.3,
-              help='Output resolution in meters/pixel')
+@click.option(
+    '--resolution', default=0.3, help='Output resolution in meters/pixel')
 def resample_geotiffs(input_dir, output_dir, resolution):
     input_paths = glob.glob(os.path.join(input_dir, '*.tif'))
     make_empty_dir(output_dir)
@@ -19,10 +19,12 @@ def resample_geotiffs(input_dir, output_dir, resolution):
     for input_path in input_paths:
         input_filename = os.path.basename(input_path)
         subprocess.call([
-            'gdalwarp', '-tr', str(resolution), str(-resolution),
-            '-r', 'bilinear', '-setci', '-co', 'ALPHA=NO',
+            'gdalwarp', '-tr',
+            str(resolution),
+            str(-resolution), '-r', 'bilinear', '-setci', '-co', 'ALPHA=NO',
             input_path,
-            os.path.join(output_dir, input_filename)])
+            os.path.join(output_dir, input_filename)
+        ])
 
 
 if __name__ == '__main__':

--- a/src/rastervision/core/box.py
+++ b/src/rastervision/core/box.py
@@ -138,7 +138,7 @@ class Box():
     @staticmethod
     def make_square(ymin, xmin, size):
         """Return new square Box."""
-        return Box(ymin, xmin, ymin+size, xmin+size)
+        return Box(ymin, xmin, ymin + size, xmin + size)
 
     def make_eroded(self, erosion_size):
         """Return new Box whose sides are eroded by erosion_size."""
@@ -162,9 +162,10 @@ class Box():
         return Box(
             max(0, math.floor(self.ymin - delta_height)),
             max(0, math.floor(self.xmin - delta_width)),
-            min(max_extent.get_height(), int(self.ymax) + delta_height),
-            min(max_extent.get_width(), int(self.xmax) + delta_width)
-        )
+            min(max_extent.get_height(),
+                int(self.ymax) + delta_height),
+            min(max_extent.get_width(),
+                int(self.xmax) + delta_width))
 
     def make_copy(self):
         return Box(*(self.tuple_format()))

--- a/src/rastervision/core/box_test.py
+++ b/src/rastervision/core/box_test.py
@@ -101,8 +101,7 @@ class TestBox(unittest.TestCase):
         square = Box(0, 0, 10, 10)
         output_square = Box.make_square(0, 0, 10)
         self.assertEqual(output_square, square)
-        self.assertEqual(
-            output_square.get_width(), output_square.get_height())
+        self.assertEqual(output_square.get_width(), output_square.get_height())
 
     def test_make_eroded(self):
         max_extent = Box.make_square(0, 0, 10)
@@ -140,17 +139,18 @@ class TestBox(unittest.TestCase):
         self.assertEqual(len(windows), 400)
 
         extent = Box(0, 0, 20, 20)
-        windows = set([window.tuple_format()
-                       for window in extent.get_windows(10, 10)])
+        windows = set(
+            [window.tuple_format() for window in extent.get_windows(10, 10)])
         expected_windows = [
             Box.make_square(0, 0, 10),
             Box.make_square(10, 0, 10),
             Box.make_square(0, 10, 10),
             Box.make_square(10, 10, 10)
         ]
-        expected_windows = set([window.tuple_format()
-                               for window in expected_windows])
+        expected_windows = set(
+            [window.tuple_format() for window in expected_windows])
         self.assertSetEqual(windows, expected_windows)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/rastervision/core/class_map.py
+++ b/src/rastervision/core/class_map.py
@@ -1,6 +1,3 @@
-import random
-
-
 class ClassItem(object):
     """A class id and associated data."""
 

--- a/src/rastervision/core/crs_transformer.py
+++ b/src/rastervision/core/crs_transformer.py
@@ -1,6 +1,3 @@
-from abc import ABC, abstractmethod
-
-
 class CRSTransformer(object):
     """Transforms map points in some CRS into pixel coordinates.
 

--- a/src/rastervision/core/evaluation.py
+++ b/src/rastervision/core/evaluation.py
@@ -46,7 +46,8 @@ class Evaluation(ABC):
         if len(self.class_to_eval_item) == 0:
             self.class_to_eval_item = evaluation.class_to_eval_item
         else:
-            for class_id, other_eval_item in evaluation.class_to_eval_item.items():
+            for class_id, other_eval_item in evaluation.class_to_eval_item.items(
+            ):
                 self.get_by_id(class_id).merge(other_eval_item)
 
         self.compute_avg()

--- a/src/rastervision/core/evaluation.py
+++ b/src/rastervision/core/evaluation.py
@@ -46,8 +46,8 @@ class Evaluation(ABC):
         if len(self.class_to_eval_item) == 0:
             self.class_to_eval_item = evaluation.class_to_eval_item
         else:
-            for class_id, other_eval_item in evaluation.class_to_eval_item.items(
-            ):
+            for class_id, other_eval_item in \
+                    evaluation.class_to_eval_item.items():
                 self.get_by_id(class_id).merge(other_eval_item)
 
         self.compute_avg()

--- a/src/rastervision/core/evaluation_item.py
+++ b/src/rastervision/core/evaluation_item.py
@@ -4,8 +4,15 @@ class EvaluationItem(object):
     None is used for values that are undefined because they involve a division
     by zero (eg. precision when there are no predictions).
     """
-    def __init__(self, precision=None, recall=None, f1=None, count_error=None,
-                 gt_count=0, class_id=None, class_name=None):
+
+    def __init__(self,
+                 precision=None,
+                 recall=None,
+                 f1=None,
+                 count_error=None,
+                 gt_count=0,
+                 class_id=None,
+                 class_name=None):
         self.precision = precision
         self.recall = recall
         self.f1 = f1
@@ -37,8 +44,8 @@ class EvaluationItem(object):
             self.precision = weighted_avg(self.precision, other.precision)
             self.recall = weighted_avg(self.recall, other.recall)
             self.f1 = weighted_avg(self.f1, other.f1)
-            self.count_error = weighted_avg(
-                self.count_error, other.count_error)
+            self.count_error = weighted_avg(self.count_error,
+                                            other.count_error)
             self.gt_count = total_gt_count
 
     def to_json(self):

--- a/src/rastervision/core/evaluation_item_test.py
+++ b/src/rastervision/core/evaluation_item_test.py
@@ -45,11 +45,12 @@ class TestEvaluationItem(unittest.TestCase):
         b = EvaluationItem(
             precision=0, recall=0, f1=0, count_error=1, gt_count=2)
         a.merge(b)
-        self.assertEqual(a.precision, 1/3)
-        self.assertEqual(a.recall, 1/3)
-        self.assertEqual(a.f1, 1/3)
-        self.assertEqual(a.count_error, 2/3)
+        self.assertEqual(a.precision, 1 / 3)
+        self.assertEqual(a.recall, 1 / 3)
+        self.assertEqual(a.f1, 1 / 3)
+        self.assertEqual(a.count_error, 2 / 3)
         self.assertEqual(a.gt_count, 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/rastervision/core/label_store.py
+++ b/src/rastervision/core/label_store.py
@@ -9,6 +9,7 @@ class LabelStore(ABC):
     between LabelStores and Labels can be understood by analogy to the
     difference between a database and result sets queried from a database.
     """
+
     @abstractmethod
     def clear(self):
         """Clear all labels."""

--- a/src/rastervision/core/labels.py
+++ b/src/rastervision/core/labels.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 
 
 class Labels(ABC):

--- a/src/rastervision/core/ml_backend.py
+++ b/src/rastervision/core/ml_backend.py
@@ -31,7 +31,8 @@ class MLBackend(ABC):
 
         Args:
             training_results: dependent on the ml_backend's process_scene_data
-            validation_results: dependent on the ml_backend's process_scene_data
+            validation_results: dependent on the ml_backend's
+                process_scene_data
             class_map: ClassMap
             options: MakeTrainingChipsConfig.Options
         """

--- a/src/rastervision/core/ml_task.py
+++ b/src/rastervision/core/ml_task.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from rastervision.core.training_data import TrainingData
 

--- a/src/rastervision/core/ml_task.py
+++ b/src/rastervision/core/ml_task.py
@@ -97,8 +97,7 @@ class MLTask(object):
     def get_class_map(self):
         return self.class_map
 
-    def make_training_chips(self, train_scenes, validation_scenes,
-                            options):
+    def make_training_chips(self, train_scenes, validation_scenes, options):
         """Make training chips.
 
         Convert Scenes with a ground_truth_label_store into training
@@ -114,13 +113,14 @@ class MLTask(object):
 
         def _process_scene(scene, type_):
             data = TrainingData()
-            print('Making {} chips for scene: {}'.format(
-                type_, scene.id), end='', flush=True)
+            print(
+                'Making {} chips for scene: {}'.format(type_, scene.id),
+                end='',
+                flush=True)
             windows = self.get_train_windows(scene, options)
             for window in windows:
                 chip = scene.raster_source.get_chip(window)
-                labels = self.get_train_labels(
-                    window, scene, options)
+                labels = self.get_train_labels(window, scene, options)
                 data.append(chip, window, labels)
                 print('.', end='', flush=True)
             print()
@@ -129,22 +129,19 @@ class MLTask(object):
             data.shuffle()
             # TODO load and delete scene data as needed to avoid
             # running out of disk space
-            return self.backend.process_scene_data(
-                scene, data, self.class_map, options)
+            return self.backend.process_scene_data(scene, data, self.class_map,
+                                                   options)
 
         def _process_scenes(scenes, type_):
-            return [
-                _process_scene(scene, type_)
-                for scene in scenes
-            ]
+            return [_process_scene(scene, type_) for scene in scenes]
 
         # TODO: parallel processing!
         processed_training_results = _process_scenes(train_scenes, TRAIN)
-        processed_validation_results = _process_scenes(
-            validation_scenes, VALIDATION)
-        self.backend.process_sceneset_results(
-            processed_training_results, processed_validation_results,
-            self.class_map, options)
+        processed_validation_results = _process_scenes(validation_scenes,
+                                                       VALIDATION)
+        self.backend.process_sceneset_results(processed_training_results,
+                                              processed_validation_results,
+                                              self.class_map, options)
 
     def train(self, options):
         """Train a model.
@@ -170,8 +167,8 @@ class MLTask(object):
             label_store = scene.prediction_label_store
             label_store.clear()
 
-            windows = self.get_predict_windows(
-                raster_source.get_extent(), options)
+            windows = self.get_predict_windows(raster_source.get_extent(),
+                                               options)
             for window in windows:
                 chip = raster_source.get_chip(window)
                 labels = self.backend.predict(chip, window, options)
@@ -179,13 +176,13 @@ class MLTask(object):
                 print('.', end='', flush=True)
             print()
 
-            labels = self.post_process_predictions(
-                label_store.get_labels(), options)
+            labels = self.post_process_predictions(label_store.get_labels(),
+                                                   options)
             label_store.set_labels(labels)
             label_store.save()
 
-            if (options.debug and options.debug_uri and
-                    self.class_map.has_all_colors()):
+            if (options.debug and options.debug_uri
+                    and self.class_map.has_all_colors()):
                 self.save_debug_predict_image(scene, options.debug_uri)
 
     def eval(self, scenes, options):
@@ -205,7 +202,6 @@ class MLTask(object):
             predictions = scene.prediction_label_store
 
             scene_evaluation = self.get_evaluation()
-            scene_evaluation.compute(
-                self.class_map, ground_truth, predictions)
+            scene_evaluation.compute(self.class_map, ground_truth, predictions)
             evaluation.merge(scene_evaluation)
         evaluation.save(options.output_uri)

--- a/src/rastervision/core/raster_stats.py
+++ b/src/rastervision/core/raster_stats.py
@@ -37,8 +37,7 @@ class RasterStats():
             mean = last(
                 imean(chip_stream(channel), axis=None, ignore_nan=True))
             self.means.append(mean)
-            std = last(
-                istd(chip_stream(channel), axis=None, ignore_nan=True))
+            std = last(istd(chip_stream(channel), axis=None, ignore_nan=True))
             self.stds.append(std)
 
     def load(self, stats_uri):
@@ -47,8 +46,5 @@ class RasterStats():
         self.stds = stats['stds']
 
     def save(self, stats_uri):
-        stats = {
-            'means': self.means,
-            'stds': self.stds
-        }
+        stats = {'means': self.means, 'stds': self.stds}
         str_to_file(json.dumps(stats), stats_uri)

--- a/src/rastervision/core/scene.py
+++ b/src/rastervision/core/scene.py
@@ -1,7 +1,9 @@
 class Scene():
     """The raster data and labels associated with an area of interest."""
 
-    def __init__(self, id=None, raster_source=None,
+    def __init__(self,
+                 id=None,
+                 raster_source=None,
                  ground_truth_label_store=None,
                  prediction_label_store=None):
         """Construct a new Scene.

--- a/src/rastervision/crs_transformers/identity_crs_transformer.py
+++ b/src/rastervision/crs_transformers/identity_crs_transformer.py
@@ -6,6 +6,7 @@ class IdentityCRSTransformer(CRSTransformer):
 
     This is useful for non-georeferenced imagery.
     """
+
     def map_to_pixel(self, map_point):
         """Identity function.
 

--- a/src/rastervision/crs_transformers/rasterio_crs_transformer.py
+++ b/src/rastervision/crs_transformers/rasterio_crs_transformer.py
@@ -27,8 +27,8 @@ class RasterioCRSTransformer(CRSTransformer):
         Returns:
             (x, y) tuple in pixel coordinates
         """
-        image_point = pyproj.transform(
-            self.map_proj, self.image_proj, map_point[0], map_point[1])
+        image_point = pyproj.transform(self.map_proj, self.image_proj,
+                                       map_point[0], map_point[1])
         pixel_point = self.image_dataset.index(image_point[0], image_point[1])
         pixel_point = (pixel_point[1], pixel_point[0])
         return pixel_point
@@ -44,6 +44,6 @@ class RasterioCRSTransformer(CRSTransformer):
         """
         image_point = self.image_dataset.ul(
             int(pixel_point[1]), int(pixel_point[0]))
-        map_point = pyproj.transform(
-            self.image_proj, self.map_proj, image_point[0], image_point[1])
+        map_point = pyproj.transform(self.image_proj, self.map_proj,
+                                     image_point[0], image_point[1])
         return map_point

--- a/src/rastervision/evaluations/classification_evaluation.py
+++ b/src/rastervision/evaluations/classification_evaluation.py
@@ -31,9 +31,12 @@ def compute_eval_items(gt_labels, pred_labels, class_map):
         class_name = class_map_item.name
 
         eval_item = EvaluationItem(
-            float(precision[class_id]), float(recall[class_id]),
-            float(f1[class_id]), gt_count=float(support[class_id]),
-            class_id=class_id, class_name=class_name)
+            float(precision[class_id]),
+            float(recall[class_id]),
+            float(f1[class_id]),
+            gt_count=float(support[class_id]),
+            class_id=class_id,
+            class_name=class_name)
         class_to_eval_item[class_id] = eval_item
 
     return class_to_eval_item
@@ -45,8 +48,8 @@ class ClassificationEvaluation(Evaluation):
         gt_labels = ground_truth_label_store.get_labels()
         pred_labels = prediction_label_store.get_labels()
 
-        self.class_to_eval_item = compute_eval_items(
-            gt_labels, pred_labels, class_map)
+        self.class_to_eval_item = compute_eval_items(gt_labels, pred_labels,
+                                                     class_map)
 
         self.compute_avg()
 

--- a/src/rastervision/evaluations/classification_evaluation_test.py
+++ b/src/rastervision/evaluations/classification_evaluation_test.py
@@ -11,10 +11,7 @@ from rastervision.label_stores.classification_label_store import (
 
 class TestClassificationEvaluation(unittest.TestCase):
     def make_class_map(self):
-        class_items = [
-            ClassItem(1, 'grassy'),
-            ClassItem(2, 'urban')
-        ]
+        class_items = [ClassItem(1, 'grassy'), ClassItem(2, 'urban')]
         return ClassMap(class_items)
 
     def make_label_store(self, class_ids):
@@ -47,49 +44,40 @@ class TestClassificationEvaluation(unittest.TestCase):
         self.assertEqual(eval_item1.gt_count, 2)
         self.assertEqual(eval_item1.precision, 1.0)
         self.assertEqual(eval_item1.recall, 0.5)
-        self.assertAlmostEqual(eval_item1.f1, 2/3, places=2)
+        self.assertAlmostEqual(eval_item1.f1, 2 / 3, places=2)
 
         eval_item2 = eval.class_to_eval_item[2]
         self.assertEqual(eval_item2.gt_count, 1)
         self.assertEqual(eval_item2.precision, 0.5)
         self.assertEqual(eval_item2.recall, 1.0)
-        self.assertAlmostEqual(eval_item2.f1, 2/3, places=2)
+        self.assertAlmostEqual(eval_item2.f1, 2 / 3, places=2)
 
         avg_item = eval.avg_item
         self.assertEqual(avg_item.gt_count, 3)
         self.assertAlmostEqual(avg_item.precision, 0.83, places=2)
-        self.assertAlmostEqual(avg_item.recall, 2/3, places=2)
-        self.assertAlmostEqual(avg_item.f1, 2/3, places=2)
+        self.assertAlmostEqual(avg_item.recall, 2 / 3, places=2)
+        self.assertAlmostEqual(avg_item.f1, 2 / 3, places=2)
 
     def test_compute_single_pred_null(self):
         eval = ClassificationEvaluation()
         class_map = self.make_class_map()
-        gt_class_ids = [
-            [1, 2],
-            [1, 2]]
+        gt_class_ids = [[1, 2], [1, 2]]
         gt_label_store = self.make_label_store(gt_class_ids)
-        pred_class_ids = [
-            [1, None],
-            [2, 2]]
+        pred_class_ids = [[1, None], [2, 2]]
         pred_label_store = self.make_label_store(pred_class_ids)
-        eval.compute(
-            class_map, gt_label_store, pred_label_store)
+        eval.compute(class_map, gt_label_store, pred_label_store)
         self.assert_eval_single_null(eval)
 
     def test_compute_single_gt_null(self):
         eval = ClassificationEvaluation()
         class_map = self.make_class_map()
-        gt_class_ids = [
-            [1, None],
-            [1, 2]]
+        gt_class_ids = [[1, None], [1, 2]]
         gt_label_store = self.make_label_store(gt_class_ids)
-        pred_class_ids = [
-            [1, 2],
-            [2, 2]]
+        pred_class_ids = [[1, 2], [2, 2]]
         pred_label_store = self.make_label_store(pred_class_ids)
-        eval.compute(
-            class_map, gt_label_store, pred_label_store)
+        eval.compute(class_map, gt_label_store, pred_label_store)
         self.assert_eval_single_null(eval)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/rastervision/evaluations/object_detection_evaluation.py
+++ b/src/rastervision/evaluations/object_detection_evaluation.py
@@ -1,11 +1,6 @@
-import json
-
-import numpy as np
-
 from object_detection.utils import object_detection_evaluation
 
 from rastervision.core.evaluation import Evaluation
-from rastervision.utils.files import str_to_file
 from rastervision.core.evaluation_item import EvaluationItem
 
 
@@ -57,10 +52,10 @@ def parse_od_eval(od_eval, class_map):
                     class_id=class_id,
                     class_name=class_name)
             else:
-                # If we use the lowest detection threshold (ie. use all detected
-                # boxes as defined by score_thresh in the predict protobuf),
-                # that means we use all detected boxes, or the last element in
-                # the precisions array.
+                # If we use the lowest detection threshold (ie. use all
+                # detected boxes as defined by score_thresh in the predict
+                # protobuf), that means we use all detected boxes, or the last
+                # element in the precisions array.
                 precision = float(precisions[-1])
                 recall = float(recalls[-1])
 

--- a/src/rastervision/evaluations/object_detection_evaluation.py
+++ b/src/rastervision/evaluations/object_detection_evaluation.py
@@ -51,8 +51,11 @@ def parse_od_eval(od_eval, class_map):
             if len(precisions) == 0 or len(recalls) == 0:
                 # No predicted boxes.
                 eval_item = EvaluationItem(
-                    precision=None, recall=0, gt_count=gt_count,
-                    class_id=class_id, class_name=class_name)
+                    precision=None,
+                    recall=0,
+                    gt_count=gt_count,
+                    class_id=class_id,
+                    class_name=class_name)
             else:
                 # If we use the lowest detection threshold (ie. use all detected
                 # boxes as defined by score_thresh in the predict protobuf),
@@ -72,9 +75,13 @@ def parse_od_eval(od_eval, class_map):
                     norm_count_error = count_error / gt_count
 
                 eval_item = EvaluationItem(
-                    precision=precision, recall=recall, f1=f1,
-                    count_error=norm_count_error, gt_count=gt_count,
-                    class_id=class_id, class_name=class_name)
+                    precision=precision,
+                    recall=recall,
+                    f1=f1,
+                    count_error=norm_count_error,
+                    gt_count=gt_count,
+                    class_id=class_id,
+                    class_name=class_name)
 
         class_to_eval_item[class_id] = eval_item
 

--- a/src/rastervision/evaluations/object_detection_evaluation_test.py
+++ b/src/rastervision/evaluations/object_detection_evaluation_test.py
@@ -8,16 +8,12 @@ from rastervision.core.class_map import ClassItem, ClassMap
 from rastervision.core.box import Box
 from rastervision.label_stores.object_detection_label_store import (
     ObjectDetectionLabelStore)
-from rastervision.labels.object_detection_labels import (
-    ObjectDetectionLabels)
+from rastervision.labels.object_detection_labels import (ObjectDetectionLabels)
 
 
 class TestObjectDetectionEvaluation(unittest.TestCase):
     def make_class_map(self):
-        class_items = [
-            ClassItem(1, 'car'),
-            ClassItem(2, 'building')
-        ]
+        class_items = [ClassItem(1, 'car'), ClassItem(2, 'building')]
         return ClassMap(class_items)
 
     def make_ground_truth_label_store(self):
@@ -43,8 +39,8 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
         class_ids = np.array([1, 1, 2])
         scores = np.ones(class_ids.shape)
         label_store = ObjectDetectionLabelStore()
-        label_store.extend(ObjectDetectionLabels(
-            npboxes, class_ids, scores=scores))
+        label_store.extend(
+            ObjectDetectionLabels(npboxes, class_ids, scores=scores))
         return label_store
 
     def test_compute(self):
@@ -53,8 +49,7 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
         gt_label_store = self.make_ground_truth_label_store()
         pred_label_store = self.make_predicted_label_store()
 
-        eval.compute(
-            class_map, gt_label_store, pred_label_store)
+        eval.compute(class_map, gt_label_store, pred_label_store)
         eval_item1 = eval.class_to_eval_item[1]
         self.assertEqual(eval_item1.gt_count, 2)
         self.assertEqual(eval_item1.precision, 1.0)
@@ -65,7 +60,7 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
         self.assertEqual(eval_item2.gt_count, 2)
         self.assertEqual(eval_item2.precision, 1.0)
         self.assertEqual(eval_item2.recall, 0.5)
-        self.assertEqual(eval_item2.f1, 2/3)
+        self.assertEqual(eval_item2.f1, 2 / 3)
 
         avg_item = eval.avg_item
         self.assertEqual(avg_item.gt_count, 4)
@@ -79,8 +74,7 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
         gt_label_store = self.make_ground_truth_label_store()
         pred_label_store = ObjectDetectionLabelStore()
 
-        eval.compute(
-            class_map, gt_label_store, pred_label_store)
+        eval.compute(class_map, gt_label_store, pred_label_store)
         eval_item1 = eval.class_to_eval_item[1]
         self.assertEqual(eval_item1.gt_count, 2)
         self.assertEqual(eval_item1.precision, None)
@@ -105,8 +99,7 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
         gt_label_store = ObjectDetectionLabelStore()
         pred_label_store = self.make_predicted_label_store()
 
-        eval.compute(
-            class_map, gt_label_store, pred_label_store)
+        eval.compute(class_map, gt_label_store, pred_label_store)
         eval_item1 = eval.class_to_eval_item[1]
         self.assertEqual(eval_item1.gt_count, 0)
         self.assertEqual(eval_item1.precision, None)
@@ -124,6 +117,7 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
         self.assertEqual(avg_item.precision, None)
         self.assertEqual(avg_item.recall, None)
         self.assertEqual(avg_item.f1, None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/rastervision/label_stores/classification_geojson_file.py
+++ b/src/rastervision/label_stores/classification_geojson_file.py
@@ -4,15 +4,14 @@ import numpy as np
 from shapely.strtree import STRtree
 from shapely import geometry
 
-from rastervision.labels.classification_labels import (
-    ClassificationLabels)
+from rastervision.labels.classification_labels import (ClassificationLabels)
 from rastervision.label_stores.object_detection_geojson_file import (
     geojson_to_labels as geojson_to_object_detection_labels)
 from rastervision.label_stores.utils import (
     add_classes_to_geojson, load_label_store_json, boxes_to_geojson)
 from rastervision.utils.files import str_to_file
 from rastervision.label_stores.classification_label_store import (
-        ClassificationLabelStore)
+    ClassificationLabelStore)
 
 
 def get_str_tree(geojson_dict, crs_transformer):
@@ -106,8 +105,7 @@ def infer_cell(str_tree, cell, ioa_thresh, use_intersection_over_cell,
 
     # Infer class id for cell.
     if len(class_ids) == 0:
-        class_id = (None if background_class_id == 0
-                    else background_class_id)
+        class_id = (None if background_class_id == 0 else background_class_id)
     elif pick_min_class_id:
         class_id = min(class_ids)
     else:
@@ -139,10 +137,10 @@ def infer_labels(geojson_dict, crs_transformer, extent, options):
 
     cells = extent.get_windows(options.cell_size, options.cell_size)
     for cell in cells:
-        class_id = infer_cell(
-            str_tree, cell, options.ioa_thresh,
-            options.use_intersection_over_cell, options.background_class_id,
-            options.pick_min_class_id)
+        class_id = infer_cell(str_tree, cell, options.ioa_thresh,
+                              options.use_intersection_over_cell,
+                              options.background_class_id,
+                              options.pick_min_class_id)
         labels.set_cell(cell, class_id)
     return labels
 
@@ -164,8 +162,8 @@ def read_labels(geojson_dict, crs_transformer, extent):
         ClassificationLabels
     """
     # Load as ObjectDetectionLabels and convert to ClassificationLabels.
-    od_labels = geojson_to_object_detection_labels(
-        geojson_dict, crs_transformer, extent)
+    od_labels = geojson_to_object_detection_labels(geojson_dict,
+                                                   crs_transformer, extent)
 
     labels = ClassificationLabels()
     boxes = od_labels.get_boxes()
@@ -216,8 +214,7 @@ def to_geojson(labels, crs_transformer, class_map):
     boxes = labels.get_cells()
     class_ids = labels.get_class_ids()
 
-    return boxes_to_geojson(
-        boxes, class_ids, crs_transformer, class_map)
+    return boxes_to_geojson(boxes, class_ids, crs_transformer, class_map)
 
 
 class ClassificationGeoJSONFile(ClassificationLabelStore):
@@ -233,8 +230,15 @@ class ClassificationGeoJSONFile(ClassificationLabelStore):
     Args:
         options: ClassificationGeoJSONFile.Options
     """
-    def __init__(self, uri, crs_transformer, options, class_map,
-                 extent, readable=True, writable=False):
+
+    def __init__(self,
+                 uri,
+                 crs_transformer,
+                 options,
+                 class_map,
+                 extent,
+                 readable=True,
+                 writable=False):
         """Construct ClassificationLabelStore backed by a GeoJSON file.
 
         Args:
@@ -258,8 +262,8 @@ class ClassificationGeoJSONFile(ClassificationLabelStore):
         geojson_dict = load_label_store_json(uri, readable)
         if geojson_dict:
             geojson_dict = add_classes_to_geojson(geojson_dict, class_map)
-            self.labels = load_geojson(
-                geojson_dict, crs_transformer, extent, options)
+            self.labels = load_geojson(geojson_dict, crs_transformer, extent,
+                                       options)
 
     def save(self):
         """Save labels to URI if writable.
@@ -268,8 +272,8 @@ class ClassificationGeoJSONFile(ClassificationLabelStore):
         written, not the original polygons.
         """
         if self.writable:
-            geojson_dict = to_geojson(
-                self.labels, self.crs_transformer, self.class_map)
+            geojson_dict = to_geojson(self.labels, self.crs_transformer,
+                                      self.class_map)
             geojson_str = json.dumps(geojson_dict)
             str_to_file(geojson_str, self.uri)
         else:

--- a/src/rastervision/label_stores/classification_geojson_file.py
+++ b/src/rastervision/label_stores/classification_geojson_file.py
@@ -58,8 +58,8 @@ def infer_cell(str_tree, cell, ioa_thresh, use_intersection_over_cell,
 
     Given a cell and a set of polygons, the problem is to infer the class_id
     that best captures the content of the cell. This is non-trivial since there
-    can be multiple polygons of differing classes overlapping with the cell. Any
-    polygons that sufficiently overlap with the cell are in the running for
+    can be multiple polygons of differing classes overlapping with the cell.
+    Any polygons that sufficiently overlap with the cell are in the running for
     setting the class_id. If there are none in the running, the cell is either
     considered null or background. See args for more details.
 
@@ -72,8 +72,8 @@ def infer_cell(str_tree, cell, ioa_thresh, use_intersection_over_cell,
             cell as the denominator in the IOA. Otherwise, use the area of the
             polygon.
         background_class_id: (None or int) If not None, class_id to use as the
-            background class; ie. the one that is used when a window contains no
-            boxes. If not set, empty windows have None set as their class_id
+            background class; ie. the one that is used when a window contains
+            no boxes. If not set, empty windows have None set as their class_id
             which is considered a null value.
         pick_min_class_id: If true, the class_id for a cell is the minimum
             class_id of the boxes in that cell. Otherwise, pick the class_id of
@@ -127,7 +127,7 @@ def infer_labels(geojson_dict, crs_transformer, extent, options):
         crs_transformer: CRSTransformer used to convert from map to pixel based
             coordinates
         extent: Box representing the bounds of the grid
-        options: rastervision.protos.label_store_pb2.ClassificationGeoJSONFile.Options
+        options: rastervision.protos.label_store_pb2.ClassificationGeoJSONFile.Options  # noqa
 
     Returns:
         ClassificationLabels
@@ -185,7 +185,7 @@ def load_geojson(geojson_dict, crs_transformer, extent, options):
         crs_transformer: CRSTransformer used to convert from map to pixel based
             coordinates
         extent: Box representing the bounds of the grid
-        options: rastervision.protos.label_store_pb2.ClassificationGeoJSONFile.Options
+        options: rastervision.protos.label_store_pb2.ClassificationGeoJSONFile.Options  # noqa
     Returns:
         ClassificationLabels
     """

--- a/src/rastervision/label_stores/classification_geojson_file_test.py
+++ b/src/rastervision/label_stores/classification_geojson_file_test.py
@@ -3,18 +3,14 @@ import tempfile
 import os
 import json
 
-import numpy as np
-from moto import mock_s3
 from shapely import geometry
 
 from rastervision.label_stores.classification_geojson_file import (
     ClassificationGeoJSONFile, get_str_tree, infer_cell, infer_labels,
     read_labels, to_geojson)
-from rastervision.labels.classification_labels import ClassificationLabels
 from rastervision.core.crs_transformer import CRSTransformer
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap, ClassItem
-from rastervision.utils.files import NotFoundException, NotWritableError
 from rastervision.protos.label_store_pb2 import (
     ClassificationGeoJSONFile as ClassificationGeoJSONFileConfig)
 
@@ -162,7 +158,7 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
                               pick_min_class_id)
         self.assertEqual(class_id, None)
 
-    def test_infer_cell4(self):
+    def test_infer_cell5(self):
         # More of box1 in cell, using intersection_over_cell with the
         # IOA high enough.
         cell = Box.make_square(0, 0, 3)
@@ -176,7 +172,7 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
                               pick_min_class_id)
         self.assertEqual(class_id, self.class_id1)
 
-    def test_infer_cell5(self):
+    def test_infer_cell6(self):
         # No boxes overlap enough, use background_class_id
         cell = Box.make_square(0, 0, 10)
         ioa_thresh = 0.5
@@ -189,7 +185,7 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
                               pick_min_class_id)
         self.assertEqual(class_id, self.background_class_id)
 
-    def test_infer_cell6(self):
+    def test_infer_cell7(self):
         # Cell doesn't overlap with any boxes.
         cell = Box.make_square(10, 10, 1)
         ioa_thresh = 0.5
@@ -202,7 +198,7 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
                               pick_min_class_id)
         self.assertEqual(class_id, None)
 
-    def test_infer_cell7(self):
+    def test_infer_cell8(self):
         # box2 overlaps more than box1, but using pick_min_class_id, so
         # picks box1.
         cell = Box.make_square(1, 1, 3)

--- a/src/rastervision/label_stores/classification_geojson_file_test.py
+++ b/src/rastervision/label_stores/classification_geojson_file_test.py
@@ -24,6 +24,7 @@ class DoubleCRSTransformer(CRSTransformer):
 
     Assumes map coords are 2x pixels coords.
     """
+
     def map_to_pixel(self, web_point):
         return (web_point[0] * 2, web_point[1] * 2)
 
@@ -35,49 +36,35 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
     def setUp(self):
         self.crs_transformer = DoubleCRSTransformer()
         self.geojson_dict = {
-            'type': 'FeatureCollection',
-            'features': [
-                {
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'Polygon',
-                        'coordinates': [
-                            [
-                                [0., 0.],
-                                [0., 1.],
-                                [1., 1.],
-                                [1., 0.],
-                                [0., 0.]
-                            ]
-                        ]
-                    },
-                    'properties': {
-                        'class_name': 'car',
-                        'class_id': 1,
-                        'score': 0.0
-                    }
+            'type':
+            'FeatureCollection',
+            'features': [{
+                'type': 'Feature',
+                'geometry': {
+                    'type':
+                    'Polygon',
+                    'coordinates': [[[0., 0.], [0., 1.], [1., 1.], [1., 0.],
+                                     [0., 0.]]]
                 },
-                {
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'Polygon',
-                        'coordinates': [
-                            [
-                                [1., 1.],
-                                [1., 2.],
-                                [2., 2.],
-                                [2., 1.],
-                                [1., 1.]
-                            ]
-                        ]
-                    },
-                    'properties': {
-                        'score': 0.0,
-                        'class_name': 'house',
-                        'class_id': 2
-                    }
+                'properties': {
+                    'class_name': 'car',
+                    'class_id': 1,
+                    'score': 0.0
                 }
-            ]
+            }, {
+                'type': 'Feature',
+                'geometry': {
+                    'type':
+                    'Polygon',
+                    'coordinates': [[[1., 1.], [1., 2.], [2., 2.], [2., 1.],
+                                     [1., 1.]]]
+                },
+                'properties': {
+                    'score': 0.0,
+                    'class_name': 'house',
+                    'class_id': 2
+                }
+            }]
         }
 
         self.class_map = ClassMap([ClassItem(1, 'car'), ClassItem(2, 'house')])
@@ -130,9 +117,9 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         background_class_id = None
         pick_min_class_id = False
 
-        class_id = infer_cell(
-            self.str_tree, cell, ioa_thresh, use_intersection_over_cell,
-            background_class_id, pick_min_class_id)
+        class_id = infer_cell(self.str_tree, cell, ioa_thresh,
+                              use_intersection_over_cell, background_class_id,
+                              pick_min_class_id)
         self.assertEqual(class_id, self.class_id1)
 
     def test_infer_cell2(self):
@@ -143,9 +130,9 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         background_class_id = None
         pick_min_class_id = False
 
-        class_id = infer_cell(
-            self.str_tree, cell, ioa_thresh, use_intersection_over_cell,
-            background_class_id, pick_min_class_id)
+        class_id = infer_cell(self.str_tree, cell, ioa_thresh,
+                              use_intersection_over_cell, background_class_id,
+                              pick_min_class_id)
         self.assertEqual(class_id, self.class_id2)
 
     def test_infer_cell3(self):
@@ -156,9 +143,9 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         background_class_id = None
         pick_min_class_id = False
 
-        class_id = infer_cell(
-            self.str_tree, cell, ioa_thresh, use_intersection_over_cell,
-            background_class_id, pick_min_class_id)
+        class_id = infer_cell(self.str_tree, cell, ioa_thresh,
+                              use_intersection_over_cell, background_class_id,
+                              pick_min_class_id)
         self.assertEqual(class_id, None)
 
     def test_infer_cell4(self):
@@ -170,9 +157,9 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         background_class_id = None
         pick_min_class_id = False
 
-        class_id = infer_cell(
-            self.str_tree, cell, ioa_thresh, use_intersection_over_cell,
-            background_class_id, pick_min_class_id)
+        class_id = infer_cell(self.str_tree, cell, ioa_thresh,
+                              use_intersection_over_cell, background_class_id,
+                              pick_min_class_id)
         self.assertEqual(class_id, None)
 
     def test_infer_cell4(self):
@@ -184,9 +171,9 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         background_class_id = None
         pick_min_class_id = False
 
-        class_id = infer_cell(
-            self.str_tree, cell, ioa_thresh, use_intersection_over_cell,
-            background_class_id, pick_min_class_id)
+        class_id = infer_cell(self.str_tree, cell, ioa_thresh,
+                              use_intersection_over_cell, background_class_id,
+                              pick_min_class_id)
         self.assertEqual(class_id, self.class_id1)
 
     def test_infer_cell5(self):
@@ -197,9 +184,9 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         background_class_id = self.background_class_id
         pick_min_class_id = False
 
-        class_id = infer_cell(
-            self.str_tree, cell, ioa_thresh, use_intersection_over_cell,
-            background_class_id, pick_min_class_id)
+        class_id = infer_cell(self.str_tree, cell, ioa_thresh,
+                              use_intersection_over_cell, background_class_id,
+                              pick_min_class_id)
         self.assertEqual(class_id, self.background_class_id)
 
     def test_infer_cell6(self):
@@ -210,9 +197,9 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         background_class_id = None
         pick_min_class_id = False
 
-        class_id = infer_cell(
-            self.str_tree, cell, ioa_thresh, use_intersection_over_cell,
-            background_class_id, pick_min_class_id)
+        class_id = infer_cell(self.str_tree, cell, ioa_thresh,
+                              use_intersection_over_cell, background_class_id,
+                              pick_min_class_id)
         self.assertEqual(class_id, None)
 
     def test_infer_cell7(self):
@@ -224,9 +211,9 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         background_class_id = None
         pick_min_class_id = True
 
-        class_id = infer_cell(
-            self.str_tree, cell, ioa_thresh, use_intersection_over_cell,
-            background_class_id, pick_min_class_id)
+        class_id = infer_cell(self.str_tree, cell, ioa_thresh,
+                              use_intersection_over_cell, background_class_id,
+                              pick_min_class_id)
         self.assertEqual(class_id, self.class_id2)
 
     def test_infer_labels(self):
@@ -239,8 +226,8 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         options.infer_cells = True
         options.cell_size = 2
 
-        labels = infer_labels(
-            self.geojson_dict, self.crs_transformer, extent, options)
+        labels = infer_labels(self.geojson_dict, self.crs_transformer, extent,
+                              options)
         cells = labels.get_cells()
 
         self.assertEqual(len(cells), 4)
@@ -291,18 +278,28 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         options.infer_cells = False
 
         label_store = ClassificationGeoJSONFile(
-            self.file_path, self.crs_transformer, options, self.class_map,
-            extent, readable=True, writable=True)
+            self.file_path,
+            self.crs_transformer,
+            options,
+            self.class_map,
+            extent,
+            readable=True,
+            writable=True)
         labels1 = label_store.get_labels()
         label_store.save()
 
         label_store = ClassificationGeoJSONFile(
-            self.file_path, self.crs_transformer, options, self.class_map,
-            extent=None, readable=True, writable=True)
+            self.file_path,
+            self.crs_transformer,
+            options,
+            self.class_map,
+            extent=None,
+            readable=True,
+            writable=True)
         labels2 = label_store.get_labels()
 
-        self.assertDictEqual(
-            labels1.cell_to_class_id, labels2.cell_to_class_id)
+        self.assertDictEqual(labels1.cell_to_class_id,
+                             labels2.cell_to_class_id)
 
 
 if __name__ == '__main__':

--- a/src/rastervision/label_stores/classification_label_store_test.py
+++ b/src/rastervision/label_stores/classification_label_store_test.py
@@ -1,7 +1,5 @@
 import unittest
 
-import numpy as np
-
 from rastervision.label_stores.classification_label_store import (
     ClassificationLabelStore)
 from rastervision.labels.classification_labels import ClassificationLabels

--- a/src/rastervision/label_stores/object_detection_geojson_file.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file.py
@@ -3,10 +3,9 @@ import json
 import numpy as np
 
 from rastervision.core.box import Box
-from rastervision.labels.object_detection_labels import (
-    ObjectDetectionLabels)
-from rastervision.label_stores.utils import (
-    add_classes_to_geojson, load_label_store_json)
+from rastervision.labels.object_detection_labels import (ObjectDetectionLabels)
+from rastervision.label_stores.utils import (add_classes_to_geojson,
+                                             load_label_store_json)
 from rastervision.label_stores.object_detection_label_store import (
     ObjectDetectionLabelStore)
 from rastervision.label_stores.utils import boxes_to_geojson
@@ -57,8 +56,13 @@ def geojson_to_labels(geojson_dict, crs_transformer, extent=None):
 
 
 class ObjectDetectionGeoJSONFile(ObjectDetectionLabelStore):
-    def __init__(self, uri, crs_transformer, class_map,
-                 extent=None, readable=True, writable=False):
+    def __init__(self,
+                 uri,
+                 crs_transformer,
+                 class_map,
+                 extent=None,
+                 readable=True,
+                 writable=False):
         """Construct ObjectDetectionLabelStore backed by a GeoJSON file.
 
         Args:
@@ -92,7 +96,10 @@ class ObjectDetectionGeoJSONFile(ObjectDetectionLabelStore):
             class_ids = self.labels.get_class_ids().tolist()
             scores = self.labels.get_scores().tolist()
             geojson_dict = boxes_to_geojson(
-                boxes, class_ids, self.crs_transformer, self.class_map,
+                boxes,
+                class_ids,
+                self.crs_transformer,
+                self.class_map,
                 scores=scores)
             geojson_str = json.dumps(geojson_dict)
             str_to_file(geojson_str, self.uri)

--- a/src/rastervision/label_stores/object_detection_geojson_file_test.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file_test.py
@@ -20,6 +20,7 @@ class DoubleCRSTransformer(CRSTransformer):
 
     Assumes map coords are 2x pixels coords.
     """
+
     def map_to_pixel(self, web_point):
         return (web_point[0] * 2, web_point[1] * 2)
 
@@ -38,47 +39,33 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
 
         self.crs_transformer = DoubleCRSTransformer()
         self.geojson_dict = {
-            'type': 'FeatureCollection',
-            'features': [
-                {
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'Polygon',
-                        'coordinates': [
-                            [
-                                [0., 0.],
-                                [0., 1.],
-                                [1., 1.],
-                                [1., 0.],
-                                [0., 0.]
-                            ]
-                        ]
-                    },
-                    'properties': {
-                        'class_name': 'car',
-                        'score': 0.9
-                    }
+            'type':
+            'FeatureCollection',
+            'features': [{
+                'type': 'Feature',
+                'geometry': {
+                    'type':
+                    'Polygon',
+                    'coordinates': [[[0., 0.], [0., 1.], [1., 1.], [1., 0.],
+                                     [0., 0.]]]
                 },
-                {
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'Polygon',
-                        'coordinates': [
-                            [
-                                [1., 1.],
-                                [1., 2.],
-                                [2., 2.],
-                                [2., 1.],
-                                [1., 1.]
-                            ]
-                        ]
-                    },
-                    'properties': {
-                        'score': 0.9,
-                        'class_name': 'house'
-                    }
+                'properties': {
+                    'class_name': 'car',
+                    'score': 0.9
                 }
-            ]
+            }, {
+                'type': 'Feature',
+                'geometry': {
+                    'type':
+                    'Polygon',
+                    'coordinates': [[[1., 1.], [1., 2.], [2., 2.], [2., 1.],
+                                     [1., 1.]]]
+                },
+                'properties': {
+                    'score': 0.9,
+                    'class_name': 'house'
+                }
+            }]
         }
 
         self.extent = Box.make_square(0, 0, 10)
@@ -96,8 +83,12 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         try:
             invalid_uri = 's3://invalid_path/invalid.json'
             ObjectDetectionGeoJSONFile(
-                invalid_uri, self.crs_transformer, self.class_map,
-                extent=self.extent, readable=False, writable=False)
+                invalid_uri,
+                self.crs_transformer,
+                self.class_map,
+                extent=self.extent,
+                readable=False,
+                writable=False)
         except NotFoundException:
             self.fail('Should not raise exception if readable=False')
 
@@ -105,19 +96,24 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         with self.assertRaises(NotFoundException):
             invalid_uri = 's3://invalid_path/invalid.json'
             ObjectDetectionGeoJSONFile(
-                invalid_uri, self.crs_transformer, self.class_map,
-                extent=self.extent, readable=True, writable=False)
+                invalid_uri,
+                self.crs_transformer,
+                self.class_map,
+                extent=self.extent,
+                readable=True,
+                writable=False)
 
     def test_read_without_extent(self):
         store = ObjectDetectionGeoJSONFile(
-            self.file_path, self.crs_transformer, self.class_map,
-            extent=None, readable=True, writable=False)
+            self.file_path,
+            self.crs_transformer,
+            self.class_map,
+            extent=None,
+            readable=True,
+            writable=False)
         labels = store.get_labels()
 
-        npboxes = np.array([
-            [0., 0., 2., 2.],
-            [2., 2., 4., 4.]
-        ])
+        npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.]])
         class_ids = np.array([1, 2])
         scores = np.array([0.9, 0.9])
         expected_labels = ObjectDetectionLabels(
@@ -128,13 +124,15 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         # Extent only includes the first box.
         extent = Box.make_square(0, 0, 3)
         store = ObjectDetectionGeoJSONFile(
-            self.file_path, self.crs_transformer, self.class_map,
-            extent=extent, readable=True, writable=False)
+            self.file_path,
+            self.crs_transformer,
+            self.class_map,
+            extent=extent,
+            readable=True,
+            writable=False)
         labels = store.get_labels()
 
-        npboxes = np.array([
-            [0., 0., 2., 2.]
-        ])
+        npboxes = np.array([[0., 0., 2., 2.]])
         class_ids = np.array([1])
         scores = np.array([0.9])
         expected_labels = ObjectDetectionLabels(
@@ -144,14 +142,15 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         # Extent includes both boxes, but clips the second.
         extent = Box.make_square(0, 0, 3.9)
         store = ObjectDetectionGeoJSONFile(
-            self.file_path, self.crs_transformer, self.class_map,
-            extent=extent, readable=True, writable=False)
+            self.file_path,
+            self.crs_transformer,
+            self.class_map,
+            extent=extent,
+            readable=True,
+            writable=False)
         labels = store.get_labels()
 
-        npboxes = np.array([
-            [0., 0., 2., 2.],
-            [2., 2., 3.9, 3.9]
-        ])
+        npboxes = np.array([[0., 0., 2., 2.], [2., 2., 3.9, 3.9]])
         class_ids = np.array([1, 2])
         scores = np.array([0.9, 0.9])
         expected_labels = ObjectDetectionLabels(
@@ -160,16 +159,24 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
 
     def test_write_not_writable(self):
         label_store = ObjectDetectionGeoJSONFile(
-            self.file_path, self.crs_transformer, self.class_map,
-            extent=None, readable=True, writable=False)
+            self.file_path,
+            self.crs_transformer,
+            self.class_map,
+            extent=None,
+            readable=True,
+            writable=False)
         with self.assertRaises(NotWritableError):
             label_store.save()
 
     def test_write_invalid_uri(self):
         invalid_uri = 's3://invalid_path/invalid.json'
         label_store = ObjectDetectionGeoJSONFile(
-            invalid_uri, self.crs_transformer, self.class_map,
-            extent=None, readable=False, writable=True)
+            invalid_uri,
+            self.crs_transformer,
+            self.class_map,
+            extent=None,
+            readable=False,
+            writable=True)
         # TODO replace with NotWritableError once
         # files.utils upload functions are improved/tested.
         with self.assertRaises(Exception):
@@ -178,14 +185,22 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
     def test_valid_uri(self):
         # Read it, write it using label_store, read it again, and compare.
         label_store = ObjectDetectionGeoJSONFile(
-            self.file_path, self.crs_transformer, self.class_map,
-            extent=None, readable=True, writable=True)
+            self.file_path,
+            self.crs_transformer,
+            self.class_map,
+            extent=None,
+            readable=True,
+            writable=True)
         labels1 = label_store.get_labels()
         label_store.save()
 
         label_store = ObjectDetectionGeoJSONFile(
-            self.file_path, self.crs_transformer, self.class_map,
-            extent=None, readable=True, writable=True)
+            self.file_path,
+            self.crs_transformer,
+            self.class_map,
+            extent=None,
+            readable=True,
+            writable=True)
         labels2 = label_store.get_labels()
 
         labels1.assert_equal(labels2)

--- a/src/rastervision/label_stores/object_detection_label_store.py
+++ b/src/rastervision/label_stores/object_detection_label_store.py
@@ -1,6 +1,5 @@
 from rastervision.core.label_store import LabelStore
-from rastervision.labels.object_detection_labels import (
-    ObjectDetectionLabels)
+from rastervision.labels.object_detection_labels import (ObjectDetectionLabels)
 
 
 class ObjectDetectionLabelStore(LabelStore):
@@ -20,8 +19,7 @@ class ObjectDetectionLabelStore(LabelStore):
         return ObjectDetectionLabels.get_overlapping(self.labels, window)
 
     def extend(self, labels):
-        self.labels = ObjectDetectionLabels.concatenate(
-            self.labels, labels)
+        self.labels = ObjectDetectionLabels.concatenate(self.labels, labels)
 
     def save(self):
         raise NotImplementedError()

--- a/src/rastervision/label_stores/object_detection_label_store_test.py
+++ b/src/rastervision/label_stores/object_detection_label_store_test.py
@@ -10,10 +10,7 @@ from rastervision.core.box import Box
 
 class TestObjectDetectionLabelStore(unittest.TestCase):
     def setUp(self):
-        self.npboxes = np.array([
-            [0., 0., 2., 2.],
-            [2., 2., 4., 4.]
-        ])
+        self.npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.]])
         self.class_ids = np.array([1, 2])
         self.scores = np.array([0.99, 0.9])
         self.labels = ObjectDetectionLabels(
@@ -44,9 +41,7 @@ class TestObjectDetectionLabelStore(unittest.TestCase):
 
         window = Box.make_square(2, 2, 2)
         labels = store.get_labels(window=window)
-        npboxes = np.array([
-            [2., 2., 4., 4.]
-        ])
+        npboxes = np.array([[2., 2., 4., 4.]])
         class_ids = np.array([2])
         scores = np.array([0.9])
         expected_labels = ObjectDetectionLabels(

--- a/src/rastervision/label_stores/utils.py
+++ b/src/rastervision/label_stores/utils.py
@@ -45,10 +45,7 @@ def boxes_to_geojson(boxes, class_ids, crs_transformer, class_map,
         }
         features.append(feature)
 
-    return {
-        'type': 'FeatureCollection',
-        'features': features
-    }
+    return {'type': 'FeatureCollection', 'features': features}
 
 
 def add_classes_to_geojson(geojson, class_map):

--- a/src/rastervision/labels/classification_labels.py
+++ b/src/rastervision/labels/classification_labels.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from rastervision.core.labels import Labels
 from rastervision.core.box import Box
 

--- a/src/rastervision/labels/classification_labels.py
+++ b/src/rastervision/labels/classification_labels.py
@@ -7,6 +7,7 @@ from rastervision.core.box import Box
 # TODO also store scores
 class ClassificationLabels(Labels):
     """Represents a spatial grid of cells associated with classes."""
+
     def __init__(self):
         self.cell_to_class_id = {}
 
@@ -43,8 +44,10 @@ class ClassificationLabels(Labels):
 
     def get_cells(self):
         """Return list of all cells (list of Box)."""
-        return [Box.from_npbox(box_tup)
-                for box_tup in self.cell_to_class_id.keys()]
+        return [
+            Box.from_npbox(box_tup)
+            for box_tup in self.cell_to_class_id.keys()
+        ]
 
     def get_class_ids(self):
         """Return list of class_ids for all cells."""

--- a/src/rastervision/labels/classification_labels_test.py
+++ b/src/rastervision/labels/classification_labels_test.py
@@ -40,21 +40,16 @@ class TestClassificationLabels(unittest.TestCase):
         cells = self.labels.get_cells()
         self.assertEqual(len(cells), 2)
         # ordering of cells isn't known
-        self.assertTrue(
-            (cells[0] == self.cell1 and
-             cells[1] == self.cell2) or
-            (cells[1] == self.cell1 and
-             cells[0] == self.cell2))
+        self.assertTrue((cells[0] == self.cell1 and cells[1] == self.cell2)
+                        or (cells[1] == self.cell1 and cells[0] == self.cell2))
 
     def test_get_class_ids(self):
         cells = self.labels.get_cells()
         class_ids = self.labels.get_class_ids()
         # check that order of class_ids corresponds to order of cells
-        if (cells[0] == self.cell1 and
-                cells[1] == self.cell2):
+        if (cells[0] == self.cell1 and cells[1] == self.cell2):
             self.assertListEqual(class_ids, [1, 2])
-        elif (cells[1] == self.cell1 and
-                cells[0] == self.cell2):
+        elif (cells[1] == self.cell1 and cells[0] == self.cell2):
             self.assertListEqual(class_ids, [2, 1])
 
     def test_extend(self):

--- a/src/rastervision/labels/object_detection_labels.py
+++ b/src/rastervision/labels/object_detection_labels.py
@@ -36,18 +36,18 @@ class ObjectDetectionLabels(Labels):
         self.boxlist.add_field('scores', scores)
 
     def assert_equal(self, expected_labels):
-        np.testing.assert_array_equal(
-            self.get_npboxes(), expected_labels.get_npboxes())
-        np.testing.assert_array_equal(
-            self.get_class_ids(), expected_labels.get_class_ids())
-        np.testing.assert_array_equal(
-            self.get_scores(), expected_labels.get_scores())
+        np.testing.assert_array_equal(self.get_npboxes(),
+                                      expected_labels.get_npboxes())
+        np.testing.assert_array_equal(self.get_class_ids(),
+                                      expected_labels.get_class_ids())
+        np.testing.assert_array_equal(self.get_scores(),
+                                      expected_labels.get_scores())
 
     @staticmethod
     def make_empty():
         npboxes = np.empty((0, 4))
-        class_ids = np.empty((0,))
-        scores = np.empty((0,))
+        class_ids = np.empty((0, ))
+        scores = np.empty((0, ))
         return ObjectDetectionLabels(npboxes, class_ids, scores)
 
     @staticmethod
@@ -175,6 +175,8 @@ class ObjectDetectionLabels(Labels):
         """
         max_output_size = 1000000
         pruned_boxlist = non_max_suppression(
-            labels.boxlist, max_output_size=max_output_size,
-            iou_threshold=merge_thresh, score_threshold=score_thresh)
+            labels.boxlist,
+            max_output_size=max_output_size,
+            iou_threshold=merge_thresh,
+            score_threshold=score_thresh)
         return ObjectDetectionLabels.from_boxlist(pruned_boxlist)

--- a/src/rastervision/labels/object_detection_labels.py
+++ b/src/rastervision/labels/object_detection_labels.py
@@ -53,8 +53,8 @@ class ObjectDetectionLabels(Labels):
     @staticmethod
     def from_boxlist(boxlist):
         """Make ObjectDetectionLabels from BoxList object."""
-        scores = boxlist.get_field('scores') \
-                 if boxlist.has_field('scores') else None
+        scores = (boxlist.get_field('scores')
+                  if boxlist.has_field('scores') else None)
         return ObjectDetectionLabels(
             boxlist.get(), boxlist.get_field('classes'), scores=scores)
 

--- a/src/rastervision/labels/object_detection_labels_test.py
+++ b/src/rastervision/labels/object_detection_labels_test.py
@@ -172,7 +172,7 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
             for pruned_box_ind, pruned_box in enumerate(pruned_npboxes):
                 if np.array_equal(pruned_box, box):
                     pruned_inds[box_ind] = pruned_box_ind
-        self.assertTrue(np.all(pruned_inds != None))
+        self.assertTrue(np.all(pruned_inds is not None))
 
         expected_labels = ObjectDetectionLabels(
             expected_npboxes[pruned_inds],

--- a/src/rastervision/labels/object_detection_labels_test.py
+++ b/src/rastervision/labels/object_detection_labels_test.py
@@ -5,16 +5,12 @@ from object_detection.utils.np_box_list import BoxList
 
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap, ClassItem
-from rastervision.labels.object_detection_labels import (
-    ObjectDetectionLabels)
+from rastervision.labels.object_detection_labels import (ObjectDetectionLabels)
 
 
 class ObjectDetectionLabelsTest(unittest.TestCase):
     def setUp(self):
-        self.class_map = ClassMap([
-            ClassItem(1, 'car'),
-            ClassItem(2, 'house')
-        ])
+        self.class_map = ClassMap([ClassItem(1, 'car'), ClassItem(2, 'house')])
 
         self.npboxes = np.array([
             [0., 0., 2., 2.],
@@ -34,8 +30,8 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
 
     def test_make_empty(self):
         npboxes = np.empty((0, 4))
-        class_ids = np.empty((0,))
-        scores = np.empty((0,))
+        class_ids = np.empty((0, ))
+        scores = np.empty((0, ))
         expected_labels = ObjectDetectionLabels(
             npboxes, class_ids, scores=scores)
 
@@ -45,12 +41,11 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
     def test_constructor(self):
         labels = ObjectDetectionLabels(
             self.npboxes, self.class_ids, scores=self.scores)
-        expected_labels = ObjectDetectionLabels(
-            self.npboxes, self.class_ids, self.scores)
+        expected_labels = ObjectDetectionLabels(self.npboxes, self.class_ids,
+                                                self.scores)
         labels.assert_equal(expected_labels)
 
-        labels = ObjectDetectionLabels(
-            self.npboxes, self.class_ids)
+        labels = ObjectDetectionLabels(self.npboxes, self.class_ids)
         scores = np.ones(self.class_ids.shape)
         expected_labels = ObjectDetectionLabels(
             self.npboxes, self.class_ids, scores=scores)
@@ -59,73 +54,51 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
     def test_get_boxes(self):
         boxes = self.labels.get_boxes()
         self.assertEqual(len(boxes), 2)
-        np.testing.assert_array_equal(
-            boxes[0].npbox_format(), self.npboxes[0, :])
-        np.testing.assert_array_equal(
-            boxes[1].npbox_format(), self.npboxes[1, :])
+        np.testing.assert_array_equal(boxes[0].npbox_format(),
+                                      self.npboxes[0, :])
+        np.testing.assert_array_equal(boxes[1].npbox_format(),
+                                      self.npboxes[1, :])
 
     def test_len(self):
         nb_labels = len(self.labels)
         self.assertEqual(self.npboxes.shape[0], nb_labels)
 
     def test_local_to_global(self):
-        local_npboxes = np.array([
-            [0., 0., 2., 2.],
-            [2., 2., 4., 4.]
-        ])
+        local_npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.]])
         window = Box.make_square(10, 10, 10)
         global_npboxes = ObjectDetectionLabels.local_to_global(
             local_npboxes, window)
 
-        expected_global_npboxes = np.array([
-            [10., 10., 12., 12.],
-            [12., 12., 14., 14.]
-        ])
+        expected_global_npboxes = np.array([[10., 10., 12., 12.],
+                                            [12., 12., 14., 14.]])
         np.testing.assert_array_equal(global_npboxes, expected_global_npboxes)
 
     def test_global_to_local(self):
-        global_npboxes = np.array([
-            [10., 10., 12., 12.],
-            [12., 12., 14., 14.]
-        ])
+        global_npboxes = np.array([[10., 10., 12., 12.], [12., 12., 14., 14.]])
         window = Box.make_square(10, 10, 10)
         local_npboxes = ObjectDetectionLabels.global_to_local(
             global_npboxes, window)
 
-        expected_local_npboxes = np.array([
-            [0., 0., 2., 2.],
-            [2., 2., 4., 4.]
-        ])
+        expected_local_npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.]])
         np.testing.assert_array_equal(local_npboxes, expected_local_npboxes)
 
     def test_local_to_normalized(self):
-        local_npboxes = np.array([
-            [0., 0., 2., 2.],
-            [2., 2., 4., 4.]
-        ])
+        local_npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.]])
         window = Box(0, 0, 10, 100)
         norm_npboxes = ObjectDetectionLabels.local_to_normalized(
             local_npboxes, window)
 
-        expected_norm_npboxes = np.array([
-            [0., 0., 0.2, 0.02],
-            [0.2, 0.02, 0.4, 0.04]
-        ])
+        expected_norm_npboxes = np.array([[0., 0., 0.2, 0.02],
+                                          [0.2, 0.02, 0.4, 0.04]])
         np.testing.assert_array_equal(norm_npboxes, expected_norm_npboxes)
 
     def test_normalized_to_local(self):
-        norm_npboxes = np.array([
-            [0., 0., 0.2, 0.02],
-            [0.2, 0.02, 0.4, 0.04]
-        ])
+        norm_npboxes = np.array([[0., 0., 0.2, 0.02], [0.2, 0.02, 0.4, 0.04]])
         window = Box(0, 0, 10, 100)
         local_npboxes = ObjectDetectionLabels.normalized_to_local(
             norm_npboxes, window)
 
-        expected_local_npboxes = np.array([
-            [0., 0., 2., 2.],
-            [2., 2., 4., 4.]
-        ])
+        expected_local_npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.]])
         np.testing.assert_array_equal(local_npboxes, expected_local_npboxes)
 
     def test_get_overlapping(self):
@@ -136,9 +109,7 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
         window = Box.make_square(0, 0, 3)
         labels = ObjectDetectionLabels.get_overlapping(
             self.labels, window, ioa_thresh=0.5)
-        npboxes = np.array([
-            [0., 0., 2., 2.]
-        ])
+        npboxes = np.array([[0., 0., 2., 2.]])
         class_ids = np.array([1])
         scores = np.array([0.9])
         expected_labels = ObjectDetectionLabels(
@@ -157,19 +128,14 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
         labels.assert_equal(expected_labels)
 
     def test_concatenate(self):
-        npboxes = np.array([
-            [4., 4., 5., 5.]
-        ])
+        npboxes = np.array([[4., 4., 5., 5.]])
         class_ids = np.array([2])
         scores = np.array([0.3])
         labels = ObjectDetectionLabels(npboxes, class_ids, scores=scores)
         new_labels = ObjectDetectionLabels.concatenate(self.labels, labels)
 
-        npboxes = np.array([
-            [0., 0., 2., 2.],
-            [2., 2., 4., 4.],
-            [4., 4., 5., 5.]
-        ])
+        npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.],
+                            [4., 4., 5., 5.]])
         class_ids = np.array([1, 2, 2])
         scores = np.array([0.9, 0.9, 0.3])
         expected_labels = ObjectDetectionLabels(
@@ -181,12 +147,8 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
         # pruned. The third box overlaps with the second, but has higher score,
         # so the second one should get pruned. The fourth box overlaps with
         # the second less than merge_thresh, so it should not get pruned.
-        npboxes = np.array([
-            [0., 0., 2., 2.],
-            [2., 2., 4., 4.],
-            [2.1, 2.1, 4.1, 4.1],
-            [3.5, 3.5, 5.5, 5.5]
-        ])
+        npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.],
+                            [2.1, 2.1, 4.1, 4.1], [3.5, 3.5, 5.5, 5.5]])
         class_ids = np.array([1, 2, 1, 2])
         scores = np.array([0.2, 0.9, 0.9, 1.0])
         labels = ObjectDetectionLabels(npboxes, class_ids, scores=scores)
@@ -197,10 +159,8 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
 
         self.assertEqual(len(pruned_labels), 2)
 
-        expected_npboxes = np.array([
-            [2.1, 2.1, 4.1, 4.1],
-            [3.5, 3.5, 5.5, 5.5]
-        ])
+        expected_npboxes = np.array([[2.1, 2.1, 4.1, 4.1],
+                                     [3.5, 3.5, 5.5, 5.5]])
         expected_class_ids = np.array([1, 2])
         expected_scores = np.array([0.9, 1.0])
 
@@ -215,7 +175,8 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
         self.assertTrue(np.all(pruned_inds != None))
 
         expected_labels = ObjectDetectionLabels(
-            expected_npboxes[pruned_inds], expected_class_ids[pruned_inds],
+            expected_npboxes[pruned_inds],
+            expected_class_ids[pruned_inds],
             scores=expected_scores[pruned_inds])
         pruned_labels.assert_equal(expected_labels)
 

--- a/src/rastervision/ml_backends/keras_classification.py
+++ b/src/rastervision/ml_backends/keras_classification.py
@@ -13,16 +13,15 @@ from keras_classification.utils import predict
 from google.protobuf import json_format
 
 from rastervision.core.ml_backend import MLBackend
-from rastervision.utils.files import (
-    make_dir, get_local_path, upload_if_needed, download_if_needed,
-    start_sync, sync_dir, load_json_config)
+from rastervision.utils.files import (make_dir, get_local_path,
+                                      upload_if_needed, download_if_needed,
+                                      start_sync, sync_dir, load_json_config)
 from rastervision.utils.misc import save_img
 from rastervision.labels.classification_labels import ClassificationLabels
 from rastervision.core.box import Box
 
 
 class FileGroup(object):
-
     def __init__(self, base_uri):
         self.temp_dir_obj = tempfile.TemporaryDirectory()
         self.temp_dir = self.temp_dir_obj.name
@@ -86,8 +85,8 @@ class ModelFiles(FileGroup):
         self.model_uri = join(self.base_uri, 'model')
         self.log_uri = join(self.base_uri, 'log.csv')
 
-    def download_backend_config(self, backend_config_uri,
-                                dataset_files, class_map):
+    def download_backend_config(self, backend_config_uri, dataset_files,
+                                class_map):
         config = load_json_config(backend_config_uri, PipelineConfig())
 
         # Update config using local paths.
@@ -101,8 +100,7 @@ class ModelFiles(FileGroup):
             dataset_files.get_local_path(dataset_files.validation_uri)
 
         del config.trainer.options.class_names[:]
-        config.trainer.options.class_names.extend(
-            class_map.get_class_names())
+        config.trainer.options.class_names.extend(class_map.get_class_names())
 
         # Save an updated copy of the config file.
         config_path = self.get_local_path(backend_config_uri)
@@ -113,7 +111,6 @@ class ModelFiles(FileGroup):
 
 
 class KerasClassification(MLBackend):
-
     def __init__(self):
         self.model = None
         # persist for when output_uri is remote
@@ -134,12 +131,10 @@ class KerasClassification(MLBackend):
         dataset_files = DatasetFiles(options.output_uri)
         self.scene_dataset_files.append(dataset_files)
 
-        scratch_dir = dataset_files.get_local_path(
-            dataset_files.scratch_uri)
+        scratch_dir = dataset_files.get_local_path(dataset_files.scratch_uri)
         # Ensure directory is unique since scene id's could be shared between
         # training and test sets.
-        scene_dir = join(scratch_dir, '{}-{}'.format(
-            scene.id, uuid.uuid4()))
+        scene_dir = join(scratch_dir, '{}-{}'.format(scene.id, uuid.uuid4()))
         class_dirs = {}
 
         for chip_idx, (chip, window, labels) in enumerate(data):
@@ -172,8 +167,7 @@ class KerasClassification(MLBackend):
             options: MakeTrainingChipsConfig.Options
         """
         dataset_files = DatasetFiles(options.output_uri)
-        training_dir = dataset_files.get_local_path(
-            dataset_files.training_uri)
+        training_dir = dataset_files.get_local_path(dataset_files.training_uri)
         validation_dir = dataset_files.get_local_path(
             dataset_files.validation_uri)
 
@@ -212,8 +206,10 @@ class KerasClassification(MLBackend):
         if urlparse(options.output_uri).scheme == 's3':
             sync_dir(options.output_uri, model_files.base_dir)
 
-        start_sync(model_files.base_dir, options.output_uri,
-                   sync_interval=options.sync_interval)
+        start_sync(
+            model_files.base_dir,
+            options.output_uri,
+            sync_interval=options.sync_interval)
         _train(backend_config_path)
 
         if urlparse(options.output_uri).scheme == 's3':

--- a/src/rastervision/ml_backends/keras_classification.py
+++ b/src/rastervision/ml_backends/keras_classification.py
@@ -18,7 +18,6 @@ from rastervision.utils.files import (make_dir, get_local_path,
                                       start_sync, sync_dir, load_json_config)
 from rastervision.utils.misc import save_img
 from rastervision.labels.classification_labels import ClassificationLabels
-from rastervision.core.box import Box
 
 
 class FileGroup(object):
@@ -126,7 +125,8 @@ class KerasClassification(MLBackend):
             options: MakeTrainingChipsConfig.Options
 
         Returns:
-            dictionary of Scene's classes and corresponding local directory path
+            dictionary of Scene's classes and corresponding local directory
+                path
         """
         dataset_files = DatasetFiles(options.output_uri)
         self.scene_dataset_files.append(dataset_files)

--- a/src/rastervision/ml_backends/tf_object_detection_api.py
+++ b/src/rastervision/ml_backends/tf_object_detection_api.py
@@ -2,12 +2,10 @@ import io
 import tempfile
 import os
 import shutil
-import zipfile
 import tarfile
 from os.path import join
 from urllib.parse import urlparse
 from subprocess import Popen
-import signal
 import atexit
 import glob
 import re
@@ -19,8 +17,6 @@ import numpy as np
 from google.protobuf import text_format
 
 from object_detection.utils import dataset_util
-from object_detection.utils.np_box_list import BoxList
-from object_detection.utils.np_box_list_ops import scale
 from object_detection.protos.string_int_label_map_pb2 import (
     StringIntLabelMap, StringIntLabelMapItem)
 from object_detection.protos.pipeline_pb2 import TrainEvalPipelineConfig
@@ -231,7 +227,8 @@ def export_inference_graph(train_root_dir,
                            config_path,
                            output_dir,
                            export_py=None):
-    export_py = export_py or '/opt/tf-models/object_detection/export_inference_graph.py'
+    export_py = (export_py or
+                 '/opt/tf-models/object_detection/export_inference_graph.py')
     checkpoint_path = get_last_checkpoint_path(train_root_dir)
     if checkpoint_path is None:
         print('No checkpoints could be found.')

--- a/src/rastervision/ml_backends/tf_object_detection_api.py
+++ b/src/rastervision/ml_backends/tf_object_detection_api.py
@@ -27,11 +27,10 @@ from object_detection.protos.pipeline_pb2 import TrainEvalPipelineConfig
 
 from rastervision.core.ml_backend import MLBackend
 from rastervision.ml_tasks.object_detection import save_debug_image
-from rastervision.labels.object_detection_labels import (
-    ObjectDetectionLabels)
-from rastervision.utils.files import (
-    get_local_path, upload_if_needed, make_dir, download_if_needed,
-    file_to_str, sync_dir, start_sync)
+from rastervision.labels.object_detection_labels import (ObjectDetectionLabels)
+from rastervision.utils.files import (get_local_path, upload_if_needed,
+                                      make_dir, download_if_needed,
+                                      file_to_str, sync_dir, start_sync)
 
 TRAIN = 'train'
 VALIDATION = 'validation'
@@ -46,32 +45,45 @@ def create_tf_example(image, window, labels, class_map, chip_id=''):
 
     npboxes = labels.get_npboxes()
     npboxes = ObjectDetectionLabels.global_to_local(npboxes, window)
-    npboxes = ObjectDetectionLabels.local_to_normalized(
-        npboxes, window)
+    npboxes = ObjectDetectionLabels.local_to_normalized(npboxes, window)
     ymins = npboxes[:, 0]
     xmins = npboxes[:, 1]
     ymaxs = npboxes[:, 2]
     xmaxs = npboxes[:, 3]
     class_ids = labels.get_class_ids()
-    class_names = [class_map.get_by_id(class_id).name.encode('utf8')
-                   for class_id in class_ids]
+    class_names = [
+        class_map.get_by_id(class_id).name.encode('utf8')
+        for class_id in class_ids
+    ]
 
-    tf_example = tf.train.Example(features=tf.train.Features(feature={
-        'image/height': dataset_util.int64_feature(height),
-        'image/width': dataset_util.int64_feature(width),
-        'image/filename': dataset_util.bytes_feature(chip_id.encode('utf8')),
-        'image/source_id': dataset_util.bytes_feature(chip_id.encode('utf8')),
-        'image/encoded': dataset_util.bytes_feature(encoded_image.getvalue()),
-        'image/format': dataset_util.bytes_feature(image_format.encode('utf8')),
-        'image/object/bbox/xmin': dataset_util.float_list_feature(xmins),
-        'image/object/bbox/xmax': dataset_util.float_list_feature(xmaxs),
-        'image/object/bbox/ymin': dataset_util.float_list_feature(ymins),
-        'image/object/bbox/ymax': dataset_util.float_list_feature(ymaxs),
-        'image/object/class/text': dataset_util.bytes_list_feature(
-            class_names),
-        'image/object/class/label': dataset_util.int64_list_feature(
-            class_ids)
-    }))
+    tf_example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                'image/height':
+                dataset_util.int64_feature(height),
+                'image/width':
+                dataset_util.int64_feature(width),
+                'image/filename':
+                dataset_util.bytes_feature(chip_id.encode('utf8')),
+                'image/source_id':
+                dataset_util.bytes_feature(chip_id.encode('utf8')),
+                'image/encoded':
+                dataset_util.bytes_feature(encoded_image.getvalue()),
+                'image/format':
+                dataset_util.bytes_feature(image_format.encode('utf8')),
+                'image/object/bbox/xmin':
+                dataset_util.float_list_feature(xmins),
+                'image/object/bbox/xmax':
+                dataset_util.float_list_feature(xmaxs),
+                'image/object/bbox/ymin':
+                dataset_util.float_list_feature(ymins),
+                'image/object/bbox/ymax':
+                dataset_util.float_list_feature(ymaxs),
+                'image/object/class/text':
+                dataset_util.bytes_list_feature(class_names),
+                'image/object/class/label':
+                dataset_util.int64_list_feature(class_ids)
+            }))
 
     return tf_example
 
@@ -164,6 +176,7 @@ def terminate_at_exit(process):
     def terminate():
         print('Terminating {}...'.format(process.pid))
         process.terminate()
+
     atexit.register(terminate)
 
 
@@ -175,20 +188,22 @@ def train(config_path, output_dir, train_py=None, eval_py=None):
     eval_py = eval_py or '/opt/tf-models/object_detection/eval.py'
 
     train_process = Popen([
-        'python', train_py,
-        '--logtostderr', '--pipeline_config_path={}'.format(config_path),
-        '--train_dir={}'.format(output_train_dir)])
+        'python', train_py, '--logtostderr',
+        '--pipeline_config_path={}'.format(config_path),
+        '--train_dir={}'.format(output_train_dir)
+    ])
     terminate_at_exit(train_process)
 
     eval_process = Popen([
-        'python', eval_py,
-        '--logtostderr', '--pipeline_config_path={}'.format(config_path),
+        'python', eval_py, '--logtostderr',
+        '--pipeline_config_path={}'.format(config_path),
         '--checkpoint_dir={}'.format(output_train_dir),
-        '--eval_dir={}'.format(output_eval_dir)])
+        '--eval_dir={}'.format(output_eval_dir)
+    ])
     terminate_at_exit(eval_process)
 
-    tensorboard_process = Popen([
-        'tensorboard', '--logdir={}'.format(output_dir)])
+    tensorboard_process = Popen(
+        ['tensorboard', '--logdir={}'.format(output_dir)])
     terminate_at_exit(tensorboard_process)
 
     train_process.wait()
@@ -207,13 +222,15 @@ def get_last_checkpoint_path(train_root_dir):
     if len(checkpoint_ids) == 0:
         return None
     checkpoint_id = max(checkpoint_ids)
-    checkpoint_path = join(
-        train_root_dir, 'train', 'model.ckpt-{}'.format(checkpoint_id))
+    checkpoint_path = join(train_root_dir, 'train',
+                           'model.ckpt-{}'.format(checkpoint_id))
     return checkpoint_path
 
 
-def export_inference_graph(
-    train_root_dir, config_path, output_dir, export_py=None):
+def export_inference_graph(train_root_dir,
+                           config_path,
+                           output_dir,
+                           export_py=None):
     export_py = export_py or '/opt/tf-models/object_detection/export_inference_graph.py'
     checkpoint_path = get_last_checkpoint_path(train_root_dir)
     if checkpoint_path is None:
@@ -222,11 +239,11 @@ def export_inference_graph(
         print('Exporting checkpoint {}...'.format(checkpoint_path))
 
         train_process = Popen([
-            'python', export_py,
-            '--input_type', 'image_tensor',
+            'python', export_py, '--input_type', 'image_tensor',
             '--pipeline_config_path', config_path,
             '--trained_checkpoint_prefix', checkpoint_path,
-            '--output_directory', output_dir])
+            '--output_directory', output_dir
+        ])
         train_process.wait()
 
         # Move frozen inference graph and clean up generated files.
@@ -238,7 +255,6 @@ def export_inference_graph(
 
 
 class TrainingPackage(object):
-
     def __init__(self, base_uri):
         self.temp_dir_obj = tempfile.TemporaryDirectory()
         self.temp_dir = self.temp_dir_obj.name
@@ -288,12 +304,12 @@ class TrainingPackage(object):
         make_dir(pretrained_model_dir)
         with tarfile.open(pretrained_model_zip_path, 'r:gz') as tar:
             tar.extractall(pretrained_model_dir)
-        model_name = os.path.splitext(os.path.splitext(
-            os.path.basename(pretrained_model_zip_uri))[0])[0]
+        model_name = os.path.splitext(
+            os.path.splitext(os.path.basename(pretrained_model_zip_uri))[0])[0]
         # The unzipped file is assumed to have a single directory with
         # the name of the model derived from the zip file.
-        pretrained_model_path = join(
-            pretrained_model_dir, model_name, 'model.ckpt')
+        pretrained_model_path = join(pretrained_model_dir, model_name,
+                                     'model.ckpt')
         return pretrained_model_path
 
     def download_config(self, pretrained_model_zip_uri, backend_config_uri):
@@ -349,14 +365,10 @@ def load_frozen_graph(inference_graph_path):
 
 def compute_prediction(image_np, window, detection_graph, session):
     image_np_expanded = np.expand_dims(image_np, axis=0)
-    image_tensor = detection_graph.get_tensor_by_name(
-        'image_tensor:0')
-    boxes = detection_graph.get_tensor_by_name(
-        'detection_boxes:0')
-    scores = detection_graph.get_tensor_by_name(
-        'detection_scores:0')
-    class_ids = detection_graph.get_tensor_by_name(
-        'detection_classes:0')
+    image_tensor = detection_graph.get_tensor_by_name('image_tensor:0')
+    boxes = detection_graph.get_tensor_by_name('detection_boxes:0')
+    scores = detection_graph.get_tensor_by_name('detection_scores:0')
+    class_ids = detection_graph.get_tensor_by_name('detection_classes:0')
 
     (boxes, scores, class_ids) = session.run(
         [boxes, scores, class_ids],
@@ -371,7 +383,6 @@ def compute_prediction(image_np, window, detection_graph, session):
 
 
 class TFObjectDetectionAPI(MLBackend):
-
     def __init__(self):
         self.detection_graph = None
         # persist scene training packages for when output_uri is remote
@@ -464,13 +475,14 @@ class TFObjectDetectionAPI(MLBackend):
             export_py = options.object_detection_options.export_py
 
             # Train model and sync output periodically.
-            start_sync(output_dir, options.output_uri,
-                       sync_interval=options.sync_interval)
+            start_sync(
+                output_dir,
+                options.output_uri,
+                sync_interval=options.sync_interval)
             train(config_path, output_dir, train_py=train_py, eval_py=eval_py)
 
             export_inference_graph(
-                output_dir, config_path, output_dir,
-                export_py=export_py)
+                output_dir, config_path, output_dir, export_py=export_py)
 
             if urlparse(options.output_uri).scheme == 's3':
                 sync_dir(output_dir, options.output_uri, delete=True)
@@ -486,5 +498,5 @@ class TFObjectDetectionAPI(MLBackend):
         # If chip is blank, then return empty predictions.
         if np.sum(np.ravel(chip)) == 0:
             return ObjectDetectionLabels.make_empty()
-        return compute_prediction(
-            chip, window, self.detection_graph, self.session)
+        return compute_prediction(chip, window, self.detection_graph,
+                                  self.session)

--- a/src/rastervision/ml_tasks/classification.py
+++ b/src/rastervision/ml_tasks/classification.py
@@ -7,8 +7,8 @@ from PIL import Image, ImageDraw
 from rastervision.core.ml_task import MLTask
 from rastervision.evaluations.classification_evaluation import (
     ClassificationEvaluation)
-from rastervision.utils.files import (
-    get_local_path, upload_if_needed, make_dir)
+from rastervision.utils.files import (get_local_path, upload_if_needed,
+                                      make_dir)
 
 
 def draw_debug_predict_image(scene, class_map):

--- a/src/rastervision/ml_tasks/object_detection.py
+++ b/src/rastervision/ml_tasks/object_detection.py
@@ -17,9 +17,14 @@ def save_debug_image(im, labels, class_map, output_path):
         scores = [1.0] * len(labels)
 
     vis_util.visualize_boxes_and_labels_on_image_array(
-        im, npboxes, class_ids, scores,
-        class_map.get_category_index(), use_normalized_coordinates=True,
-        line_thickness=2, max_boxes_to_draw=None)
+        im,
+        npboxes,
+        class_ids,
+        scores,
+        class_map.get_category_index(),
+        use_normalized_coordinates=True,
+        line_thickness=2,
+        max_boxes_to_draw=None)
     save_img(im, output_path)
 
 
@@ -93,8 +98,8 @@ class ObjectDetection(MLTask):
         raster_source = scene.raster_source
         label_store = scene.ground_truth_label_store
         # Make positive windows which contain labels.
-        pos_windows = make_pos_windows(
-            raster_source.get_extent(), label_store, options)
+        pos_windows = make_pos_windows(raster_source.get_extent(), label_store,
+                                       options)
         nb_pos_windows = len(pos_windows)
 
         # Make negative windows which do not contain labels.
@@ -108,9 +113,9 @@ class ObjectDetection(MLTask):
         else:
             nb_neg_windows = 100  # just make some
         max_attempts = 100 * nb_neg_windows
-        neg_windows = make_neg_windows(
-            raster_source, label_store, options.chip_size,
-            nb_neg_windows, max_attempts)
+        neg_windows = make_neg_windows(raster_source, label_store,
+                                       options.chip_size, nb_neg_windows,
+                                       max_attempts)
 
         return pos_windows + neg_windows
 
@@ -118,7 +123,8 @@ class ObjectDetection(MLTask):
         window_labels = scene.ground_truth_label_store.get_labels(
             window=window)
         return ObjectDetectionLabels.get_overlapping(
-            window_labels, window,
+            window_labels,
+            window,
             ioa_thresh=options.object_detection_options.ioa_thresh,
             clip=True)
 

--- a/src/rastervision/raster_sources/geotiff_files.py
+++ b/src/rastervision/raster_sources/geotiff_files.py
@@ -31,8 +31,7 @@ class GeoTiffFiles(RasterioRasterSource):
 
     def build_image_dataset(self):
         print('Loading GeoTiffFFiles...')
-        imagery_path = download_and_build_vrt(
-            self.uris, self.temp_dir.name)
+        imagery_path = download_and_build_vrt(self.uris, self.temp_dir.name)
         return rasterio.open(imagery_path)
 
     def get_crs_transformer(self):

--- a/src/rastervision/raster_sources/rasterio_raster_source.py
+++ b/src/rastervision/raster_sources/rasterio_raster_source.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from rastervision.core.raster_source import RasterSource
 from rastervision.core.box import Box
-from rastervision.utils.files import download_if_needed
 
 
 def load_window(image_dataset, window=None):

--- a/src/rastervision/raster_sources/rasterio_raster_source.py
+++ b/src/rastervision/raster_sources/rasterio_raster_source.py
@@ -29,8 +29,7 @@ class RasterioRasterSource(RasterSource):
         pass
 
     def get_extent(self):
-        return Box(
-            0, 0, self.image_dataset.height, self.image_dataset.width)
+        return Box(0, 0, self.image_dataset.height, self.image_dataset.width)
 
     def _get_chip(self, window):
         return load_window(self.image_dataset, window.rasterio_format())

--- a/src/rastervision/run.py
+++ b/src/rastervision/run.py
@@ -1,8 +1,8 @@
 import click
 
-from rastervision.builders import (
-    compute_raster_stats_builder, make_training_chips_builder, train_builder,
-    predict_builder, eval_builder)
+from rastervision.builders import (compute_raster_stats_builder,
+                                   make_training_chips_builder, train_builder,
+                                   predict_builder, eval_builder)
 
 
 def _compute_raster_stats(config_uri):
@@ -70,7 +70,6 @@ run.add_command(make_training_chips)
 run.add_command(train)
 run.add_command(predict)
 run.add_command(eval)
-
 
 if __name__ == '__main__':
     run()

--- a/src/rastervision/utils/batch.py
+++ b/src/rastervision/utils/batch.py
@@ -7,8 +7,12 @@ import boto3
 s3_bucket = environ.get('S3_BUCKET')
 
 
-def _batch_submit(branch_name, command, attempts=3, gpu=False,
-                  parent_job_ids=[], array_size=None):
+def _batch_submit(branch_name,
+                  command,
+                  attempts=3,
+                  gpu=False,
+                  parent_job_ids=[],
+                  array_size=None):
     """
         Submit a job to run on Batch.
 
@@ -46,8 +50,8 @@ def _batch_submit(branch_name, command, attempts=3, gpu=False,
 
     job_id = client.submit_job(**kwargs)['jobId']
 
-    click.echo(
-        'Submitted job with jobName={} and jobId={}'.format(job_name, job_id))
+    click.echo('Submitted job with jobName={} and jobId={}'.format(
+        job_name, job_id))
 
     return job_id
 

--- a/src/rastervision/utils/files.py
+++ b/src/rastervision/utils/files.py
@@ -66,9 +66,10 @@ def sync_dir(src_dir, dest_uri, delete=False):
 def _is_raster(uri, s3_test=False):
     if s3_test:
         uri = uri.replace('s3://', '/vsis3/')
+
     try:
         rasterio.open(uri)
-    except:
+    except Exception:
         return False
     return uri
 
@@ -199,7 +200,7 @@ try:
     # can we interact with directory?
     explicit_temp_dir_valid = (os.path.isdir(explicit_temp_dir) and Path.touch(
         Path(os.path.join(explicit_temp_dir, '.can_touch'))))
-except:
+except Exception:
     print('Root temporary directory cannot be used: {}. Using root: {}'.format(
         explicit_temp_dir, RV_TEMP_DIR))
     tempfile.tempdir = RV_TEMP_DIR  # no guarantee this will work

--- a/src/rastervision/utils/files_test.py
+++ b/src/rastervision/utils/files_test.py
@@ -6,8 +6,8 @@ import json
 import boto3
 from moto import mock_s3
 
-from rastervision.utils.files import (
-    file_to_str, NotFoundException, load_json_config, ProtobufParseException)
+from rastervision.utils.files import (file_to_str, NotFoundException,
+                                      load_json_config, ProtobufParseException)
 from rastervision.protos.machine_learning_pb2 import MachineLearning
 
 
@@ -29,8 +29,7 @@ class TestFileToStr(unittest.TestCase):
         self.bucket_name = 'mock_bucket'
         self.s3.create_bucket(Bucket=self.bucket_name)
         self.s3_path = 's3://{}/{}'.format(self.bucket_name, self.file_name)
-        self.s3.upload_file(
-            self.file_path, self.bucket_name, self.file_name)
+        self.s3.upload_file(self.file_path, self.bucket_name, self.file_name)
 
     def tearDown(self):
         self.temp_dir.cleanup()
@@ -73,21 +72,17 @@ class TestLoadJsonConfig(unittest.TestCase):
         config = {
             'task': 'CLASSIFICATION',
             'backend': 'KERAS_CLASSIFICATION',
-            'class_items': [
-                {
-                    'id': 1,
-                    'name': 'car'
-                }
-            ]
+            'class_items': [{
+                'id': 1,
+                'name': 'car'
+            }]
         }
         self.write_config_file(config)
         ml_config = load_json_config(self.file_path, MachineLearning())
-        self.assertEqual(
-            ml_config.task,
-            MachineLearning.Backend.Value('KERAS_CLASSIFICATION'))
-        self.assertEqual(
-            ml_config.backend,
-            MachineLearning.Task.Value('CLASSIFICATION'))
+        self.assertEqual(ml_config.task,
+                         MachineLearning.Backend.Value('KERAS_CLASSIFICATION'))
+        self.assertEqual(ml_config.backend,
+                         MachineLearning.Task.Value('CLASSIFICATION'))
         self.assertEqual(ml_config.class_items[0].id, 1)
         self.assertEqual(ml_config.class_items[0].name, 'car')
         self.assertEqual(len(ml_config.class_items), 1)
@@ -96,12 +91,10 @@ class TestLoadJsonConfig(unittest.TestCase):
         config = {
             'task': 'CLASSIFICATION',
             'backend': 'KERAS_CLASSIFICATION',
-            'class_items': [
-                {
-                    'id': 1,
-                    'name': 'car'
-                }
-            ],
+            'class_items': [{
+                'id': 1,
+                'name': 'car'
+            }],
             'bogus_field': 0
         }
 
@@ -110,9 +103,7 @@ class TestLoadJsonConfig(unittest.TestCase):
             load_json_config(self.file_path, MachineLearning())
 
     def test_bogus_value(self):
-        config = {
-            'task': 'bogus_value'
-        }
+        config = {'task': 'bogus_value'}
         self.write_config_file(config)
         with self.assertRaises(ProtobufParseException):
             load_json_config(self.file_path, MachineLearning())

--- a/src/scripts/format_code
+++ b/src/scripts/format_code
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
+    set -x
+fi
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+SRC_DIR="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Reformat Python code inline using yapf.
+"
+}
+
+if [ "${1:-}" = "--help" ]; then
+        usage
+else
+    yapf -ipr -e "*_pb2.py" "$SRC_DIR"
+fi

--- a/src/scripts/install_deps
+++ b/src/scripts/install_deps
@@ -17,7 +17,8 @@ rm /tmp/protoc3.zip
 pip install keras==2.1.* flake8==3.5.* awscli==1.15.* lxml==4.2.* \
     shapely==1.6.* boto3==1.6.* pyproj==1.9.5.* imageio==2.3.* \
     scikit-learn==0.19.* six==1.11.* h5py==2.7.* matplotlib==2.1.* \
-    pillow==5.0.* click==6.* npstreams==1.4.* moto==1.3.* coverage==4.5.*
+    pillow==5.0.* click==6.* npstreams==1.4.* moto==1.3.* coverage==4.5.* \
+    yapf==0.22.*
 
 # Install Rasterio
 add-apt-repository ppa:ubuntugis/ppa

--- a/src/scripts/integration_tests.py
+++ b/src/scripts/integration_tests.py
@@ -12,7 +12,6 @@ import tensorflow
 
 import rastervision.workflows.chain as chain_workflow
 
-
 CLASSIFICATION = 'classification'
 all_tests = [CLASSIFICATION]
 
@@ -20,8 +19,7 @@ np.random.seed(1234)
 tensorflow.set_random_seed(5678)
 
 TEST_ROOT_DIR = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    '../fixtures/tests')
+    os.path.dirname(os.path.abspath(__file__)), '../fixtures/tests')
 
 
 class TestError():
@@ -31,14 +29,9 @@ class TestError():
         self.details = details
 
     def __str__(self):
-        return (
-            'Error\n' +
-            '------\n' +
-            'Test: {}\n'.format(self.test) +
-            'Message: {}\n'.format(self.message) +
-            'Details: {}'.format(str(self.details)) if self.details else '' +
-            '\n'
-        )
+        return ('Error\n' + '------\n' + 'Test: {}\n'.format(self.test) +
+                'Message: {}\n'.format(self.message) + 'Details: {}'.format(
+                    str(self.details)) if self.details else '' + '\n')
 
 
 def get_test_dir(test):
@@ -59,10 +52,9 @@ def get_expected_eval_path(test):
 
 def get_actual_eval_path(test, temp_dir):
     return os.path.join(
-        temp_dir,
-        ('rv-output/raw-datasets/{}-test/datasets/' +
-         'default/models/default/predictions/default/evals/default/' +
-         'output/eval.json').format(test))
+        temp_dir, ('rv-output/raw-datasets/{}-test/datasets/' +
+                   'default/models/default/predictions/default/evals/default/'
+                   + 'output/eval.json').format(test))
 
 
 def open_json(path):
@@ -91,10 +83,11 @@ def check_eval_item(test, expected_item, actual_item):
     class_name = expected_item['class_name']
 
     if math.fabs(expected_item['f1'] - actual_item['f1']) > f1_threshold:
-        errors.append(TestError(
-            test, 'F1 scores are not close enough',
-            'for class_name: {} expected f1: {}, actual f1: {}'.format(
-                class_name, expected_item['f1'], actual_item['f1'])))
+        errors.append(
+            TestError(
+                test, 'F1 scores are not close enough',
+                'for class_name: {} expected f1: {}, actual f1: {}'.format(
+                    class_name, expected_item['f1'], actual_item['f1'])))
 
     return errors
 
@@ -116,8 +109,9 @@ def check_eval(test, temp_dir):
                     lambda x: x['class_name'] == class_name, actual_eval))
             errors.extend(check_eval_item(test, expected_item, actual_item))
     else:
-        errors.append(TestError(
-            test, 'actual eval file does not exist', actual_eval_path))
+        errors.append(
+            TestError(test, 'actual eval file does not exist',
+                      actual_eval_path))
 
     return errors
 
@@ -131,9 +125,9 @@ def run_test(test, temp_dir):
     try:
         chain_workflow._main(workflow_path, tasks, run=True)
     except Exception as exc:
-        errors.append(TestError(
-            test, 'raised an exception while running',
-            traceback.format_exc()))
+        errors.append(
+            TestError(test, 'raised an exception while running',
+                      traceback.format_exc()))
         return errors
 
     # Check that the eval is similar to expected eval.
@@ -162,8 +156,8 @@ def main(tests):
                 print(error)
 
         for test in tests:
-            nb_test_errors = len(list(filter(
-                lambda error: error.test == test, errors)))
+            nb_test_errors = len(
+                list(filter(lambda error: error.test == test, errors)))
             if nb_test_errors == 0:
                 print('{} test passed!'.format(test))
 

--- a/src/scripts/style_tests
+++ b/src/scripts/style_tests
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
+    set -x
+fi
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+SRC_DIR="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Test that code is compliant with yapf (code formatter) and flake8.
+"
+}
+
+
+if [ "${1:-}" = "--help" ]; then
+    usage
+else
+    echo "Checking that code is consistent with flake8..."
+    flake8 "$SRC_DIR" --exclude "*_pb2.py"
+
+    # Exit code of 0 if yapf has a non-empty diff
+    # (ie. scripts/format_code needs to be run)
+    echo "Checking that code is consistent with yapf..."
+    if !(yapf -dpr -e "*_pb2.py" "$SRC_DIR" > /dev/null); then
+        echo "Code has not been formatted by yapf. Need to run ./scripts/format_code."
+        exit 0
+    fi
+fi

--- a/src/scripts/unit_tests
+++ b/src/scripts/unit_tests
@@ -1,3 +1,20 @@
 #!/bin/bash
 
-python -m unittest discover rastervision "*_test.py"
+set -e
+
+if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Run all unit tests.
+"
+}
+
+if [ "${1:-}" = "--help" ]; then
+    usage
+else
+    python -m unittest discover rastervision "*_test.py"
+fi


### PR DESCRIPTION
## Overview

This PR adds automatic code formatting using https://github.com/google/yapf. Running `scripts/format_code` will modify Python files inline to comply with pep8 style. This also adds `scripts/style_tests` which is run by CI, and a PR template.

### Checklist

- [x] Ran scripts/format_code and commit any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I also looked at https://github.com/ambv/black and https://github.com/hhatto/autopep8, and went with yapf because it seemed the most popular and is configurable. I don't have strong opinions about how the styling should happen, so I didn't spend too much time researching these. 

There are some things `yapf` can't do automatically which have to be fixed manually such as unused imports and reflowing PyDocs to be < 80 chars wide.

## Testing Instructions

* Rebuild Docker image to get new dependency.
* Add some extraneous new lines to a Python source file.
* Run `./scripts/style_tests` and see that it fails.
* Run `./scripts/format_code` and see changes.

Closes #317
Closes #300