### PR TITLE
Add more PyDocs and unit tests for utils.files

### DIFF
--- a/src/rastervision/label_stores/object_detection_geojson_file_test.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file_test.py
@@ -13,8 +13,8 @@ from rastervision.labels.object_detection_labels import ObjectDetectionLabels
 from rastervision.core.crs_transformer import CRSTransformer
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap, ClassItem
-from rastervision.utils.files import NotFoundException, NotWritableError
 from rastervision.utils.files import (NotReadableError,
+                                      NotWritableError)
 
 
 class DoubleCRSTransformer(CRSTransformer):
@@ -260,9 +260,7 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
             extent=None,
             readable=False,
             writable=True)
-        # TODO replace with NotWritableError once
-        # files.utils upload functions are improved/tested.
-        with self.assertRaises(Exception):
+        with self.assertRaises(NotWritableError):
             label_store.save()
 
     def test_valid_uri(self):

--- a/src/rastervision/label_stores/object_detection_geojson_file_test.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file_test.py
@@ -14,6 +14,7 @@ from rastervision.core.crs_transformer import CRSTransformer
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap, ClassItem
 from rastervision.utils.files import NotFoundException, NotWritableError
+from rastervision.utils.files import (NotReadableError,
 
 
 class DoubleCRSTransformer(CRSTransformer):
@@ -171,11 +172,11 @@ class TestObjectDetectionJsonFile(unittest.TestCase):
                 extent=self.extent,
                 readable=False,
                 writable=False)
-        except NotFoundException:
+        except NotReadableError:
             self.fail('Should not raise exception if readable=False')
 
     def test_read_invalid_uri_readable_true(self):
-        with self.assertRaises(NotFoundException):
+        with self.assertRaises(NotReadableError):
             invalid_uri = 's3://invalid_path/invalid.json'
             ObjectDetectionGeoJSONFile(
                 invalid_uri,

--- a/src/rastervision/utils/files.py
+++ b/src/rastervision/utils/files.py
@@ -1,7 +1,6 @@
 import io
 import os
 from pathlib import Path
-import rasterio
 import shutil
 import subprocess
 import tempfile
@@ -63,15 +62,7 @@ def sync_dir(src_dir, dest_uri, delete=False):
     subprocess.run(command)
 
 
-def _is_raster(uri, s3_test=False):
-    if s3_test:
-        uri = uri.replace('s3://', '/vsis3/')
 
-    try:
-        rasterio.open(uri)
-    except Exception:
-        return False
-    return uri
 
 
 def download_if_needed(uri, download_dir):
@@ -84,10 +75,6 @@ def download_if_needed(uri, download_dir):
 
     parsed_uri = urlparse(uri)
     if parsed_uri.scheme == 's3':
-        vsis3_path = _is_raster(uri, s3_test=True)
-        if vsis3_path:
-            return vsis3_path
-
         try:
             print('Downloading {} to {}'.format(uri, path))
             s3 = boto3.client('s3')

--- a/src/rastervision/utils/files.py
+++ b/src/rastervision/utils/files.py
@@ -12,7 +12,7 @@ import botocore
 from google.protobuf import json_format
 
 
-class NotFoundException(Exception):
+class NotReadableError(Exception):
     pass
 
 
@@ -80,16 +80,28 @@ def download_if_needed(uri, download_dir):
             s3 = boto3.client('s3')
             s3.download_file(parsed_uri.netloc, parsed_uri.path[1:], path)
         except botocore.exceptions.ClientError:
-            raise NotFoundException('Could not access {}'.format(uri))
+            raise NotReadableError('Could not read {}'.format(uri))
     else:
         not_found = not os.path.isfile(path)
         if not_found:
-            raise NotFoundException('Could not access {}'.format(uri))
+            raise NotReadableError('Could not read {}'.format(uri))
 
     return path
 
 
 def file_to_str(file_uri):
+    """Download contents of text file into a string.
+
+    Args:
+        file_uri: (string) URI of file
+
+    Returns:
+        (string) with contents of text file
+
+    Raises:
+        NotReadableError if URI cannot be read from
+    """
+
     parsed_uri = urlparse(file_uri)
     if parsed_uri.scheme == 's3':
         with io.BytesIO() as file_buffer:

--- a/src/rastervision/utils/files_test.py
+++ b/src/rastervision/utils/files_test.py
@@ -6,52 +6,155 @@ import json
 import boto3
 from moto import mock_s3
 
-from rastervision.utils.files import (file_to_str, NotFoundException,
-                                      load_json_config, ProtobufParseException)
+from rastervision.utils.files import (
+    file_to_str, str_to_file, download_if_needed, upload_if_needed,
+    NotReadableError, NotWritableError, load_json_config,
+    ProtobufParseException, make_dir, get_local_path)
 from rastervision.protos.machine_learning_pb2 import MachineLearning
 
 
-class TestFileToStr(unittest.TestCase):
+class TestMakeDir(unittest.TestCase):
     def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_default_args(self):
+        dir = os.path.join(self.temp_dir.name, 'hello')
+        make_dir(dir)
+        self.assertTrue(os.path.isdir(dir))
+
+    def test_check_empty(self):
+        path = os.path.join(self.temp_dir.name, 'hello', 'hello.txt')
+        dir = os.path.dirname(path)
+        str_to_file('hello', path)
+
+        make_dir(dir, check_empty=False)
+        with self.assertRaises(Exception):
+            make_dir(dir, check_empty=True)
+
+    def test_force_empty(self):
+        path = os.path.join(self.temp_dir.name, 'hello', 'hello.txt')
+        dir = os.path.dirname(path)
+        str_to_file('hello', path)
+
+        make_dir(dir, force_empty=False)
+        self.assertTrue(os.path.isfile(path))
+        make_dir(dir, force_empty=True)
+        is_empty = len(os.listdir(dir)) == 0
+        self.assertTrue(is_empty)
+
+    def test_use_dirname(self):
+        path = os.path.join(self.temp_dir.name, 'hello', 'hello.txt')
+        dir = os.path.dirname(path)
+        make_dir(path, use_dirname=True)
+        self.assertTrue(os.path.isdir(dir))
+
+
+class TestGetLocalPath(unittest.TestCase):
+    def test_local(self):
+        download_dir = '/download_dir'
+        uri = '/my/file.txt'
+        path = get_local_path(uri, download_dir)
+        self.assertEqual(path, uri)
+
+    def test_s3(self):
+        download_dir = '/download_dir'
+        uri = 's3://bucket/my/file.txt'
+        path = get_local_path(uri, download_dir)
+        self.assertEqual(path, '/download_dir/s3/bucket/my/file.txt')
+
+
+class TestFileToStr(unittest.TestCase):
+    """Test file_to_str and str_to_file."""
+
+    def setUp(self):
+        # Setup mock S3 bucket.
         self.mock_s3 = mock_s3()
         self.mock_s3.start()
-
-        # Save temp file.
-        self.file_name = 'hello.txt'
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.file_path = os.path.join(self.temp_dir.name, self.file_name)
-        self.file_contents = 'hello'
-        with open(self.file_path, 'w') as myfile:
-            myfile.write(self.file_contents)
-
-        # Upload file to mock S3 bucket.
         self.s3 = boto3.client('s3')
         self.bucket_name = 'mock_bucket'
         self.s3.create_bucket(Bucket=self.bucket_name)
+
+        self.content_str = 'hello'
+        self.file_name = 'hello.txt'
         self.s3_path = 's3://{}/{}'.format(self.bucket_name, self.file_name)
-        self.s3.upload_file(self.file_path, self.bucket_name, self.file_name)
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.local_path = os.path.join(self.temp_dir.name, self.file_name)
 
     def tearDown(self):
         self.temp_dir.cleanup()
         self.mock_s3.stop()
 
-    def test_s3(self):
-        str = file_to_str(self.s3_path)
-        self.assertEqual(str, self.file_contents)
+    def test_file_to_str_local(self):
+        str_to_file(self.content_str, self.local_path)
+        content_str = file_to_str(self.local_path)
+        self.assertEqual(self.content_str, content_str)
 
-    def test_local(self):
-        str = file_to_str(self.file_path)
-        self.assertEqual(str, self.file_contents)
-
-    def test_wrong_s3(self):
-        wrong_path = 's3://{}/{}'.format(self.bucket_name, 'x.txt')
-        with self.assertRaises(NotFoundException):
-            file_to_str(wrong_path)
-
-    def test_wrong_local(self):
         wrong_path = '/wrongpath/x.txt'
-        with self.assertRaises(NotFoundException):
+        with self.assertRaises(NotReadableError):
             file_to_str(wrong_path)
+
+    def test_file_to_str_s3(self):
+        wrong_path = 's3://wrongpath/x.txt'
+
+        with self.assertRaises(NotWritableError):
+            str_to_file(self.content_str, wrong_path)
+
+        str_to_file(self.content_str, self.s3_path)
+        content_str = file_to_str(self.s3_path)
+        self.assertEqual(self.content_str, content_str)
+
+        with self.assertRaises(NotReadableError):
+            file_to_str(wrong_path)
+
+
+class TestDownloadIfNeeded(unittest.TestCase):
+    """Test download_if_needed and upload_if_needed and str_to_file."""
+
+    def setUp(self):
+        # Setup mock S3 bucket.
+        self.mock_s3 = mock_s3()
+        self.mock_s3.start()
+        self.s3 = boto3.client('s3')
+        self.bucket_name = 'mock_bucket'
+        self.s3.create_bucket(Bucket=self.bucket_name)
+
+        self.content_str = 'hello'
+        self.file_name = 'hello.txt'
+        self.s3_path = 's3://{}/{}'.format(self.bucket_name, self.file_name)
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.local_path = os.path.join(self.temp_dir.name, self.file_name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+        self.mock_s3.stop()
+
+    def test_download_if_needed_local(self):
+        with self.assertRaises(NotReadableError):
+            download_if_needed(self.local_path, self.temp_dir.name)
+
+        str_to_file(self.content_str, self.local_path)
+        upload_if_needed(self.local_path, self.local_path)
+        local_path = download_if_needed(self.local_path, self.temp_dir.name)
+        self.assertEqual(local_path, self.local_path)
+
+    def test_download_if_needed_s3(self):
+        with self.assertRaises(NotReadableError):
+            download_if_needed(self.s3_path, self.temp_dir.name)
+
+        str_to_file(self.content_str, self.local_path)
+        upload_if_needed(self.local_path, self.s3_path)
+        local_path = download_if_needed(self.s3_path, self.temp_dir.name)
+        content_str = file_to_str(local_path)
+        self.assertEqual(self.content_str, content_str)
+
+        wrong_path = 's3://wrongpath/x.txt'
+        with self.assertRaises(NotWritableError):
+            upload_if_needed(local_path, wrong_path)
 
 
 class TestLoadJsonConfig(unittest.TestCase):


### PR DESCRIPTION
## Overview

This PR adds more PyDocs and unit tests for `rastervision.utils.files`, and improves error handling for upload operations which now raise a `NotWritableError`. This also removes windowed reading of GeoTIFFs on S3 by Rasterio which is probably slowing things down.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Testing
* I ran the following command to test that things haven't broken when reading GeoTiffs off of S3:
```
python -m rastervision.workflows.chain \
    /opt/data/lf-dev/workflow-configs/object-detection/cowc-potsdam-test.json \
    --run --simulated-remote
```
and locally:
```
python -m rastervision.workflows.chain \
    /opt/data/lf-dev/workflow-configs/object-detection/cowc-potsdam-test.json \
    --run
```

Closes #323 
