### PR TITLE
Use subset of channels for means and stds

### DIFF
--- a/src/rastervision/builders/raster_transformer_builder.py
+++ b/src/rastervision/builders/raster_transformer_builder.py
@@ -1,5 +1,12 @@
 from rastervision.core.raster_transformer import RasterTransformer
+from rastervision.core.raster_stats import RasterStats
 
 
 def build(config):
-    return RasterTransformer(config)
+    raster_stats = None
+    if config.stats_uri:
+        raster_stats = RasterStats()
+        raster_stats.load(config.stats_uri)
+
+    return RasterTransformer(
+        channel_order=config.channel_order, raster_stats=raster_stats)

--- a/src/rastervision/core/raster_transformer_test.py
+++ b/src/rastervision/core/raster_transformer_test.py
@@ -1,0 +1,66 @@
+import unittest
+
+import numpy as np
+
+from rastervision.core.raster_transformer import RasterTransformer
+from rastervision.core.raster_stats import RasterStats
+
+
+class TestRasterTransformer(unittest.TestCase):
+    def test_no_channel_order_no_stats(self):
+        transformer = RasterTransformer()
+        chip = np.ones((2, 2, 3)).astype(np.uint8)
+        out_chip = transformer.transform(chip)
+        np.testing.assert_equal(chip, out_chip)
+
+        # Need to supply raster_stats for non-uint8 chips.
+        chip = np.ones((2, 2, 3))
+        with self.assertRaises(ValueError):
+            out_chip = transformer.transform(chip)
+
+    def test_no_channel_order_has_stats(self):
+        raster_stats = RasterStats()
+        raster_stats.means = np.ones((4, ))
+        raster_stats.stds = np.ones((4, )) * 2
+
+        # All values have z-score of 1, which translates to
+        # uint8 value of 170.
+        transformer = RasterTransformer(raster_stats=raster_stats)
+        chip = np.ones((2, 2, 4)) * 3
+        out_chip = transformer.transform(chip)
+        expected_out_chip = np.ones((2, 2, 4)) * 170
+        np.testing.assert_equal(out_chip, expected_out_chip)
+
+    def test_has_channel_order_no_stats(self):
+        channel_order = [0, 1, 2]
+        transformer = RasterTransformer(channel_order=channel_order)
+        chip = np.ones((2, 2, 4)).astype(np.uint8)
+        chip[:, :, :] *= np.array([0, 1, 2, 3]).astype(np.uint8)
+        out_chip = transformer.transform(chip)
+        expected_out_chip = np.ones((2, 2, 3)).astype(np.uint8)
+        expected_out_chip[:, :, :] *= np.array([0, 1, 2]).astype(np.uint8)
+        np.testing.assert_equal(out_chip, expected_out_chip)
+
+    def test_has_channel_order_has_stats(self):
+        raster_stats = RasterStats()
+        raster_stats.means = np.ones((4, ))
+        raster_stats.stds = np.ones((4, )) * 2
+        channel_order = [0, 1, 2]
+        transformer = RasterTransformer(
+            raster_stats=raster_stats, channel_order=channel_order)
+
+        chip = np.ones((2, 2, 4)) * [3, 3, 3, 0]
+        out_chip = transformer.transform(chip)
+        expected_out_chip = np.ones((2, 2, 3)) * 170
+        np.testing.assert_equal(out_chip, expected_out_chip)
+
+        # Also test when chip has same number of channels as channel_order
+        # but different number of channels than stats.
+        chip = np.ones((2, 2, 3)) * [3, 3, 3]
+        out_chip = transformer.transform(chip)
+        expected_out_chip = np.ones((2, 2, 3)) * 170
+        np.testing.assert_equal(out_chip, expected_out_chip)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

In production we were using 4 channel imagery with a `channel_order` of `[0, 1, 2]` and then switched to using 3 channel imagery. This caused an error because the `means` and `stds` in `raster_stats` were of length 4. This PR makes it so the `channel_order` is first applied to the `means` and `stds`, and adds unit tests for `RasterTransformer`.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* I made the following change to simulate using 3 band imagery on the cowc-potsdam-test workflow and saw that it worked.
```
diff --git a/src/rastervision/core/raster_transformer.py b/src/rastervision/core/raster_transformer.py
index d88458c..7e4c9e9 100644
--- a/src/rastervision/core/raster_transformer.py
+++ b/src/rastervision/core/raster_transformer.py
@@ -29,6 +29,8 @@ class RasterTransformer(object):
             [height, width, channels] uint8 numpy array where channels is equal
                 to len(channel_order)
         """
+        chip = chip[:, :, 0:3]
+
         if self.channel_order is None:
             channel_order = np.arange(chip.shape[2])
         else:
```

Closes #327
