### PR TITLE
Bring TensorFlow Object Detection proto files into the project

### DIFF
--- a/rastervision/backend/MANIFEST.in
+++ b/rastervision/backend/MANIFEST.in
@@ -1,1 +1,0 @@
-model_defaults.json

--- a/rastervision/backend/tf_object_detection.py
+++ b/rastervision/backend/tf_object_detection.py
@@ -137,7 +137,7 @@ def merge_tf_records(output_path, src_records):
 
 
 def make_tf_class_map(class_map):
-    from object_detection.protos.string_int_label_map_pb2 import (
+    from rastervision.protos.tf_object_detection.string_int_label_map_pb2 import (
         StringIntLabelMap, StringIntLabelMapItem)
 
     tf_class_map = StringIntLabelMap()
@@ -484,7 +484,8 @@ class TrainingPackage(object):
         return pretrained_model_path
 
     def download_config(self):
-        from object_detection.protos.pipeline_pb2 import TrainEvalPipelineConfig
+        from rastervision.protos.tf_object_detection.pipeline_pb2 \
+            import TrainEvalPipelineConfig
         """Download a model and backend config and update its fields.
 
         This is used before training a model. This downloads and unzips a bunch

--- a/rastervision/backend/tf_object_detection_config.py
+++ b/rastervision/backend/tf_object_detection_config.py
@@ -6,6 +6,7 @@ import rastervision as rv
 from rastervision.backend import (BackendConfig, BackendConfigBuilder,
                                   TFObjectDetection)
 from rastervision.protos.backend_pb2 import BackendConfig as BackendConfigMsg
+from rastervision.protos.tf_object_detection.pipeline_pb2 import TrainEvalPipelineConfig
 from rastervision.utils.files import file_to_str
 from rastervision.utils.misc import set_nested_keys
 
@@ -293,7 +294,6 @@ class TFObjectDetectionConfigBuilder(BackendConfigBuilder):
                      here:
                      https://github.com/tensorflow/models/tree/eef6bb5bd3b3cd5fcf54306bf29750b7f9f9a5ea/research/object_detection/samples/configs # noqa
         """
-        from object_detection.protos.pipeline_pb2 import TrainEvalPipelineConfig
 
         template_json = None
         if type(template) is dict:

--- a/rastervision/protos/tf_object_detection/LICENSE
+++ b/rastervision/protos/tf_object_detection/LICENSE
@@ -1,0 +1,203 @@
+Copyright 2016 The TensorFlow Authors.  All rights reserved.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016, The Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rastervision/protos/tf_object_detection/NOTICE
+++ b/rastervision/protos/tf_object_detection/NOTICE
@@ -1,0 +1,1 @@
+These proto files are taken from the TensorFlow "models" project, and are copyright 2016 The TensorFlow Authors and licensed under the Apache 2.0 license. The file package names and import statements have been modified by Azavea, Inc.

--- a/rastervision/protos/tf_object_detection/anchor_generator.proto
+++ b/rastervision/protos/tf_object_detection/anchor_generator.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 import "rastervision/protos/tf_object_detection/grid_anchor_generator.proto";
 import "rastervision/protos/tf_object_detection/ssd_anchor_generator.proto";

--- a/rastervision/protos/tf_object_detection/anchor_generator.proto
+++ b/rastervision/protos/tf_object_detection/anchor_generator.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+import "rastervision/protos/tf_object_detection/grid_anchor_generator.proto";
+import "rastervision/protos/tf_object_detection/ssd_anchor_generator.proto";
+import "rastervision/protos/tf_object_detection/multiscale_anchor_generator.proto";
+
+// Configuration proto for the anchor generator to use in the object detection
+// pipeline. See core/anchor_generator.py for details.
+message AnchorGenerator {
+  oneof anchor_generator_oneof {
+    GridAnchorGenerator grid_anchor_generator = 1;
+    SsdAnchorGenerator ssd_anchor_generator = 2;
+    MultiscaleAnchorGenerator multiscale_anchor_generator = 3;
+  }
+}

--- a/rastervision/protos/tf_object_detection/argmax_matcher.proto
+++ b/rastervision/protos/tf_object_detection/argmax_matcher.proto
@@ -1,0 +1,29 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for ArgMaxMatcher. See
+// matchers/argmax_matcher.py for details.
+message ArgMaxMatcher {
+  // Threshold for positive matches.
+  optional float matched_threshold = 1 [default = 0.5];
+
+  // Threshold for negative matches.
+  optional float unmatched_threshold = 2 [default = 0.5];
+
+  // Whether to construct ArgMaxMatcher without thresholds.
+  optional bool ignore_thresholds = 3 [default = false];
+
+  // If True then negative matches are the ones below the unmatched_threshold,
+  // whereas ignored matches are in between the matched and umatched
+  // threshold. If False, then negative matches are in between the matched
+  // and unmatched threshold, and everything lower than unmatched is ignored.
+  optional bool negatives_lower_than_unmatched = 4 [default = true];
+
+  // Whether to ensure each row is matched to at least one column.
+  optional bool force_match_for_each_row = 5 [default = false];
+
+  // Force constructed match objects to use matrix multiplication based gather
+  // instead of standard tf.gather
+  optional bool use_matmul_gather = 6 [default = false];
+}

--- a/rastervision/protos/tf_object_detection/argmax_matcher.proto
+++ b/rastervision/protos/tf_object_detection/argmax_matcher.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for ArgMaxMatcher. See
 // matchers/argmax_matcher.py for details.

--- a/rastervision/protos/tf_object_detection/bipartite_matcher.proto
+++ b/rastervision/protos/tf_object_detection/bipartite_matcher.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for bipartite matcher. See
+// matchers/bipartite_matcher.py for details.
+message BipartiteMatcher {
+  // Force constructed match objects to use matrix multiplication based gather
+  // instead of standard tf.gather
+  optional bool use_matmul_gather = 6 [default = false];
+}

--- a/rastervision/protos/tf_object_detection/bipartite_matcher.proto
+++ b/rastervision/protos/tf_object_detection/bipartite_matcher.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for bipartite matcher. See
 // matchers/bipartite_matcher.py for details.

--- a/rastervision/protos/tf_object_detection/box_coder.proto
+++ b/rastervision/protos/tf_object_detection/box_coder.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+import "rastervision/protos/tf_object_detection/faster_rcnn_box_coder.proto";
+import "rastervision/protos/tf_object_detection/keypoint_box_coder.proto";
+import "rastervision/protos/tf_object_detection/mean_stddev_box_coder.proto";
+import "rastervision/protos/tf_object_detection/square_box_coder.proto";
+
+// Configuration proto for the box coder to be used in the object detection
+// pipeline. See core/box_coder.py for details.
+message BoxCoder {
+  oneof box_coder_oneof {
+    FasterRcnnBoxCoder faster_rcnn_box_coder = 1;
+    MeanStddevBoxCoder mean_stddev_box_coder = 2;
+    SquareBoxCoder square_box_coder = 3;
+    KeypointBoxCoder keypoint_box_coder = 4;
+  }
+}

--- a/rastervision/protos/tf_object_detection/box_coder.proto
+++ b/rastervision/protos/tf_object_detection/box_coder.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 import "rastervision/protos/tf_object_detection/faster_rcnn_box_coder.proto";
 import "rastervision/protos/tf_object_detection/keypoint_box_coder.proto";

--- a/rastervision/protos/tf_object_detection/box_predictor.proto
+++ b/rastervision/protos/tf_object_detection/box_predictor.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 import "rastervision/protos/tf_object_detection/hyperparams.proto";
 

--- a/rastervision/protos/tf_object_detection/box_predictor.proto
+++ b/rastervision/protos/tf_object_detection/box_predictor.proto
@@ -1,0 +1,202 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+import "rastervision/protos/tf_object_detection/hyperparams.proto";
+
+// Configuration proto for box predictor. See core/box_predictor.py for details.
+message BoxPredictor {
+  oneof box_predictor_oneof {
+    ConvolutionalBoxPredictor convolutional_box_predictor = 1;
+    MaskRCNNBoxPredictor mask_rcnn_box_predictor = 2;
+    RfcnBoxPredictor rfcn_box_predictor = 3;
+    WeightSharedConvolutionalBoxPredictor
+        weight_shared_convolutional_box_predictor = 4;
+  }
+}
+
+// Configuration proto for MaskHead in predictors.
+// Next id: 4
+message MaskHead {
+  // The height and the width of the predicted mask. Only used when
+  // predict_instance_masks is true.
+  optional int32 mask_height = 1 [default = 15];
+  optional int32 mask_width = 2 [default = 15];
+
+  // Whether to predict class agnostic masks. Only used when
+  // predict_instance_masks is true.
+  optional bool masks_are_class_agnostic = 3 [default = true];
+}
+
+// Configuration proto for Convolutional box predictor.
+// Next id: 13
+message ConvolutionalBoxPredictor {
+  // Hyperparameters for convolution ops used in the box predictor.
+  optional Hyperparams conv_hyperparams = 1;
+
+  // Minimum feature depth prior to predicting box encodings and class
+  // predictions.
+  optional int32 min_depth = 2 [default = 0];
+
+  // Maximum feature depth prior to predicting box encodings and class
+  // predictions. If max_depth is set to 0, no additional feature map will be
+  // inserted before location and class predictions.
+  optional int32 max_depth = 3 [default = 0];
+
+  // Number of the additional conv layers before the predictor.
+  optional int32 num_layers_before_predictor = 4 [default = 0];
+
+  // Whether to use dropout for class prediction.
+  optional bool use_dropout = 5 [default = true];
+
+  // Keep probability for dropout
+  optional float dropout_keep_probability = 6 [default = 0.8];
+
+  // Size of final convolution kernel. If the spatial resolution of the feature
+  // map is smaller than the kernel size, then the kernel size is set to
+  // min(feature_width, feature_height).
+  optional int32 kernel_size = 7 [default = 1];
+
+  // Size of the encoding for boxes.
+  optional int32 box_code_size = 8 [default = 4];
+
+  // Whether to apply sigmoid to the output of class predictions.
+  // TODO(jonathanhuang): Do we need this since we have a post processing
+  // module.?
+  optional bool apply_sigmoid_to_scores = 9 [default = false];
+
+  optional float class_prediction_bias_init = 10 [default = 0.0];
+
+  // Whether to use depthwise separable convolution for box predictor layers.
+  optional bool use_depthwise = 11 [default = false];
+
+  // Configs for a mask prediction head.
+  optional MaskHead mask_head = 12;
+}
+
+// Configuration proto for weight shared convolutional box predictor.
+// Next id: 18
+message WeightSharedConvolutionalBoxPredictor {
+  // Hyperparameters for convolution ops used in the box predictor.
+  optional Hyperparams conv_hyperparams = 1;
+
+  // Number of the additional conv layers before the predictor.
+  optional int32 num_layers_before_predictor = 4 [default = 0];
+
+  // Output depth for the convolution ops prior to predicting box encodings
+  // and class predictions.
+  optional int32 depth = 2 [default = 0];
+
+  // Size of final convolution kernel. If the spatial resolution of the feature
+  // map is smaller than the kernel size, then the kernel size is set to
+  // min(feature_width, feature_height).
+  optional int32 kernel_size = 7 [default = 3];
+
+  // Size of the encoding for boxes.
+  optional int32 box_code_size = 8 [default = 4];
+
+  // Bias initialization for class prediction. It has been show to stabilize
+  // training where there are large number of negative boxes. See
+  // https://arxiv.org/abs/1708.02002 for details.
+  optional float class_prediction_bias_init = 10 [default = 0.0];
+
+  // Whether to use dropout for class prediction.
+  optional bool use_dropout = 11 [default = false];
+
+  // Keep probability for dropout.
+  optional float dropout_keep_probability = 12 [default = 0.8];
+
+  // Whether to share the multi-layer tower between box prediction and class
+  // prediction heads.
+  optional bool share_prediction_tower = 13 [default = false];
+
+  // Whether to use depthwise separable convolution for box predictor layers.
+  optional bool use_depthwise = 14 [default = false];
+
+  // Configs for a mask prediction head.
+  optional MaskHead mask_head = 15;
+
+  // Enum to specify how to convert the detection scores at inference time.
+  enum ScoreConverter {
+    // Input scores equals output scores.
+    IDENTITY = 0;
+
+    // Applies a sigmoid on input scores.
+    SIGMOID = 1;
+  }
+
+  // Callable elementwise score converter at inference time.
+  optional ScoreConverter score_converter = 16 [default = IDENTITY];
+
+  // If specified, apply clipping to box encodings.
+  message BoxEncodingsClipRange {
+    optional float min = 1;
+    optional float max = 2;
+  }
+  optional BoxEncodingsClipRange box_encodings_clip_range = 17;
+}
+
+// TODO(alirezafathi): Refactor the proto file to be able to configure mask rcnn
+// head easily.
+message MaskRCNNBoxPredictor {
+  // Hyperparameters for fully connected ops used in the box predictor.
+  optional Hyperparams fc_hyperparams = 1;
+
+  // Whether to use dropout op prior to the both box and class predictions.
+  optional bool use_dropout = 2 [default = false];
+
+  // Keep probability for dropout. This is only used if use_dropout is true.
+  optional float dropout_keep_probability = 3 [default = 0.5];
+
+  // Size of the encoding for the boxes.
+  optional int32 box_code_size = 4 [default = 4];
+
+  // Hyperparameters for convolution ops used in the box predictor.
+  optional Hyperparams conv_hyperparams = 5;
+
+  // Whether to predict instance masks inside detection boxes.
+  optional bool predict_instance_masks = 6 [default = false];
+
+  // The depth for the first conv2d_transpose op applied to the
+  // image_features in the mask prediction branch. If set to 0, the value
+  // will be set automatically based on the number of channels in the image
+  // features and the number of classes.
+  optional int32 mask_prediction_conv_depth = 7 [default = 256];
+
+  // Whether to predict keypoints inside detection boxes.
+  optional bool predict_keypoints = 8 [default = false];
+
+  // The height and the width of the predicted mask.
+  optional int32 mask_height = 9 [default = 15];
+  optional int32 mask_width = 10 [default = 15];
+
+  // The number of convolutions applied to image_features in the mask prediction
+  // branch.
+  optional int32 mask_prediction_num_conv_layers = 11 [default = 2];
+  optional bool masks_are_class_agnostic = 12 [default = false];
+
+  // Whether to use one box for all classes rather than a different box for each
+  // class.
+  optional bool share_box_across_classes = 13 [default = false];
+}
+
+message RfcnBoxPredictor {
+  // Hyperparameters for convolution ops used in the box predictor.
+  optional Hyperparams conv_hyperparams = 1;
+
+  // Bin sizes for RFCN crops.
+  optional int32 num_spatial_bins_height = 2 [default = 3];
+
+  optional int32 num_spatial_bins_width = 3 [default = 3];
+
+  // Target depth to reduce the input image features to.
+  optional int32 depth = 4 [default = 1024];
+
+  // Size of the encoding for the boxes.
+  optional int32 box_code_size = 5 [default = 4];
+
+  // Size to resize the rfcn crops to.
+  optional int32 crop_height = 6 [default = 12];
+
+  optional int32 crop_width = 7 [default = 12];
+}

--- a/rastervision/protos/tf_object_detection/eval.proto
+++ b/rastervision/protos/tf_object_detection/eval.proto
@@ -1,0 +1,79 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Message for configuring DetectionModel evaluation jobs (eval.py).
+message EvalConfig {
+  optional uint32 batch_size = 25 [default=1];
+  // Number of visualization images to generate.
+  optional uint32 num_visualizations = 1 [default=10];
+
+  // Number of examples to process of evaluation.
+  optional uint32 num_examples = 2 [default=5000, deprecated=true];
+
+  // How often to run evaluation.
+  optional uint32 eval_interval_secs = 3 [default=300];
+
+  // Maximum number of times to run evaluation. If set to 0, will run forever.
+  optional uint32 max_evals = 4 [default=0, deprecated=true];
+
+  // Whether the TensorFlow graph used for evaluation should be saved to disk.
+  optional bool save_graph = 5 [default=false];
+
+  // Path to directory to store visualizations in. If empty, visualization
+  // images are not exported (only shown on Tensorboard).
+  optional string visualization_export_dir = 6 [default=""];
+
+  // BNS name of the TensorFlow master.
+  optional string eval_master = 7 [default=""];
+
+  // Type of metrics to use for evaluation.
+  repeated string metrics_set = 8;
+
+  // Path to export detections to COCO compatible JSON format.
+  optional string export_path = 9 [default=''];
+
+  // Option to not read groundtruth labels and only export detections to
+  // COCO-compatible JSON file.
+  optional bool ignore_groundtruth = 10 [default=false];
+
+  // Use exponential moving averages of variables for evaluation.
+  // TODO(rathodv): When this is false make sure the model is constructed
+  // without moving averages in restore_fn.
+  optional bool use_moving_averages = 11 [default=false];
+
+  // Whether to evaluate instance masks.
+  // Note that since there is no evaluation code currently for instance
+  // segmenation this option is unused.
+  optional bool eval_instance_masks = 12 [default=false];
+
+  // Minimum score threshold for a detected object box to be visualized
+  optional float min_score_threshold = 13 [default=0.5];
+
+  // Maximum number of detections to visualize
+  optional int32 max_num_boxes_to_visualize = 14 [default=20];
+
+  // When drawing a single detection, each label is by default visualized as
+  // <label name> : <label score>. One can skip the name or/and score using the
+  // following fields:
+  optional bool skip_scores = 15 [default=false];
+  optional bool skip_labels = 16 [default=false];
+
+  // Whether to show groundtruth boxes in addition to detected boxes in
+  // visualizations.
+  optional bool visualize_groundtruth_boxes = 17 [default=false];
+
+  // Box color for visualizing groundtruth boxes.
+  optional string groundtruth_box_visualization_color = 18 [default="black"];
+
+  // Whether to keep image identifier in filename when exported to
+  // visualization_export_dir.
+  optional bool keep_image_id_for_visualization_export = 19 [default=false];
+
+  // Whether to retain original images (i.e. not pre-processed) in the tensor
+  // dictionary, so that they can be displayed in Tensorboard.
+  optional bool retain_original_images = 23 [default=true];
+
+  // If True, additionally include per-category metrics.
+  optional bool include_metrics_per_category = 24 [default=false];
+}

--- a/rastervision/protos/tf_object_detection/eval.proto
+++ b/rastervision/protos/tf_object_detection/eval.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Message for configuring DetectionModel evaluation jobs (eval.py).
 message EvalConfig {

--- a/rastervision/protos/tf_object_detection/faster_rcnn.proto
+++ b/rastervision/protos/tf_object_detection/faster_rcnn.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 import "rastervision/protos/tf_object_detection/anchor_generator.proto";
 import "rastervision/protos/tf_object_detection/box_predictor.proto";

--- a/rastervision/protos/tf_object_detection/faster_rcnn.proto
+++ b/rastervision/protos/tf_object_detection/faster_rcnn.proto
@@ -1,0 +1,182 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+import "rastervision/protos/tf_object_detection/anchor_generator.proto";
+import "rastervision/protos/tf_object_detection/box_predictor.proto";
+import "rastervision/protos/tf_object_detection/hyperparams.proto";
+import "rastervision/protos/tf_object_detection/image_resizer.proto";
+import "rastervision/protos/tf_object_detection/losses.proto";
+import "rastervision/protos/tf_object_detection/post_processing.proto";
+
+// Configuration for Faster R-CNN models.
+// See meta_architectures/faster_rcnn_meta_arch.py and models/model_builder.py
+//
+// Naming conventions:
+// Faster R-CNN models have two stages: a first stage region proposal network
+// (or RPN) and a second stage box classifier.  We thus use the prefixes
+// `first_stage_` and `second_stage_` to indicate the stage to which each
+// parameter pertains when relevant.
+message FasterRcnn {
+
+  // Whether to construct only the Region Proposal Network (RPN).
+  optional int32 number_of_stages = 1 [default=2];
+
+  // Number of classes to predict.
+  optional int32 num_classes = 3;
+
+  // Image resizer for preprocessing the input image.
+  optional ImageResizer image_resizer = 4;
+
+  // Feature extractor config.
+  optional FasterRcnnFeatureExtractor feature_extractor = 5;
+
+
+  // (First stage) region proposal network (RPN) parameters.
+
+  // Anchor generator to compute RPN anchors.
+  optional AnchorGenerator first_stage_anchor_generator = 6;
+
+  // Atrous rate for the convolution op applied to the
+  // `first_stage_features_to_crop` tensor to obtain box predictions.
+  optional int32 first_stage_atrous_rate = 7 [default=1];
+
+  // Hyperparameters for the convolutional RPN box predictor.
+  optional Hyperparams first_stage_box_predictor_conv_hyperparams = 8;
+
+  // Kernel size to use for the convolution op just prior to RPN box
+  // predictions.
+  optional int32 first_stage_box_predictor_kernel_size = 9 [default=3];
+
+  // Output depth for the convolution op just prior to RPN box predictions.
+  optional int32 first_stage_box_predictor_depth = 10 [default=512];
+
+  // The batch size to use for computing the first stage objectness and
+  // location losses.
+  optional int32 first_stage_minibatch_size = 11 [default=256];
+
+  // Fraction of positive examples per image for the RPN.
+  optional float first_stage_positive_balance_fraction = 12 [default=0.5];
+
+  // Non max suppression score threshold applied to first stage RPN proposals.
+  optional float first_stage_nms_score_threshold = 13 [default=0.0];
+
+  // Non max suppression IOU threshold applied to first stage RPN proposals.
+  optional float first_stage_nms_iou_threshold = 14 [default=0.7];
+
+  // Maximum number of RPN proposals retained after first stage postprocessing.
+  optional int32 first_stage_max_proposals = 15 [default=300];
+
+  // First stage RPN localization loss weight.
+  optional float first_stage_localization_loss_weight = 16 [default=1.0];
+
+  // First stage RPN objectness loss weight.
+  optional float first_stage_objectness_loss_weight = 17 [default=1.0];
+
+
+  // Per-region cropping parameters.
+  // Note that if a R-FCN model is constructed the per region cropping
+  // parameters below are ignored.
+
+  // Output size (width and height are set to be the same) of the initial
+  // bilinear interpolation based cropping during ROI pooling.
+  optional int32 initial_crop_size = 18;
+
+  // Kernel size of the max pool op on the cropped feature map during
+  // ROI pooling.
+  optional int32 maxpool_kernel_size = 19;
+
+  // Stride of the max pool op on the cropped feature map during ROI pooling.
+  optional int32 maxpool_stride = 20;
+
+
+  // (Second stage) box classifier parameters
+
+  // Hyperparameters for the second stage box predictor. If box predictor type
+  // is set to rfcn_box_predictor, a R-FCN model is constructed, otherwise a
+  // Faster R-CNN model is constructed.
+  optional BoxPredictor second_stage_box_predictor  = 21;
+
+  // The batch size per image used for computing the classification and refined
+  // location loss of the box classifier.
+  // Note that this field is ignored if `hard_example_miner` is configured.
+  optional int32 second_stage_batch_size = 22 [default=64];
+
+  // Fraction of positive examples to use per image for the box classifier.
+  optional float second_stage_balance_fraction = 23 [default=0.25];
+
+  // Post processing to apply on the second stage box classifier predictions.
+  // Note: the `score_converter` provided to the FasterRCNNMetaArch constructor
+  // is taken from this `second_stage_post_processing` proto.
+  optional PostProcessing second_stage_post_processing = 24;
+
+  // Second stage refined localization loss weight.
+  optional float second_stage_localization_loss_weight = 25 [default=1.0];
+
+  // Second stage classification loss weight
+  optional float second_stage_classification_loss_weight = 26 [default=1.0];
+
+  // Second stage instance mask loss weight. Note that this is only applicable
+  // when `MaskRCNNBoxPredictor` is selected for second stage and configured to
+  // predict instance masks.
+  optional float second_stage_mask_prediction_loss_weight = 27 [default=1.0];
+
+  // If not left to default, applies hard example mining only to classification
+  // and localization loss..
+  optional HardExampleMiner hard_example_miner = 28;
+
+  // Loss for second stage box classifers, supports Softmax and Sigmoid.
+  // Note that score converter must be consistent with loss type.
+  // When there are multiple labels assigned to the same boxes, recommend
+  // to use sigmoid loss and enable merge_multiple_label_boxes.
+  // If not specified, Softmax loss is used as default.
+  optional ClassificationLoss second_stage_classification_loss = 29;
+
+  // Whether to update batch_norm inplace during training. This is required
+  // for batch norm to work correctly on TPUs. When this is false, user must add
+  // a control dependency on tf.GraphKeys.UPDATE_OPS for train/loss op in order
+  // to update the batch norm moving average parameters.
+  optional bool inplace_batchnorm_update = 30 [default = false];
+
+  // Force the use of matrix multiplication based crop and resize instead of
+  // standard tf.image.crop_and_resize while computing second stage input
+  // feature maps.
+  optional bool use_matmul_crop_and_resize = 31 [default = false];
+
+  // Normally, anchors generated for a given image size are pruned during
+  // training if they lie outside the image window. Setting this option to true,
+  // clips the anchors to be within the image instead of pruning.
+  optional bool clip_anchors_to_image = 32 [default = false];
+
+  // After peforming matching between anchors and targets, in order to pull out
+  // targets for training Faster R-CNN meta architecture we perform a gather
+  // operation. This options specifies whether to use an alternate
+  // implementation of tf.gather that is faster on TPUs.
+  optional bool use_matmul_gather_in_matcher = 33 [default = false];
+
+  // Whether to use the balanced positive negative sampler implementation with
+  // static shape guarantees.
+  optional bool use_static_balanced_label_sampler = 34 [default = false];
+
+  // If True, uses implementation of ops with static shape guarantees.
+  optional bool use_static_shapes = 35 [default = false];
+
+  // Whether the masks present in groundtruth should be resized in the model to
+  // match the image size.
+  optional bool resize_masks = 36 [default = true];
+}
+
+
+message FasterRcnnFeatureExtractor {
+  // Type of Faster R-CNN model (e.g., 'faster_rcnn_resnet101';
+  // See builders/model_builder.py for expected types).
+  optional string type = 1;
+
+  // Output stride of extracted RPN feature map.
+  optional int32 first_stage_features_stride = 2 [default=16];
+
+  // Whether to update batch norm parameters during training or not.
+  // When training with a relative large batch size (e.g. 8), it could be
+  // desirable to enable batch norm update.
+  optional bool batch_norm_trainable = 3 [default=false];
+}

--- a/rastervision/protos/tf_object_detection/faster_rcnn_box_coder.proto
+++ b/rastervision/protos/tf_object_detection/faster_rcnn_box_coder.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for FasterRCNNBoxCoder. See
+// box_coders/faster_rcnn_box_coder.py for details.
+message FasterRcnnBoxCoder {
+  // Scale factor for anchor encoded box center.
+  optional float y_scale = 1 [default = 10.0];
+  optional float x_scale = 2 [default = 10.0];
+
+  // Scale factor for anchor encoded box height.
+  optional float height_scale = 3 [default = 5.0];
+
+  // Scale factor for anchor encoded box width.
+  optional float width_scale = 4 [default = 5.0];
+}

--- a/rastervision/protos/tf_object_detection/faster_rcnn_box_coder.proto
+++ b/rastervision/protos/tf_object_detection/faster_rcnn_box_coder.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for FasterRCNNBoxCoder. See
 // box_coders/faster_rcnn_box_coder.py for details.

--- a/rastervision/protos/tf_object_detection/graph_rewriter.proto
+++ b/rastervision/protos/tf_object_detection/graph_rewriter.proto
@@ -1,0 +1,23 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Message to configure graph rewriter for the tf graph.
+message GraphRewriter {
+  optional Quantization quantization = 1;
+}
+
+// Message for quantization options. See
+// tensorflow/contrib/quantize/python/quantize.py for details.
+message Quantization {
+  // Number of steps to delay before quantization takes effect during training.
+  optional int32 delay = 1 [default = 500000];
+
+  // Number of bits to use for quantizing weights.
+  // Only 8 bit is supported for now.
+  optional int32 weight_bits = 2 [default = 8];
+
+  // Number of bits to use for quantizing activations.
+  // Only 8 bit is supported for now.
+  optional int32 activation_bits = 3 [default = 8];
+}

--- a/rastervision/protos/tf_object_detection/graph_rewriter.proto
+++ b/rastervision/protos/tf_object_detection/graph_rewriter.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Message to configure graph rewriter for the tf graph.
 message GraphRewriter {

--- a/rastervision/protos/tf_object_detection/grid_anchor_generator.proto
+++ b/rastervision/protos/tf_object_detection/grid_anchor_generator.proto
@@ -1,0 +1,34 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for GridAnchorGenerator. See
+// anchor_generators/grid_anchor_generator.py for details.
+message GridAnchorGenerator {
+   // Anchor height in pixels.
+  optional int32 height = 1 [default = 256];
+
+  // Anchor width in pixels.
+  optional int32 width = 2 [default = 256];
+
+  // Anchor stride in height dimension in pixels.
+  optional int32 height_stride = 3 [default = 16];
+
+  // Anchor stride in width dimension in pixels.
+  optional int32 width_stride = 4 [default = 16];
+
+  // Anchor height offset in pixels.
+  optional int32 height_offset = 5 [default = 0];
+
+  // Anchor width offset in pixels.
+  optional int32 width_offset = 6 [default = 0];
+
+  // At any given location, len(scales) * len(aspect_ratios) anchors are
+  // generated with all possible combinations of scales and aspect ratios.
+
+  // List of scales for the anchors.
+  repeated float scales = 7;
+
+  // List of aspect ratios for the anchors.
+  repeated float aspect_ratios = 8;
+}

--- a/rastervision/protos/tf_object_detection/grid_anchor_generator.proto
+++ b/rastervision/protos/tf_object_detection/grid_anchor_generator.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for GridAnchorGenerator. See
 // anchor_generators/grid_anchor_generator.py for details.

--- a/rastervision/protos/tf_object_detection/hyperparams.proto
+++ b/rastervision/protos/tf_object_detection/hyperparams.proto
@@ -1,0 +1,115 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for the convolution op hyperparameters to use in the
+// object detection pipeline.
+message Hyperparams {
+
+  // Operations affected by hyperparameters.
+  enum Op {
+    // Convolution, Separable Convolution, Convolution transpose.
+    CONV = 1;
+
+    // Fully connected
+    FC = 2;
+  }
+  optional Op op = 1 [default = CONV];
+
+  // Regularizer for the weights of the convolution op.
+  optional Regularizer regularizer = 2;
+
+  // Initializer for the weights of the convolution op.
+  optional Initializer initializer = 3;
+
+  // Type of activation to apply after convolution.
+  enum Activation {
+    // Use None (no activation)
+    NONE = 0;
+
+    // Use tf.nn.relu
+    RELU = 1;
+
+    // Use tf.nn.relu6
+    RELU_6 = 2;
+  }
+  optional Activation activation = 4 [default = RELU];
+
+  // BatchNorm hyperparameters. If this parameter is NOT set then BatchNorm is
+  // not applied!
+  optional BatchNorm batch_norm = 5;
+
+  // Whether depthwise convolutions should be regularized. If this parameter is
+  // NOT set then the conv hyperparams will default to the parent scope.
+  optional bool regularize_depthwise = 6 [default = false];
+}
+
+// Proto with one-of field for regularizers.
+message Regularizer {
+  oneof regularizer_oneof {
+    L1Regularizer l1_regularizer = 1;
+    L2Regularizer l2_regularizer = 2;
+  }
+}
+
+// Configuration proto for L1 Regularizer.
+// See https://www.tensorflow.org/api_docs/python/tf/contrib/layers/l1_regularizer
+message L1Regularizer {
+  optional float weight = 1 [default = 1.0];
+}
+
+// Configuration proto for L2 Regularizer.
+// See https://www.tensorflow.org/api_docs/python/tf/contrib/layers/l2_regularizer
+message L2Regularizer {
+  optional float weight = 1 [default = 1.0];
+}
+
+// Proto with one-of field for initializers.
+message Initializer {
+  oneof initializer_oneof {
+    TruncatedNormalInitializer truncated_normal_initializer = 1;
+    VarianceScalingInitializer variance_scaling_initializer = 2;
+    RandomNormalInitializer random_normal_initializer = 3;
+  }
+}
+
+// Configuration proto for truncated normal initializer. See
+// https://www.tensorflow.org/api_docs/python/tf/truncated_normal_initializer
+message TruncatedNormalInitializer {
+  optional float mean = 1 [default = 0.0];
+  optional float stddev = 2 [default = 1.0];
+}
+
+// Configuration proto for variance scaling initializer. See
+// https://www.tensorflow.org/api_docs/python/tf/contrib/layers/
+// variance_scaling_initializer
+message VarianceScalingInitializer {
+  optional float factor = 1 [default = 2.0];
+  optional bool uniform = 2 [default = false];
+  enum Mode {
+    FAN_IN = 0;
+    FAN_OUT = 1;
+    FAN_AVG = 2;
+  }
+  optional Mode mode = 3 [default = FAN_IN];
+}
+
+// Configuration proto for random normal initializer. See
+// https://www.tensorflow.org/api_docs/python/tf/random_normal_initializer
+message RandomNormalInitializer {
+  optional float mean = 1 [default = 0.0];
+  optional float stddev = 2 [default = 1.0];
+}
+
+// Configuration proto for batch norm to apply after convolution op. See
+// https://www.tensorflow.org/api_docs/python/tf/contrib/layers/batch_norm
+message BatchNorm {
+  optional float decay = 1 [default = 0.999];
+  optional bool center = 2 [default = true];
+  optional bool scale = 3 [default = false];
+  optional float epsilon = 4 [default = 0.001];
+  // Whether to train the batch norm variables. If this is set to false during
+  // training, the current value of the batch_norm variables are used for
+  // forward pass but they are never updated.
+  optional bool train = 5 [default = true];
+}

--- a/rastervision/protos/tf_object_detection/hyperparams.proto
+++ b/rastervision/protos/tf_object_detection/hyperparams.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for the convolution op hyperparameters to use in the
 // object detection pipeline.

--- a/rastervision/protos/tf_object_detection/image_resizer.proto
+++ b/rastervision/protos/tf_object_detection/image_resizer.proto
@@ -1,0 +1,59 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for image resizing operations.
+// See builders/image_resizer_builder.py for details.
+message ImageResizer {
+  oneof image_resizer_oneof {
+    KeepAspectRatioResizer keep_aspect_ratio_resizer = 1;
+    FixedShapeResizer fixed_shape_resizer = 2;
+  }
+}
+
+// Enumeration type for image resizing methods provided in TensorFlow.
+enum ResizeType {
+  BILINEAR = 0; // Corresponds to tf.image.ResizeMethod.BILINEAR
+  NEAREST_NEIGHBOR = 1; // Corresponds to tf.image.ResizeMethod.NEAREST_NEIGHBOR
+  BICUBIC = 2; // Corresponds to tf.image.ResizeMethod.BICUBIC
+  AREA = 3; // Corresponds to tf.image.ResizeMethod.AREA
+}
+
+// Configuration proto for image resizer that keeps aspect ratio.
+message KeepAspectRatioResizer {
+  // Desired size of the smaller image dimension in pixels.
+  optional int32 min_dimension = 1 [default = 600];
+
+  // Desired size of the larger image dimension in pixels.
+  optional int32 max_dimension = 2 [default = 1024];
+
+  // Desired method when resizing image.
+  optional ResizeType resize_method = 3 [default = BILINEAR];
+
+  // Whether to pad the image with zeros so the output spatial size is
+  // [max_dimension, max_dimension]. Note that the zeros are padded to the
+  // bottom and the right of the resized image.
+  optional bool pad_to_max_dimension = 4 [default = false];
+
+  // Whether to also resize the image channels from 3 to 1 (RGB to grayscale).
+  optional bool convert_to_grayscale = 5 [default = false];
+
+  // Per-channel pad value. This is only used when pad_to_max_dimension is True.
+  // If unspecified, a default pad value of 0 is applied to all channels.
+  repeated float per_channel_pad_value = 6;
+}
+
+// Configuration proto for image resizer that resizes to a fixed shape.
+message FixedShapeResizer {
+  // Desired height of image in pixels.
+  optional int32 height = 1 [default = 300];
+
+  // Desired width of image in pixels.
+  optional int32 width = 2 [default = 300];
+
+  // Desired method when resizing image.
+  optional ResizeType resize_method = 3 [default = BILINEAR];
+
+  // Whether to also resize the image channels from 3 to 1 (RGB to grayscale).
+  optional bool convert_to_grayscale = 4 [default = false];
+}

--- a/rastervision/protos/tf_object_detection/image_resizer.proto
+++ b/rastervision/protos/tf_object_detection/image_resizer.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for image resizing operations.
 // See builders/image_resizer_builder.py for details.

--- a/rastervision/protos/tf_object_detection/input_reader.proto
+++ b/rastervision/protos/tf_object_detection/input_reader.proto
@@ -1,0 +1,123 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for defining input readers that generate Object Detection
+// Examples from input sources. Input readers are expected to generate a
+// dictionary of tensors, with the following fields populated:
+//
+// 'image': an [image_height, image_width, channels] image tensor that detection
+//    will be run on.
+// 'groundtruth_classes': a [num_boxes] int32 tensor storing the class
+//    labels of detected boxes in the image.
+// 'groundtruth_boxes': a [num_boxes, 4] float tensor storing the coordinates of
+//    detected boxes in the image.
+// 'groundtruth_instance_masks': (Optional), a [num_boxes, image_height,
+//    image_width] float tensor storing binary mask of the objects in boxes.
+
+// Instance mask format. Note that PNG masks are much more space efficient.
+enum InstanceMaskType {
+  DEFAULT = 0;          // Default implementation, currently NUMERICAL_MASKS
+  NUMERICAL_MASKS = 1;  // [num_masks, H, W] float32 binary masks.
+  PNG_MASKS = 2;        // Encoded PNG masks.
+}
+
+// Next id: 24
+message InputReader {
+  // Name of input reader. Typically used to describe the dataset that is read
+  // by this input reader.
+  optional string name = 23 [default=""];
+
+  // Path to StringIntLabelMap pbtxt file specifying the mapping from string
+  // labels to integer ids.
+  optional string label_map_path = 1 [default=""];
+
+  // Whether data should be processed in the order they are read in, or
+  // shuffled randomly.
+  optional bool shuffle = 2 [default=true];
+
+  // Buffer size to be used when shuffling.
+  optional uint32 shuffle_buffer_size = 11 [default = 2048];
+
+  // Buffer size to be used when shuffling file names.
+  optional uint32 filenames_shuffle_buffer_size = 12 [default = 100];
+
+  // The number of times a data source is read. If set to zero, the data source
+  // will be reused indefinitely.
+  optional uint32 num_epochs = 5 [default=0];
+
+  // Integer representing how often an example should be sampled. To feed
+  // only 1/3 of your data into your model, set `sample_1_of_n_examples` to 3.
+  // This is particularly useful for evaluation, where you might not prefer to
+  // evaluate all of your samples.
+  optional uint32 sample_1_of_n_examples = 22 [default=1];
+
+  // Number of file shards to read in parallel.
+  optional uint32 num_readers = 6 [default=64];
+
+  // Number of batches to produce in parallel. If this is run on a 2x2 TPU set
+  // this to 8.
+  optional uint32 num_parallel_batches = 19 [default=8];
+
+  // Number of batches to prefetch. Prefetch decouples input pipeline and
+  // model so they can be pipelined resulting in higher throughput. Set this
+  // to a small constant and increment linearly until the improvements become
+  // marginal or you exceed your cpu memory budget. Setting this to -1,
+  // automatically tunes this value for you.
+  optional int32 num_prefetch_batches = 20 [default=2];
+
+  // Maximum number of records to keep in reader queue.
+  optional uint32 queue_capacity = 3 [default=2000, deprecated=true];
+
+  // Minimum number of records to keep in reader queue. A large value is needed
+  // to generate a good random shuffle.
+  optional uint32 min_after_dequeue = 4 [default=1000, deprecated=true];
+
+  // Number of records to read from each reader at once.
+  optional uint32 read_block_length = 15 [default=32];
+
+  // Number of decoded records to prefetch before batching.
+  optional uint32 prefetch_size = 13 [default = 512, deprecated=true];
+
+  // Number of parallel decode ops to apply.
+  optional uint32 num_parallel_map_calls = 14 [default = 64, deprecated=true];
+
+  // If positive, TfExampleDecoder will try to decode rasters of additional
+  // channels from tf.Examples.
+  optional int32 num_additional_channels = 18 [default = 0];
+
+  // Number of groundtruth keypoints per object.
+  optional uint32 num_keypoints = 16 [default = 0];
+
+  // Maximum number of boxes to pad to during training / evaluation.
+  // Set this to at least the maximum amount of boxes in the input data,
+  // otherwise some groundtruth boxes may be clipped.
+  optional int32 max_number_of_boxes = 21 [default=100];
+
+  // Whether to load groundtruth instance masks.
+  optional bool load_instance_masks = 7 [default = false];
+
+  // Type of instance mask.
+  optional InstanceMaskType mask_type = 10 [default = NUMERICAL_MASKS];
+
+  // Whether to use the display name when decoding examples. This is only used
+  // when mapping class text strings to integers.
+  optional bool use_display_name = 17 [default = false];
+
+  oneof input_reader {
+    TFRecordInputReader tf_record_input_reader = 8;
+    ExternalInputReader external_input_reader = 9;
+  }
+}
+
+// An input reader that reads TF Example protos from local TFRecord files.
+message TFRecordInputReader {
+  // Path(s) to `TFRecordFile`s.
+  repeated string input_path = 1;
+}
+
+// An externally defined input reader. Users may define an extension to this
+// proto to interface their own input readers.
+message ExternalInputReader {
+  extensions 1 to 999;
+}

--- a/rastervision/protos/tf_object_detection/input_reader.proto
+++ b/rastervision/protos/tf_object_detection/input_reader.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for defining input readers that generate Object Detection
 // Examples from input sources. Input readers are expected to generate a

--- a/rastervision/protos/tf_object_detection/keypoint_box_coder.proto
+++ b/rastervision/protos/tf_object_detection/keypoint_box_coder.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for KeypointBoxCoder. See
+// box_coders/keypoint_box_coder.py for details.
+message KeypointBoxCoder {
+  optional int32 num_keypoints = 1;
+
+  // Scale factor for anchor encoded box center and keypoints.
+  optional float y_scale = 2 [default = 10.0];
+  optional float x_scale = 3 [default = 10.0];
+
+  // Scale factor for anchor encoded box height.
+  optional float height_scale = 4 [default = 5.0];
+
+  // Scale factor for anchor encoded box width.
+  optional float width_scale = 5 [default = 5.0];
+}

--- a/rastervision/protos/tf_object_detection/keypoint_box_coder.proto
+++ b/rastervision/protos/tf_object_detection/keypoint_box_coder.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for KeypointBoxCoder. See
 // box_coders/keypoint_box_coder.py for details.

--- a/rastervision/protos/tf_object_detection/losses.proto
+++ b/rastervision/protos/tf_object_detection/losses.proto
@@ -1,0 +1,164 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Message for configuring the localization loss, classification loss and hard
+// example miner used for training object detection models. See core/losses.py
+// for details
+message Loss {
+  // Localization loss to use.
+  optional LocalizationLoss localization_loss = 1;
+
+  // Classification loss to use.
+  optional ClassificationLoss classification_loss = 2;
+
+  // If not left to default, applies hard example mining.
+  optional HardExampleMiner hard_example_miner = 3;
+
+  // Classification loss weight.
+  optional float classification_weight = 4 [default=1.0];
+
+  // Localization loss weight.
+  optional float localization_weight = 5 [default=1.0];
+
+  // If not left to default, applies random example sampling.
+  optional RandomExampleSampler random_example_sampler = 6;
+}
+
+// Configuration for bounding box localization loss function.
+message LocalizationLoss {
+  oneof localization_loss {
+    WeightedL2LocalizationLoss weighted_l2 = 1;
+    WeightedSmoothL1LocalizationLoss weighted_smooth_l1 = 2;
+    WeightedIOULocalizationLoss weighted_iou = 3;
+  }
+}
+
+// L2 location loss: 0.5 * ||weight * (a - b)|| ^ 2
+message WeightedL2LocalizationLoss {
+  // DEPRECATED, do not use.
+  // Output loss per anchor.
+  optional bool anchorwise_output = 1 [default=false];
+}
+
+// SmoothL1 (Huber) location loss.
+// The smooth L1_loss is defined elementwise as .5 x^2 if |x| <= delta and
+// delta * (|x|-0.5*delta) otherwise, where x is the difference between
+// predictions and target.
+message WeightedSmoothL1LocalizationLoss {
+  // DEPRECATED, do not use.
+  // Output loss per anchor.
+  optional bool anchorwise_output = 1 [default=false];
+
+  // Delta value for huber loss.
+  optional float delta = 2 [default=1.0];
+}
+
+// Intersection over union location loss: 1 - IOU
+message WeightedIOULocalizationLoss {
+}
+
+// Configuration for class prediction loss function.
+message ClassificationLoss {
+  oneof classification_loss {
+    WeightedSigmoidClassificationLoss weighted_sigmoid = 1;
+    WeightedSoftmaxClassificationLoss weighted_softmax = 2;
+    WeightedSoftmaxClassificationAgainstLogitsLoss weighted_logits_softmax = 5;
+    BootstrappedSigmoidClassificationLoss bootstrapped_sigmoid = 3;
+    SigmoidFocalClassificationLoss weighted_sigmoid_focal = 4;
+  }
+}
+
+// Classification loss using a sigmoid function over class predictions.
+message WeightedSigmoidClassificationLoss {
+  // DEPRECATED, do not use.
+  // Output loss per anchor.
+  optional bool anchorwise_output = 1 [default=false];
+}
+
+// Sigmoid Focal cross entropy loss as described in
+// https://arxiv.org/abs/1708.02002
+message SigmoidFocalClassificationLoss {
+  // DEPRECATED, do not use.
+  optional bool anchorwise_output = 1 [default = false];
+  // modulating factor for the loss.
+  optional float gamma = 2 [default = 2.0];
+  // alpha weighting factor for the loss.
+  optional float alpha = 3;
+}
+
+// Classification loss using a softmax function over class predictions.
+message WeightedSoftmaxClassificationLoss {
+  // DEPRECATED, do not use.
+  // Output loss per anchor.
+  optional bool anchorwise_output = 1 [default=false];
+  // Scale logit (input) value before calculating softmax classification loss.
+  // Typically used for softmax distillation.
+  optional float logit_scale = 2 [default = 1.0];
+}
+
+// Classification loss using a softmax function over class predictions and
+// a softmax function over the groundtruth labels (assumed to be logits).
+message WeightedSoftmaxClassificationAgainstLogitsLoss {
+  // DEPRECATED, do not use.
+  optional bool anchorwise_output = 1 [default = false];
+  // Scale and softmax groundtruth logits before calculating softmax
+  // classification loss. Typically used for softmax distillation with teacher
+  // annotations stored as logits.
+  optional float logit_scale = 2 [default = 1.0];
+}
+
+// Classification loss using a sigmoid function over the class prediction with
+// the highest prediction score.
+message BootstrappedSigmoidClassificationLoss {
+  // Interpolation weight between 0 and 1.
+  optional float alpha = 1;
+
+  // Whether hard boot strapping should be used or not. If true, will only use
+  // one class favored by model. Othewise, will use all predicted class
+  // probabilities.
+  optional bool hard_bootstrap = 2 [default=false];
+
+  // DEPRECATED, do not use.
+  // Output loss per anchor.
+  optional bool anchorwise_output = 3 [default=false];
+}
+
+// Configuration for hard example miner.
+message HardExampleMiner {
+  // Maximum number of hard examples to be selected per image (prior to
+  // enforcing max negative to positive ratio constraint).  If set to 0,
+  // all examples obtained after NMS are considered.
+  optional int32 num_hard_examples = 1 [default=64];
+
+  // Minimum intersection over union for an example to be discarded during NMS.
+  optional float iou_threshold = 2 [default=0.7];
+
+  // Whether to use classification losses ('cls', default), localization losses
+  // ('loc') or both losses ('both'). In the case of 'both', cls_loss_weight and
+  // loc_loss_weight are used to compute weighted sum of the two losses.
+  enum LossType {
+    BOTH = 0;
+    CLASSIFICATION = 1;
+    LOCALIZATION = 2;
+  }
+  optional LossType loss_type = 3 [default=BOTH];
+
+  // Maximum number of negatives to retain for each positive anchor. If
+  // num_negatives_per_positive is 0 no prespecified negative:positive ratio is
+  // enforced.
+  optional int32 max_negatives_per_positive = 4 [default=0];
+
+  // Minimum number of negative anchors to sample for a given image. Setting
+  // this to a positive number samples negatives in an image without any
+  // positive anchors and thus not bias the model towards having at least one
+  // detection per image.
+  optional int32 min_negatives_per_image = 5 [default=0];
+}
+
+// Configuration for random example sampler.
+message RandomExampleSampler {
+  // The desired fraction of positive samples in batch when applying random
+  // example sampling.
+  optional float positive_sample_fraction = 1 [default = 0.01];
+}

--- a/rastervision/protos/tf_object_detection/losses.proto
+++ b/rastervision/protos/tf_object_detection/losses.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Message for configuring the localization loss, classification loss and hard
 // example miner used for training object detection models. See core/losses.py

--- a/rastervision/protos/tf_object_detection/matcher.proto
+++ b/rastervision/protos/tf_object_detection/matcher.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+import "rastervision/protos/tf_object_detection/argmax_matcher.proto";
+import "rastervision/protos/tf_object_detection/bipartite_matcher.proto";
+
+// Configuration proto for the matcher to be used in the object detection
+// pipeline. See core/matcher.py for details.
+message Matcher {
+  oneof matcher_oneof {
+    ArgMaxMatcher argmax_matcher = 1;
+    BipartiteMatcher bipartite_matcher = 2;
+  }
+}

--- a/rastervision/protos/tf_object_detection/matcher.proto
+++ b/rastervision/protos/tf_object_detection/matcher.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 import "rastervision/protos/tf_object_detection/argmax_matcher.proto";
 import "rastervision/protos/tf_object_detection/bipartite_matcher.proto";

--- a/rastervision/protos/tf_object_detection/mean_stddev_box_coder.proto
+++ b/rastervision/protos/tf_object_detection/mean_stddev_box_coder.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for MeanStddevBoxCoder. See
+// box_coders/mean_stddev_box_coder.py for details.
+message MeanStddevBoxCoder {
+  // The standard deviation used to encode and decode boxes.
+  optional float stddev = 1 [default=0.01];
+}

--- a/rastervision/protos/tf_object_detection/mean_stddev_box_coder.proto
+++ b/rastervision/protos/tf_object_detection/mean_stddev_box_coder.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for MeanStddevBoxCoder. See
 // box_coders/mean_stddev_box_coder.py for details.

--- a/rastervision/protos/tf_object_detection/model.proto
+++ b/rastervision/protos/tf_object_detection/model.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 import "rastervision/protos/tf_object_detection/faster_rcnn.proto";
 import "rastervision/protos/tf_object_detection/ssd.proto";

--- a/rastervision/protos/tf_object_detection/model.proto
+++ b/rastervision/protos/tf_object_detection/model.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+import "rastervision/protos/tf_object_detection/faster_rcnn.proto";
+import "rastervision/protos/tf_object_detection/ssd.proto";
+
+// Top level configuration for DetectionModels.
+message DetectionModel {
+  oneof model {
+    FasterRcnn faster_rcnn = 1;
+    Ssd ssd = 2;
+  }
+}

--- a/rastervision/protos/tf_object_detection/multiscale_anchor_generator.proto
+++ b/rastervision/protos/tf_object_detection/multiscale_anchor_generator.proto
@@ -1,0 +1,26 @@
+  syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for RetinaNet anchor generator described in
+// https://arxiv.org/abs/1708.02002. See
+// anchor_generators/multiscale_grid_anchor_generator.py for details.
+message MultiscaleAnchorGenerator {
+  // minimum level in feature pyramid
+  optional int32 min_level = 1 [default = 3];
+
+  // maximum level in feature pyramid
+  optional int32 max_level = 2 [default = 7];
+
+  // Scale of anchor to feature stride
+  optional float anchor_scale = 3 [default = 4.0];
+
+  // Aspect ratios for anchors at each grid point.
+  repeated float aspect_ratios = 4;
+
+  // Number of intermediate scale each scale octave
+  optional int32 scales_per_octave = 5 [default = 2];
+
+  // Whether to produce anchors in normalized coordinates.
+  optional bool normalize_coordinates = 6 [default = true];
+}

--- a/rastervision/protos/tf_object_detection/multiscale_anchor_generator.proto
+++ b/rastervision/protos/tf_object_detection/multiscale_anchor_generator.proto
@@ -1,6 +1,6 @@
   syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for RetinaNet anchor generator described in
 // https://arxiv.org/abs/1708.02002. See

--- a/rastervision/protos/tf_object_detection/optimizer.proto
+++ b/rastervision/protos/tf_object_detection/optimizer.proto
@@ -1,0 +1,91 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Messages for configuring the optimizing strategy for training object
+// detection models.
+
+// Top level optimizer message.
+message Optimizer {
+  oneof optimizer {
+    RMSPropOptimizer rms_prop_optimizer = 1;
+    MomentumOptimizer momentum_optimizer = 2;
+    AdamOptimizer adam_optimizer = 3;
+  }
+  optional bool use_moving_average = 4 [default = true];
+  optional float moving_average_decay = 5 [default = 0.9999];
+}
+
+// Configuration message for the RMSPropOptimizer
+// See: https://www.tensorflow.org/api_docs/python/tf/train/RMSPropOptimizer
+message RMSPropOptimizer {
+  optional LearningRate learning_rate = 1;
+  optional float momentum_optimizer_value = 2 [default = 0.9];
+  optional float decay = 3 [default = 0.9];
+  optional float epsilon = 4 [default = 1.0];
+}
+
+// Configuration message for the MomentumOptimizer
+// See: https://www.tensorflow.org/api_docs/python/tf/train/MomentumOptimizer
+message MomentumOptimizer {
+  optional LearningRate learning_rate = 1;
+  optional float momentum_optimizer_value = 2 [default = 0.9];
+}
+
+// Configuration message for the AdamOptimizer
+// See: https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
+message AdamOptimizer {
+  optional LearningRate learning_rate = 1;
+}
+
+// Configuration message for optimizer learning rate.
+message LearningRate {
+  oneof learning_rate {
+    ConstantLearningRate constant_learning_rate = 1;
+    ExponentialDecayLearningRate exponential_decay_learning_rate = 2;
+    ManualStepLearningRate manual_step_learning_rate = 3;
+    CosineDecayLearningRate cosine_decay_learning_rate = 4;
+  }
+}
+
+// Configuration message for a constant learning rate.
+message ConstantLearningRate {
+  optional float learning_rate = 1 [default = 0.002];
+}
+
+// Configuration message for an exponentially decaying learning rate.
+// See https://www.tensorflow.org/versions/master/api_docs/python/train/ \
+//     decaying_the_learning_rate#exponential_decay
+message ExponentialDecayLearningRate {
+  optional float initial_learning_rate = 1 [default = 0.002];
+  optional uint32 decay_steps = 2 [default = 4000000];
+  optional float decay_factor = 3 [default = 0.95];
+  optional bool staircase = 4 [default = true];
+  optional float burnin_learning_rate = 5 [default = 0.0];
+  optional uint32 burnin_steps =  6 [default = 0];
+  optional float min_learning_rate =  7 [default = 0.0];
+}
+
+// Configuration message for a manually defined learning rate schedule.
+message ManualStepLearningRate {
+  optional float initial_learning_rate = 1 [default = 0.002];
+  message LearningRateSchedule {
+    optional uint32 step = 1;
+    optional float learning_rate = 2 [default = 0.002];
+  }
+  repeated LearningRateSchedule schedule = 2;
+
+  // Whether to linearly interpolate learning rates for steps in
+  // [0, schedule[0].step].
+  optional bool warmup = 3 [default = false];
+}
+
+// Configuration message for a cosine decaying learning rate as defined in
+// object_detection/utils/learning_schedules.py
+message CosineDecayLearningRate {
+  optional float learning_rate_base = 1 [default = 0.002];
+  optional uint32 total_steps = 2 [default = 4000000];
+  optional float warmup_learning_rate = 3 [default = 0.0002];
+  optional uint32 warmup_steps = 4 [default = 10000];
+  optional uint32 hold_base_rate_steps = 5 [default = 0];
+}

--- a/rastervision/protos/tf_object_detection/optimizer.proto
+++ b/rastervision/protos/tf_object_detection/optimizer.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Messages for configuring the optimizing strategy for training object
 // detection models.

--- a/rastervision/protos/tf_object_detection/pipeline.proto
+++ b/rastervision/protos/tf_object_detection/pipeline.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 import "rastervision/protos/tf_object_detection/eval.proto";
 import "rastervision/protos/tf_object_detection/graph_rewriter.proto";

--- a/rastervision/protos/tf_object_detection/pipeline.proto
+++ b/rastervision/protos/tf_object_detection/pipeline.proto
@@ -1,0 +1,22 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+import "rastervision/protos/tf_object_detection/eval.proto";
+import "rastervision/protos/tf_object_detection/graph_rewriter.proto";
+import "rastervision/protos/tf_object_detection/input_reader.proto";
+import "rastervision/protos/tf_object_detection/model.proto";
+import "rastervision/protos/tf_object_detection/train.proto";
+
+// Convenience message for configuring a training and eval pipeline. Allows all
+// of the pipeline parameters to be configured from one file.
+// Next id: 7
+message TrainEvalPipelineConfig {
+  optional DetectionModel model = 1;
+  optional TrainConfig train_config = 2;
+  optional InputReader train_input_reader = 3;
+  optional EvalConfig eval_config = 4;
+  repeated InputReader eval_input_reader = 5;
+  optional GraphRewriter graph_rewriter = 6;
+  extensions 1000 to max;
+}

--- a/rastervision/protos/tf_object_detection/post_processing.proto
+++ b/rastervision/protos/tf_object_detection/post_processing.proto
@@ -1,0 +1,49 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for non-max-suppression operation on a batch of
+// detections.
+message BatchNonMaxSuppression {
+  // Scalar threshold for score (low scoring boxes are removed).
+  optional float score_threshold = 1 [default = 0.0];
+
+  // Scalar threshold for IOU (boxes that have high IOU overlap
+  // with previously selected boxes are removed).
+  optional float iou_threshold = 2 [default = 0.6];
+
+  // Maximum number of detections to retain per class.
+  optional int32 max_detections_per_class = 3 [default = 100];
+
+  // Maximum number of detections to retain across all classes.
+  optional int32 max_total_detections = 5 [default = 100];
+
+  // Whether to use the implementation of NMS that guarantees static shapes.
+  optional bool use_static_shapes = 6 [default = false];
+}
+
+// Configuration proto for post-processing predicted boxes and
+// scores.
+message PostProcessing {
+  // Non max suppression parameters.
+  optional BatchNonMaxSuppression batch_non_max_suppression = 1;
+
+  // Enum to specify how to convert the detection scores.
+  enum ScoreConverter {
+    // Input scores equals output scores.
+    IDENTITY = 0;
+
+    // Applies a sigmoid on input scores.
+    SIGMOID = 1;
+
+    // Applies a softmax on input scores
+    SOFTMAX = 2;
+  }
+
+  // Score converter to use.
+  optional ScoreConverter score_converter = 2 [default = IDENTITY];
+  // Scale logit (input) value before conversion in post-processing step.
+  // Typically used for softmax distillation, though can be used to scale for
+  // other reasons.
+  optional float logit_scale = 3 [default = 1.0];
+}

--- a/rastervision/protos/tf_object_detection/post_processing.proto
+++ b/rastervision/protos/tf_object_detection/post_processing.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for non-max-suppression operation on a batch of
 // detections.

--- a/rastervision/protos/tf_object_detection/preprocessor.proto
+++ b/rastervision/protos/tf_object_detection/preprocessor.proto
@@ -1,0 +1,420 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Message for defining a preprocessing operation on input data.
+// See: //third_party/tensorflow_models/object_detection/core/preprocessor.py
+message PreprocessingStep {
+  oneof preprocessing_step {
+    NormalizeImage normalize_image = 1;
+    RandomHorizontalFlip random_horizontal_flip = 2;
+    RandomPixelValueScale random_pixel_value_scale = 3;
+    RandomImageScale random_image_scale = 4;
+    RandomRGBtoGray random_rgb_to_gray = 5;
+    RandomAdjustBrightness random_adjust_brightness = 6;
+    RandomAdjustContrast random_adjust_contrast = 7;
+    RandomAdjustHue random_adjust_hue = 8;
+    RandomAdjustSaturation random_adjust_saturation = 9;
+    RandomDistortColor random_distort_color = 10;
+    RandomJitterBoxes random_jitter_boxes = 11;
+    RandomCropImage random_crop_image = 12;
+    RandomPadImage random_pad_image = 13;
+    RandomCropPadImage random_crop_pad_image = 14;
+    RandomCropToAspectRatio random_crop_to_aspect_ratio = 15;
+    RandomBlackPatches random_black_patches = 16;
+    RandomResizeMethod random_resize_method = 17;
+    ScaleBoxesToPixelCoordinates scale_boxes_to_pixel_coordinates = 18;
+    ResizeImage resize_image = 19;
+    SubtractChannelMean subtract_channel_mean = 20;
+    SSDRandomCrop ssd_random_crop = 21;
+    SSDRandomCropPad ssd_random_crop_pad = 22;
+    SSDRandomCropFixedAspectRatio ssd_random_crop_fixed_aspect_ratio = 23;
+    SSDRandomCropPadFixedAspectRatio ssd_random_crop_pad_fixed_aspect_ratio = 24;
+    RandomVerticalFlip random_vertical_flip = 25;
+    RandomRotation90 random_rotation90 = 26;
+    RGBtoGray rgb_to_gray = 27;
+    ConvertClassLogitsToSoftmax convert_class_logits_to_softmax = 28;
+  }
+}
+
+// Normalizes pixel values in an image.
+// For every channel in the image, moves the pixel values from the range
+// [original_minval, original_maxval] to [target_minval, target_maxval].
+message NormalizeImage {
+  optional float original_minval = 1;
+  optional float original_maxval = 2;
+  optional float target_minval = 3 [default=0];
+  optional float target_maxval = 4 [default=1];
+}
+
+// Randomly horizontally flips the image and detections 50% of the time.
+message RandomHorizontalFlip {
+  // Specifies a mapping from the original keypoint indices to horizontally
+  // flipped indices. This is used in the event that keypoints are specified,
+  // in which case when the image is horizontally flipped the keypoints will
+  // need to be permuted. E.g. for keypoints representing left_eye, right_eye,
+  // nose_tip, mouth, left_ear, right_ear (in that order), one might specify
+  // the keypoint_flip_permutation below:
+  // keypoint_flip_permutation: 1
+  // keypoint_flip_permutation: 0
+  // keypoint_flip_permutation: 2
+  // keypoint_flip_permutation: 3
+  // keypoint_flip_permutation: 5
+  // keypoint_flip_permutation: 4
+  repeated int32 keypoint_flip_permutation = 1;
+}
+
+// Randomly vertically flips the image and detections 50% of the time.
+message RandomVerticalFlip {
+  // Specifies a mapping from the original keypoint indices to vertically
+  // flipped indices. This is used in the event that keypoints are specified,
+  // in which case when the image is vertically flipped the keypoints will
+  // need to be permuted. E.g. for keypoints representing left_eye, right_eye,
+  // nose_tip, mouth, left_ear, right_ear (in that order), one might specify
+  // the keypoint_flip_permutation below:
+  // keypoint_flip_permutation: 1
+  // keypoint_flip_permutation: 0
+  // keypoint_flip_permutation: 2
+  // keypoint_flip_permutation: 3
+  // keypoint_flip_permutation: 5
+  // keypoint_flip_permutation: 4
+  repeated int32 keypoint_flip_permutation = 1;
+}
+
+// Randomly rotates the image and detections by 90 degrees counter-clockwise
+// 50% of the time.
+message RandomRotation90 {}
+
+// Randomly scales the values of all pixels in the image by some constant value
+// between [minval, maxval], then clip the value to a range between [0, 1.0].
+message RandomPixelValueScale {
+  optional float minval = 1 [default=0.9];
+  optional float maxval = 2 [default=1.1];
+}
+
+// Randomly enlarges or shrinks image (keeping aspect ratio).
+message RandomImageScale {
+  optional float min_scale_ratio = 1 [default=0.5];
+  optional float max_scale_ratio = 2 [default=2.0];
+}
+
+// Randomly convert entire image to grey scale.
+message RandomRGBtoGray {
+  optional float probability = 1 [default=0.1];
+}
+
+// Randomly changes image brightness by up to max_delta. Image outputs will be
+// saturated between 0 and 1.
+message RandomAdjustBrightness {
+  optional float max_delta=1 [default=0.2];
+}
+
+// Randomly scales contract by a value between [min_delta, max_delta].
+message RandomAdjustContrast {
+  optional float min_delta = 1 [default=0.8];
+  optional float max_delta = 2 [default=1.25];
+}
+
+// Randomly alters hue by a value of up to max_delta.
+message RandomAdjustHue {
+  optional float max_delta = 1 [default=0.02];
+}
+
+// Randomly changes saturation by a value between [min_delta, max_delta].
+message RandomAdjustSaturation {
+  optional float min_delta = 1 [default=0.8];
+  optional float max_delta = 2 [default=1.25];
+}
+
+// Performs a random color distortion. color_orderings should either be 0 or 1.
+message RandomDistortColor {
+  optional int32 color_ordering = 1;
+}
+
+// Randomly jitters corners of boxes in the image determined by ratio.
+// ie. If a box is [100, 200] and ratio is 0.02, the corners can move by [1, 4].
+message RandomJitterBoxes {
+  optional float ratio = 1 [default=0.05];
+}
+
+// Randomly crops the image and bounding boxes.
+message RandomCropImage {
+  // Cropped image must cover at least one box by this fraction.
+  optional float min_object_covered = 1 [default=1.0];
+
+  // Aspect ratio bounds of cropped image.
+  optional float min_aspect_ratio = 2 [default=0.75];
+  optional float max_aspect_ratio = 3 [default=1.33];
+
+  // Allowed area ratio of cropped image to original image.
+  optional float min_area = 4 [default=0.1];
+  optional float max_area = 5 [default=1.0];
+
+  // Minimum overlap threshold of cropped boxes to keep in new image. If the
+  // ratio between a cropped bounding box and the original is less than this
+  // value, it is removed from the new image.
+  optional float overlap_thresh = 6 [default=0.3];
+
+  // Probability of keeping the original image.
+  optional float random_coef = 7 [default=0.0];
+}
+
+// Randomly adds padding to the image.
+message RandomPadImage {
+  // Minimum dimensions for padded image. If unset, will use original image
+  // dimension as a lower bound.
+  optional float min_image_height = 1;
+  optional float min_image_width = 2;
+
+  // Maximum dimensions for padded image. If unset, will use double the original
+  // image dimension as a lower bound.
+  optional float max_image_height = 3;
+  optional float max_image_width = 4;
+
+  // Color of the padding. If unset, will pad using average color of the input
+  // image.
+  repeated float pad_color = 5;
+}
+
+// Randomly crops an image followed by a random pad.
+message RandomCropPadImage {
+  // Cropping operation must cover at least one box by this fraction.
+  optional float min_object_covered = 1 [default=1.0];
+
+  // Aspect ratio bounds of image after cropping operation.
+  optional float min_aspect_ratio = 2 [default=0.75];
+  optional float max_aspect_ratio = 3 [default=1.33];
+
+  // Allowed area ratio of image after cropping operation.
+  optional float min_area = 4 [default=0.1];
+  optional float max_area = 5 [default=1.0];
+
+  // Minimum overlap threshold of cropped boxes to keep in new image. If the
+  // ratio between a cropped bounding box and the original is less than this
+  // value, it is removed from the new image.
+  optional float overlap_thresh = 6 [default=0.3];
+
+  // Probability of keeping the original image during the crop operation.
+  optional float random_coef = 7 [default=0.0];
+
+  // Maximum dimensions for padded image. If unset, will use double the original
+  // image dimension as a lower bound. Both of the following fields should be
+  // length 2.
+  repeated float min_padded_size_ratio = 8;
+  repeated float max_padded_size_ratio = 9;
+
+  // Color of the padding. If unset, will pad using average color of the input
+  // image. This field should be of length 3.
+  repeated float pad_color = 10;
+}
+
+// Randomly crops an iamge to a given aspect ratio.
+message RandomCropToAspectRatio {
+  // Aspect ratio.
+  optional float aspect_ratio = 1 [default=1.0];
+
+  // Minimum overlap threshold of cropped boxes to keep in new image. If the
+  // ratio between a cropped bounding box and the original is less than this
+  // value, it is removed from the new image.
+  optional float overlap_thresh = 2 [default=0.3];
+}
+
+// Randomly adds black square patches to an image.
+message RandomBlackPatches {
+  // The maximum number of black patches to add.
+  optional int32 max_black_patches = 1 [default=10];
+
+  // The probability of a black patch being added to an image.
+  optional float probability = 2 [default=0.5];
+
+  // Ratio between the dimension of the black patch to the minimum dimension of
+  // the image (patch_width = patch_height = min(image_height, image_width)).
+  optional float size_to_image_ratio = 3 [default=0.1];
+}
+
+// Randomly resizes the image up to [target_height, target_width].
+message RandomResizeMethod {
+  optional float target_height = 1;
+  optional float target_width = 2;
+}
+
+// Converts the RGB image to a grayscale image. This also converts the image
+// depth from 3 to 1, unlike RandomRGBtoGray which does not change the image
+// depth.
+message RGBtoGray {}
+
+// Scales boxes from normalized coordinates to pixel coordinates.
+message ScaleBoxesToPixelCoordinates {
+}
+
+// Resizes images to [new_height, new_width].
+message ResizeImage {
+  optional int32 new_height = 1;
+  optional int32 new_width = 2;
+  enum Method {
+    AREA=1;
+    BICUBIC=2;
+    BILINEAR=3;
+    NEAREST_NEIGHBOR=4;
+  }
+  optional Method method = 3 [default=BILINEAR];
+}
+
+// Normalizes an image by subtracting a mean from each channel.
+message SubtractChannelMean {
+  // The mean to subtract from each channel. Should be of same dimension of
+  // channels in the input image.
+  repeated float means = 1;
+}
+
+message SSDRandomCropOperation {
+  // Cropped image must cover at least this fraction of one original bounding
+  // box.
+  optional float min_object_covered = 1;
+
+  // The aspect ratio of the cropped image must be within the range of
+  // [min_aspect_ratio, max_aspect_ratio].
+  optional float min_aspect_ratio = 2;
+  optional float max_aspect_ratio = 3;
+
+  // The area of the cropped image must be within the range of
+  // [min_area, max_area].
+  optional float min_area = 4;
+  optional float max_area = 5;
+
+  // Cropped box area ratio must be above this threhold to be kept.
+  optional float overlap_thresh = 6;
+
+  // Probability a crop operation is skipped.
+  optional float random_coef = 7;
+}
+
+// Randomly crops a image according to:
+//     Liu et al., SSD: Single shot multibox detector.
+// This preprocessing step defines multiple SSDRandomCropOperations. Only one
+// operation (chosen at random) is actually performed on an image.
+message SSDRandomCrop {
+  repeated SSDRandomCropOperation operations = 1;
+}
+
+message SSDRandomCropPadOperation {
+  // Cropped image must cover at least this fraction of one original bounding
+  // box.
+  optional float min_object_covered = 1;
+
+  // The aspect ratio of the cropped image must be within the range of
+  // [min_aspect_ratio, max_aspect_ratio].
+  optional float min_aspect_ratio = 2;
+  optional float max_aspect_ratio = 3;
+
+  // The area of the cropped image must be within the range of
+  // [min_area, max_area].
+  optional float min_area = 4;
+  optional float max_area = 5;
+
+  // Cropped box area ratio must be above this threhold to be kept.
+  optional float overlap_thresh = 6;
+
+  // Probability a crop operation is skipped.
+  optional float random_coef = 7;
+
+  // Min ratio of padded image height and width to the input image's height and
+  // width. Two entries per operation.
+  repeated float min_padded_size_ratio = 8;
+
+  // Max ratio of padded image height and width to the input image's height and
+  // width. Two entries per operation.
+  repeated float max_padded_size_ratio = 9;
+
+  // Padding color.
+  optional float pad_color_r = 10;
+  optional float pad_color_g = 11;
+  optional float pad_color_b = 12;
+}
+
+// Randomly crops and pads an image according to:
+//     Liu et al., SSD: Single shot multibox detector.
+// This preprocessing step defines multiple SSDRandomCropPadOperations. Only one
+// operation (chosen at random) is actually performed on an image.
+message SSDRandomCropPad {
+  repeated SSDRandomCropPadOperation operations = 1;
+}
+
+message SSDRandomCropFixedAspectRatioOperation {
+  // Cropped image must cover at least this fraction of one original bounding
+  // box.
+  optional float min_object_covered = 1;
+
+  // The area of the cropped image must be within the range of
+  // [min_area, max_area].
+  optional float min_area = 4;
+  optional float max_area = 5;
+
+  // Cropped box area ratio must be above this threhold to be kept.
+  optional float overlap_thresh = 6;
+
+  // Probability a crop operation is skipped.
+  optional float random_coef = 7;
+}
+
+// Randomly crops a image to a fixed aspect ratio according to:
+//     Liu et al., SSD: Single shot multibox detector.
+// Multiple SSDRandomCropFixedAspectRatioOperations are defined by this
+// preprocessing step. Only one operation (chosen at random) is actually
+// performed on an image.
+message SSDRandomCropFixedAspectRatio {
+  repeated SSDRandomCropFixedAspectRatioOperation operations = 1;
+
+  // Aspect ratio to crop to. This value is used for all crop operations.
+  optional float aspect_ratio = 2 [default=1.0];
+}
+
+message SSDRandomCropPadFixedAspectRatioOperation {
+  // Cropped image must cover at least this fraction of one original bounding
+  // box.
+  optional float min_object_covered = 1;
+
+  // The aspect ratio of the cropped image must be within the range of
+  // [min_aspect_ratio, max_aspect_ratio].
+  optional float min_aspect_ratio = 2;
+  optional float max_aspect_ratio = 3;
+
+  // The area of the cropped image must be within the range of
+  // [min_area, max_area].
+  optional float min_area = 4;
+  optional float max_area = 5;
+
+  // Cropped box area ratio must be above this threhold to be kept.
+  optional float overlap_thresh = 6;
+
+  // Probability a crop operation is skipped.
+  optional float random_coef = 7;
+}
+
+// Randomly crops and pads an image to a fixed aspect ratio according to:
+//     Liu et al., SSD: Single shot multibox detector.
+// Multiple SSDRandomCropPadFixedAspectRatioOperations are defined by this
+// preprocessing step. Only one operation (chosen at random) is actually
+// performed on an image.
+message SSDRandomCropPadFixedAspectRatio {
+  repeated SSDRandomCropPadFixedAspectRatioOperation operations = 1;
+
+  // Aspect ratio to pad to. This value is used for all crop and pad operations.
+  optional float aspect_ratio = 2 [default=1.0];
+
+  // Min ratio of padded image height and width to the input image's height and
+  // width. Two entries per operation.
+  repeated float min_padded_size_ratio = 3;
+
+  // Max ratio of padded image height and width to the input image's height and
+  // width. Two entries per operation.
+  repeated float max_padded_size_ratio = 4;
+}
+
+// Converts class logits to softmax optionally scaling the values by temperature
+// first.
+message ConvertClassLogitsToSoftmax {
+
+  // Scale to use on logits before applying softmax.
+  optional float temperature = 1 [default=1.0];
+}

--- a/rastervision/protos/tf_object_detection/preprocessor.proto
+++ b/rastervision/protos/tf_object_detection/preprocessor.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Message for defining a preprocessing operation on input data.
 // See: //third_party/tensorflow_models/object_detection/core/preprocessor.py

--- a/rastervision/protos/tf_object_detection/region_similarity_calculator.proto
+++ b/rastervision/protos/tf_object_detection/region_similarity_calculator.proto
@@ -1,0 +1,33 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for region similarity calculators. See
+// core/region_similarity_calculator.py for details.
+message RegionSimilarityCalculator {
+  oneof region_similarity {
+    NegSqDistSimilarity neg_sq_dist_similarity = 1;
+    IouSimilarity iou_similarity = 2;
+    IoaSimilarity ioa_similarity = 3;
+    ThresholdedIouSimilarity thresholded_iou_similarity = 4;
+  }
+}
+
+// Configuration for negative squared distance similarity calculator.
+message NegSqDistSimilarity {
+}
+
+// Configuration for intersection-over-union (IOU) similarity calculator.
+message IouSimilarity {
+}
+
+// Configuration for intersection-over-area (IOA) similarity calculator.
+message IoaSimilarity {
+}
+
+// Configuration for thresholded-intersection-over-union similarity calculator.
+message ThresholdedIouSimilarity {
+
+  // IOU threshold used for filtering scores.
+  optional float iou_threshold = 1 [default = 0.5];
+}

--- a/rastervision/protos/tf_object_detection/region_similarity_calculator.proto
+++ b/rastervision/protos/tf_object_detection/region_similarity_calculator.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for region similarity calculators. See
 // core/region_similarity_calculator.py for details.

--- a/rastervision/protos/tf_object_detection/square_box_coder.proto
+++ b/rastervision/protos/tf_object_detection/square_box_coder.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for SquareBoxCoder. See
+// box_coders/square_box_coder.py for details.
+message SquareBoxCoder {
+  // Scale factor for anchor encoded box center.
+  optional float y_scale = 1 [default = 10.0];
+  optional float x_scale = 2 [default = 10.0];
+
+  // Scale factor for anchor encoded box length.
+  optional float length_scale = 3 [default = 5.0];
+}

--- a/rastervision/protos/tf_object_detection/square_box_coder.proto
+++ b/rastervision/protos/tf_object_detection/square_box_coder.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for SquareBoxCoder. See
 // box_coders/square_box_coder.py for details.

--- a/rastervision/protos/tf_object_detection/ssd.proto
+++ b/rastervision/protos/tf_object_detection/ssd.proto
@@ -1,0 +1,169 @@
+syntax = "proto2";
+package object_detection.protos;
+
+import "rastervision/protos/tf_object_detection/anchor_generator.proto";
+import "rastervision/protos/tf_object_detection/box_coder.proto";
+import "rastervision/protos/tf_object_detection/box_predictor.proto";
+import "rastervision/protos/tf_object_detection/hyperparams.proto";
+import "rastervision/protos/tf_object_detection/image_resizer.proto";
+import "rastervision/protos/tf_object_detection/matcher.proto";
+import "rastervision/protos/tf_object_detection/losses.proto";
+import "rastervision/protos/tf_object_detection/post_processing.proto";
+import "rastervision/protos/tf_object_detection/region_similarity_calculator.proto";
+
+// Configuration for Single Shot Detection (SSD) models.
+// Next id: 21
+message Ssd {
+
+  // Number of classes to predict.
+  optional int32 num_classes = 1;
+
+  // Image resizer for preprocessing the input image.
+  optional ImageResizer image_resizer = 2;
+
+  // Feature extractor config.
+  optional SsdFeatureExtractor feature_extractor = 3;
+
+  // Box coder to encode the boxes.
+  optional BoxCoder box_coder = 4;
+
+  // Matcher to match groundtruth with anchors.
+  optional Matcher matcher = 5;
+
+  // Region similarity calculator to compute similarity of boxes.
+  optional RegionSimilarityCalculator similarity_calculator = 6;
+
+  // Whether background targets are to be encoded as an all
+  // zeros vector or a one-hot vector (where background is the 0th class).
+  optional bool encode_background_as_zeros = 12 [default=false];
+
+  // classification weight to be associated to negative
+  // anchors (default: 1.0). The weight must be in [0., 1.].
+  optional float negative_class_weight = 13 [default = 1.0];
+
+  // Box predictor to attach to the features.
+  optional BoxPredictor box_predictor = 7;
+
+  // Anchor generator to compute anchors.
+  optional AnchorGenerator anchor_generator = 8;
+
+  // Post processing to apply on the predictions.
+  optional PostProcessing post_processing = 9;
+
+  // Whether to normalize the loss by number of groundtruth boxes that match to
+  // the anchors.
+  optional bool normalize_loss_by_num_matches = 10 [default=true];
+
+  // Whether to normalize the localization loss by the code size of the box
+  // encodings. This is applied along with other normalization factors.
+  optional bool normalize_loc_loss_by_codesize = 14 [default=false];
+
+  // Loss configuration for training.
+  optional Loss loss = 11;
+
+  // Whether to update batch norm parameters during training or not.
+  // When training with a relative small batch size (e.g. 1), it is
+  // desirable to disable batch norm update and use pretrained batch norm
+  // params.
+  //
+  // Note: Some feature extractors are used with canned arg_scopes
+  // (e.g resnet arg scopes).  In these cases training behavior of batch norm
+  // variables may depend on both values of `batch_norm_trainable` and
+  // `is_training`.
+  //
+  // When canned arg_scopes are used with feature extractors `conv_hyperparams`
+  // will apply only to the additional layers that are added and are outside the
+  // canned arg_scope.
+  optional bool freeze_batchnorm = 16 [default = false];
+
+  // Whether to update batch_norm inplace during training. This is required
+  // for batch norm to work correctly on TPUs. When this is false, user must add
+  // a control dependency on tf.GraphKeys.UPDATE_OPS for train/loss op in order
+  // to update the batch norm moving average parameters.
+  optional bool inplace_batchnorm_update = 15 [default = false];
+
+  // Whether to weight the regression loss by the score of the ground truth box
+  // the anchor matches to.
+  optional bool weight_regression_loss_by_score = 17 [default=false];
+
+  // Whether to compute expected loss with respect to balanced positive/negative
+  // sampling scheme. If false, use explicit sampling.
+  optional bool use_expected_classification_loss_under_sampling = 18 [default=false];
+
+  // Minimum number of effective negative samples.
+  // Only applies if use_expected_classification_loss_under_sampling is true.
+  optional float minimum_negative_sampling = 19 [default=0];
+
+  // Desired number of effective negative samples per positive sample.
+  // Only applies if use_expected_classification_loss_under_sampling is true.
+  optional float desired_negative_sampling_ratio = 20 [default=3];
+}
+
+
+message SsdFeatureExtractor {
+  reserved 6;
+
+  // Type of ssd feature extractor.
+  optional string type = 1;
+
+  // The factor to alter the depth of the channels in the feature extractor.
+  optional float depth_multiplier = 2 [default=1.0];
+
+  // Minimum number of the channels in the feature extractor.
+  optional int32 min_depth = 3 [default=16];
+
+  // Hyperparameters that affect the layers of feature extractor added on top
+  // of the base feature extractor.
+  optional Hyperparams conv_hyperparams = 4;
+
+  // Normally, SSD feature extractors are constructed by reusing an existing
+  // base feature extractor (that has its own hyperparams) and adding new layers
+  // on top of it. `conv_hyperparams` above normally applies only to the new
+  // layers while base feature extractor uses its own default hyperparams. If
+  // this value is set to true, the base feature extractor's hyperparams will be
+  // overridden with the `conv_hyperparams`.
+  optional bool override_base_feature_extractor_hyperparams = 9 [default = false];
+
+  // The nearest multiple to zero-pad the input height and width dimensions to.
+  // For example, if pad_to_multiple = 2, input dimensions are zero-padded
+  // until the resulting dimensions are even.
+  optional int32 pad_to_multiple = 5 [default = 1];
+
+  // Whether to use explicit padding when extracting SSD multiresolution
+  // features. This will also apply to the base feature extractor if a MobileNet
+  // architecture is used.
+  optional bool use_explicit_padding = 7 [default=false];
+
+  // Whether to use depthwise separable convolutions for to extract additional
+  // feature maps added by SSD.
+  optional bool use_depthwise = 8 [default=false];
+
+  // Feature Pyramid Networks config.
+  optional FeaturePyramidNetworks fpn = 10;
+}
+
+// Configuration for Feature Pyramid Networks.
+message FeaturePyramidNetworks {
+  // We recommend to use multi_resolution_feature_map_generator with FPN, and
+  // the levels there must match the levels defined below for better
+  // performance.
+  // Correspondence from FPN levels to Resnet/Mobilenet V1 feature maps:
+  // FPN Level        Resnet Feature Map      Mobilenet-V1 Feature Map
+  //     2               Block 1                Conv2d_3_pointwise
+  //     3               Block 2                Conv2d_5_pointwise
+  //     4               Block 3                Conv2d_11_pointwise
+  //     5               Block 4                Conv2d_13_pointwise
+  //     6               Bottomup_5             bottom_up_Conv2d_14
+  //     7               Bottomup_6             bottom_up_Conv2d_15
+  //     8               Bottomup_7             bottom_up_Conv2d_16
+  //     9               Bottomup_8             bottom_up_Conv2d_17
+
+  // minimum level in feature pyramid
+  optional int32 min_level = 1 [default = 3];
+
+  // maximum level in feature pyramid
+  optional int32 max_level = 2 [default = 7];
+
+  // channel depth for additional coarse feature layers.
+  optional int32 additional_layer_depth = 3 [default = 256];
+}

--- a/rastervision/protos/tf_object_detection/ssd.proto
+++ b/rastervision/protos/tf_object_detection/ssd.proto
@@ -1,5 +1,5 @@
 syntax = "proto2";
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 import "rastervision/protos/tf_object_detection/anchor_generator.proto";
 import "rastervision/protos/tf_object_detection/box_coder.proto";

--- a/rastervision/protos/tf_object_detection/ssd_anchor_generator.proto
+++ b/rastervision/protos/tf_object_detection/ssd_anchor_generator.proto
@@ -1,0 +1,55 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+// Configuration proto for SSD anchor generator described in
+// https://arxiv.org/abs/1512.02325. See
+// anchor_generators/multiple_grid_anchor_generator.py for details.
+message SsdAnchorGenerator {
+  // Number of grid layers to create anchors for.
+  optional int32 num_layers = 1 [default = 6];
+
+  // Scale of anchors corresponding to finest resolution.
+  optional float min_scale = 2 [default = 0.2];
+
+  // Scale of anchors corresponding to coarsest resolution
+  optional float max_scale = 3 [default = 0.95];
+
+  // Can be used to override min_scale->max_scale, with an explicitly defined
+  // set of scales.  If empty, then min_scale->max_scale is used.
+  repeated float scales = 12;
+
+  // Aspect ratios for anchors at each grid point.
+  repeated float aspect_ratios = 4;
+
+  // When this aspect ratio is greater than 0, then an additional
+  // anchor, with an interpolated scale is added with this aspect ratio.
+  optional float interpolated_scale_aspect_ratio = 13 [default = 1.0];
+
+  // Whether to use the following aspect ratio and scale combination for the
+  // layer with the finest resolution : (scale=0.1, aspect_ratio=1.0),
+  // (scale=min_scale, aspect_ration=2.0), (scale=min_scale, aspect_ratio=0.5).
+  optional bool reduce_boxes_in_lowest_layer = 5 [default = true];
+
+  // The base anchor size in height dimension.
+  optional float base_anchor_height = 6 [default = 1.0];
+
+  // The base anchor size in width dimension.
+  optional float base_anchor_width = 7 [default = 1.0];
+
+  // Anchor stride in height dimension in pixels for each layer. The length of
+  // this field is expected to be equal to the value of num_layers.
+  repeated int32 height_stride = 8;
+
+  // Anchor stride in width dimension in pixels for each layer. The length of
+  // this field is expected to be equal to the value of num_layers.
+  repeated int32 width_stride = 9;
+
+  // Anchor height offset in pixels for each layer. The length of this field is
+  // expected to be equal to the value of num_layers.
+  repeated int32 height_offset = 10;
+
+  // Anchor width offset in pixels for each layer. The length of this field is
+  // expected to be equal to the value of num_layers.
+  repeated int32 width_offset = 11;
+}

--- a/rastervision/protos/tf_object_detection/ssd_anchor_generator.proto
+++ b/rastervision/protos/tf_object_detection/ssd_anchor_generator.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 // Configuration proto for SSD anchor generator described in
 // https://arxiv.org/abs/1512.02325. See

--- a/rastervision/protos/tf_object_detection/string_int_label_map.proto
+++ b/rastervision/protos/tf_object_detection/string_int_label_map.proto
@@ -1,0 +1,24 @@
+// Message to store the mapping from class label strings to class id. Datasets
+// use string labels to represent classes while the object detection framework
+// works with class ids. This message maps them so they can be converted back
+// and forth as needed.
+syntax = "proto2";
+
+package object_detection.protos;
+
+message StringIntLabelMapItem {
+  // String name. The most common practice is to set this to a MID or synsets
+  // id.
+  optional string name = 1;
+
+  // Integer id that maps to the string name above. Label ids should start from
+  // 1.
+  optional int32 id = 2;
+
+  // Human readable string label.
+  optional string display_name = 3;
+};
+
+message StringIntLabelMap {
+  repeated StringIntLabelMapItem item = 1;
+};

--- a/rastervision/protos/tf_object_detection/string_int_label_map.proto
+++ b/rastervision/protos/tf_object_detection/string_int_label_map.proto
@@ -4,7 +4,7 @@
 // and forth as needed.
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 message StringIntLabelMapItem {
   // String name. The most common practice is to set this to a MID or synsets

--- a/rastervision/protos/tf_object_detection/train.proto
+++ b/rastervision/protos/tf_object_detection/train.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package object_detection.protos;
+package rastervision.protos.tf_object_detection;
 
 import "rastervision/protos/tf_object_detection/optimizer.proto";
 import "rastervision/protos/tf_object_detection/preprocessor.proto";

--- a/rastervision/protos/tf_object_detection/train.proto
+++ b/rastervision/protos/tf_object_detection/train.proto
@@ -1,0 +1,118 @@
+syntax = "proto2";
+
+package object_detection.protos;
+
+import "rastervision/protos/tf_object_detection/optimizer.proto";
+import "rastervision/protos/tf_object_detection/preprocessor.proto";
+
+// Message for configuring DetectionModel training jobs (train.py).
+// Next id: 27
+message TrainConfig {
+  // Effective batch size to use for training.
+  // For TPU (or sync SGD jobs), the batch size per core (or GPU) is going to be
+  // `batch_size` / number of cores (or `batch_size` / number of GPUs).
+  optional uint32 batch_size = 1 [default=32];
+
+  // Data augmentation options.
+  repeated PreprocessingStep data_augmentation_options = 2;
+
+  // Whether to synchronize replicas during training.
+  optional bool sync_replicas = 3 [default=false];
+
+  // How frequently to keep checkpoints.
+  optional uint32 keep_checkpoint_every_n_hours = 4 [default=1000];
+
+  // Optimizer used to train the DetectionModel.
+  optional Optimizer optimizer = 5;
+
+  // If greater than 0, clips gradients by this value.
+  optional float gradient_clipping_by_norm = 6 [default=0.0];
+
+  // Checkpoint to restore variables from. Typically used to load feature
+  // extractor variables trained outside of object detection.
+  optional string fine_tune_checkpoint = 7 [default=""];
+
+  // Type of checkpoint to restore variables from, e.g. 'classification' or
+  // 'detection'. Provides extensibility to from_detection_checkpoint.
+  // Typically used to load feature extractor variables from trained models.
+  optional string fine_tune_checkpoint_type = 22 [default=""];
+
+  // [Deprecated]: use fine_tune_checkpoint_type instead.
+  // Specifies if the finetune checkpoint is from an object detection model.
+  // If from an object detection model, the model being trained should have
+  // the same parameters with the exception of the num_classes parameter.
+  // If false, it assumes the checkpoint was a object classification model.
+  optional bool from_detection_checkpoint = 8 [default=false, deprecated=true];
+
+  // Whether to load all checkpoint vars that match model variable names and
+  // sizes. This option is only available if `from_detection_checkpoint` is
+  // True.
+  optional bool load_all_detection_checkpoint_vars = 19 [default = false];
+
+  // Number of steps to train the DetectionModel for. If 0, will train the model
+  // indefinitely.
+  optional uint32 num_steps = 9 [default=0];
+
+  // Number of training steps between replica startup.
+  // This flag must be set to 0 if sync_replicas is set to true.
+  optional float startup_delay_steps = 10 [default=15];
+
+  // If greater than 0, multiplies the gradient of bias variables by this
+  // amount.
+  optional float bias_grad_multiplier = 11 [default=0];
+
+  // Variables that should be updated during training. Note that variables which
+  // also match the patterns in freeze_variables will be excluded.
+  repeated string update_trainable_variables = 25;
+
+  // Variables that should not be updated during training. If
+  // update_trainable_variables is not empty, only eliminates the included
+  // variables according to freeze_variables patterns.
+  repeated string freeze_variables = 12;
+
+  // Number of replicas to aggregate before making parameter updates.
+  optional int32 replicas_to_aggregate = 13 [default=1];
+
+  // Maximum number of elements to store within a queue.
+  optional int32 batch_queue_capacity = 14 [default=150];
+
+  // Number of threads to use for batching.
+  optional int32 num_batch_queue_threads = 15 [default=8];
+
+  // Maximum capacity of the queue used to prefetch assembled batches.
+  optional int32 prefetch_queue_capacity = 16 [default=5];
+
+  // If true, boxes with the same coordinates will be merged together.
+  // This is useful when each box can have multiple labels.
+  // Note that only Sigmoid classification losses should be used.
+  optional bool merge_multiple_label_boxes = 17 [default=false];
+
+  // If true, will use multiclass scores from object annotations as ground
+  // truth. Currently only compatible with annotated image inputs.
+  optional bool use_multiclass_scores = 24 [default = false];
+
+  // Whether to add regularization loss to `total_loss`. This is true by
+  // default and adds all regularization losses defined in the model to
+  // `total_loss`.
+  // Setting this option to false is very useful while debugging the model and
+  // losses.
+  optional bool add_regularization_loss = 18 [default=true];
+
+  // Maximum number of boxes used during training.
+  // Set this to at least the maximum amount of boxes in the input data.
+  // Otherwise, it may cause "Data loss: Attempted to pad to a smaller size
+  // than the input element" errors.
+  optional int32 max_number_of_boxes = 20 [default=100, deprecated=true];
+
+  // Whether to remove padding along `num_boxes` dimension of the groundtruth
+  // tensors.
+  optional bool unpad_groundtruth_tensors = 21 [default=true];
+
+  // Whether to retain original images (i.e. not pre-processed) in the tensor
+  // dictionary, so that they can be displayed in Tensorboard. Note that this
+  // will lead to a larger memory footprint.
+  optional bool retain_original_images = 23 [default=false];
+
+  // Whether to use bfloat16 for training.
+  optional bool use_bfloat16 = 26 [default=false];
+}

--- a/scripts/compile
+++ b/scripts/compile
@@ -12,4 +12,5 @@ cd $DIR/..
 # Compile protobuf files into python files
 protoc --python_out=. rastervision/protos/keras_classification/*.proto
 protoc --python_out=. rastervision/protos/deeplab/*.proto
+protoc --python_out=. rastervision/protos/tf_object_detection/*.proto
 protoc --python_out=. rastervision/protos/*.proto


### PR DESCRIPTION
We currently have to access the `object_detection` package when calling `from_proto` on a TFObjectDetectionConfig. This requires an installation and breaks the "no backends needed for configuration" rule that we've been operating with.

This PR brings the TFOD protobuf definition files into the project, makes the necessary changes to use them alongside of TFOD, and includes the proper notices to be in compliance with Apache 2.0.