### PR TITLE
Fix clearing of ground_truth_label_store out of prediction package construction

### DIFF
--- a/src/rastervision/core/predict_package.py
+++ b/src/rastervision/core/predict_package.py
@@ -68,7 +68,7 @@ def make_scene_config(scene_template,
             the other arguments of this function injected into it
     """
     scene = copy.deepcopy(scene_template)
-    scene.ground_truth_label_store.Clear()
+    scene.ClearField('ground_truth_label_store')
     label_store = scene.prediction_label_store
     if label_store.HasField('object_detection_geojson_file'):
         label_store.object_detection_geojson_file.uri = \


### PR DESCRIPTION
## Overview

This fixes an issue I was coming up with when  using prediction packages. The line that I changed would actually _add_ a ground_truth_label_store field to the prediction config, and cause the label_store_builder to fail. This change clears the field of `ground_truth_label_store` if it exists.

## Testing Instructions

Run unit tests with the predict_package.py in it's old state, see fail, run in new state.