### PR TITLE
Skip objects that are too big

### DIFF
--- a/src/rastervision/core/box.py
+++ b/src/rastervision/core/box.py
@@ -5,6 +5,10 @@ import numpy as np
 from shapely.geometry import box as ShapelyBox
 
 
+class BoxSizeError(ValueError):
+    pass
+
+
 class Box():
     """A multi-purpose box (ie. rectangle)."""
 
@@ -96,6 +100,12 @@ class Box():
         Args:
             size: the width and height of the new Box
         """
+        if size < self.get_width():
+            raise BoxSizeError('size of random container cannot be < width')
+
+        if size < self.get_height():
+            raise BoxSizeError('size of random container cannot be < height')
+
         lb = self.ymin - (size - self.get_height())
         ub = self.ymin
         rand_y = random.randint(lb, ub)
@@ -113,10 +123,10 @@ class Box():
             size: the height and width of the new Box
         """
         if size >= self.get_width():
-            raise ValueError('size of random square cannot be >= width')
+            raise BoxSizeError('size of random square cannot be >= width')
 
         if size >= self.get_height():
-            raise ValueError('size of random square cannot be >= height')
+            raise BoxSizeError('size of random square cannot be >= height')
 
         lb = self.ymin
         ub = self.ymax - size

--- a/src/rastervision/core/box_test.py
+++ b/src/rastervision/core/box_test.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from rastervision.core.box import Box
+from rastervision.core.box import Box, BoxSizeError
 from shapely.geometry import box as ShapelyBox
 
 np.random.seed(1)
@@ -63,6 +63,11 @@ class TestBox(unittest.TestCase):
             self.assertEqual(container.get_width(), size)
             self.assertTrue(container.get_shapely().contains(
                 self.box.get_shapely()))
+
+    def test_make_random_square_container_too_big(self):
+        size = 1
+        with self.assertRaises(BoxSizeError):
+            self.box.make_random_square_container(size)
 
     def test_make_random_square(self):
         window = Box(5, 5, 15, 15)


### PR DESCRIPTION
## Overview

If an object is bigger than the chip size, skip over it and print a warning.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* I ran `make_training_chips` with the following change to force one of the objects to be greater than the chip size. I also updated the unit tests.
```
diff --git a/src/rastervision/label_stores/object_detection_geojson_file.py b/src/rastervision/label_stores/object_detection_geojson_file.py
index adc98f3..d27fd6a 100644
--- a/src/rastervision/label_stores/object_detection_geojson_file.py
+++ b/src/rastervision/label_stores/object_detection_geojson_file.py
@@ -63,9 +63,15 @@ def geojson_to_labels(geojson_dict, crs_transformer, extent=None):
     else:
         labels = ObjectDetectionLabels.make_empty()

+    boxes[0][0] = 0
+    boxes[0][1] = 0
+    boxes[0][2] = 400
+    boxes[0][3] = 400
+
```

Closes #372
