### PR TITLE
WIP: Convert nodata values to zeros

### DIFF
--- a/src/rastervision/raster_sources/rasterio_raster_source.py
+++ b/src/rastervision/raster_sources/rasterio_raster_source.py
@@ -9,11 +9,19 @@ from rastervision.core.box import Box
 def load_window(image_dataset, window=None):
     """Load a window of an image from a TIFF file.
 
+    Converts nodata values to 0.
+
     Args:
         window: ((row_start, row_stop), (col_start, col_stop)) or
         ((y_min, y_max), (x_min, x_max))
     """
     im = image_dataset.read(window=window, boundless=True)
+
+    # Handle non-zero NODATA values by setting the data to 0.
+    for channel, nodata in enumerate(image_dataset.nodatavals):
+        if nodata is not None and nodata != 0:
+            im[channel, im[channel] == nodata] = 0
+
     im = np.transpose(im, axes=[1, 2, 0])
     return im
 

--- a/src/rastervision/raster_sources/rasterio_raster_source_test.py
+++ b/src/rastervision/raster_sources/rasterio_raster_source_test.py
@@ -1,0 +1,41 @@
+import unittest
+import tempfile
+import os
+
+import rasterio
+import numpy as np
+
+from rastervision.raster_sources.rasterio_raster_source import (load_window)
+from rastervision.core.box import Box
+
+
+class RasterioRasterSourceTest(unittest.TestCase):
+    def test_load_window(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # make geotiff filled with ones and zeros with nodata == 1
+            image_path = os.path.join(temp_dir, 'temp.tif')
+            height = 100
+            width = 100
+            nb_channels = 3
+            image_dataset = rasterio.open(
+                image_path,
+                'w',
+                driver='GTiff',
+                height=height,
+                width=width,
+                count=nb_channels,
+                dtype=np.uint8,
+                nodata=1)
+            im = np.random.randint(0, 2, (height, width, nb_channels)).astype(
+                np.uint8)
+            for channel in range(nb_channels):
+                image_dataset.write(im[:, :, channel], channel + 1)
+
+            # Should be all zeros after converting nodata values to zero.
+            window = Box.make_square(0, 0, 100).rasterio_format()
+            chip = load_window(image_dataset, window=window)
+            np.testing.assert_equal(chip, np.zeros(chip.shape))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

This converts nodata values in GeoTIFFs to zeros, which RV interprets as nodata values.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

See https://github.com/azavea/raster-vision/issues/365