### PR TITLE
Enable making predict package in remote environment

### DIFF
--- a/src/rastervision/core/predict_package.py
+++ b/src/rastervision/core/predict_package.py
@@ -41,6 +41,7 @@ def save_predict_package(predict_config):
             .raster_source.raster_transformer.stats_uri, temp_dir)
 
         package_path = get_local_path(package_uri, temp_dir)
+        make_dir(package_path, use_dirname=True)
         with zipfile.ZipFile(package_path, 'w') as package_zip:
             package_zip.write(config_path, arcname=config_fn)
             package_zip.write(model_path, arcname=model_fn)


### PR DESCRIPTION
## Overview

This PR makes a one-line fix to prevent crashing when creating the prediction package in a remote environment.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* I tested this by running predict remotely. I don't think you need to test this.
