### PR TITLE
Docker: Optional Container Name

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -47,6 +47,11 @@ do
         RUNTIME="--runtime=nvidia"
         shift # past argument
         ;;
+        --name)
+        shift
+        NAME="--name $1"
+        shift
+        ;;
         *)    # unknown option
         POSITIONAL+=("$1") # save it in an array for later
         shift # past argument
@@ -57,7 +62,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
-    docker run ${RUNTIME} --rm -it ${TENSORBOARD} ${AWS} \
+    docker run ${RUNTIME} ${NAME} --rm -it ${TENSORBOARD} ${AWS} \
         -v "$SRC":/opt/src \
         -v ${RASTER_VISION_DATA_DIR}:/opt/data \
         ${IMAGE} "${@:1}"


### PR DESCRIPTION
## Overview

This adds optional `--name` switch to docker command line.  It is useful for the container to have a name if things need to be copied to/from it.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
