### PR TITLE
Temporary Directory Machinery

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0.618
+        base: auto 
+        # advanced
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null

--- a/src/integration_tests/integration_tests.py
+++ b/src/integration_tests/integration_tests.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from tempfile import TemporaryDirectory
 import json
 import os
 import math
@@ -16,6 +15,7 @@ from integration_tests.object_detection_tests.experiment \
     import ObjectDetectionIntegrationTest
 from integration_tests.chip_classification_tests.experiment \
     import ChipClassificationIntegrationTest
+from rastervision.rv_config import RVConfig
 
 all_tests = [rv.CHIP_CLASSIFICATION, rv.OBJECT_DETECTION]
 
@@ -220,7 +220,7 @@ def main(tests):
 
     tests = list(map(lambda x: x.upper(), tests))
 
-    with TemporaryDirectory() as temp_dir:
+    with RVConfig.get_tmp_dir() as temp_dir:
         errors = []
         for test in tests:
             if test not in all_tests:

--- a/src/rastervision/backend/tf_object_detection.py
+++ b/src/rastervision/backend/tf_object_detection.py
@@ -1,7 +1,6 @@
 import rastervision as rv
 
 import io
-import tempfile
 import os
 import shutil
 import tarfile
@@ -22,6 +21,7 @@ from rastervision.utils.files import (get_local_path, upload_or_copy, make_dir,
                                       download_if_needed, sync_to_dir,
                                       start_sync)
 from rastervision.utils.misc import save_img
+from rastervision.rv_config import RVConfig
 
 TRAIN = 'train'
 VALIDATION = 'validation'
@@ -622,7 +622,7 @@ class TFObjectDetection(Backend):
             if self.config.debug:
                 debug_zip_path = training_package.get_local_path(
                     training_package.get_debug_chips_uri(split))
-                with tempfile.TemporaryDirectory() as debug_dir:
+                with RVConfig.get_tmp_dir() as debug_dir:
                     make_debug_images(record_path, self.class_map, debug_dir)
                     shutil.make_archive(
                         os.path.splitext(debug_zip_path)[0], 'zip', debug_dir)

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -40,11 +40,6 @@ def main(profile):
           'about the commands to be run, but will not actually '
           'run the commands'))
 @click.option(
-    '--rm-tmp-dir',
-    is_flag=True,
-    help=('Remove the top-level temporary directory.'
-          'Use with great caution'))
-@click.option(
     '--skip-file-check',
     '-x',
     is_flag=True,
@@ -84,13 +79,13 @@ def main(profile):
     default=False,
     help=('Rerun commands, regardless if '
           'their output files already exist.'))
-def run(runner, commands, experiment_module, dry_run, rm_tmp_dir,
-        skip_file_check, arg, prefix, methods, filters, rerun):
+def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
+        prefix, methods, filters, rerun):
     """Run Raster Vision commands from experiments, using the
     experiment runner named RUNNER."""
     darg = dict(arg)
     if 'tmp_dir' in darg:
-        RVConfig.set_tmp_dir(darg['tmp_dir'], rm_tmp_dir)
+        RVConfig.set_tmp_dir(darg['tmp_dir'])
 
     # Validate runner
     valid_runners = list(

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -1,6 +1,5 @@
 """Raster Vision main program"""
 import sys
-from tempfile import TemporaryDirectory
 
 import click
 
@@ -209,7 +208,7 @@ def predict(predict_package, image_uri, output_uri, update_stats,
         channel_order = [
             int(channel_ind) for channel_ind in channel_order.split(' ')
         ]
-    with TemporaryDirectory() as tmp_dir:
+    with RVConfig.get_tmp_dir() as tmp_dir:
         predict = rv.Predictor(predict_package, tmp_dir, update_stats,
                                channel_order).predict
         predict(image_uri, output_uri)

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -40,6 +40,11 @@ def main(profile):
           'about the commands to be run, but will not actually '
           'run the commands'))
 @click.option(
+    '--rm-tmp-dir',
+    is_flag=True,
+    help=('Remove the top-level temporary directory.'
+          'Use with great caution'))
+@click.option(
     '--skip-file-check',
     '-x',
     is_flag=True,
@@ -79,13 +84,13 @@ def main(profile):
     default=False,
     help=('Rerun commands, regardless if '
           'their output files already exist.'))
-def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
-        prefix, methods, filters, rerun):
+def run(runner, commands, experiment_module, dry_run, rm_tmp_dir,
+        skip_file_check, arg, prefix, methods, filters, rerun):
     """Run Raster Vision commands from experiments, using the
     experiment runner named RUNNER."""
     darg = dict(arg)
     if 'tmp_dir' in darg:
-        RVConfig.set_tmp_dir(darg['tmp_dir'])
+        RVConfig.set_tmp_dir(darg['tmp_dir'], rm_tmp_dir)
 
     # Validate runner
     valid_runners = list(

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -84,6 +84,10 @@ def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
         prefix, methods, filters, rerun):
     """Run Raster Vision commands from experiments, using the
     experiment runner named RUNNER."""
+    darg = dict(arg)
+    if 'tmp_dir' in darg:
+        RVConfig.set_tempdir(darg['tmp_dir'])
+
     # Validate runner
     valid_runners = list(
         map(lambda x: x.lower(), rv.ExperimentRunner.list_runners()))

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -86,7 +86,7 @@ def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
     experiment runner named RUNNER."""
     darg = dict(arg)
     if 'tmp_dir' in darg:
-        RVConfig.set_tempdir(darg['tmp_dir'])
+        RVConfig.set_tmp_dir(darg['tmp_dir'])
 
     # Validate runner
     valid_runners = list(

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -7,6 +7,7 @@ import click
 import rastervision as rv
 from rastervision.experiment import (ExperimentLoader, LoaderError)
 from rastervision.runner import (ExperimentRunner)
+from rastervision.rv_config import RVConfig
 
 
 def print_error(msg):

--- a/src/rastervision/runner/command_runner.py
+++ b/src/rastervision/runner/command_runner.py
@@ -1,9 +1,8 @@
-from tempfile import TemporaryDirectory
-
 import rastervision as rv
+from rastervision.rv_config import RVConfig
 from rastervision.plugin import PluginRegistry
-from rastervision.utils.files import load_json_config
 from rastervision.protos.command_pb2 import CommandConfig as CommandConfigMsg
+from rastervision.utils.files import load_json_config
 
 
 class CommandRunner:
@@ -13,7 +12,7 @@ class CommandRunner:
         CommandRunner.run_from_proto(msg)
 
     def run_from_proto(msg):
-        with TemporaryDirectory() as tmp_dir:
+        with RVConfig.get_tmp_dir() as tmp_dir:
             PluginRegistry.get_instance().add_plugins_from_proto(msg.plugins)
             command_config = rv.command.CommandConfig.from_proto(msg)
             command = command_config.create_command(tmp_dir)

--- a/src/rastervision/runner/local_experiment_runner.py
+++ b/src/rastervision/runner/local_experiment_runner.py
@@ -1,8 +1,8 @@
 import os
-from tempfile import TemporaryDirectory
 
 from rastervision.runner import ExperimentRunner
 from rastervision.utils.files import save_json_config
+from rastervision.rv_config import RVConfig
 
 
 class LocalExperimentRunner(ExperimentRunner):
@@ -28,5 +28,5 @@ class LocalExperimentRunner(ExperimentRunner):
         if self.tmp_dir:
             run_commands(self.tmp_dir)
         else:
-            with TemporaryDirectory() as tmp_dir:
+            with RVConfig.get_tmp_dir() as tmp_dir:
                 run_commands(tmp_dir)

--- a/src/rastervision/rv_config.py
+++ b/src/rastervision/rv_config.py
@@ -1,6 +1,9 @@
 import os
 import json
 import tempfile
+import shutil
+import atexit
+
 from pathlib import Path
 
 from everett.manager import (ConfigManager, ConfigDictEnv, ConfigEnvFileEnv,
@@ -27,7 +30,7 @@ class RVConfig:
         return tempfile.TemporaryDirectory()
 
     @staticmethod
-    def set_tmp_dir(tmp_dir=None, delete_tmp_dir_atexit=False):
+    def set_tmp_dir(tmp_dir=None, rm_tmp_dir=False):
         """Set RVConfig.tmp_dir to well-known value.
 
         This static method sets the value of RVConfig.tmp_dir to some
@@ -75,6 +78,11 @@ class RVConfig:
 
         finally:
             make_dir(RVConfig.tmp_dir)
+            tmp_dir = RVConfig.tmp_dir
+            if rm_tmp_dir:
+                atexit.register(lambda: shutil.rmtree(tmp_dir))
+                print('{} directory will be removed upon nominal exit.'.format(
+                    tmp_dir))
             print('Temporary directory is: {}'.format(RVConfig.tmp_dir))
 
     @staticmethod
@@ -86,10 +94,10 @@ class RVConfig:
                  rv_home=None,
                  config_overrides=None,
                  tmp_dir=None,
-                 delete_tmp_dir_atexit=False):
+                 rm_tmp_dir=False):
 
         if tmp_dir is not None:
-            self.set_tmp_dir(tmp_dir, delete_tmp_dir_atexit)
+            self.set_tmp_dir(tmp_dir, rm_tmp_dir)
 
         if profile is None:
             if os.environ.get('RV_PROFILE'):

--- a/src/rastervision/rv_config.py
+++ b/src/rastervision/rv_config.py
@@ -1,9 +1,6 @@
 import os
 import json
 import tempfile
-import shutil
-import atexit
-
 from pathlib import Path
 
 from everett.manager import (ConfigManager, ConfigDictEnv, ConfigEnvFileEnv,
@@ -30,7 +27,7 @@ class RVConfig:
         return tempfile.TemporaryDirectory()
 
     @staticmethod
-    def set_tmp_dir(tmp_dir=None, rm_tmp_dir=False):
+    def set_tmp_dir(tmp_dir=None):
         """Set RVConfig.tmp_dir to well-known value.
 
         This static method sets the value of RVConfig.tmp_dir to some
@@ -78,11 +75,6 @@ class RVConfig:
 
         finally:
             make_dir(RVConfig.tmp_dir)
-            tmp_dir = RVConfig.tmp_dir
-            if rm_tmp_dir:
-                atexit.register(lambda: shutil.rmtree(tmp_dir))
-                print('{} directory will be removed upon nominal exit.'.format(
-                    tmp_dir))
             print('Temporary directory is: {}'.format(RVConfig.tmp_dir))
 
     @staticmethod
@@ -93,11 +85,10 @@ class RVConfig:
                  profile=None,
                  rv_home=None,
                  config_overrides=None,
-                 tmp_dir=None,
-                 rm_tmp_dir=False):
+                 tmp_dir=None):
 
         if tmp_dir is not None:
-            self.set_tmp_dir(tmp_dir, rm_tmp_dir)
+            self.set_tmp_dir(tmp_dir)
 
         if profile is None:
             if os.environ.get('RV_PROFILE'):

--- a/src/rastervision/rv_config.py
+++ b/src/rastervision/rv_config.py
@@ -1,15 +1,52 @@
 import os
 import json
+import tempfile
+from pathlib import Path
 
 from everett.manager import (ConfigManager, ConfigDictEnv, ConfigEnvFileEnv,
                              ConfigIniEnv, ConfigOSEnv)
 
 import rastervision as rv
 from rastervision.utils.files import file_to_str
+from rastervision.filesystem.local_filesystem import make_dir
 
 
 class RVConfig:
     DEFAULT_PROFILE = 'default'
+
+    @staticmethod
+    def set_tempdir(path=None):
+        # Ensure that RV temp directory exists. We need to use a custom location for
+        # the temporary directory so it will be mirrored on the host file system which
+        # is needed for running in a Docker container with limited space on EC2.
+        RV_TEMP_DIR = '/opt/data/tmp/'
+
+        # find explicitly set tempdir
+        explicit_temp_dir = next(
+            iter([
+                os.environ.get(k) for k in ['TMPDIR', 'TEMP', 'TMP']
+                if k in os.environ
+            ] + [path, tempfile.tempdir]))
+        try:
+            # try to create directory
+            if not os.path.exists(explicit_temp_dir):
+                os.makedirs(explicit_temp_dir, exist_ok=True)
+            # can we interact with directory?
+            explicit_temp_dir_valid = (
+                os.path.isdir(explicit_temp_dir) and Path.touch(
+                    Path(os.path.join(explicit_temp_dir, '.can_touch'))))
+        except Exception:
+            print(
+                'Root temporary directory cannot be used: {}. Using root: {}'.
+                format(explicit_temp_dir, RV_TEMP_DIR))
+            tempfile.tempdir = RV_TEMP_DIR  # no guarantee this will work
+            make_dir(RV_TEMP_DIR)
+        finally:
+            # now, ensure uniqueness for this process
+            # the host may be running more than one rastervision process
+            RV_TEMP_DIR = tempfile.mkdtemp()
+            tempfile.tempdir = RV_TEMP_DIR
+            print('Temporary directory is: {}'.format(tempfile.tempdir))
 
     @staticmethod
     def get_instance():

--- a/src/rastervision/task/chip_classification.py
+++ b/src/rastervision/task/chip_classification.py
@@ -1,9 +1,9 @@
 from os.path import join
-import tempfile
 
 import numpy as np
 from PIL import Image, ImageDraw
 
+from rastervision.rv_config import RVConfig
 from rastervision.core import Box
 from rastervision.task import Task
 from rastervision.utils.files import (get_local_path, upload_or_copy, make_dir)
@@ -58,7 +58,7 @@ class ChipClassification(Task):
         img = draw_debug_predict_image(scene, self.config.class_map)
         # Saving to a jpg leads to segfault for unknown reasons.
         debug_image_uri = join(debug_dir_uri, scene.id + '.png')
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with RVConfig.get_tmp_dir() as temp_dir:
             debug_image_path = get_local_path(debug_image_uri, temp_dir)
             make_dir(debug_image_path, use_dirname=True)
             img.save(debug_image_path)

--- a/src/rastervision/utils/files.py
+++ b/src/rastervision/utils/files.py
@@ -4,8 +4,8 @@ from threading import Timer
 
 from google.protobuf import json_format
 
-from rastervision.filesystem.filesystem import ProtobufParseException
 from rastervision.filesystem.filesystem import FileSystem
+from rastervision.filesystem.filesystem import ProtobufParseException
 from rastervision.filesystem.local_filesystem import make_dir
 
 

--- a/src/rastervision/utils/files.py
+++ b/src/rastervision/utils/files.py
@@ -1,8 +1,6 @@
 import os
 import shutil
-import tempfile
 from threading import Timer
-from pathlib import Path
 
 from google.protobuf import json_format
 
@@ -251,34 +249,3 @@ def save_json_config(message, uri, fs=None):
     """
     json_str = json_format.MessageToJson(message)
     str_to_file(json_str, uri, fs=fs)
-
-
-# Ensure that RV temp directory exists. We need to use a custom location for
-# the temporary directory so it will be mirrored on the host file system which
-# is needed for running in a Docker container with limited space on EC2.
-RV_TEMP_DIR = '/opt/data/tmp/'
-
-# find explicitly set tempdir
-explicit_temp_dir = next(
-    iter([
-        os.environ.get(k) for k in ['TMPDIR', 'TEMP', 'TMP'] if k in os.environ
-    ] + [tempfile.tempdir]))
-
-try:
-    # try to create directory
-    if not os.path.exists(explicit_temp_dir):
-        os.makedirs(explicit_temp_dir, exist_ok=True)
-    # can we interact with directory?
-    explicit_temp_dir_valid = (os.path.isdir(explicit_temp_dir) and Path.touch(
-        Path(os.path.join(explicit_temp_dir, '.can_touch'))))
-except Exception:
-    print('Root temporary directory cannot be used: {}. Using root: {}'.format(
-        explicit_temp_dir, RV_TEMP_DIR))
-    tempfile.tempdir = RV_TEMP_DIR  # no guarantee this will work
-    make_dir(RV_TEMP_DIR)
-finally:
-    # now, ensure uniqueness for this process
-    # the host may be running more than one rastervision process
-    RV_TEMP_DIR = tempfile.mkdtemp()
-    tempfile.tempdir = RV_TEMP_DIR
-    print('Temporary directory is: {}'.format(tempfile.tempdir))

--- a/src/scripts/unit_tests
+++ b/src/scripts/unit_tests
@@ -22,6 +22,6 @@ else
     if ! [ -x "$(command -v coverage)" ]; then
 	python -m unittest discover tests
     else
-	coverage run --append --source=rastervision --omit=rastervision/protos -m unittest discover tests
+	coverage run --source=rastervision --omit=rastervision/protos -m unittest discover tests
     fi
 fi

--- a/src/tests/command/test_bundle_command.py
+++ b/src/tests/command/test_bundle_command.py
@@ -1,12 +1,12 @@
 import os
 import unittest
 import zipfile
-from tempfile import TemporaryDirectory
 
 import rastervision as rv
 from rastervision.command import BundleCommandConfig
 from rastervision.protos.command_pb2 import CommandConfig as CommandConfigMsg
 from rastervision.utils.files import (make_dir, load_json_config)
+from rastervision.rv_config import RVConfig
 
 from tests import data_file_path
 
@@ -60,7 +60,7 @@ class TestBundleCommand(unittest.TestCase):
                                 .build()
             return b
 
-        with TemporaryDirectory() as tmp_dir:
+        with RVConfig.get_tmp_dir() as tmp_dir:
             task = get_task(tmp_dir)
             backend = get_backend(task, tmp_dir)
             analyzer = self.get_analyzer(tmp_dir)
@@ -114,7 +114,7 @@ class TestBundleCommand(unittest.TestCase):
                                 .build()
             return b
 
-        with TemporaryDirectory() as tmp_dir:
+        with RVConfig.get_tmp_dir() as tmp_dir:
             task = get_task(tmp_dir)
             backend = get_backend(task, tmp_dir)
             analyzer = self.get_analyzer(tmp_dir)

--- a/src/tests/data/label_source/test_chip_classification_geojson_source.py
+++ b/src/tests/data/label_source/test_chip_classification_geojson_source.py
@@ -1,5 +1,4 @@
 import unittest
-import tempfile
 import os
 import json
 
@@ -11,6 +10,7 @@ from rastervision.data.label_source import (get_str_tree, infer_cell,
                                             infer_labels, read_labels)
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap, ClassItem
+from rastervision.rv_config import RVConfig
 
 from tests.data.mock_crs_transformer import DoubleCRSTransformer
 
@@ -61,7 +61,7 @@ class TestChipClassificationGeoJSONSource(unittest.TestCase):
         self.str_tree = get_str_tree(self.geojson_dict, self.crs_transformer)
 
         self.file_name = 'labels.json'
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = RVConfig.get_tmp_dir()
         self.file_path = os.path.join(self.temp_dir.name, self.file_name)
 
         with open(self.file_path, 'w') as label_file:

--- a/src/tests/data/label_source/test_object_detection_geojson_source.py
+++ b/src/tests/data/label_source/test_object_detection_geojson_source.py
@@ -1,5 +1,4 @@
 import unittest
-import tempfile
 import os
 import json
 
@@ -15,6 +14,7 @@ from rastervision.data import ObjectDetectionLabels
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap, ClassItem
 from rastervision.filesystem import NotReadableError
+from rastervision.rv_config import RVConfig
 
 from tests.data.mock_crs_transformer import DoubleCRSTransformer
 
@@ -25,7 +25,7 @@ class TestObjectDetectionGeoJSONSource(unittest.TestCase):
         self.mock_s3.start()
 
         self.file_name = 'labels.json'
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = RVConfig.get_tmp_dir()
         self.file_path = os.path.join(self.temp_dir.name, self.file_name)
 
         self.crs_transformer = DoubleCRSTransformer()

--- a/src/tests/data/label_store/test_chip_classification_geojson_store.py
+++ b/src/tests/data/label_store/test_chip_classification_geojson_store.py
@@ -1,14 +1,14 @@
 import unittest
-import tempfile
 import os
 import json
 
 from rastervision.data import (ChipClassificationGeoJSONSource,
                                ChipClassificationGeoJSONStore)
-from rastervision.data.label_source.chip_classification_geojson_source import read_labels
-from rastervision.data.label_store.utils import classification_labels_to_geojson
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap, ClassItem
+from rastervision.data.label_source.chip_classification_geojson_source import read_labels
+from rastervision.data.label_store.utils import classification_labels_to_geojson
+from rastervision.rv_config import RVConfig
 
 from tests.data.mock_crs_transformer import DoubleCRSTransformer
 
@@ -49,7 +49,7 @@ class TestChipClassificationGeoJSONStore(unittest.TestCase):
         self.class_map = ClassMap([ClassItem(1, 'car'), ClassItem(2, 'house')])
 
         self.file_name = 'labels.json'
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = RVConfig.get_tmp_dir()
         self.file_path = os.path.join(self.temp_dir.name, self.file_name)
 
         with open(self.file_path, 'w') as label_file:

--- a/src/tests/data/label_store/test_object_detection_geojson_store.py
+++ b/src/tests/data/label_store/test_object_detection_geojson_store.py
@@ -1,5 +1,4 @@
 import unittest
-import tempfile
 import os
 import json
 
@@ -11,6 +10,7 @@ from rastervision.data.label_source.utils import (
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap, ClassItem
 from rastervision.filesystem import NotWritableError
+from rastervision.rv_config import RVConfig
 
 from tests.data.mock_crs_transformer import DoubleCRSTransformer
 
@@ -18,7 +18,7 @@ from tests.data.mock_crs_transformer import DoubleCRSTransformer
 class TestObjectDetectionGeoJSONSource(unittest.TestCase):
     def setUp(self):
         self.file_name = 'labels.json'
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = RVConfig.get_tmp_dir()
         self.file_path = os.path.join(self.temp_dir.name, self.file_name)
 
         self.crs_transformer = DoubleCRSTransformer()

--- a/src/tests/data/raster_source/test_geotiff_source.py
+++ b/src/tests/data/raster_source/test_geotiff_source.py
@@ -1,6 +1,5 @@
 import unittest
 import os
-from tempfile import TemporaryDirectory
 
 import numpy as np
 import rasterio
@@ -9,13 +8,14 @@ import rastervision as rv
 from rastervision.core import Box
 from rastervision.utils.misc import save_img
 from rastervision.data.raster_source.rasterio_source import load_window
+from rastervision.rv_config import RVConfig
 
 from tests import data_file_path
 
 
 class TestGeoTiffSource(unittest.TestCase):
     def test_load_window(self):
-        with TemporaryDirectory() as temp_dir:
+        with RVConfig.get_tmp_dir() as temp_dir:
             # make geotiff filled with ones and zeros with nodata == 1
             image_path = os.path.join(temp_dir, 'temp.tif')
             height = 100
@@ -42,7 +42,7 @@ class TestGeoTiffSource(unittest.TestCase):
 
     def test_get_dtype(self):
         img_path = data_file_path('small-rgb-tile.tif')
-        with TemporaryDirectory() as tmp_dir:
+        with RVConfig.get_tmp_dir() as tmp_dir:
             source = rv.data.GeoTiffSourceConfig(uris=[img_path]) \
                             .create_source(tmp_dir)
 
@@ -74,7 +74,7 @@ class TestGeoTiffSource(unittest.TestCase):
         self.assertEqual(out_chip.shape[2], 3)
 
     def test_uses_channel_order(self):
-        with TemporaryDirectory() as tmp_dir:
+        with RVConfig.get_tmp_dir() as tmp_dir:
             img_path = os.path.join(tmp_dir, 'img.tif')
             chip = np.ones((2, 2, 4)).astype(np.uint8)
             chip[:, :, :] *= np.array([0, 1, 2, 3]).astype(np.uint8)

--- a/src/tests/data/raster_source/test_image_source.py
+++ b/src/tests/data/raster_source/test_image_source.py
@@ -1,17 +1,17 @@
 import unittest
 import os
-from tempfile import TemporaryDirectory
 
 import numpy as np
 
 import rastervision as rv
 from rastervision.core.raster_stats import RasterStats
 from rastervision.utils.misc import save_img
+from rastervision.rv_config import RVConfig
 
 
 class TestImageSource(unittest.TestCase):
     def test_applies_transforms(self):
-        with TemporaryDirectory() as tmp_dir:
+        with RVConfig.get_tmp_dir() as tmp_dir:
             stats_uri = os.path.join(tmp_dir, 'stats.json')
             img_path = os.path.join(tmp_dir, 'img.tif')
 

--- a/src/tests/data/raster_transformer/test_raster_transformer.py
+++ b/src/tests/data/raster_transformer/test_raster_transformer.py
@@ -1,11 +1,11 @@
 import unittest
 import os
-from tempfile import TemporaryDirectory
 
 import numpy as np
 
-from rastervision.core.raster_stats import RasterStats
 import rastervision as rv
+from rastervision.core.raster_stats import RasterStats
+from rastervision.rv_config import RVConfig
 
 
 class TestRasterTransformer(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestRasterTransformer(unittest.TestCase):
         raster_stats.means = list(np.ones((4, )))
         raster_stats.stds = list(np.ones((4, )) * 2)
 
-        with TemporaryDirectory() as tmp_dir:
+        with RVConfig.get_tmp_dir() as tmp_dir:
             stats_uri = os.path.join(tmp_dir, 'stats.json')
             raster_stats.save(stats_uri)
 

--- a/src/tests/evaluation/test_chip_classification_evaluator.py
+++ b/src/tests/evaluation/test_chip_classification_evaluator.py
@@ -1,9 +1,9 @@
 import unittest
 import os
 import json
-from tempfile import TemporaryDirectory
 
 import rastervision as rv
+from rastervision.rv_config import RVConfig
 
 from tests import data_file_path
 
@@ -38,7 +38,7 @@ class TestChipClassificationEvaluator(unittest.TestCase):
                           .with_aoi_uri(aoi_uri) \
                           .build()
 
-        with TemporaryDirectory() as tmp_dir:
+        with RVConfig.get_tmp_dir() as tmp_dir:
             scene = s.create_scene(task, tmp_dir)
 
             output_uri = os.path.join(tmp_dir, 'eval.json')

--- a/src/tests/task/test_chip_classification.py
+++ b/src/tests/task/test_chip_classification.py
@@ -1,7 +1,7 @@
 import unittest
-from tempfile import TemporaryDirectory
 
 import rastervision as rv
+from rastervision.rv_config import RVConfig
 
 from tests import data_file_path
 
@@ -42,7 +42,7 @@ class TestChipClassification(unittest.TestCase):
                           .with_aoi_uri(aoi_uri) \
                           .build()
 
-        with TemporaryDirectory() as tmp_dir:
+        with RVConfig.get_tmp_dir() as tmp_dir:
             scene = s.create_scene(task_config, tmp_dir)
             backend = backend_config.create_backend(task_config)
             task = task_config.create_task(backend)

--- a/src/tests/test_rv_config.py
+++ b/src/tests/test_rv_config.py
@@ -1,3 +1,22 @@
+import os
+import platform
+import unittest
+
+from rastervision.rv_config import RVConfig
+
+
+class TestRVConfig(unittest.TestCase):
+    def test_set_tmp_dir(self):
+        if platform.system() == 'Linux':
+            directory = '/tmp/xxx/yyy'
+            while os.path.exists(directory):
+                directory = directory + 'yyy'
+            self.assertFalse(os.path.exists(directory))
+            RVConfig.set_tmp_dir(directory, rm_tmp_dir=True)
+            self.assertTrue(os.path.exists(directory))
+            self.assertTrue(os.path.isdir(directory))
+
+
 # import os
 # import json
 # import unittest

--- a/src/tests/test_rv_config.py
+++ b/src/tests/test_rv_config.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import unittest
+import shutil
 
 from rastervision.rv_config import RVConfig
 
@@ -8,13 +9,14 @@ from rastervision.rv_config import RVConfig
 class TestRVConfig(unittest.TestCase):
     def test_set_tmp_dir(self):
         if platform.system() == 'Linux':
-            directory = '/tmp/xxx/yyy'
+            directory = '/tmp/xxx/'
             while os.path.exists(directory):
-                directory = directory + 'yyy'
+                directory = directory + 'xxx/'
             self.assertFalse(os.path.exists(directory))
-            RVConfig.set_tmp_dir(directory, rm_tmp_dir=True)
+            RVConfig.set_tmp_dir(directory)
             self.assertTrue(os.path.exists(directory))
             self.assertTrue(os.path.isdir(directory))
+            shutil.rmtree(directory)
 
 
 # import os

--- a/src/tests/utils/test_files.py
+++ b/src/tests/utils/test_files.py
@@ -1,4 +1,3 @@
-import tempfile
 import os
 import unittest
 import json
@@ -11,6 +10,7 @@ from rastervision.utils.files import (
     NotReadableError, NotWritableError, load_json_config,
     ProtobufParseException, make_dir, get_local_path, file_exists)
 from rastervision.protos.model_config_pb2 import ModelConfig
+from rastervision.rv_config import RVConfig
 
 
 class TestMakeDir(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestMakeDir(unittest.TestCase):
         self.s3.create_bucket(Bucket=self.bucket_name)
 
         # Temporary directory
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = RVConfig.get_tmp_dir()
 
     def tearDown(self):
         self.temp_dir.cleanup()
@@ -149,7 +149,7 @@ class TestFileToStr(unittest.TestCase):
         self.file_name = 'hello.txt'
         self.s3_path = 's3://{}/{}'.format(self.bucket_name, self.file_name)
 
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = RVConfig.get_tmp_dir()
         self.local_path = os.path.join(self.temp_dir.name, self.file_name)
 
     def tearDown(self):
@@ -194,7 +194,7 @@ class TestDownloadIfNeeded(unittest.TestCase):
         self.file_name = 'hello.txt'
         self.s3_path = 's3://{}/{}'.format(self.bucket_name, self.file_name)
 
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = RVConfig.get_tmp_dir()
         self.local_path = os.path.join(self.temp_dir.name, self.file_name)
 
     def tearDown(self):
@@ -228,7 +228,7 @@ class TestDownloadIfNeeded(unittest.TestCase):
 class TestLoadJsonConfig(unittest.TestCase):
     def setUp(self):
         self.file_name = 'config.json'
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = RVConfig.get_tmp_dir()
         self.file_path = os.path.join(self.temp_dir.name, self.file_name)
 
     def tearDown(self):


### PR DESCRIPTION
## Overview

- [x] This block of code needs to be refactored into a proper place, and cleaned up a bit to make it more clear exactly what it does.
- [x] The temporary directory configuration should be a setting inside the raster vision configuration (`rv_config`) and also a command line argument (in the `main` method in `cli/main.py`).
- ~~I noticed in the refactor that you made it so `tmp_dir` is passed into a lot of functions. I think this is unnecessary because this line of code makes it so that all temp dirs created with `tempfile` are inside `RV_TEMP_DIR`.~~  (Will be handled in subsequent pull request.)
- ~~Cleanup with `atexit`~~
- [x] Avoid use of `tempfile.tempdir` as global variable

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #400
