### PR TITLE
Allow running an experiment from a file

### DIFF
--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -90,9 +90,7 @@ def main(profile, verbose):
     default=False,
     help=('Rerun commands, regardless if '
           'their output files already exist.'))
-@click.option(
-    '--tempdir',
-    help=('Temporary directory to use for this run.'))
+@click.option('--tempdir', help=('Temporary directory to use for this run.'))
 def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
         prefix, methods, path, filters, rerun, tempdir):
     """Run Raster Vision commands from experiments, using the
@@ -146,8 +144,7 @@ def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
             print_error(
                 'No experiments found in {}.'.format(experiment_module))
         elif path:
-            print_error(
-                'No experiments found in {}.'.format(path))
+            print_error('No experiments found in {}.'.format(path))
         else:
             print_error('No experiments found.')
 

--- a/src/rastervision/cli/main.py
+++ b/src/rastervision/cli/main.py
@@ -85,13 +85,16 @@ def main(profile, verbose):
     default=False,
     help=('Rerun commands, regardless if '
           'their output files already exist.'))
+@click.option(
+    '--tempdir',
+    help=('Temporary directory to use for this run.'))
 def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
-        prefix, methods, filters, rerun):
+        prefix, methods, path, filters, rerun, tempdir):
     """Run Raster Vision commands from experiments, using the
     experiment runner named RUNNER."""
-    darg = dict(arg)
-    if 'tmp_dir' in darg:
-        RVConfig.set_tmp_dir(darg['tmp_dir'])
+
+    if tempdir:
+        RVConfig.set_tmp_dir(tempdir)
 
     # Validate runner
     valid_runners = list(

--- a/src/rastervision/experiment/experiment_loader.py
+++ b/src/rastervision/experiment/experiment_loader.py
@@ -35,15 +35,15 @@ class ExperimentLoader:
         path = os.path.splitext(os.path.normpath(path))[0]
 
         _relpath = os.path.relpath(path, self._top_level_dir)
-        assert not os.path.isabs(_relpath), "Path must be within the project"
-        assert not _relpath.startswith('..'), "Path must be within the project"
+        assert not os.path.isabs(_relpath), 'Path must be within the project'
+        assert not _relpath.startswith('..'), 'Path must be within the project'
 
         name = _relpath.replace(os.path.sep, '.')
         return name
 
     def load_from_file(self, path):
         name = self._get_name_from_path(path)
-        return  self.load_from_module(name)
+        return self.load_from_module(name)
 
     def load_from_module(self, name):
         result = []

--- a/src/rastervision/experiment/experiment_loader.py
+++ b/src/rastervision/experiment/experiment_loader.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 from importlib import import_module
 from fnmatch import fnmatchcase
 
@@ -21,6 +22,28 @@ class ExperimentLoader:
         self.exp_method_prefix = experiment_method_prefix
         self.exp_method_patterns = experiment_method_patterns
         self.exp_name_patterns = experiment_name_patterns
+
+        self._top_level_dir = os.path.abspath(os.curdir)
+
+    def _get_name_from_path(self, path):
+        """Gets an importable  name from a path.
+
+        Note: This code is from the python unittest library
+        """
+        if path == self._top_level_dir:
+            return '.'
+        path = os.path.splitext(os.path.normpath(path))[0]
+
+        _relpath = os.path.relpath(path, self._top_level_dir)
+        assert not os.path.isabs(_relpath), "Path must be within the project"
+        assert not _relpath.startswith('..'), "Path must be within the project"
+
+        name = _relpath.replace(os.path.sep, '.')
+        return name
+
+    def load_from_file(self, path):
+        name = self._get_name_from_path(path)
+        return  self.load_from_module(name)
 
     def load_from_module(self, name):
         result = []

--- a/src/tests/experiment/test_experiment_loader.py
+++ b/src/tests/experiment/test_experiment_loader.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import rastervision as rv
 from rastervision.experiment import ExperimentLoader
@@ -84,6 +85,17 @@ class TestExperimentConfig(unittest.TestCase):
         args = {'required_param': 'yes', 'dummy': 1}
         loader = ExperimentLoader(experiment_args=args)
         experiments = loader.load_from_module(__name__)
+        self.assertEqual(len(experiments), 3)
+        e_names = set(map(lambda e: e.id, experiments))
+        self.assertEqual(
+            e_names,
+            set(['experiment_1', 'experiment_1_yes', 'experiment_2_yes']))
+
+    def test_load_file(self):
+        path = os.path.abspath(__file__)
+        args = {'required_param': 'yes', 'dummy': 1}
+        loader = ExperimentLoader(experiment_args=args)
+        experiments = loader.load_from_file(path)
         self.assertEqual(len(experiments), 3)
         e_names = set(map(lambda e: e.id, experiments))
         self.assertEqual(


### PR DESCRIPTION
## Overview

This provides  an option to run an ExperimentSet from a file. Right now we have only the ability to run from a  module name.

After this change  these  two are equivalent:

```
> rastervision run local -n -p integration_tests/object_detection_tests/experiment.py  -a tmp_dir foo
> rastervision run local -n -e integration_tests.object_detection_tests.experiment  -a tmp_dir foo

Also modify the `run` command to have an explicit `tmp_dir` argument, as not to overload the purpose of the `-a` option (which is for passing arguments into experiment methods).

