### PR TITLE
WIP: Add RV config and use it for submitting Batch jobs

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -21,6 +21,8 @@ Run raster-vision image locally.
 --aws forwards AWS credentials.
 --tensorboard maps port 6006
 --gpu use the NVIDIA runtime and GPU image
+--name <name> gives the container a name
+--rv-config forwards RV config
 All arguments after above options are passed to 'docker run'.
 "
 }
@@ -36,6 +38,10 @@ do
     case $key in
         --aws)
         AWS="-e AWS_PROFILE=${AWS_PROFILE:-default} -v ${HOME}/.aws:/root/.aws:ro"
+        shift # past argument
+        ;;
+        --rv-config)
+        RV_CONFIG="-e RV_PROFILE=${RV_PROFILE} -v ${HOME}/.rastervision:/root/.rastervision:ro"
         shift # past argument
         ;;
         --tensorboard)
@@ -62,7 +68,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
-    docker run ${RUNTIME} ${NAME} --rm -it ${TENSORBOARD} ${AWS} \
+    docker run ${RUNTIME} ${NAME} --rm -it ${TENSORBOARD} ${RV_CONFIG} ${AWS} \
         -v "$SRC":/opt/src \
         -v ${RASTER_VISION_DATA_DIR}:/opt/data \
         ${IMAGE} "${@:1}"

--- a/src/rastervision/utils/batch.py
+++ b/src/rastervision/utils/batch.py
@@ -1,41 +1,53 @@
-from os import environ
 import uuid
+import subprocess
 
 import click
 import boto3
 
-s3_bucket = environ.get('S3_BUCKET')
+from rastervision.utils.rv_config import get_rv_config
 
 
-def _batch_submit(branch_name,
-                  command,
-                  attempts=3,
-                  gpu=False,
-                  parent_job_ids=[],
-                  array_size=None):
+def is_branch_valid(repo, branch):
+    ls_branch_command = [
+        'git', 'ls-remote', '--heads', repo, branch]
+
+    if not subprocess.run(ls_branch_command, stdout=subprocess.PIPE).stdout:
+        print('Error: remote branch {} does not exist'.format(branch))
+        return False
+    return True
+
+
+def _batch_submit(command, branch='develop', attempts=3, job_queue=None,
+                  job_def=None, github_repo=None, profile=None,
+                  parent_job_ids=[], array_size=None):
     """
         Submit a job to run on Batch.
 
         Args:
-            branch_name: Branch with code to run on Batch
-            command: Command in quotes to run on Batch
+            repo: URI for Github repo with code to run
+            branch: Branch with code to run
+            command: Command in quotes to run
     """
-    full_command = ['run_rv', branch_name]
+    config = get_rv_config(batch_job_queue=job_queue, batch_job_def=job_def,
+                           github_repo=github_repo, profile=profile)
+    job_queue = config['batch_job_queue']
+    job_def = config['batch_job_def']
+    github_repo = config['github_repo']
+
+    if not is_branch_valid(github_repo, branch):
+        exit(1)
+
+    full_command = ['run_rv', github_repo, branch]
     full_command.extend(command.split())
 
     client = boto3.client('batch')
-    job_queue = 'raster-vision-gpu' if gpu else \
-        'raster-vision-cpu'
-    job_definition = 'raster-vision-gpu' if gpu else \
-        'raster-vision-cpu'
-
     job_name = str(uuid.uuid4())
     depends_on = [{'jobId': job_id} for job_id in parent_job_ids]
 
     kwargs = {
         'jobName': job_name,
         'jobQueue': job_queue,
-        'jobDefinition': job_definition,
+        'jobDefinition': job_def,
         'containerOverrides': {
             'command': full_command
         },
@@ -57,12 +69,18 @@ def _batch_submit(branch_name,
 
 
 @click.command()
-@click.argument('branch_name')
 @click.argument('command')
+@click.option('--branch', default='develop')
 @click.option('--attempts', default=3, help='Number of times to retry job')
-@click.option('--gpu', is_flag=True, help='Use CPU EC2 instances')
-def batch_submit(branch_name, command, attempts, gpu):
-    _batch_submit(branch_name, command, attempts=attempts, gpu=gpu)
+@click.option('--job-queue', help='Batch job queue')
+@click.option('--job-def', help='Batch job definition')
+@click.option('--github-repo', help='Github repo with code to run')
+@click.option('--profile', help='RV configuration profile to use')
+def batch_submit(command, branch, attempts, job_queue, job_def,
+                 github_repo, profile):
+    _batch_submit(command, branch=branch, attempts=attempts,
+                  job_queue=job_queue, job_def=job_def,
+                  github_repo=github_repo, profile=profile)
 
 
 if __name__ == '__main__':

--- a/src/rastervision/utils/rv_config.py
+++ b/src/rastervision/utils/rv_config.py
@@ -1,0 +1,122 @@
+import configparser
+import os
+from os.path import join
+from pathlib import Path
+
+from rastervision.utils.files import (file_to_str, NotReadableError)
+
+HOME_CONFIG_PATH = join(str(Path.home()), '.rastervision', 'config.ini')
+
+
+def _get_profile(profile=None):
+    if profile is not None:
+        return profile
+    return os.environ.get('RV_PROFILE', 'default')
+
+
+def _get_from_args(batch_job_queue=None, batch_job_def=None, github_repo=None):
+    return {
+        'batch_job_def': batch_job_def,
+        'batch_job_queue': batch_job_queue,
+        'github_repo': github_repo
+    }
+
+
+def _get_empty():
+    return _get_from_args()
+
+
+def _get_from_env():
+    return {
+        'batch_job_def': os.environ.get('RV_BATCH_JOB_DEF'),
+        'batch_job_queue': os.environ.get('RV_BATCH_JOB_QUEUE'),
+        'github_repo': os.environ.get('RV_GITHUB_REPO')
+    }
+
+
+def _get_from_file(config_uri, profile=None):
+    profile = _get_profile(profile=profile)
+    try:
+        config_str = file_to_str(config_uri)
+        config = configparser.ConfigParser()
+        config.read_string(config_str)
+        if profile in config:
+            return config[profile]
+        return _get_empty()
+    except NotReadableError:
+        return _get_empty()
+
+
+def _get_from_env_file(profile=None):
+    profile = _get_profile(profile=profile)
+    config_uri = os.environ.get('RV_CONFIG_URI')
+    if config_uri is None:
+        return _get_empty()
+    return _get_from_file(config_uri, profile=profile)
+
+
+def _merge_dict(base, override):
+    new_dict = dict(base)
+    for key, val in override.items():
+        if val is not None:
+            new_dict[key] = val
+    return new_dict
+
+
+def _validate_config(config):
+    var_names = ['batch_job_queue', 'batch_job_def', 'github_repo']
+    for var_name in var_names:
+        if config[var_name] is None:
+            raise ValueError('Cannot find {} in RV config'.format(var_name))
+
+
+def get_rv_config(batch_job_queue=None, batch_job_def=None, github_repo=None,
+                  profile=None, home_config_path=HOME_CONFIG_PATH):
+    """Get an RV configuration dictionary.
+
+    This computes an RV configuration dictionary from configuration files,
+    environment variables, and arguments to this function. It uses a
+    precedence hierarchy (similar to the AWS CLI) to determine how values are
+    overridden.
+
+    There are two optional configuration files: the environment
+    config file (pointed to by env var `RV_CONFIG_URI` which can be remote) and
+    the home config file (at ~/.rastervision/config.ini). The files should be
+    in the format of a .ini parsable by the built-in Python configparser. They
+    should contain sections which are referred to as profiles. The profile that
+    is used is determined by the `profile` argument if provided or the
+    `RV_PROFILE` env var.
+
+    The optional environment variables include: `RV_BATCH_JOB_DEF`,
+    `RV_BATCH_JOB_QUEUE`, and `RV_GITHUB_REPO`.
+
+    The precedence ordering is:
+    arguments > env vars > home config file > env config file
+
+    Args:
+        batch_job_queue: the AWS Batch job queue name to use when running
+            remote jobs
+        batch_job_def: the AWS Batch job definition name to use
+        github_repo: the Github repo containing the branch of RV to download
+            and utilize when running remote jobs
+        profile: the section of the config file with fields to use
+        home_config_path: path to the home config file
+
+    Returns:
+        Dict of form
+        {
+            'batch_job_queue': '...',
+            'batch_job_def': '...',
+            'github_repo': '...'
+        }
+    """
+    profile = _get_profile(profile=profile)
+    config = _get_from_env_file(profile=profile)
+    config = _merge_dict(config,
+                         _get_from_file(home_config_path, profile=profile))
+    config = _merge_dict(config, _get_from_env())
+    config = _merge_dict(config, _get_from_args(
+        batch_job_queue=batch_job_queue, batch_job_def=batch_job_def,
+        github_repo=github_repo))
+    _validate_config(config)
+    return config

--- a/src/rastervision/utils/rv_config_test.py
+++ b/src/rastervision/utils/rv_config_test.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest import mock
+import tempfile
+from os.path import join
+
+from rastervision.utils.rv_config import get_rv_config
+from rastervision.utils.files import str_to_file
+
+
+class TestConfig(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir_obj = tempfile.TemporaryDirectory()
+        self.temp_dir = self.temp_dir_obj.name
+        self.env_config_path = join(self.temp_dir, 'env_config.ini')
+        self.home_config_path = join(self.temp_dir, 'home_config.ini')
+
+    def tearDown(self):
+        self.temp_dir_obj.cleanup()
+
+    def test_precedence(self):
+        env_patches = {
+            'RV_CONFIG_URI': self.env_config_path,
+            'RV_GITHUB_REPO': 'c'
+        }
+        with mock.patch.dict('os.environ', env_patches):
+            env_config_str = """
+[default]
+batch_job_def = a
+"""
+            str_to_file(env_config_str, self.env_config_path)
+
+            home_config_str = """
+[default]
+batch_job_def = b
+batch_job_queue = a
+github_repo = a
+"""
+            str_to_file(home_config_str, self.home_config_path)
+
+            config = get_rv_config(
+                batch_job_queue='d',
+                home_config_path=self.home_config_path)
+
+            expected_config = {
+                'batch_job_queue': 'd',
+                'github_repo': 'c',
+                'batch_job_def': 'b'
+            }
+            self.assertDictEqual(expected_config, config)
+        # TODO set env vars back
+
+    def test_no_files(self):
+        env_patches = {
+            'RV_GITHUB_REPO': 'a',
+            'RV_BATCH_JOB_DEF': 'b'
+        }
+        with mock.patch.dict('os.environ', env_patches):
+            config = get_rv_config(
+                batch_job_queue='c',
+                home_config_path=self.home_config_path)
+
+            expected_config = {
+                'batch_job_queue': 'c',
+                'github_repo': 'a',
+                'batch_job_def': 'b'
+            }
+            self.assertDictEqual(expected_config, config)
+
+    def abstract_test_profile(self, profile):
+        home_config_str = """
+[a]
+batch_job_def = a
+batch_job_queue = a
+github_repo = a
+[b]
+batch_job_def = b
+batch_job_queue = b
+github_repo = b
+"""
+        str_to_file(home_config_str, self.home_config_path)
+        config = get_rv_config(
+            home_config_path=self.home_config_path,
+            profile=profile)
+
+        expected_config = {
+            'batch_job_queue': 'b',
+            'github_repo': 'b',
+            'batch_job_def': 'b'
+        }
+        self.assertDictEqual(expected_config, config)
+
+    def test_profile(self):
+        self.abstract_test_profile('b')
+
+    def test_profile_in_env(self):
+        env_patches = {
+            'RV_PROFILE': 'b',
+        }
+        with mock.patch.dict('os.environ', env_patches):
+            self.abstract_test_profile(None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/scripts/run_rv
+++ b/src/scripts/run_rv
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-# Script to run a command on a specific branch of RV. Used for running commands
-# in AWS Batch jobs.
+# Script to run a command using a specific repo and branch of RV.
+# Used for running commands in AWS Batch jobs.
 
 set -ex
 
-BRANCH=$1
-COMMAND="${@:2}"
+REPO=$1
+BRANCH=$2
+COMMAND="${@:3}"
 
-git clone -b $BRANCH https://github.com/azavea/raster-vision.git /tmp/raster-vision
+git clone -b $BRANCH $REPO /tmp/raster-vision
 cp -R /tmp/raster-vision/src/* /opt/src/
 /opt/src/scripts/compile
 $COMMAND


### PR DESCRIPTION
## Overview

This PR adds the ability to configure the RV library. It follows the pattern used by the AWS CLI where the config file has profiles which can be selected, and there is a precedence hierarchy where env vars and functional arguments can be used to override config files. The PyDoc for the`get_rv_config` function provides further details. Currently, the variables in the config are used to control Batch job submission. The config is used by the `batch_submit` function to eliminate a few hard-coded constants, and also allows specifying the Github repo with the code to run remotely.

### Checklist

- [ ] Ran scripts/format_code and commited any changes
- [ ] Documentation updated if needed
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Notes

This is a WIP PR at the moment because the corresponding changes have not been propagated to the chain workflow runner. I haven't done this because that code is getting removed after I add the new config library in #348. This can still be tested though using the batch submit script directly.

## Testing Instructions

* Make an RV config file at `~/.rastervision/config.ini` containing something like: 
```
[cpu]
batch_job_def = raster-vision-cpu
batch_job_queue = raster-vision-cpu
github_repo = https://github.com/azavea/raster-vision.git

[gpu]
batch_job_def = raster-vision-gpu
batch_job_queue = raster-vision-gpu
github_repo = https://github.com/azavea/raster-vision.git
```
* Get an RV console with the RV config forwarded using 
```
./scripts/run --aws --rv-config
```
* In the console, submit a job as follows and check in the Batch console that the right thing happened.
```
python -m rastervision.utils.batch \
    "python -m rastervision.run --help" \
    --profile cpu
```
* Experiment with overriding config values using env vars and/or command line arguments.

Closes #XXX
