### PR TITLE
Patch DeepLab to Support Custom Datasets

### DIFF
--- a/src/scripts/install_deps
+++ b/src/scripts/install_deps
@@ -43,3 +43,44 @@ rm -R temp
 protoc object_detection/protos/*.proto --python_out=.
 pip install cython==0.28.*
 pip install pycocotools==2.0.*
+
+# Patch Deeplab
+cat > /tmp/patch.diff <<EOF
+diff --git a/research/deeplab/datasets/segmentation_dataset.py b/research/deeplab/datasets/segmentation_dataset.py
+index 65c0604..b763f55 100644
+--- a/research/deeplab/datasets/segmentation_dataset.py
++++ b/research/deeplab/datasets/segmentation_dataset.py
+@@ -49,6 +49,7 @@ References:
+   through ADE20K dataset", In Proc. of CVPR, 2017.
+ """
+ import collections
++import os
+ import os.path
+ import tensorflow as tf
+ 
+@@ -108,11 +109,21 @@ _ADE20K_INFORMATION = DatasetDescriptor(
+     ignore_label=0,
+ )
+ 
++_CUSTOM_INFORMATION = DatasetDescriptor(
++    splits_to_sizes={
++        'train': int(os.environ.get('DL_CUSTOM_TRAIN') or 1000),
++        'validation': int(os.environ.get('DL_CUSTOM_VALIDATION') or 1000),
++    },
++    num_classes=int(os.environ.get('DL_CUSTOM_CLASSES') or 10),
++    ignore_label=int(os.environ.get('DL_CUSTOM_IGNORE') or 0),
++)
++
+ 
+ _DATASETS_INFORMATION = {
+     'cityscapes': _CITYSCAPES_INFORMATION,
+     'pascal_voc_seg': _PASCAL_VOC_SEG_INFORMATION,
+     'ade20k': _ADE20K_INFORMATION,
++    'custom': _CUSTOM_INFORMATION,
+ }
+ 
+ # Default file pattern of TFRecord of TensorFlow Example.
+EOF
+cd /opt/tf-models/deeplab
+patch -p3 < /tmp/patch.diff
+rm /tmp/patch.diff


### PR DESCRIPTION
## Overview

This patches DeepLab to allow custom datasets.  I may eventually submit these changes to `tensorflow/models`.  `azavea/models` seems to be a snapshot of upstream, but if these changes are more appropriate for that repo then I can submit them there.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

