### PR TITLE
Disable Codecov Statuses

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,16 +1,4 @@
 coverage:
-  threshold: 0.618    
   status:
-    project:
-      default:
-        # basic
-        target: auto
-        base: auto
-        # advanced
-        branches: null
-        if_no_uploads: error
-        if_not_found: success
-        if_ci_failed: error
-        only_pulls: false
-        flags: null
-        paths: null
+    project: off
+    patch: off


### PR DESCRIPTION
This should prevent changes in PR and patch coverage from causing test failures.

There is no real way to test this because configuration is pulled from the configuration file in the default branch.

If your PR fails after being merged into `develop`, it **should** pass if you start the CI again.