### PR TITLE
note on tensorflow versions

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,6 +181,8 @@ list the output here to save space, but give it a try:
 
 When we're ready to run, we just remove the ``-n`` flag:
 
+.. note:: TensorFlow 1.10 will not work on some older computers due to unsupported vector instructions. Consider building a custom wheel to run the newer version of TensorFlow.
+
 .. code-block:: console
 
    > rastervision run local -p tiny_spacenet.py


### PR DESCRIPTION
## Overview

Currently due to a TensorFlow issue, the quickstart failed on an older computer. This PR adds a note about this issue in the quickstart docs.