### PR TITLE
Add nodata data augmentation for object detection

### DIFF
--- a/src/rastervision/protos/make_training_chips.proto
+++ b/src/rastervision/protos/make_training_chips.proto
@@ -18,6 +18,12 @@ message MakeTrainingChipsConfig {
         required float neg_ratio = 1;
 
         /*
+            The probability of adding a random square of zeros (RV's nodata
+            value) to negative chips.
+        */
+        required float nodata_aug_prob = 5 [default=0.0];
+
+        /*
             When a box is partially outside of a training chip, it is not
             clear if (a clipped version) of the box should be included in
             the chip. If the IOA (intersection over area) of the box with the

--- a/src/rastervision/samples/workflow-configs/object-detection/cowc-potsdam-test.json
+++ b/src/rastervision/samples/workflow-configs/object-detection/cowc-potsdam-test.json
@@ -46,7 +46,8 @@
     "make_training_chips_options": {
         "object_detection_options": {
             "neg_ratio": 1.0,
-            "ioa_thresh": 0.8
+            "ioa_thresh": 0.8,
+            "nodata_aug_prob": 0.5
         }
     },
     "train_options": {


### PR DESCRIPTION
## Overview

Object detection models trained on rectangular scenes without NODATA on the border values often have trouble making predictions on scenes with irregular borders containing NODATA values. This PR adds a new data augmentation option to handle this problem. It randomly adds squares filled with zeros to negative chips. It only works on negative chips since blacking  out random parts of positive chips could mask objects, which would be misleading to the training algorithm. This only works for object detection since there is no notion of negative chips for the other tasks.

### Checklist

- [ ] Ran scripts/format_code and commited any changes
- [ ] Documentation updated if needed
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Notes

* TFOD has a builtin augmentation option to randomly add black squares but it apparently does it indiscriminately, adding black squares even when there is a label on top of it, which seems less correct.

## Testing Instructions

* Run test cowc-potsdam workflow and check that some negative chips have black squares in them.

Closes #365  
