### PR TITLE
Fixes while testing AWS Runner

### DIFF
--- a/src/Dockerfile-cpu
+++ b/src/Dockerfile-cpu
@@ -16,11 +16,12 @@ RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 WORKDIR /opt/src/
 ENV PYTHONPATH=/opt/src:/opt/tf-models:/opt/tf-models/slim:$PYTHONPATH
 
+# Install requirements.txt
+COPY ./requirements.txt /opt/src/requirements.txt
+RUN pip install -r requirements.txt
+
 COPY scripts/run_rv /usr/local/bin/
 COPY ./ /opt/src/
 RUN /opt/src/scripts/compile
-
-# Install requirements.txt
-RUN pip install -r requirements.txt
 
 CMD ["bash"]

--- a/src/Dockerfile-gpu
+++ b/src/Dockerfile-gpu
@@ -16,6 +16,10 @@ RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 WORKDIR /opt/src/
 ENV PYTHONPATH=/opt/src:/opt/tf-models:/opt/tf-models/slim:$PYTHONPATH
 
+# Install requirements.txt
+COPY ./requirements.txt /opt/src/requirements.txt
+RUN pip install -r requirements.txt
+
 COPY scripts/run_rv /usr/local/bin/
 COPY ./ /opt/src/
 RUN /opt/src/scripts/compile

--- a/src/rastervision/backend/keras_classification.py
+++ b/src/rastervision/backend/keras_classification.py
@@ -1,7 +1,6 @@
 from os.path import join
 import os
 import shutil
-from urllib.parse import urlparse
 import uuid
 
 import numpy as np
@@ -9,8 +8,8 @@ from google.protobuf import json_format
 
 from rastervision.backend import Backend
 from rastervision.utils.files import (make_dir, get_local_path, upload_or_copy,
-                                      download_if_needed, start_sync, sync_to_dir,
-                                      sync_from_dir)
+                                      download_if_needed, start_sync,
+                                      sync_to_dir, sync_from_dir)
 from rastervision.utils.misc import save_img
 from rastervision.data import ChipClassificationLabels
 
@@ -228,14 +227,16 @@ class KerasClassification(Backend):
         # Get output from potential previous run so we can resume training.
         sync_from_dir(self.config.training_output_uri, model_files.base_dir)
 
-        sync = start_sync(model_files.base_dir,
-                          self.config.training_output_uri,
-                          sync_interval=self.config.train_options.sync_interval)
-        with sync as s:
+        sync = start_sync(
+            model_files.base_dir,
+            self.config.training_output_uri,
+            sync_interval=self.config.train_options.sync_interval)
+        with sync:
             _train(backend_config_path, pretrained_model_path)
 
         # Perform final sync
-        sync_to_dir(model_files.base_dir, self.config.training_output_uri, delete=True)
+        sync_to_dir(
+            model_files.base_dir, self.config.training_output_uri, delete=True)
 
     def load_model(self, tmp_dir):
         from keras_classification.builders import model_builder

--- a/src/rastervision/backend/keras_classification.py
+++ b/src/rastervision/backend/keras_classification.py
@@ -9,7 +9,8 @@ from google.protobuf import json_format
 
 from rastervision.backend import Backend
 from rastervision.utils.files import (make_dir, get_local_path, upload_or_copy,
-                                      download_if_needed, start_sync, sync_dir)
+                                      download_if_needed, start_sync, sync_to_dir,
+                                      sync_from_dir)
 from rastervision.utils.misc import save_img
 from rastervision.data import ChipClassificationLabels
 
@@ -225,20 +226,16 @@ class KerasClassification(Backend):
         backend_config_path, pretrained_model_path = model_paths
 
         # Get output from potential previous run so we can resume training.
-        if urlparse(self.config.training_output_uri).scheme == 's3':
-            sync_dir(self.config.training_output_uri, model_files.base_dir)
+        sync_from_dir(self.config.training_output_uri, model_files.base_dir)
 
-        start_sync(
-            model_files.base_dir,
-            self.config.training_output_uri,
-            sync_interval=self.config.train_options.sync_interval)
-        _train(backend_config_path, pretrained_model_path)
+        sync = start_sync(model_files.base_dir,
+                          self.config.training_output_uri,
+                          sync_interval=self.config.train_options.sync_interval)
+        with sync as s:
+            _train(backend_config_path, pretrained_model_path)
 
-        if urlparse(self.config.training_output_uri).scheme == 's3':
-            sync_dir(
-                model_files.base_dir,
-                self.config.training_output_uri,
-                delete=True)
+        # Perform final sync
+        sync_to_dir(model_files.base_dir, self.config.training_output_uri, delete=True)
 
     def load_model(self, tmp_dir):
         from keras_classification.builders import model_builder

--- a/src/rastervision/backend/tf_object_detection.py
+++ b/src/rastervision/backend/tf_object_detection.py
@@ -6,7 +6,6 @@ import os
 import shutil
 import tarfile
 from os.path import join
-from urllib.parse import urlparse
 from subprocess import Popen
 import atexit
 import glob
@@ -20,7 +19,8 @@ from google.protobuf import text_format, json_format
 from rastervision.backend import Backend
 from rastervision.data import ObjectDetectionLabels
 from rastervision.utils.files import (get_local_path, upload_or_copy, make_dir,
-                                      download_if_needed, sync_to_dir, start_sync)
+                                      download_if_needed, sync_to_dir,
+                                      start_sync)
 from rastervision.utils.misc import save_img
 
 TRAIN = 'train'
@@ -454,7 +454,6 @@ class TrainingPackage(object):
 
     def download_config(self):
         from object_detection.protos.pipeline_pb2 import TrainEvalPipelineConfig
-
         """Download a model and backend config and update its fields.
 
         This is used before training a model. This downloads and unzips a bunch
@@ -658,10 +657,11 @@ class TFObjectDetection(Backend):
         export_py = self.config.script_locations.export_uri
 
         # Train model and sync output periodically.
-        sync = start_sync(output_dir,
-                          self.config.training_output_uri,
-                          sync_interval=self.config.train_options.sync_interval)
-        with sync as s:
+        sync = start_sync(
+            output_dir,
+            self.config.training_output_uri,
+            sync_interval=self.config.train_options.sync_interval)
+        with sync:
             train(
                 config_path,
                 output_dir,

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -6,6 +6,7 @@ import click
 
 import rastervision as rv
 from rastervision.experiment import (ExperimentLoader, LoaderError)
+from rastervision.runner import (ExperimentRunner)
 
 
 def print_error(msg):
@@ -80,7 +81,7 @@ def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
                                                   '", "'.join(valid_runners)))
         sys.exit(1)
 
-    runner = rv.ExperimentRunner.get_runner(runner)
+    runner = ExperimentRunner.get_runner(runner)
 
     if experiment_module:
         module_to_load = experiment_module
@@ -114,9 +115,7 @@ def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
         experiments,
         commands_to_run=commands,
         rerun_commands=rerun,
-        skip_file_check=skip_file_check,
-        rv_repo=rv_repo,
-        rv_branch=rv_branch)
+        skip_file_check=skip_file_check)
 
 
 @main.command()

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -197,7 +197,7 @@ def predict(predict_package, image_uri, output_uri, update_stats,
 
 @main.command(
     'run_command', short_help='Run a command from configuration file.')
-@click.argument('command_config_uri', type=click.Path(exists=True))
+@click.argument('command_config_uri')
 def run_command(command_config_uri):
     """Run a command from a serialized command configuration
     at COMMAND_CONFIG_URI.

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -39,6 +39,11 @@ def main(profile):
           'about the commands to be run, but will not actually '
           'run the commands'))
 @click.option(
+    '--skip-file-check',
+    '-x',
+    is_flag=True,
+    help=('Skip the step that verifies that file exist.'))
+@click.option(
     '--arg',
     '-a',
     type=(str, str),
@@ -58,7 +63,8 @@ def main(profile):
     '--rv-branch',
     help=('Specifies the branch of the raster vision repo '
           'to use for executing commands remotely'))
-def run(runner, commands, experiment_module, dry_run, arg, rerun, rv_branch):
+def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
+        rerun, rv_branch):
     """Run Raster Vision commands from experiments, using the
     experiment runner named RUNNER."""
     # Validate runner
@@ -100,7 +106,11 @@ def run(runner, commands, experiment_module, dry_run, arg, rerun, rv_branch):
         else:
             print_error('No experiments found.')
 
-    runner.run(experiments, commands_to_run=commands, rerun_commands=rerun)
+    runner.run(
+        experiments,
+        commands_to_run=commands,
+        rerun_commands=rerun,
+        skip_file_check=skip_file_check)
 
 
 @main.command()

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -60,11 +60,15 @@ def main(profile):
     help=('Rerun commands, regardless if '
           'their output files already exist.'))
 @click.option(
+    '--rv-repo',
+    help=('Specifies the raster vision repository '
+          'to use for executing commands remotely'))
+@click.option(
     '--rv-branch',
     help=('Specifies the branch of the raster vision repo '
           'to use for executing commands remotely'))
 def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
-        rerun, rv_branch):
+        rerun, rv_repo, rv_branch):
     """Run Raster Vision commands from experiments, using the
     experiment runner named RUNNER."""
     # Validate runner
@@ -110,7 +114,9 @@ def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
         experiments,
         commands_to_run=commands,
         rerun_commands=rerun,
-        skip_file_check=skip_file_check)
+        skip_file_check=skip_file_check,
+        rv_repo=rv_repo,
+        rv_branch=rv_branch)
 
 
 @main.command()

--- a/src/rastervision/command/analyze_command_config.py
+++ b/src/rastervision/command/analyze_command_config.py
@@ -82,6 +82,9 @@ class AnalyzeCommandConfigBuilder(CommandConfigBuilder):
 
         return b
 
+    def get_root_uri(self, experiment_config):
+        return experiment_config.analyze_uri
+
     def with_experiment(self, experiment_config):
         b = super().with_experiment(experiment_config)
         b = b.with_task(experiment_config.task)

--- a/src/rastervision/command/analyze_command_config.py
+++ b/src/rastervision/command/analyze_command_config.py
@@ -8,8 +8,8 @@ from rastervision.protos.command_pb2 \
 
 
 class AnalyzeCommandConfig(CommandConfig):
-    def __init__(self, task, scenes, analyzers):
-        super().__init__(rv.ANALYZE)
+    def __init__(self, root_uri, task, scenes, analyzers):
+        super().__init__(rv.ANALYZE, root_uri)
         self.task = task
         self.scenes = scenes
         self.analyzers = analyzers
@@ -43,6 +43,7 @@ class AnalyzeCommandConfig(CommandConfig):
 
 class AnalyzeCommandConfigBuilder(CommandConfigBuilder):
     def __init__(self, prev=None):
+        super().__init__(prev)
         if prev is None:
             self.task = None
             self.scenes = None
@@ -52,34 +53,38 @@ class AnalyzeCommandConfigBuilder(CommandConfigBuilder):
             self.scenes = prev.scenes
             self.analyzers = prev.analyzers
 
-    def build(self):
-        if self.task is None:
-            raise rv.ConfigError(
-                'task not set. Use with_task or with_experiment')
+    def validate(self):
+        super().validate()
         if self.scenes is None:
             raise rv.ConfigError(
                 'scenes not set. Use with_scenes or with_experiment')
         if self.analyzers is None:
             raise rv.ConfigError(
                 'analyzers not set. Use with_analyzers or with_experiment')
-        return AnalyzeCommandConfig(self.task, self.scenes, self.analyzers)
+
+    def build(self):
+        self.validate()
+        return AnalyzeCommandConfig(self.root_uri, self.task, self.scenes,
+                                    self.analyzers)
 
     def from_proto(self, msg):
-        self.process_plugins(msg)
-        msg = msg.analyze_config
+        b = super().from_proto(msg)
 
-        task = rv.TaskConfig.from_proto(msg.task)
-        scenes = list(map(rv.SceneConfig.from_proto, msg.scenes))
-        analyzers = list(map(rv.AnalyzerConfig.from_proto, msg.analyzers))
+        conf = msg.analyze_config
 
-        b = self.with_task(task)
+        task = rv.TaskConfig.from_proto(conf.task)
+        scenes = list(map(rv.SceneConfig.from_proto, conf.scenes))
+        analyzers = list(map(rv.AnalyzerConfig.from_proto, conf.analyzers))
+
+        b = b.with_task(task)
         b = b.with_scenes(scenes)
         b = b.with_analyzers(analyzers)
 
         return b
 
     def with_experiment(self, experiment_config):
-        b = self.with_task(experiment_config.task)
+        b = super().with_experiment(experiment_config)
+        b = b.with_task(experiment_config.task)
         b = b.with_scenes(experiment_config.dataset.all_scenes())
         b = b.with_analyzers(experiment_config.analyzers)
         return b

--- a/src/rastervision/command/bundle_command_config.py
+++ b/src/rastervision/command/bundle_command_config.py
@@ -89,6 +89,9 @@ class BundleCommandConfigBuilder(CommandConfigBuilder):
 
         return b
 
+    def get_root_uri(self, experiment_config):
+        return experiment_config.bundle_uri
+
     def with_experiment(self, experiment_config):
         b = super().with_experiment(experiment_config)
         b = b.with_task(experiment_config.task)

--- a/src/rastervision/command/chip_command_config.py
+++ b/src/rastervision/command/chip_command_config.py
@@ -8,8 +8,9 @@ from rastervision.protos.command_pb2 \
 
 
 class ChipCommandConfig(CommandConfig):
-    def __init__(self, task, backend, augmentors, train_scenes, val_scenes):
-        super().__init__(rv.CHIP)
+    def __init__(self, root_uri, task, backend, augmentors, train_scenes,
+                 val_scenes):
+        super().__init__(rv.CHIP, root_uri)
         self.task = task
         self.backend = backend
         self.augmentors = augmentors
@@ -58,6 +59,7 @@ class ChipCommandConfig(CommandConfig):
 
 class ChipCommandConfigBuilder(CommandConfigBuilder):
     def __init__(self, prev=None):
+        super().__init__(prev)
         if prev is None:
             self.task = None
             self.backend = None
@@ -71,7 +73,8 @@ class ChipCommandConfigBuilder(CommandConfigBuilder):
             self.train_scenes = prev.train_scenes
             self.val_scenes = prev.val_scenes
 
-    def build(self):
+    def validate(self):
+        super().validate()
         if self.task is None:
             raise rv.ConfigError(
                 'Task not set. Use with_task or with_experiment')
@@ -80,20 +83,24 @@ class ChipCommandConfigBuilder(CommandConfigBuilder):
             raise rv.ConfigError(
                 'Backend not set. Use with_backend or with_experiment')
 
-        return ChipCommandConfig(self.task, self.backend, self.augmentors,
-                                 self.train_scenes, self.val_scenes)
+    def build(self):
+        self.validate()
+        return ChipCommandConfig(self.root_uri, self.task, self.backend,
+                                 self.augmentors, self.train_scenes,
+                                 self.val_scenes)
 
     def from_proto(self, msg):
-        self.process_plugins(msg)
-        msg = msg.chip_config
+        b = super().from_proto(msg)
 
-        task = rv.TaskConfig.from_proto(msg.task)
-        backend = rv.BackendConfig.from_proto(msg.backend)
-        augmentors = list(map(rv.AugmentorConfig.from_proto, msg.augmentors))
-        train_scenes = list(map(rv.SceneConfig.from_proto, msg.train_scenes))
-        val_scenes = list(map(rv.SceneConfig.from_proto, msg.train_scenes))
+        conf = conf.chip_config
 
-        b = self.with_task(task)
+        task = rv.TaskConfig.from_proto(conf.task)
+        backend = rv.BackendConfig.from_proto(conf.backend)
+        augmentors = list(map(rv.AugmentorConfig.from_proto, conf.augmentors))
+        train_scenes = list(map(rv.SceneConfig.from_proto, conf.train_scenes))
+        val_scenes = list(map(rv.SceneConfig.from_proto, conf.train_scenes))
+
+        b = b.with_task(task)
         b = b.with_backend(backend)
         b = b.with_augmentors(augmentors)
         b = b.with_train_scenes(train_scenes)
@@ -102,7 +109,8 @@ class ChipCommandConfigBuilder(CommandConfigBuilder):
         return b
 
     def with_experiment(self, experiment_config):
-        b = self.with_task(experiment_config.task)
+        b = super().with_experiment(experiment_config)
+        b = b.with_task(experiment_config.task)
         b = b.with_backend(experiment_config.backend)
         b = b.with_augmentors(experiment_config.dataset.augmentors)
         b = b.with_train_scenes(experiment_config.dataset.train_scenes)

--- a/src/rastervision/command/chip_command_config.py
+++ b/src/rastervision/command/chip_command_config.py
@@ -92,7 +92,7 @@ class ChipCommandConfigBuilder(CommandConfigBuilder):
     def from_proto(self, msg):
         b = super().from_proto(msg)
 
-        conf = conf.chip_config
+        conf = msg.chip_config
 
         task = rv.TaskConfig.from_proto(conf.task)
         backend = rv.BackendConfig.from_proto(conf.backend)

--- a/src/rastervision/command/chip_command_config.py
+++ b/src/rastervision/command/chip_command_config.py
@@ -108,6 +108,9 @@ class ChipCommandConfigBuilder(CommandConfigBuilder):
 
         return b
 
+    def get_root_uri(self, experiment_config):
+        return experiment_config.chip_uri
+
     def with_experiment(self, experiment_config):
         b = super().with_experiment(experiment_config)
         b = b.with_task(experiment_config.task)

--- a/src/rastervision/command/command_config.py
+++ b/src/rastervision/command/command_config.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from copy import deepcopy
 
 import rastervision as rv
 from rastervision.plugin import PluginRegistry
@@ -7,8 +8,9 @@ from rastervision.protos.command_pb2 \
 
 
 class CommandConfig(ABC):
-    def __init__(self, command_type):
+    def __init__(self, command_type, root_uri):
         self.command_type = command_type
+        self.root_uri = root_uri
 
     @abstractmethod
     def create_command(self, tmp_dir):
@@ -20,7 +22,9 @@ class CommandConfig(ABC):
         """
         plugin_config = PluginRegistry.get_instance().to_proto()
         return CommandConfigMsg(
-            command_type=self.command_type, plugins=plugin_config)
+            command_type=self.command_type,
+            root_uri=self.root_uri,
+            plugins=plugin_config)
 
     def to_builder(self):
         return rv._registry.get_command_config_builder(self.command_type)(self)
@@ -43,29 +47,42 @@ class CommandConfig(ABC):
 
 
 class CommandConfigBuilder(ABC):
+    def __init__(self, prev):
+        if prev is None:
+            self.root_uri = None
+        else:
+            self.root_uri = prev.root_uri
+
     @abstractmethod
     def build(self, prev=None):
         """Returns the configuration that is built by this builder.
         """
         pass
 
-    @abstractmethod
     def from_proto(self, msg):
         """Return a builder that takes the configuration from the proto message
            as its starting point.
         """
-        pass
 
-    def process_plugins(self, msg):
-        """Process plugins from a command config protobuf message."""
+        # Process plugins from a command config protobuf message.
         if msg.HasField('plugins'):
             PluginRegistry.get_instance().add_plugins_from_proto(msg.plugins)
-        return self
 
-    @abstractmethod
-    def with_experiment(self, experiment):
+        return self.with_root_uri(msg.root_uri)
+
+    def validate(self):
+        if self.root_uri is None:
+            raise rv.ConfigError(
+                'root_uri not set. Use with_root_uri or with_experiment')
+
+    def with_experiment(self, experiment_config):
         """Generate all required information from this experiment.
            It is sufficient to only call 'with_experiment' before
            calling .build()
         """
-        pass
+        return self.with_root_uri(experiment_config.analyze_uri)
+
+    def with_root_uri(self, root_uri):
+        b = deepcopy(self)
+        b.root_uri = root_uri
+        return b

--- a/src/rastervision/command/command_config.py
+++ b/src/rastervision/command/command_config.py
@@ -59,6 +59,11 @@ class CommandConfigBuilder(ABC):
         """
         pass
 
+    @abstractmethod
+    def get_root_uri(self, experiment_config):
+        """Return the root URI for this command for a given experiment"""
+        pass
+
     def from_proto(self, msg):
         """Return a builder that takes the configuration from the proto message
            as its starting point.
@@ -80,7 +85,7 @@ class CommandConfigBuilder(ABC):
            It is sufficient to only call 'with_experiment' before
            calling .build()
         """
-        return self.with_root_uri(experiment_config.analyze_uri)
+        return self.with_root_uri(self.get_root_uri(experiment_config))
 
     def with_root_uri(self, root_uri):
         b = deepcopy(self)

--- a/src/rastervision/command/eval_command_config.py
+++ b/src/rastervision/command/eval_command_config.py
@@ -8,8 +8,8 @@ from rastervision.protos.command_pb2 \
 
 
 class EvalCommandConfig(CommandConfig):
-    def __init__(self, task, scenes, evaluators):
-        super().__init__(rv.EVAL)
+    def __init__(self, root_uri, task, scenes, evaluators):
+        super().__init__(rv.EVAL, root_uri)
         self.task = task
         self.scenes = scenes
         self.evaluators = evaluators
@@ -43,6 +43,7 @@ class EvalCommandConfig(CommandConfig):
 
 class EvalCommandConfigBuilder(CommandConfigBuilder):
     def __init__(self, prev=None):
+        super().__init__(prev)
         if prev is None:
             self.task = None
             self.scenes = None
@@ -52,7 +53,8 @@ class EvalCommandConfigBuilder(CommandConfigBuilder):
             self.scenes = prev.scenes
             self.evaluators = prev.evaluators
 
-    def build(self):
+    def validate(self):
+        super().validate()
         if self.task is None:
             raise rv.ConfigError(
                 'task not set. Use with_task or with_experiment')
@@ -62,24 +64,30 @@ class EvalCommandConfigBuilder(CommandConfigBuilder):
         if self.evaluators is None:
             raise rv.ConfigError(
                 'evaluators not set. Use with_evaluators or with_experiment')
-        return EvalCommandConfig(self.task, self.scenes, self.evaluators)
+
+    def build(self):
+        self.validate()
+        return EvalCommandConfig(self.root_uri, self.task, self.scenes,
+                                 self.evaluators)
 
     def from_proto(self, msg):
-        self.process_plugins(msg)
-        msg = msg.eval_config
+        b = super().from_proto(msg)
 
-        task = rv.TaskConfig.from_proto(msg.task)
-        scenes = list(map(rv.SceneConfig.from_proto, msg.scenes))
-        evaluators = list(map(rv.EvaluatorConfig.from_proto, msg.evaluators))
+        conf = msg.eval_config
 
-        b = self.with_task(task)
+        task = rv.TaskConfig.from_proto(conf.task)
+        scenes = list(map(rv.SceneConfig.from_proto, conf.scenes))
+        evaluators = list(map(rv.EvaluatorConfig.from_proto, conf.evaluators))
+
+        b = b.with_task(task)
         b = b.with_scenes(scenes)
         b = b.with_evaluators(evaluators)
 
         return b
 
     def with_experiment(self, experiment_config):
-        b = self.with_task(experiment_config.task)
+        b = super().with_experiment(experiment_config)
+        b = b.with_task(experiment_config.task)
         b = b.with_scenes(experiment_config.dataset.validation_scenes)
         b = b.with_evaluators(experiment_config.evaluators)
         return b

--- a/src/rastervision/command/eval_command_config.py
+++ b/src/rastervision/command/eval_command_config.py
@@ -85,6 +85,9 @@ class EvalCommandConfigBuilder(CommandConfigBuilder):
 
         return b
 
+    def get_root_uri(self, experiment_config):
+        return experiment_config.eval_uri
+
     def with_experiment(self, experiment_config):
         b = super().with_experiment(experiment_config)
         b = b.with_task(experiment_config.task)

--- a/src/rastervision/command/predict_command_config.py
+++ b/src/rastervision/command/predict_command_config.py
@@ -8,8 +8,8 @@ from rastervision.protos.command_pb2 \
 
 
 class PredictCommandConfig(CommandConfig):
-    def __init__(self, task, backend, scenes):
-        super().__init__(rv.PREDICT)
+    def __init__(self, root_uri, task, backend, scenes):
+        super().__init__(rv.PREDICT, root_uri)
         self.task = task
         self.backend = backend
         self.scenes = scenes
@@ -47,6 +47,7 @@ class PredictCommandConfig(CommandConfig):
 
 class PredictCommandConfigBuilder(CommandConfigBuilder):
     def __init__(self, prev=None):
+        super().__init__(prev)
         if prev is None:
             self.task = None
             self.backend = None
@@ -56,7 +57,8 @@ class PredictCommandConfigBuilder(CommandConfigBuilder):
             self.backend = prev.backend
             self.scenes = prev.scenes
 
-    def build(self):
+    def validate(self):
+        super().validate()
         if self.task is None:
             raise rv.ConfigError(
                 'Task not set. Use with_task or with_experiment')
@@ -65,24 +67,29 @@ class PredictCommandConfigBuilder(CommandConfigBuilder):
             raise rv.ConfigError(
                 'Backend not set. Use with_backend or with_experiment')
 
-        return PredictCommandConfig(self.task, self.backend, self.scenes)
+    def build(self):
+        self.validate()
+        return PredictCommandConfig(self.root_uri, self.task, self.backend,
+                                    self.scenes)
 
     def from_proto(self, msg):
-        self.process_plugins(msg)
-        msg = msg.predict_config
+        b = b.from_proto(msg)
 
-        task = rv.TaskConfig.from_proto(msg.task)
-        backend = rv.BackendConfig.from_proto(msg.backend)
-        scenes = list(map(rv.SceneConfig.from_proto, msg.scenes))
+        conf = msg.predict_config
 
-        b = self.with_task(task)
+        task = rv.TaskConfig.from_proto(conf.task)
+        backend = rv.BackendConfig.from_proto(conf.backend)
+        scenes = list(map(rv.SceneConfig.from_proto, conf.scenes))
+
+        b = b.with_task(task)
         b = b.with_backend(backend)
         b = b.with_scenes(scenes)
 
         return b
 
     def with_experiment(self, experiment_config):
-        b = self.with_task(experiment_config.task)
+        b = super().with_experiment(experiment_config)
+        b = b.with_task(experiment_config.task)
         b = b.with_backend(experiment_config.backend)
         b = b.with_scenes(experiment_config.dataset.validation_scenes +
                           experiment_config.dataset.test_scenes)

--- a/src/rastervision/command/predict_command_config.py
+++ b/src/rastervision/command/predict_command_config.py
@@ -87,6 +87,9 @@ class PredictCommandConfigBuilder(CommandConfigBuilder):
 
         return b
 
+    def get_root_uri(self, experiment_config):
+        return experiment_config.predict_uri
+
     def with_experiment(self, experiment_config):
         b = super().with_experiment(experiment_config)
         b = b.with_task(experiment_config.task)

--- a/src/rastervision/command/predict_command_config.py
+++ b/src/rastervision/command/predict_command_config.py
@@ -73,7 +73,7 @@ class PredictCommandConfigBuilder(CommandConfigBuilder):
                                     self.scenes)
 
     def from_proto(self, msg):
-        b = b.from_proto(msg)
+        b = super().from_proto(msg)
 
         conf = msg.predict_config
 

--- a/src/rastervision/command/train_command_config.py
+++ b/src/rastervision/command/train_command_config.py
@@ -74,6 +74,9 @@ class TrainCommandConfigBuilder(CommandConfigBuilder):
 
         return b
 
+    def get_root_uri(self, experiment_config):
+        return experiment_config.train_uri
+
     def with_experiment(self, experiment_config):
         b = super().with_experiment(experiment_config)
         b = b.with_task(experiment_config.task)

--- a/src/rastervision/filesystem/filesystem.py
+++ b/src/rastervision/filesystem/filesystem.py
@@ -70,7 +70,8 @@ class FileSystem(ABC):
 
     @staticmethod
     @abstractmethod
-    def sync_from_dir(src_dir_uri: str, dest_dir_uri: str,
+    def sync_from_dir(src_dir_uri: str,
+                      dest_dir_uri: str,
                       delete: bool = False) -> None:
         """Syncs a local directory to a destination.
 

--- a/src/rastervision/filesystem/filesystem.py
+++ b/src/rastervision/filesystem/filesystem.py
@@ -57,8 +57,28 @@ class FileSystem(ABC):
 
     @staticmethod
     @abstractmethod
-    def sync_dir(src_dir_uri: str, dest_dir_uri: str,
-                 delete: bool = False) -> None:
+    def sync_to_dir(src_dir_uri: str, dest_dir_uri: str,
+                    delete: bool = False) -> None:
+        """Syncs a local directory to a destination.
+
+        Arguments:
+           - src_dir_uri: Source directory to sync from. Must be a local directoy.
+           - dest_dir_uri: A destination that can be sync to by this FileSystem.
+           - delete: True if the destination should be deleted first. Defaults to False.
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def sync_from_dir(src_dir_uri: str, dest_dir_uri: str,
+                      delete: bool = False) -> None:
+        """Syncs a local directory to a destination.
+
+        Arguments:
+           - src_dir_uri: Source directory to sync from. Must be a local directoy.
+           - dest_dir_uri: A destination that can be sync to by this FileSystem.
+           - delete: True if the destination should be deleted first. Defaults to False.
+        """
         pass
 
     @staticmethod

--- a/src/rastervision/filesystem/http_filesystem.py
+++ b/src/rastervision/filesystem/http_filesystem.py
@@ -46,9 +46,14 @@ class HttpFileSystem(FileSystem):
         raise NotWritableError('Could not write {}'.format(uri))
 
     @staticmethod
-    def sync_dir(src_dir_uri: str, dest_dir_uri: str,
-                 delete: bool = False) -> None:
+    def sync_to_dir(src_dir_uri: str, dest_dir_uri: str,
+                    delete: bool = False) -> None:
         raise NotWritableError('Could not write {}'.format(dest_dir_uri))
+
+    @staticmethod
+    def sync_from_dir(src_dir_uri: str, dest_dir_uri: str,
+                      delete: bool = False) -> None:
+        raise NotReadbleError('Cannot read directory from HTTP {}'.format(source_dir_uri))
 
     @staticmethod
     def copy_to(src_path: str, dst_uri: str) -> None:

--- a/src/rastervision/filesystem/http_filesystem.py
+++ b/src/rastervision/filesystem/http_filesystem.py
@@ -51,9 +51,11 @@ class HttpFileSystem(FileSystem):
         raise NotWritableError('Could not write {}'.format(dest_dir_uri))
 
     @staticmethod
-    def sync_from_dir(src_dir_uri: str, dest_dir_uri: str,
+    def sync_from_dir(src_dir_uri: str,
+                      dest_dir_uri: str,
                       delete: bool = False) -> None:
-        raise NotReadbleError('Cannot read directory from HTTP {}'.format(source_dir_uri))
+        raise NotReadableError(
+            'Cannot read directory from HTTP {}'.format(src_dir_uri))
 
     @staticmethod
     def copy_to(src_path: str, dst_uri: str) -> None:

--- a/src/rastervision/filesystem/local_filesystem.py
+++ b/src/rastervision/filesystem/local_filesystem.py
@@ -68,8 +68,9 @@ class LocalFileSystem(FileSystem):
             content_file.write(data)
 
     @staticmethod
-    def sync_from_dir(src_dir_uri: str, dest_dir_uri: str,
-                 delete: bool = False) -> None:
+    def sync_from_dir(src_dir_uri: str,
+                      dest_dir_uri: str,
+                      delete: bool = False) -> None:
         if src_dir_uri == dest_dir_uri:
             return
 
@@ -88,9 +89,9 @@ class LocalFileSystem(FileSystem):
                         ignored = set()
                         for f in files:
                             if f not in ignored:
-                                recursive_overwrite(os.path.join(src, f),
-                                                    os.path.join(dest, f),
-                                                    ignore)
+                                recursive_overwrite(
+                                    os.path.join(src, f), os.path.join(
+                                        dest, f), ignore)
             else:
                 shutil.copyfile(src, dest)
 
@@ -98,7 +99,7 @@ class LocalFileSystem(FileSystem):
 
     @staticmethod
     def sync_to_dir(src_dir_uri: str, dest_dir_uri: str,
-                 delete: bool = False) -> None:
+                    delete: bool = False) -> None:
         LocalFileSystem.sync_from_dir(src_dir_uri, dest_dir_uri, delete)
 
     @staticmethod

--- a/src/rastervision/filesystem/local_filesystem.py
+++ b/src/rastervision/filesystem/local_filesystem.py
@@ -68,9 +68,38 @@ class LocalFileSystem(FileSystem):
             content_file.write(data)
 
     @staticmethod
-    def sync_dir(src_dir_uri: str, dest_dir_uri: str,
+    def sync_from_dir(src_dir_uri: str, dest_dir_uri: str,
                  delete: bool = False) -> None:
-        shutil.copytree(src_dir_uri, dest_dir_uri)
+        if src_dir_uri == dest_dir_uri:
+            return
+
+        if delete:
+            shutil.rmtree(dest_dir_uri)
+
+        # https://stackoverflow.com/a/15824216/841563
+        def recursive_overwrite(src, dest, ignore=None):
+            if os.path.isdir(src):
+                if not os.path.isdir(dest):
+                    os.makedirs(dest)
+                    files = os.listdir(src)
+                    if ignore is not None:
+                        ignored = ignore(src, files)
+                    else:
+                        ignored = set()
+                        for f in files:
+                            if f not in ignored:
+                                recursive_overwrite(os.path.join(src, f),
+                                                    os.path.join(dest, f),
+                                                    ignore)
+            else:
+                shutil.copyfile(src, dest)
+
+        recursive_overwrite(src_dir_uri, dest_dir_uri)
+
+    @staticmethod
+    def sync_to_dir(src_dir_uri: str, dest_dir_uri: str,
+                 delete: bool = False) -> None:
+        LocalFileSystem.sync_from_dir(src_dir_uri, dest_dir_uri, delete)
 
     @staticmethod
     def copy_to(src_path: str, dst_uri: str) -> None:

--- a/src/rastervision/filesystem/s3_filesystem.py
+++ b/src/rastervision/filesystem/s3_filesystem.py
@@ -70,7 +70,8 @@ class S3FileSystem(FileSystem):
                 raise NotWritableError('Could not write {}'.format(uri)) from e
 
     @staticmethod
-    def sync_from_dir(src_dir_uri: str, dest_dir_uri: str,
+    def sync_from_dir(src_dir_uri: str,
+                      dest_dir_uri: str,
                       delete: bool = False) -> None:
         command = ['aws', 's3', 'sync', src_dir_uri, dest_dir_uri]
         if delete:

--- a/src/rastervision/filesystem/s3_filesystem.py
+++ b/src/rastervision/filesystem/s3_filesystem.py
@@ -17,16 +17,17 @@ class S3FileSystem(FileSystem):
     def file_exists(uri: str) -> bool:
         # Lazily load boto
         import boto3
+        import botocore
 
         s3 = boto3.resource('s3')
         parsed_uri = urlparse(uri)
-        bucket = s3.Bucket(parsed_uri.netloc)
+        bucket = parsed_uri.netloc
         key = parsed_uri.path[1:]
-        objs = list(bucket.objects.filter(Prefix=key))
-        if len(objs) > 0 and objs[0].key == key:
-            return True
-        else:
+        try:
+            s3.Object(bucket, key).load()
+        except botocore.exceptions.ClientError as e:
             return False
+        return True
 
     @staticmethod
     def read_str(uri: str) -> str:

--- a/src/rastervision/filesystem/s3_filesystem.py
+++ b/src/rastervision/filesystem/s3_filesystem.py
@@ -70,8 +70,16 @@ class S3FileSystem(FileSystem):
                 raise NotWritableError('Could not write {}'.format(uri)) from e
 
     @staticmethod
-    def sync_dir(src_dir_uri: str, dest_dir_uri: str,
-                 delete: bool = False) -> None:
+    def sync_from_dir(src_dir_uri: str, dest_dir_uri: str,
+                      delete: bool = False) -> None:
+        command = ['aws', 's3', 'sync', src_dir_uri, dest_dir_uri]
+        if delete:
+            command.append('--delete')
+        subprocess.run(command)
+
+    @staticmethod
+    def sync_to_dir(src_dir_uri: str, dest_dir_uri: str,
+                    delete: bool = False) -> None:
         command = ['aws', 's3', 'sync', src_dir_uri, dest_dir_uri]
         if delete:
             command.append('--delete')
@@ -92,7 +100,7 @@ class S3FileSystem(FileSystem):
                 raise NotWritableError(
                     'Could not write {}'.format(dst_uri)) from e
         else:
-            S3FileSystem.sync_dir(src_path, dst_uri, delete=True)
+            S3FileSystem.sync_to_dir(src_path, dst_uri, delete=True)
 
     @staticmethod
     def copy_from(uri: str, path: str) -> None:

--- a/src/rastervision/protos/command.proto
+++ b/src/rastervision/protos/command.proto
@@ -52,15 +52,16 @@ message CommandConfig {
     }
 
     required string command_type = 1;
+    required string root_uri = 2;
 
     oneof command_config {
-        AnalyzeConfig analyze_config = 2;
-        ChipConfig chip_config = 3;
-        TrainConfig train_config = 4;
-        PredictConfig predict_config = 5;
-        EvalConfig eval_config = 6;
-        BundleConfig bundle_config = 7;
+        AnalyzeConfig analyze_config = 3;
+        ChipConfig chip_config = 4;
+        TrainConfig train_config = 5;
+        PredictConfig predict_config = 6;
+        EvalConfig eval_config = 7;
+        BundleConfig bundle_config = 8;
     }
 
-    optional PluginConfig plugins = 8;
+    optional PluginConfig plugins = 9;
 }

--- a/src/rastervision/registry.py
+++ b/src/rastervision/registry.py
@@ -110,7 +110,7 @@ class Registry:
 
         self.experiment_runners = {
             rv.LOCAL: rv.runner.LocalExperimentRunner,
-            rv.AWS_BATCH: rv.runner.LocalExperimentRunner
+            rv.AWS_BATCH: rv.runner.AwsBatchExperimentRunner
         }
 
         self.filesystems = [

--- a/src/rastervision/runner/aws_batch_experiment_runner.py
+++ b/src/rastervision/runner/aws_batch_experiment_runner.py
@@ -9,8 +9,23 @@ from rastervision.runner import ExperimentRunner
 from rastervision.utils.files import save_json_config
 
 
-def make_command(command_config_uri):
-    return 'python -m rastervision run_command {}'.format(command_config_uri)
+def make_command(command_config_uri, run_options=None):
+    command = 'python -m rastervision run_command {}'.format(
+        command_config_uri)
+    if run_options is None:
+        return command
+    else:
+        if run_options.rv_repo is None:
+            rv_repo = 'https://github.com/azavea/raster-vision'
+        else:
+            rv_repo = run_options.rv_repo
+
+        if run_options.rv_branch is None:
+            rv_branch = 'develop'
+        else:
+            rv_branch = rv_options.rv_branch
+
+        return 'scripts/run_rv {} {} {}'.format(rv_repo, rv_branch, command)
 
 
 def batch_submit(command_type,
@@ -90,7 +105,7 @@ class AwsBatchExperimentRunner(ExperimentRunner):
                 job_definition = 'raster-vision-cpu'
         self.job_definition = job_definition
 
-    def _run_experiment(self, command_dag):
+    def _run_experiment(self, command_dag, run_options=None):
         """Runs all commands on AWS Batch."""
 
         ids_to_job = {}
@@ -115,7 +130,7 @@ class AwsBatchExperimentRunner(ExperimentRunner):
                             cur_command, upstream_command))
                 parent_job_ids.append(ids_to_job[upstream_id])
 
-            batch_run_command = make_command(command_uri)
+            batch_run_command = make_command(command_uri, run_options)
             job_id = batch_submit(
                 command_config.command_type,
                 self.job_queue,

--- a/src/rastervision/runner/aws_batch_experiment_runner.py
+++ b/src/rastervision/runner/aws_batch_experiment_runner.py
@@ -20,7 +20,7 @@ def batch_submit(command_type,
                  command,
                  attempts=3,
                  gpu=False,
-                 parent_job_ids=[],
+                 parent_job_ids=None,
                  array_size=None):
     """
         Submit a job to run on Batch.
@@ -29,6 +29,9 @@ def batch_submit(command_type,
             branch_name: Branch with code to run on Batch
             command: Command in quotes to run on Batch
     """
+    if parent_job_ids is None:
+        parent_job_ids = []
+
     full_command = ['run_rv', branch_name]
     full_command.extend(command.split())
 
@@ -68,8 +71,8 @@ class AwsBatchExperimentRunner(ExperimentRunner):
         batch_config = rv_config.get_subconfig('AWS_BATCH')
 
         self.branch = batch_config('branch', default='develop')
-        self.attempts = batch_config('attempts', parser=int, default=1)
-        self.gpu = batch_config('gpu', parser=bool, default=True)
+        self.attempts = batch_config('attempts', parser=int, default='1')
+        self.gpu = batch_config('gpu', parser=bool, default='true')
 
         job_queue = batch_config('job_queue', default='')
         if not job_queue:
@@ -95,21 +98,28 @@ class AwsBatchExperimentRunner(ExperimentRunner):
             command_config = command_dag.get_command(command_id)
             command_root_uri = command_config.root_uri
             command_uri = os.path.join(command_root_uri, 'command-config.json')
+            print('Saving command configuration to {}...'.format(command_uri))
             save_json_config(command_config.to_proto(), command_uri)
 
             parent_job_ids = []
             for upstream_id in command_dag.get_upstream_command_ids(
                     command_id):
                 if upstream_id not in ids_to_job:
+                    cur_command = (command_config.command_type, command_id)
+                    u = command_dag.get_command(upstream_id)
+                    upstream_command = (u.command_type, upstream_id)
                     raise Exception(
                         '{} command has parent command of {}, '
                         'but does not exist in previous batch submissions - '
-                        'topological sort on command_dag error.')
-                parent_job_ids.append(ids_to_job(upstream_id))
+                        'topological sort on command_dag error.'.format(
+                            cur_command, upstream_command))
+                parent_job_ids.append(ids_to_job[upstream_id])
 
             batch_run_command = make_command(command_uri)
             job_id = batch_submit(
                 command_config.command_type,
+                self.job_queue,
+                self.job_definition,
                 self.branch,
                 batch_run_command,
                 attempts=self.attempts,

--- a/src/rastervision/runner/command_dag.py
+++ b/src/rastervision/runner/command_dag.py
@@ -106,4 +106,5 @@ class CommandDAG:
         """Returns the command ids for upstream commands for the command
         with the given id.
         """
-        return self.command_dag.in_edges(command_id)
+        return list(
+            map(lambda x: x[0], self.command_id_dag.in_edges(command_id)))

--- a/src/rastervision/runner/command_dag.py
+++ b/src/rastervision/runner/command_dag.py
@@ -8,7 +8,10 @@ class CommandDAG:
     """ A directed acyclic graph of command definitions.
     """
 
-    def __init__(self, command_definitions, rerun_commands=False):
+    def __init__(self,
+                 command_definitions,
+                 rerun_commands=False,
+                 skip_file_check=False):
         """Generates a CommandDAG from a list of CommandDefinitions
 
         This logic checks if there are any non-exsiting URIs that are
@@ -30,20 +33,22 @@ class CommandDAG:
                 uri_dag.add_edge(idx, output_uri)
 
         # Find all source input_uris, and ensure they exist.
+        if not skip_file_check:
+            unsolved_sources = [
+                uri for uri in uri_dag.nodes
+                if (type(uri) == str and len(uri_dag.in_edges(uri)) == 0)
+            ]
 
-        unsolved_sources = [
-            uri for uri in uri_dag.nodes
-            if (type(uri) == str and len(uri_dag.in_edges(uri)) == 0)
-        ]
+            missing_files = []
+            for uri in unsolved_sources:
+                print('Ensuring file exists: {}'.format(uri))
+                if not file_exists(uri):
+                    missing_files.append(uri)
 
-        missing_files = [
-            uri for uri in unsolved_sources if not file_exists(uri)
-        ]
-
-        if any(missing_files):
-            raise rv.ConfigError(
-                'Files do not exist and are not supplied by commands:\n'
-                '\t{}\n'.format(',\b\t'.join(missing_files)))
+            if any(missing_files):
+                raise rv.ConfigError(
+                    'Files do not exist and are not supplied by commands:\n'
+                    '\t{}\n'.format(',\b\t'.join(missing_files)))
 
         # If we are not rerunning, remove commands that have existing outputs.
         if not rerun_commands:

--- a/src/rastervision/runner/command_runner.py
+++ b/src/rastervision/runner/command_runner.py
@@ -9,9 +9,12 @@ from rastervision.protos.command_pb2 import CommandConfig as CommandConfigMsg
 class CommandRunner:
     @staticmethod
     def run(command_config_uri):
-        with TemporaryDirectory as tmp_dir:
-            msg = load_json_config(command_config_uri, CommandConfigMsg())
-            PluginRegistry.get_instance().add_plugins(msg.plugins)
-            command_config = rv.CommandConfig.from_proto(msg)
+        msg = load_json_config(command_config_uri, CommandConfigMsg())
+        CommandRunner.run_from_proto(msg)
+
+    def run_from_proto(msg):
+        with TemporaryDirectory() as tmp_dir:
+            PluginRegistry.get_instance().add_plugins_from_proto(msg.plugins)
+            command_config = rv.command.CommandConfig.from_proto(msg)
             command = command_config.create_command(tmp_dir)
             command.run(tmp_dir)

--- a/src/rastervision/runner/experiment_runner.py
+++ b/src/rastervision/runner/experiment_runner.py
@@ -6,11 +6,20 @@ from rastervision.runner import (CommandDefinition, CommandDAG)
 
 
 class ExperimentRunner(ABC):
+    class RunOptions:
+        def __init__(self, rv_repo=None, rv_branch=None):
+            self.rv_repo = rv_repo
+            self.rv_branch = rv_branch
+
     def run(self,
             experiments: Union[List[rv.ExperimentConfig], rv.ExperimentConfig],
             commands_to_run=rv.ALL_COMMANDS,
             rerun_commands=False,
-            skip_file_check=False):
+            skip_file_check=False,
+            run_options=None):
+        if run_options is None:
+            run_options = ExperimentRunner.RunOptions()
+
         if not isinstance(experiments, list):
             experiments = [experiments]
 
@@ -63,10 +72,10 @@ class ExperimentRunner(ABC):
         command_dag = CommandDAG(
             unique_commands, rerun_commands, skip_file_check=skip_file_check)
 
-        self._run_experiment(command_dag)
+        self._run_experiment(command_dag, run_options)
 
     @abstractmethod
-    def _run_experiment(self, command_list, command_dag):
+    def _run_experiment(self, command_dag, run_options=None):
         pass
 
     @staticmethod

--- a/src/rastervision/runner/experiment_runner.py
+++ b/src/rastervision/runner/experiment_runner.py
@@ -9,7 +9,8 @@ class ExperimentRunner(ABC):
     def run(self,
             experiments: Union[List[rv.ExperimentConfig], rv.ExperimentConfig],
             commands_to_run=rv.ALL_COMMANDS,
-            rerun_commands=False):
+            rerun_commands=False,
+            skip_file_check=False):
         if not isinstance(experiments, list):
             experiments = [experiments]
 
@@ -59,7 +60,8 @@ class ExperimentRunner(ABC):
                 'ERROR: Command outputs will'
                 'override each other: \n{}\n'.format(s))
 
-        command_dag = CommandDAG(unique_commands, rerun_commands)
+        command_dag = CommandDAG(
+            unique_commands, rerun_commands, skip_file_check=skip_file_check)
 
         self._run_experiment(command_dag)
 

--- a/src/rastervision/runner/experiment_runner.py
+++ b/src/rastervision/runner/experiment_runner.py
@@ -6,20 +6,11 @@ from rastervision.runner import (CommandDefinition, CommandDAG)
 
 
 class ExperimentRunner(ABC):
-    class RunOptions:
-        def __init__(self, rv_repo=None, rv_branch=None):
-            self.rv_repo = rv_repo
-            self.rv_branch = rv_branch
-
     def run(self,
             experiments: Union[List[rv.ExperimentConfig], rv.ExperimentConfig],
             commands_to_run=rv.ALL_COMMANDS,
             rerun_commands=False,
-            skip_file_check=False,
-            run_options=None):
-        if run_options is None:
-            run_options = ExperimentRunner.RunOptions()
-
+            skip_file_check=False):
         if not isinstance(experiments, list):
             experiments = [experiments]
 
@@ -72,10 +63,10 @@ class ExperimentRunner(ABC):
         command_dag = CommandDAG(
             unique_commands, rerun_commands, skip_file_check=skip_file_check)
 
-        self._run_experiment(command_dag, run_options)
+        self._run_experiment(command_dag)
 
     @abstractmethod
-    def _run_experiment(self, command_dag, run_options=None):
+    def _run_experiment(self, command_dag):
         pass
 
     @staticmethod

--- a/src/rastervision/runner/local_experiment_runner.py
+++ b/src/rastervision/runner/local_experiment_runner.py
@@ -7,7 +7,7 @@ class LocalExperimentRunner(ExperimentRunner):
     def __init__(self, tmp_dir=None):
         self.tmp_dir = tmp_dir
 
-    def _run_experiment(self, command_dag, run_options=None):
+    def _run_experiment(self, command_dag):
         """Runs all commands on this machine."""
 
         def run_commands(tmp_dir):

--- a/src/rastervision/runner/local_experiment_runner.py
+++ b/src/rastervision/runner/local_experiment_runner.py
@@ -7,7 +7,7 @@ class LocalExperimentRunner(ExperimentRunner):
     def __init__(self, tmp_dir=None):
         self.tmp_dir = tmp_dir
 
-    def _run_experiment(self, command_dag):
+    def _run_experiment(self, command_dag, run_options=None):
         """Runs all commands on this machine."""
 
         def run_commands(tmp_dir):

--- a/src/rastervision/utils/files.py
+++ b/src/rastervision/utils/files.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-from urllib.parse import urlparse
 import tempfile
 from threading import Timer
 from pathlib import Path
@@ -84,6 +83,7 @@ def start_sync(src_dir_uri, dest_dir_uri, sync_interval=600, fs=None):
         sync_interval: (int) period in seconds for syncing
         fs:  Optional FileSystem to use
     """
+
     def _sync_dir():
         print('Syncing {} to {}...'.format(src_dir_uri, dest_dir_uri))
         sync_to_dir(src_dir_uri, dest_dir_uri, delete=False, fs=fs)

--- a/src/rastervision/utils/files.py
+++ b/src/rastervision/utils/files.py
@@ -37,8 +37,26 @@ def get_local_path(uri, download_dir, fs=None):
     return path
 
 
-def sync_dir(src_dir_uri, dest_dir_uri, delete=False, fs=None):
-    """Synchronize a local and remote directory.
+def sync_to_dir(src_dir_uri, dest_dir_uri, delete=False, fs=None):
+    """Synchronize a local to a local or remote directory.
+
+    Transfers files from source to destination directories so that the
+    destination has all the source files. If delete is True, also delete
+    files in the destination to match those in the source directory.
+
+    Args:
+        src_dir_uri: (string) URI of local source directory
+        dest_dir_uri: (string) URI of destination directory
+        delete: (bool)
+        fs: Optional FileSystem to use for destination
+    """
+    if not fs:
+        fs = FileSystem.get_file_system(dest_dir_uri, 'w')
+    fs.sync_to_dir(src_dir_uri, dest_dir_uri, delete=delete)
+
+
+def sync_from_dir(src_dir_uri, dest_dir_uri, delete=False, fs=None):
+    """Synchronize a local or remote directory to a local directory.
 
     Transfers files from source to destination directories so that the
     destination has all the source files. If delete is True, also delete
@@ -46,37 +64,44 @@ def sync_dir(src_dir_uri, dest_dir_uri, delete=False, fs=None):
 
     Args:
         src_dir_uri: (string) URI of source directory
-        dest_dir_uri: (string) URI of destination directory
+        dest_dir_uri: (string) URI of local destination directory
         delete: (bool)
         fs: Optional FileSystem to use
     """
     if not fs:
-        fs = FileSystem.get_file_system(dest_dir_uri, 'w')
-    fs.sync_dir(src_dir_uri, dest_dir_uri, delete=delete)
+        fs = FileSystem.get_file_system(src_dir_uri, 'r')
+    fs.sync_from_dir(src_dir_uri, dest_dir_uri, delete=delete)
 
 
 def start_sync(src_dir_uri, dest_dir_uri, sync_interval=600, fs=None):
     """Start syncing a directory on a schedule.
 
-    Calls sync_dir on a schedule.
+    Calls sync_to_dir on a schedule.
 
     Args:
-        src_dir_uri: (string) URI of source directory
+        src_dir_uri: (string) Path of the local source directory
         dest_dir_uri: (string) URI of destination directory
         sync_interval: (int) period in seconds for syncing
         fs:  Optional FileSystem to use
     """
+    def _sync_dir():
+        print('Syncing {} to {}...'.format(src_dir_uri, dest_dir_uri))
+        sync_to_dir(src_dir_uri, dest_dir_uri, delete=False, fs=fs)
 
-    def _sync_dir(delete=True):
-        sync_dir(src_dir_uri, dest_dir_uri, delete=delete, fs=fs)
-        thread = Timer(sync_interval, _sync_dir)
-        thread.daemon = True
-        thread.start()
+    class SyncThread:
+        def __init__(self):
+            thread = Timer(sync_interval, _sync_dir)
+            thread.daemon = True
+            thread.start()
+            self.thread = thread
 
-    if urlparse(dest_dir_uri).scheme == 's3':
-        # On first sync, we don't want to delete files on S3 to match
-        # the contents of output_dir since there's nothing there yet.
-        _sync_dir(delete=False)
+        def __enter__(self):
+            return self.thread
+
+        def __exit__(self, type, value, traceback):
+            self.thread.cancel()
+
+    return SyncThread()
 
 
 def download_if_needed(uri, download_dir, fs=None):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,14 @@
 networkx==2.1
 everett==0.9
 pluginbase==0.7
+npstreams==1.4.*
+lxml==4.2.*
+shapely==1.6.*
+pyproj==1.9.5.*
+imageio==2.3.*
+scikit-learn==0.19.*
+six==1.11.*
+h5py==2.7.*
+matplotlib==2.1.*
+pillow==5.0.*
+click==6.*

--- a/src/scripts/install_deps
+++ b/src/scripts/install_deps
@@ -19,7 +19,7 @@ pip install keras==2.1.* flake8==3.5.* awscli==1.15.* boto3==1.6.* \
 
 # Install Rasterio
 add-apt-repository ppa:ubuntugis/ppa
-apt-gget update
+apt-get update
 apt-get install -y python-numpy=1:1.11.* gdal-bin=2.1.* \
     libgdal-dev=2.1.*
 pip install rasterio==0.36.*

--- a/src/scripts/install_deps
+++ b/src/scripts/install_deps
@@ -14,15 +14,12 @@ rm -R /tmp/protoc3
 rm /tmp/protoc3.zip
 
 # Install Python deps
-pip install keras==2.1.* flake8==3.5.* awscli==1.15.* lxml==4.2.* \
-    shapely==1.6.* boto3==1.6.* pyproj==1.9.5.* imageio==2.3.* \
-    scikit-learn==0.19.* six==1.11.* h5py==2.7.* matplotlib==2.1.* \
-    pillow==5.0.* click==6.* npstreams==1.4.* moto==1.3.* coverage==4.5.* \
-    yapf==0.22.* unify==0.4
+pip install keras==2.1.* flake8==3.5.* awscli==1.15.* boto3==1.6.* \
+    moto==1.3.* coverage==4.5.* yapf==0.22.* unify==0.4
 
 # Install Rasterio
 add-apt-repository ppa:ubuntugis/ppa
-apt-get update
+apt-gget update
 apt-get install -y python-numpy=1:1.11.* gdal-bin=2.1.* \
     libgdal-dev=2.1.*
 pip install rasterio==0.36.*

--- a/src/scripts/run_rv
+++ b/src/scripts/run_rv
@@ -5,10 +5,11 @@
 
 set -ex
 
-BRANCH=$1
-COMMAND="${@:2}"
+REPO=$1
+BRANCH=$2
+COMMAND="${@:3}"
 
-git clone -b $BRANCH https://github.com/azavea/raster-vision.git /tmp/raster-vision
+git clone -b $BRANCH $REPO /tmp/raster-vision
 cp -R /tmp/raster-vision/src/* /opt/src/
 /opt/src/scripts/compile
 $COMMAND

--- a/src/tests/data-files/plugins/noop_filesystem.py
+++ b/src/tests/data-files/plugins/noop_filesystem.py
@@ -27,8 +27,14 @@ class NoopFileSystem(FileSystem):
         pass
 
     @staticmethod
-    def sync_dir(src_dir_uri: str, dest_dir_uri: str,
-                 delete: bool = False) -> None:
+    def sync_from_dir(src_dir_uri: str,
+                      dest_dir_uri: str,
+                      delete: bool = False) -> None:
+        pass
+
+    @staticmethod
+    def sync_to_dir(src_dir_uri: str, dest_dir_uri: str,
+                    delete: bool = False) -> None:
         pass
 
     @staticmethod

--- a/src/tests/data-files/plugins/noop_runner.py
+++ b/src/tests/data-files/plugins/noop_runner.py
@@ -1,6 +1,4 @@
-import rastervision as rv
-from rastervision.runner import (ExperimentRunner,
-                                 CommandRunner)
+from rastervision.runner import (ExperimentRunner, CommandRunner)
 
 NOOP_RUNNER = 'NOOP_RUNNER'
 
@@ -10,6 +8,7 @@ class NoopExperimentRunner(ExperimentRunner):
         for command_config in command_dag.get_sorted_commands():
             msg = command_config.to_proto()
             CommandRunner.run_from_proto(msg)
+
 
 def register_plugin(plugin_registry):
     plugin_registry.register_experiment_runner(NOOP_RUNNER,

--- a/src/tests/data-files/plugins/noop_runner.py
+++ b/src/tests/data-files/plugins/noop_runner.py
@@ -5,7 +5,7 @@ NOOP_RUNNER = 'NOOP_RUNNER'
 
 
 class NoopExperimentRunner(ExperimentRunner):
-    def _run_experiment(self, command_dag):
+    def _run_experiment(self, command_dag, run_options):
         for command_config in command_dag.get_sorted_commands():
             msg = command_config.to_proto()
             cc = rv.command.CommandConfig.from_proto(msg)

--- a/src/tests/data-files/plugins/noop_runner.py
+++ b/src/tests/data-files/plugins/noop_runner.py
@@ -1,17 +1,15 @@
 import rastervision as rv
-from rastervision.runner import ExperimentRunner
+from rastervision.runner import (ExperimentRunner,
+                                 CommandRunner)
 
 NOOP_RUNNER = 'NOOP_RUNNER'
 
 
 class NoopExperimentRunner(ExperimentRunner):
-    def _run_experiment(self, command_dag, run_options):
+    def _run_experiment(self, command_dag):
         for command_config in command_dag.get_sorted_commands():
             msg = command_config.to_proto()
-            cc = rv.command.CommandConfig.from_proto(msg)
-            command = cc.create_command('NONE')
-            command.run('NONE')
-
+            CommandRunner.run_from_proto(msg)
 
 def register_plugin(plugin_registry):
     plugin_registry.register_experiment_runner(NOOP_RUNNER,


### PR DESCRIPTION
## Overview

Various fixes that were made while testing the AWS Batch runner:

- Add command line flag to skip file existing check, since that can take a while
- Added root_uri to command configuration
- Rewrote how we were checking for file existence on S3, since the way we were doing it took long against bucket/prefix pairs that contained a lot of files
- Moved requirements that are expected to be installed in the pip installable version into requirements.txt
- Fixed new file system architecture, where `sync_dir` was only checking for the destination URI, where `sync_dir` was being both to pull files down locally and push them up. Split into `sync_from_dir` and `sync_to_dir`.
- Made sync return a ContextManager object so that the sync thread stopped when not needed anymore.
- Fixed typos and other silly mistakes

