### PR TITLE
Make chips for validation scenes

### DIFF
--- a/src/rastervision/command/chip_command_config.py
+++ b/src/rastervision/command/chip_command_config.py
@@ -104,7 +104,7 @@ class ChipCommandConfigBuilder(CommandConfigBuilder):
         backend = rv.BackendConfig.from_proto(conf.backend)
         augmentors = list(map(rv.AugmentorConfig.from_proto, conf.augmentors))
         train_scenes = list(map(rv.SceneConfig.from_proto, conf.train_scenes))
-        val_scenes = list(map(rv.SceneConfig.from_proto, conf.train_scenes))
+        val_scenes = list(map(rv.SceneConfig.from_proto, conf.val_scenes))
 
         b = b.with_task(task)
         b = b.with_backend(backend)


### PR DESCRIPTION
## Overview

This PR fixes a typo that made it so the validation chips were the same as the training chips.

## Testing Instructions

* Run the chip command for an experiment where the training and validation scenes differ and observe the output. I did this for the Potsdam experiment in #408 