### PR TITLE
Use tag of azavea/models

### DIFF
--- a/rastervision/runner/command_dag.py
+++ b/rastervision/runner/command_dag.py
@@ -45,7 +45,7 @@ class CommandDAG:
 
             with click.progressbar(
                     unsolved_sources,
-                    label='Ensuring input files exists ') as uris:
+                    label='Ensuring input files exist  ') as uris:
                 for uri in uris:
                     if not file_exists(uri):
                         missing_files.append(uri)

--- a/scripts/install_deps
+++ b/scripts/install_deps
@@ -24,7 +24,7 @@ apt-get install jq -y
 # Install TF Object Detection API in /opt/tf-models
 mkdir -p /opt/tf-models/temp/
 cd /opt/tf-models/temp/
-git clone --single-branch -b upgrade-sept-2018 https://github.com/azavea/models.git
+git clone --single-branch -b AZ-v1.11-RV-v0.8.0 https://github.com/azavea/models.git
 mv models/research/object_detection/ ../object_detection
 mv models/research/deeplab/ ../deeplab
 mv models/research/slim/ ../slim


### PR DESCRIPTION
Moves to using a release tag of Azavea's fork of tensorflow/models.

Also fixes a typo.

Fixes #438 