### PR TITLE
Selectively Disable Coverage Where Integration Tests Are Used

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,6 @@ omit =
     rastervision/task/semantic_segmentation.py
     rastervision/predictor.py
     rastervision/cli/main.py
+    rastervision/backend/keras_classification/**.py
+    rastervision/backend/tf_deeplab.py
+    rastervision/backend/tf_object_detection.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,4 @@ omit =
     rastervision/task/object_detection.py
     rastervision/task/semantic_segmentation.py
     rastervision/predictor.py
+    rastervision/cli/main.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source =
+    rastervision/
+omit =
+    rastervision/protos/**.py
+    rastervision/utils/filter_geojson.py
+    rastervision/utils/geojson.py
+    rastervision/utils/misc.py
+    rastervision/task/chip_classification.py
+    rastervision/task/object_detection.py
+    rastervision/task/semantic_segmentation.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,3 +9,4 @@ omit =
     rastervision/task/chip_classification.py
     rastervision/task/object_detection.py
     rastervision/task/semantic_segmentation.py
+    rastervision/predictor.py

--- a/rastervision/version.py
+++ b/rastervision/version.py
@@ -1,2 +1,2 @@
 """Library verison"""
-__version__ = '0.8.0'
+__version__ = '0.8.0'  # pragma: no cover

--- a/scripts/unit_tests
+++ b/scripts/unit_tests
@@ -22,6 +22,6 @@ else
     if ! [ -x "$(command -v coverage)" ]; then
 	python -m unittest discover tests
     else
-	coverage run --source=rastervision '--omit=rastervision/protos/**.py' -m unittest discover tests
+	coverage run -m unittest discover tests
     fi
 fi

--- a/tests/cli/test_verbosity.py
+++ b/tests/cli/test_verbosity.py
@@ -1,0 +1,12 @@
+import unittest
+
+from rastervision.cli import Verbosity
+
+
+class TestVerbosity(unittest.TestCase):
+    def test_verbosity(self):
+        self.assertTrue(type(Verbosity.get()) == int)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -196,3 +196,7 @@ class NoopAnalyzerConfigBuilder(AnalyzerConfigBuilder):
 def register_plugin(plugin_registry):
     plugin_registry.register_config_builder(rv.ANALYZER, NOOP_ANALYZER,
                                             NoopAnalyzerConfigBuilder)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_rv_config.py
+++ b/tests/test_rv_config.py
@@ -23,3 +23,7 @@ class TestRVConfig(unittest.TestCase):
             self.assertTrue(os.path.exists(directory))
             self.assertTrue(os.path.isdir(directory))
             shutil.rmtree(directory)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

Code coverage statistics for the unit tests are not collected for code that is better tested (or only testable) by integration tests.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Depends on #497 

