### PR TITLE
Add nodata handling to rasterio raster source.

### DIFF
--- a/src/rastervision/raster_sources/rasterio_raster_source.py
+++ b/src/rastervision/raster_sources/rasterio_raster_source.py
@@ -14,7 +14,14 @@ def load_window(image_dataset, window=None):
         ((y_min, y_max), (x_min, x_max))
     """
     im = image_dataset.read(window=window, boundless=True)
+
+    # Handle non-zero NODATA values by setting the data to 0.
+    for i, nodata in enumerate(image_dataset.nodatavals):
+        if nodata is not None and nodata != 0:
+            im[i, im[i] == nodata] = 0
+
     im = np.transpose(im, axes=[1, 2, 0])
+
     return im
 
 


### PR DESCRIPTION
## Overview

This small change ensures that if the incoming raster has a non-zero NODATA value that  it is replaced with a 0, which the system expects.

### Notes

We haven't written unit tests for the raster source code yet, this seemed like a small enough change that could go through; debatable.


