### PR TITLE
Add batching of chips for prediction 

### DIFF
--- a/src/rastervision/core/evaluation_item.py
+++ b/src/rastervision/core/evaluation_item.py
@@ -36,7 +36,7 @@ class EvaluationItem(object):
 
             def weighted_avg(self_val, other_val):
                 if self_val is None and other_val is None:
-                    return None
+                    return 0.0
                 # Handle a single None value by setting them to zero.
                 return (self_ratio * (self_val or 0) +
                         other_ratio * (other_val or 0))

--- a/src/rastervision/core/ml_backend.py
+++ b/src/rastervision/core/ml_backend.py
@@ -48,12 +48,12 @@ class MLBackend(ABC):
         pass
 
     @abstractmethod
-    def predict(self, chip, options):
+    def predict(self, chips, windows, options):
         """Return predictions for a chip using model.
 
         Args:
-            chip: [height, width, channels] numpy array
+            chips: [[height, width, channels], ...] numpy array of chips
+            windows: List of boxes that are the windows aligned with the chips.
             options: PredictConfig.Options
         """
-        # TODO predict by the batch-load to make better use of the gpu
         pass

--- a/src/rastervision/evaluations/classification_evaluation.py
+++ b/src/rastervision/evaluations/classification_evaluation.py
@@ -54,6 +54,6 @@ class ClassificationEvaluation(Evaluation):
         self.compute_avg()
 
     def compute_avg(self):
-        self.avg_item = EvaluationItem(class_name='average')
+        self.avg_item = EvaluationItem(class_name='average', class_id=-1)
         for eval_item in self.class_to_eval_item.values():
             self.avg_item.merge(eval_item)

--- a/src/rastervision/evaluations/object_detection_evaluation_test.py
+++ b/src/rastervision/evaluations/object_detection_evaluation_test.py
@@ -89,9 +89,9 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
 
         avg_item = eval.avg_item
         self.assertEqual(avg_item.gt_count, 4)
-        self.assertEqual(avg_item.precision, None)
+        self.assertEqual(avg_item.precision, 0.0)
         self.assertEqual(avg_item.recall, 0.0)
-        self.assertEqual(avg_item.f1, None)
+        self.assertEqual(avg_item.f1, 0.0)
 
     def test_compute_no_ground_truth(self):
         eval = ObjectDetectionEvaluation()

--- a/src/rastervision/ml_backends/tf_deeplab.py
+++ b/src/rastervision/ml_backends/tf_deeplab.py
@@ -535,5 +535,5 @@ class TFDeeplab(MLBackend):
         if urlparse(train_logdir).scheme == 's3':
             sync_dir(train_logdir_local, train_logdir, delete=True)
 
-    def predict(self, chip, options):
+    def predict(self, chips, windows, options):
         return 1

--- a/src/rastervision/protos/predict.proto
+++ b/src/rastervision/protos/predict.proto
@@ -35,6 +35,10 @@ message PredictConfig {
         // used when training the model.
         optional int32 chip_size = 3;
 
+        // Number of chips to feed to the backend at one time
+        // for prediction.
+        optional int32 batch_size = 10 [default=10];
+
         optional bool debug = 4 [default=true];
         // Root of dir to write debug files to.
         optional string debug_uri = 7;

--- a/src/scripts/integration_tests.py
+++ b/src/scripts/integration_tests.py
@@ -86,7 +86,9 @@ def check_eval_item(test, expected_item, actual_item):
     f1_threshold = 0.01
     class_name = expected_item['class_name']
 
-    if math.fabs(expected_item['f1'] - actual_item['f1']) > f1_threshold:
+    expected_f1 = expected_item['f1'] or 0.0
+    actual_f1 = actual_item['f1'] or 0.0
+    if math.fabs(expected_f1 - actual_f1) > f1_threshold:
         errors.append(
             TestError(
                 test, 'F1 scores are not close enough',


### PR DESCRIPTION
## Overview

Adds the ability to batch up chips and send off to the backend  for processing. Allows the backend to more efficiently process larger sets of data, rather than sequentially going through small amounts of data.

## Testing Instructions

* Run integration  tests
* Tested against other GPU scenarios. Resulted in small speedup.

Closes #356
