### PR TITLE
Support multipolygon geojson label stores

### DIFF
--- a/src/rastervision/label_stores/object_detection_geojson_file.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file.py
@@ -66,8 +66,9 @@ def geojson_to_labels(geojson_dict, crs_transformer, extent=None):
             polygon_to_label(coordinates, crs_transformer)
         else:
             raise Exception(
-                "Geometries of type {} are not supported in object detection labels.".format(geom_type))
-        
+                "Geometries of type {} are not supported in object detection \
+                labels.".format(geom_type))
+
     boxes = np.array([box.npbox_format() for box in boxes], dtype=float)
     class_ids = np.array(class_ids)
     scores = np.array(scores)

--- a/src/rastervision/label_stores/object_detection_geojson_file.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file.py
@@ -32,18 +32,42 @@ def geojson_to_labels(geojson_dict, crs_transformer, extent=None):
     class_ids = []
     scores = []
 
-    for feature in features:
+    def polygon_to_label(polygon, crs_transformer, multipolygon=False):
         # Convert polygon to pixel coords and then convert to bounding box.
-        polygon = feature['geometry']['coordinates'][0]
-        polygon = [crs_transformer.map_to_pixel(p) for p in polygon]
-        xmin, ymin = np.min(polygon, axis=0)
-        xmax, ymax = np.max(polygon, axis=0)
-        boxes.append(Box(ymin, xmin, ymax, xmax))
+        # polygon = feature['geometry']['coordinates'][0]
+        if multipolygon:
+            for i in range(len(polygon)):
+                polygon = [crs_transformer.map_to_pixel(p) for p in polygon[i]]
+                xmin, ymin = np.min(polygon, axis=0)
+                xmax, ymax = np.max(polygon, axis=0)
+                boxes.append(Box(ymin, xmin, ymax, xmax))
 
-        properties = feature['properties']
-        class_ids.append(properties['class_id'])
-        scores.append(properties.get('score', 1.0))
+                properties = feature['properties']
+                class_ids.append(properties['class_id'])
+                scores.append(properties.get('score', 1.0))
+        else:
+            polygon = feature['geometry']['coordinates'][0]
+            polygon = [crs_transformer.map_to_pixel(p) for p in polygon]
+            xmin, ymin = np.min(polygon, axis=0)
+            xmax, ymax = np.max(polygon, axis=0)
+            boxes.append(Box(ymin, xmin, ymax, xmax))
 
+            properties = feature['properties']
+            class_ids.append(properties['class_id'])
+            scores.append(properties.get('score', 1.0))
+
+    for feature in features:
+        geom_type = feature['geometry']['type']
+        coordinates = feature['geometry']['coordinates']
+        if geom_type == 'MultiPolygon':
+            for polygon in coordinates:
+                polygon_to_label(polygon, crs_transformer, True)
+        elif geom_type == 'Polygon':
+            polygon_to_label(coordinates, crs_transformer)
+        else:
+            raise Exception(
+                "Geometries of type {} are not supported in object detection labels.".format(geom_type))
+        
     boxes = np.array([box.npbox_format() for box in boxes], dtype=float)
     class_ids = np.array(class_ids)
     scores = np.array(scores)

--- a/src/rastervision/label_stores/object_detection_geojson_file.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file.py
@@ -32,38 +32,24 @@ def geojson_to_labels(geojson_dict, crs_transformer, extent=None):
     class_ids = []
     scores = []
 
-    def polygon_to_label(polygon, crs_transformer, multipolygon=False):
-        # Convert polygon to pixel coords and then convert to bounding box.
-        # polygon = feature['geometry']['coordinates'][0]
-        if multipolygon:
-            for i in range(len(polygon)):
-                polygon = [crs_transformer.map_to_pixel(p) for p in polygon[i]]
-                xmin, ymin = np.min(polygon, axis=0)
-                xmax, ymax = np.max(polygon, axis=0)
-                boxes.append(Box(ymin, xmin, ymax, xmax))
+    def polygon_to_label(polygon, crs_transformer):
+        polygon = [crs_transformer.map_to_pixel(p) for p in polygon]
+        xmin, ymin = np.min(polygon, axis=0)
+        xmax, ymax = np.max(polygon, axis=0)
+        boxes.append(Box(ymin, xmin, ymax, xmax))
 
-                properties = feature['properties']
-                class_ids.append(properties['class_id'])
-                scores.append(properties.get('score', 1.0))
-        else:
-            polygon = feature['geometry']['coordinates'][0]
-            polygon = [crs_transformer.map_to_pixel(p) for p in polygon]
-            xmin, ymin = np.min(polygon, axis=0)
-            xmax, ymax = np.max(polygon, axis=0)
-            boxes.append(Box(ymin, xmin, ymax, xmax))
-
-            properties = feature['properties']
-            class_ids.append(properties['class_id'])
-            scores.append(properties.get('score', 1.0))
+        properties = feature['properties']
+        class_ids.append(properties['class_id'])
+        scores.append(properties.get('score', 1.0))
 
     for feature in features:
         geom_type = feature['geometry']['type']
         coordinates = feature['geometry']['coordinates']
         if geom_type == 'MultiPolygon':
             for polygon in coordinates:
-                polygon_to_label(polygon, crs_transformer, True)
+                polygon_to_label(polygon[0], crs_transformer)
         elif geom_type == 'Polygon':
-            polygon_to_label(coordinates, crs_transformer)
+            polygon_to_label(coordinates[0], crs_transformer)
         else:
             raise Exception(
                 "Geometries of type {} are not supported in object detection \

--- a/src/rastervision/label_stores/object_detection_geojson_file_test.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file_test.py
@@ -70,117 +70,34 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         }
 
         self.multipolygon_geojson_dict = {
-            'type': 'FeatureCollection',
-            'features': [
-                {
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'MultiPolygon',
-                        'coordinates': [
-                            [
-                                [
-                                    [0., 0.],
-                                    [0., 1.],
-                                    [1., 1.],
-                                    [1., 0.],
-                                    [0., 0.]
-                                ]
-                            ]
-                        ]
-                    },
-                    'properties': {
-                        'class_name': 'car',
-                        'score': 0.9
-                    }
+            'type':
+            'FeatureCollection',
+            'features': [{
+                'type': 'Feature',
+                'geometry': {
+                    'type':
+                    'MultiPolygon',
+                    'coordinates': [[[[0., 0.], [0., 1.], [1., 1.], [1., 0.],
+                                      [0., 0.]]]]
                 },
-                {
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'MultiPolygon',
-                        'coordinates': [
-                            [
-                                [
-                                    [1., 1.],
-                                    [1., 2.],
-                                    [2., 2.],
-                                    [2., 1.],
-                                    [1., 1.]
-                                ]
-                            ],
-                            [
-                                [
-                                    [1., 0.],
-                                    [1., 1.],
-                                    [2., 1.],
-                                    [2., 0.],
-                                    [1., 0.]
-                                ]
-                            ]
-                        ]
-                    },
-                    'properties': {
-                        'score': 0.9,
-                        'class_name': 'house'
-                    }
+                'properties': {
+                    'class_name': 'car',
+                    'score': 0.9
                 }
-            ]
-        }
-
-        self.multipolygon_geojson_dict = {
-            'type': 'FeatureCollection',
-            'features': [
-                {
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'MultiPolygon',
-                        'coordinates': [
-                            [
-                                [
-                                    [0., 0.],
-                                    [0., 1.],
-                                    [1., 1.],
-                                    [1., 0.],
-                                    [0., 0.]
-                                ]
-                            ]
-                        ]
-                    },
-                    'properties': {
-                        'class_name': 'car',
-                        'score': 0.9
-                    }
+            }, {
+                'type': 'Feature',
+                'geometry': {
+                    'type':
+                    'MultiPolygon',
+                    'coordinates':
+                    [[[[1., 1.], [1., 2.], [2., 2.], [2., 1.], [1., 1.]]],
+                     [[[1., 0.], [1., 1.], [2., 1.], [2., 0.], [1., 0.]]]]
                 },
-                {
-                    'type': 'Feature',
-                    'geometry': {
-                        'type': 'MultiPolygon',
-                        'coordinates': [
-                            [
-                                [
-                                    [1., 1.],
-                                    [1., 2.],
-                                    [2., 2.],
-                                    [2., 1.],
-                                    [1., 1.]
-                                ]
-                            ],
-                            [
-                                [
-                                    [1., 0.],
-                                    [1., 1.],
-                                    [2., 1.],
-                                    [2., 0.],
-                                    [1., 0.]
-                                ]
-                            ]
-                        ]
-                    },
-                    'properties': {
-                        'score': 0.9,
-                        'class_name': 'house'
-                    }
+                'properties': {
+                    'score': 0.9,
+                    'class_name': 'house'
                 }
-            ]
+            }]
         }
 
         self.extent = Box.make_square(0, 0, 10)
@@ -195,29 +112,25 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         self.temp_dir.cleanup()
 
     def test_multipolygon_geojson_to_labels(self):
-       geojson = add_classes_to_geojson(self.multipolygon_geojson_dict, self.class_map)
-       labels = geojson_to_labels(geojson, self.crs_transformer)
-       label_coordinates = labels.boxlist.get()
+        geojson = add_classes_to_geojson(self.multipolygon_geojson_dict,
+                                         self.class_map)
+        labels = geojson_to_labels(geojson, self.crs_transformer)
+        label_coordinates = labels.boxlist.get()
 
-       expected_box_coordinates = np.array([
-           [0., 0., 2., 2.],
-           [2., 2., 4., 4.],
-           [0., 2., 2., 4.]
-       ])
-       self.assertTrue(np.array_equal(label_coordinates, expected_box_coordinates))
+        expected_box_coordinates = np.array(
+            [[0., 0., 2., 2.], [2., 2., 4., 4.], [0., 2., 2., 4.]])
+        self.assertTrue(
+            np.array_equal(label_coordinates, expected_box_coordinates))
 
     def test_polygon_geojson_to_labels(self):
-       geojson = add_classes_to_geojson(
-           self.geojson_dict, self.class_map)
-       labels = geojson_to_labels(geojson, self.crs_transformer)
-       label_coordinates = labels.boxlist.get()
+        geojson = add_classes_to_geojson(self.geojson_dict, self.class_map)
+        labels = geojson_to_labels(geojson, self.crs_transformer)
+        label_coordinates = labels.boxlist.get()
 
-       expected_box_coordinates = np.array([
-           [0., 0., 2., 2.],
-           [2., 2., 4., 4.]
-       ])
-       self.assertTrue(np.array_equal(
-           label_coordinates, expected_box_coordinates))
+        expected_box_coordinates = np.array([[0., 0., 2., 2.],
+                                             [2., 2., 4., 4.]])
+        self.assertTrue(
+            np.array_equal(label_coordinates, expected_box_coordinates))
 
     def test_read_invalid_uri_readable_false(self):
         try:

--- a/src/rastervision/label_stores/object_detection_geojson_file_test.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file_test.py
@@ -7,7 +7,8 @@ import numpy as np
 from moto import mock_s3
 
 from rastervision.label_stores.object_detection_geojson_file import (
-    ObjectDetectionGeoJSONFile)
+    ObjectDetectionGeoJSONFile, geojson_to_labels)
+from rastervision.label_stores.utils import add_classes_to_geojson
 from rastervision.labels.object_detection_labels import ObjectDetectionLabels
 from rastervision.core.crs_transformer import CRSTransformer
 from rastervision.core.box import Box
@@ -68,6 +69,63 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
             }]
         }
 
+        self.multipolygon_geojson_dict = {
+            'type': 'FeatureCollection',
+            'features': [
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'MultiPolygon',
+                        'coordinates': [
+                            [
+                                [
+                                    [0., 0.],
+                                    [0., 1.],
+                                    [1., 1.],
+                                    [1., 0.],
+                                    [0., 0.]
+                                ]
+                            ]
+                        ]
+                    },
+                    'properties': {
+                        'class_name': 'car',
+                        'score': 0.9
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'geometry': {
+                        'type': 'MultiPolygon',
+                        'coordinates': [
+                            [
+                                [
+                                    [1., 1.],
+                                    [1., 2.],
+                                    [2., 2.],
+                                    [2., 1.],
+                                    [1., 1.]
+                                ]
+                            ],
+                            [
+                                [
+                                    [1., 0.],
+                                    [1., 1.],
+                                    [2., 1.],
+                                    [2., 0.],
+                                    [1., 0.]
+                                ]
+                            ]
+                        ]
+                    },
+                    'properties': {
+                        'score': 0.9,
+                        'class_name': 'house'
+                    }
+                }
+            ]
+        }
+
         self.extent = Box.make_square(0, 0, 10)
         self.class_map = ClassMap([ClassItem(1, 'car'), ClassItem(2, 'house')])
 
@@ -78,6 +136,31 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
     def tearDown(self):
         self.mock_s3.stop()
         self.temp_dir.cleanup()
+
+    def test_multipolygon_geojson_to_labels(self):
+       geojson = add_classes_to_geojson(self.multipolygon_geojson_dict, self.class_map)
+       labels = geojson_to_labels(geojson, self.crs_transformer)
+       label_coordinates = labels.boxlist.get()
+
+       expected_box_coordinates = np.array([
+           [0., 0., 2., 2.],
+           [2., 2., 4., 4.],
+           [0., 2., 2., 4.]
+       ])
+       self.assertTrue(np.array_equal(label_coordinates, expected_box_coordinates))
+
+    def test_polygon_geojson_to_labels(self):
+       geojson = add_classes_to_geojson(
+           self.geojson_dict, self.class_map)
+       labels = geojson_to_labels(geojson, self.crs_transformer)
+       label_coordinates = labels.boxlist.get()
+
+       expected_box_coordinates = np.array([
+           [0., 0., 2., 2.],
+           [2., 2., 4., 4.]
+       ])
+       self.assertTrue(np.array_equal(
+           label_coordinates, expected_box_coordinates))
 
     def test_read_invalid_uri_readable_false(self):
         try:

--- a/src/rastervision/label_stores/object_detection_geojson_file_test.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file_test.py
@@ -30,6 +30,7 @@ class DoubleCRSTransformer(CRSTransformer):
 
 
 class TestObjectDetectionJsonFile(unittest.TestCase):
+
     def setUp(self):
         self.mock_s3 = mock_s3()
         self.mock_s3.start()
@@ -133,20 +134,30 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         labels = geojson_to_labels(geojson, self.crs_transformer)
         label_coordinates = labels.boxlist.get()
 
-        expected_box_coordinates = np.array(
+        # construct expected labels object
+        expected_npboxes = np.array(
             [[0., 0., 2., 2.], [2., 2., 4., 4.], [0., 2., 2., 4.]])
-        self.assertTrue(
-            np.array_equal(label_coordinates, expected_box_coordinates))
+        expected_class_ids = np.array([1, 2, 2])
+        expected_scores = np.array([0.9, 0.9, 0.9])
+        expected_labels = ObjectDetectionLabels(
+            expected_npboxes, expected_class_ids, expected_scores)
+
+        labels.assert_equal(expected_labels)
 
     def test_polygon_geojson_to_labels(self):
         geojson = add_classes_to_geojson(self.geojson_dict, self.class_map)
         labels = geojson_to_labels(geojson, self.crs_transformer)
         label_coordinates = labels.boxlist.get()
 
-        expected_box_coordinates = np.array([[0., 0., 2., 2.],
-                                             [2., 2., 4., 4.]])
-        self.assertTrue(
-            np.array_equal(label_coordinates, expected_box_coordinates))
+        # construct expected labels object
+        expected_npboxes = np.array(
+            [[0., 0., 2., 2.], [2., 2., 4., 4.]])
+        expected_class_ids = np.array([1, 2])
+        expected_scores = np.array([0.9, 0.9])
+        expected_labels = ObjectDetectionLabels(
+            expected_npboxes, expected_class_ids, expected_scores)
+
+        labels.assert_equal(expected_labels)
 
     def test_read_invalid_geometry_type(self):
         with self.assertRaises(Exception):

--- a/src/rastervision/label_stores/object_detection_geojson_file_test.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file_test.py
@@ -100,6 +100,22 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
             }]
         }
 
+        self.linestring_geojson_dict = {
+            "type":
+            "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": {
+                    'score': 0.9,
+                    'class_name': 'house'
+                },
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[0., 0.], [0., 1.]]
+                }
+            }]
+        }
+
         self.extent = Box.make_square(0, 0, 10)
         self.class_map = ClassMap([ClassItem(1, 'car'), ClassItem(2, 'house')])
 
@@ -131,6 +147,12 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
                                              [2., 2., 4., 4.]])
         self.assertTrue(
             np.array_equal(label_coordinates, expected_box_coordinates))
+
+    def test_read_invalid_geometry_type(self):
+        with self.assertRaises(Exception):
+            geojson = add_classes_to_geojson(self.linestring_geojson_dict,
+                                             self.class_map)
+            geojson_to_labels(geojson, self.crs_transformer, extent=None)
 
     def test_read_invalid_uri_readable_false(self):
         try:

--- a/src/rastervision/label_stores/object_detection_geojson_file_test.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file_test.py
@@ -30,7 +30,6 @@ class DoubleCRSTransformer(CRSTransformer):
 
 
 class TestObjectDetectionJsonFile(unittest.TestCase):
-
     def setUp(self):
         self.mock_s3 = mock_s3()
         self.mock_s3.start()
@@ -132,11 +131,10 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
         geojson = add_classes_to_geojson(self.multipolygon_geojson_dict,
                                          self.class_map)
         labels = geojson_to_labels(geojson, self.crs_transformer)
-        label_coordinates = labels.boxlist.get()
 
         # construct expected labels object
-        expected_npboxes = np.array(
-            [[0., 0., 2., 2.], [2., 2., 4., 4.], [0., 2., 2., 4.]])
+        expected_npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.],
+                                     [0., 2., 2., 4.]])
         expected_class_ids = np.array([1, 2, 2])
         expected_scores = np.array([0.9, 0.9, 0.9])
         expected_labels = ObjectDetectionLabels(
@@ -147,11 +145,9 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
     def test_polygon_geojson_to_labels(self):
         geojson = add_classes_to_geojson(self.geojson_dict, self.class_map)
         labels = geojson_to_labels(geojson, self.crs_transformer)
-        label_coordinates = labels.boxlist.get()
 
         # construct expected labels object
-        expected_npboxes = np.array(
-            [[0., 0., 2., 2.], [2., 2., 4., 4.]])
+        expected_npboxes = np.array([[0., 0., 2., 2.], [2., 2., 4., 4.]])
         expected_class_ids = np.array([1, 2])
         expected_scores = np.array([0.9, 0.9])
         expected_labels = ObjectDetectionLabels(


### PR DESCRIPTION
## Overview

This PR enables raster vision to handle geojson files encoded as multipolygons when creating training chips for object detection. 

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This has been tested by creating training chips from the spacenet dataset.

## Testing Instructions

* Run unit tests `python -m rastervision.label_stores.object_detection_geojson_file_test`

Closes #330 
