### PR TITLE
Unit Tests: Expect 0.0 Instead of `None`

### DIFF
--- a/src/rastervision/evaluations/object_detection_evaluation_test.py
+++ b/src/rastervision/evaluations/object_detection_evaluation_test.py
@@ -89,9 +89,9 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
 
         avg_item = eval.avg_item
         self.assertEqual(avg_item.gt_count, 4)
-        self.assertEqual(avg_item.precision, None)
+        self.assertEqual(avg_item.precision, 0.0)
         self.assertEqual(avg_item.recall, 0.0)
-        self.assertEqual(avg_item.f1, None)
+        self.assertEqual(avg_item.f1, 0.0)
 
     def test_compute_no_ground_truth(self):
         eval = ObjectDetectionEvaluation()


### PR DESCRIPTION
The unit tests have been updated to account for this change in https://github.com/azavea/raster-vision/pull/369

```diff
--- a/src/rastervision/core/evaluation_item.py
+++ b/src/rastervision/core/evaluation_item.py
@@ -36,7 +36,7 @@ def merge(self, other):

             def weighted_avg(self_val, other_val):
                 if self_val is None and other_val is None:
-                    return None
+                    return 0.0
                 # Handle a single None value by setting them to zero.
                 return (self_ratio * (self_val or 0) +
                         other_ratio * (other_val or 0))
```

## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
