### PR TITLE
Unit Tests: `command` Directory

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source =
+    rastervision/
+omit =
+    rastervision/protos/**.py
+    rastervision/utils/filter_geojson.py
+    rastervision/utils/geojson.py
+    rastervision/utils/misc.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,6 @@ omit =
     rastervision/utils/filter_geojson.py
     rastervision/utils/geojson.py
     rastervision/utils/misc.py
+    rastervision/task/chip_classification.py
+    rastervision/task/object_detection.py
+    rastervision/task/semantic_segmentation.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,9 @@ omit =
     rastervision/utils/filter_geojson.py
     rastervision/utils/geojson.py
     rastervision/utils/misc.py
+    rastervision/command/analyze_command.py
+    rastervision/command/bundle_command.py
+    rastervision/command/chip_command.py
+    rastervision/command/eval_command.py
+    rastervision/command/predict_command.py
+    rastervision/command/train_command.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,3 @@ omit =
     rastervision/utils/filter_geojson.py
     rastervision/utils/geojson.py
     rastervision/utils/misc.py
-    rastervision/task/chip_classification.py
-    rastervision/task/object_detection.py
-    rastervision/task/semantic_segmentation.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,9 +6,3 @@ omit =
     rastervision/utils/filter_geojson.py
     rastervision/utils/geojson.py
     rastervision/utils/misc.py
-    rastervision/command/analyze_command.py
-    rastervision/command/bundle_command.py
-    rastervision/command/chip_command.py
-    rastervision/command/eval_command.py
-    rastervision/command/predict_command.py
-    rastervision/command/train_command.py

--- a/rastervision/utils/files.py
+++ b/rastervision/utils/files.py
@@ -73,7 +73,8 @@ def sync_from_dir(src_dir_uri, dest_dir_uri, delete=False, fs=None):
     fs.sync_from_dir(src_dir_uri, dest_dir_uri, delete=delete)
 
 
-def start_sync(src_dir_uri, dest_dir_uri, sync_interval=600, fs=None):
+def start_sync(src_dir_uri, dest_dir_uri, sync_interval=600,
+               fs=None):  # pragma: no cover
     """Start syncing a directory on a schedule.
 
     Calls sync_to_dir on a schedule.

--- a/rastervision/utils/files.py
+++ b/rastervision/utils/files.py
@@ -157,7 +157,7 @@ def file_exists(uri, fs=None):
     return fs.file_exists(uri)
 
 
-def list_paths(uri, ext=None, fs=None):
+def list_paths(uri, ext='', fs=None):
     if uri is None:
         return None
 

--- a/scripts/unit_tests
+++ b/scripts/unit_tests
@@ -22,6 +22,6 @@ else
     if ! [ -x "$(command -v coverage)" ]; then
 	python -m unittest discover tests
     else
-	coverage run --source=rastervision '--omit=rastervision/protos/**.py' -m unittest discover tests
+	coverage run -m unittest discover tests
     fi
 fi

--- a/tests/command/test_analyze_command_config.py
+++ b/tests/command/test_analyze_command_config.py
@@ -5,6 +5,17 @@ from rastervision.rv_config import RVConfig
 
 
 class TestAnalyzeCommand(unittest.TestCase):
+    def test_command_create(self):
+        with RVConfig.get_tmp_dir() as tmp_dir:
+            cmd = rv.command.AnalyzeCommandConfig.builder() \
+                                                 .with_task('') \
+                                                 .with_root_uri(tmp_dir) \
+                                                 .with_scenes('') \
+                                                 .with_analyzers('') \
+                                                 .build() \
+                                                 .create_command()
+            self.assertTrue(cmd, rv.command.AnalyzeCommand)
+
     def test_no_config_error(self):
         try:
             with RVConfig.get_tmp_dir() as tmp_dir:

--- a/tests/command/test_analyze_command_config.py
+++ b/tests/command/test_analyze_command_config.py
@@ -1,13 +1,16 @@
 import unittest
 
 import rastervision as rv
+from rastervision.rv_config import RVConfig
 
 
 class TestAnalyzeCommand(unittest.TestCase):
     def test_no_config_error(self):
+        tmp = RVConfig.get_tmp_dir()
         try:
             rv.command.AnalyzeCommandConfig.builder() \
                                            .with_task('') \
+                                           .with_root_uri(tmp) \
                                            .with_scenes('') \
                                            .with_analyzers('') \
                                            .build()

--- a/tests/command/test_analyze_command_config.py
+++ b/tests/command/test_analyze_command_config.py
@@ -6,14 +6,14 @@ from rastervision.rv_config import RVConfig
 
 class TestAnalyzeCommand(unittest.TestCase):
     def test_no_config_error(self):
-        tmp = RVConfig.get_tmp_dir()
         try:
-            rv.command.AnalyzeCommandConfig.builder() \
-                                           .with_task('') \
-                                           .with_root_uri(tmp) \
-                                           .with_scenes('') \
-                                           .with_analyzers('') \
-                                           .build()
+            with RVConfig.get_tmp_dir() as tmp_dir:
+                rv.command.AnalyzeCommandConfig.builder() \
+                                               .with_task('') \
+                                               .with_root_uri(tmp_dir) \
+                                               .with_scenes('') \
+                                               .with_analyzers('') \
+                                               .build()
         except rv.ConfigError:
             self.fail('rv.ConfigError raised unexpectedly')
 

--- a/tests/command/test_bundle_command.py
+++ b/tests/command/test_bundle_command.py
@@ -67,6 +67,7 @@ class TestBundleCommand(unittest.TestCase):
             scene = self.get_scene(tmp_dir)
             cmd = BundleCommandConfig.builder() \
                                      .with_task(task) \
+                                     .with_root_uri(tmp_dir) \
                                      .with_backend(backend) \
                                      .with_analyzers([analyzer]) \
                                      .with_scene(scene) \
@@ -121,6 +122,7 @@ class TestBundleCommand(unittest.TestCase):
             scene = self.get_scene(tmp_dir)
             cmd = BundleCommandConfig.builder() \
                                      .with_task(task) \
+                                     .with_root_uri(tmp_dir) \
                                      .with_backend(backend) \
                                      .with_analyzers([analyzer]) \
                                      .with_scene(scene) \

--- a/tests/command/test_chip_command_config.py
+++ b/tests/command/test_chip_command_config.py
@@ -1,6 +1,7 @@
 import unittest
 
 import rastervision as rv
+from rastervision.rv_config import RVConfig
 
 
 class TestChipCommand(unittest.TestCase):
@@ -37,9 +38,11 @@ class TestChipCommand(unittest.TestCase):
                                         .build()
 
     def test_no_config_error(self):
+        tmp = RVConfig.get_tmp_dir()
         try:
             rv.command.ChipCommandConfig.builder() \
                                         .with_task('') \
+                                        .with_root_uri(tmp) \
                                         .with_backend('') \
                                         .with_train_scenes('') \
                                         .with_val_scenes('') \

--- a/tests/command/test_chip_command_config.py
+++ b/tests/command/test_chip_command_config.py
@@ -5,6 +5,18 @@ from rastervision.rv_config import RVConfig
 
 
 class TestChipCommand(unittest.TestCase):
+    def test_command_create(self):
+        with RVConfig.get_tmp_dir() as tmp_dir:
+            cmd = rv.command.ChipCommandConfig.builder() \
+                                              .with_task('') \
+                                              .with_backend('') \
+                                              .with_train_scenes('') \
+                                              .with_val_scenes('') \
+                                              .with_root_uri(tmp_dir) \
+                                              .build() \
+                                              .create_command()
+            self.assertTrue(cmd, rv.command.ChipCommand)
+
     def test_missing_config_task(self):
         with self.assertRaises(rv.ConfigError):
             rv.command.ChipCommandConfig.builder() \

--- a/tests/command/test_chip_command_config.py
+++ b/tests/command/test_chip_command_config.py
@@ -38,15 +38,15 @@ class TestChipCommand(unittest.TestCase):
                                         .build()
 
     def test_no_config_error(self):
-        tmp = RVConfig.get_tmp_dir()
         try:
-            rv.command.ChipCommandConfig.builder() \
-                                        .with_task('') \
-                                        .with_root_uri(tmp) \
-                                        .with_backend('') \
-                                        .with_train_scenes('') \
-                                        .with_val_scenes('') \
-                                        .build()
+            with RVConfig.get_tmp_dir() as tmp_dir:
+                rv.command.ChipCommandConfig.builder() \
+                                            .with_task('') \
+                                            .with_root_uri(tmp_dir) \
+                                            .with_backend('') \
+                                            .with_train_scenes('') \
+                                            .with_val_scenes('') \
+                                            .build()
         except rv.ConfigError:
             self.fail('rv.ConfigError raised unexpectedly')
 

--- a/tests/command/test_eval_command.py
+++ b/tests/command/test_eval_command.py
@@ -5,6 +5,17 @@ from rastervision.rv_config import RVConfig
 
 
 class TestEvalCommand(unittest.TestCase):
+    def test_command_create(self):
+        with RVConfig.get_tmp_dir() as tmp_dir:
+            cmd = rv.command.EvalCommandConfig.builder() \
+                                              .with_task('') \
+                                              .with_root_uri(tmp_dir) \
+                                              .with_scenes('') \
+                                              .with_evaluators('') \
+                                              .build() \
+                                              .create_command()
+            self.assertTrue(cmd, rv.command.EvalCommand)
+
     def test_missing_config_task(self):
         with self.assertRaises(rv.ConfigError):
             rv.command.EvalCommandConfig.builder() \

--- a/tests/command/test_eval_command.py
+++ b/tests/command/test_eval_command.py
@@ -1,6 +1,7 @@
 import unittest
 
 import rastervision as rv
+from rastervision.rv_config import RVConfig
 
 
 class TestEvalCommand(unittest.TestCase):
@@ -26,9 +27,11 @@ class TestEvalCommand(unittest.TestCase):
                                         .build()
 
     def test_no_config_error(self):
+        tmp = RVConfig.get_tmp_dir()
         try:
             rv.command.EvalCommandConfig.builder() \
                                         .with_task('') \
+                                        .with_root_uri(tmp) \
                                         .with_scenes('') \
                                         .with_evaluators('') \
                                         .build()

--- a/tests/command/test_eval_command.py
+++ b/tests/command/test_eval_command.py
@@ -27,14 +27,14 @@ class TestEvalCommand(unittest.TestCase):
                                         .build()
 
     def test_no_config_error(self):
-        tmp = RVConfig.get_tmp_dir()
         try:
-            rv.command.EvalCommandConfig.builder() \
-                                        .with_task('') \
-                                        .with_root_uri(tmp) \
-                                        .with_scenes('') \
-                                        .with_evaluators('') \
-                                        .build()
+            with RVConfig.get_tmp_dir() as tmp_dir:
+                rv.command.EvalCommandConfig.builder() \
+                                            .with_task('') \
+                                            .with_root_uri(tmp_dir) \
+                                            .with_scenes('') \
+                                            .with_evaluators('') \
+                                            .build()
         except rv.ConfigError:
             self.fail('rv.ConfigError raised unexpectedly')
 

--- a/tests/command/test_predict_command.py
+++ b/tests/command/test_predict_command.py
@@ -5,6 +5,17 @@ from rastervision.rv_config import RVConfig
 
 
 class PredictCommand(unittest.TestCase):
+    def test_command_create(self):
+        with RVConfig.get_tmp_dir() as tmp_dir:
+            cmd = rv.command.PredictCommandConfig.builder() \
+                                                 .with_task('') \
+                                                 .with_root_uri(tmp_dir) \
+                                                 .with_scenes('') \
+                                                 .with_backend('') \
+                                                 .build() \
+                                                 .create_command()
+            self.assertTrue(cmd, rv.command.PredictCommand)
+
     def test_missing_config_task(self):
         with self.assertRaises(rv.ConfigError):
             rv.command.PredictCommandConfig.builder() \

--- a/tests/command/test_predict_command.py
+++ b/tests/command/test_predict_command.py
@@ -27,14 +27,14 @@ class PredictCommand(unittest.TestCase):
                                            .build()
 
     def test_no_config_error(self):
-        tmp = RVConfig.get_tmp_dir()
         try:
-            rv.command.PredictCommandConfig.builder() \
-                                           .with_task('') \
-                                           .with_root_uri(tmp) \
-                                           .with_backend('') \
-                                           .with_scenes(['']) \
-                                           .build()
+            with RVConfig.get_tmp_dir() as tmp_dir:
+                rv.command.PredictCommandConfig.builder() \
+                                               .with_task('') \
+                                               .with_root_uri(tmp_dir) \
+                                               .with_backend('') \
+                                               .with_scenes(['']) \
+                                               .build()
         except rv.ConfigError:
             self.fail('rv.ConfigError raised unexpectedly')
 

--- a/tests/command/test_predict_command.py
+++ b/tests/command/test_predict_command.py
@@ -1,6 +1,7 @@
 import unittest
 
 import rastervision as rv
+from rastervision.rv_config import RVConfig
 
 
 class PredictCommand(unittest.TestCase):
@@ -26,9 +27,11 @@ class PredictCommand(unittest.TestCase):
                                            .build()
 
     def test_no_config_error(self):
+        tmp = RVConfig.get_tmp_dir()
         try:
             rv.command.PredictCommandConfig.builder() \
                                            .with_task('') \
+                                           .with_root_uri(tmp) \
                                            .with_backend('') \
                                            .with_scenes(['']) \
                                            .build()

--- a/tests/command/test_train_command.py
+++ b/tests/command/test_train_command.py
@@ -18,13 +18,13 @@ class TrainCommand(unittest.TestCase):
                                          .build()
 
     def test_no_config_error(self):
-        tmp = RVConfig.get_tmp_dir()
         try:
-            rv.command.TrainCommandConfig.builder() \
-                                         .with_task('') \
-                                         .with_root_uri(tmp) \
-                                         .with_backend('') \
-                                         .build()
+            with RVConfig.get_tmp_dir() as tmp_dir:
+                rv.command.TrainCommandConfig.builder() \
+                                             .with_task('') \
+                                             .with_root_uri(tmp_dir) \
+                                             .with_backend('') \
+                                             .build()
         except rv.ConfigError:
             self.fail('rv.ConfigError raised unexpectedly')
 

--- a/tests/command/test_train_command.py
+++ b/tests/command/test_train_command.py
@@ -1,6 +1,7 @@
 import unittest
 
 import rastervision as rv
+from rastervision.rv_config import RVConfig
 
 
 class TrainCommand(unittest.TestCase):
@@ -17,9 +18,11 @@ class TrainCommand(unittest.TestCase):
                                          .build()
 
     def test_no_config_error(self):
+        tmp = RVConfig.get_tmp_dir()
         try:
             rv.command.TrainCommandConfig.builder() \
                                          .with_task('') \
+                                         .with_root_uri(tmp) \
                                          .with_backend('') \
                                          .build()
         except rv.ConfigError:

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -10,7 +10,7 @@ import rastervision as rv
 from rastervision.utils.files import (
     file_to_str, str_to_file, download_if_needed, upload_or_copy,
     load_json_config, ProtobufParseException, make_dir, get_local_path,
-    file_exists, sync_from_dir, sync_to_dir)
+    file_exists, sync_from_dir, sync_to_dir, list_paths)
 from rastervision.filesystem import (NotReadableError, NotWritableError)
 from rastervision.filesystem.filesystem import FileSystem
 from rastervision.protos.task_pb2 import TaskConfig as TaskConfigMsg
@@ -328,13 +328,12 @@ class TestS3Misc(unittest.TestCase):
         directory = os.path.dirname(path)
         make_dir(directory, check_empty=False)
 
-        fs = FileSystem.get_file_system(s3_path, 'r')
-
         with open(path, 'w+') as file:
             file.write(self.lorem)
         upload_or_copy(path, s3_path)
 
-        self.assertEqual(len(fs.list_paths(s3_directory)), 1)
+        list_paths(s3_directory)
+        self.assertEqual(len(list_paths(s3_directory)), 1)
 
 
 class TestLocalMisc(unittest.TestCase):
@@ -374,7 +373,7 @@ class TestLocalMisc(unittest.TestCase):
         fs.write_bytes(path, bytes([0x00, 0x01]))
         sync_from_dir(src, dst, delete=True)
 
-        self.assertEqual(len(fs.list_paths(dst)), 1)
+        self.assertEqual(len(list_paths(dst)), 1)
 
     def test_sync_from_dir_noop_local(self):
         path = os.path.join(self.temp_dir.name, 'lorem', 'ipsum.txt')
@@ -385,7 +384,7 @@ class TestLocalMisc(unittest.TestCase):
         fs.write_bytes(path, bytes([0x00, 0x01]))
         sync_from_dir(src, src, delete=True)
 
-        self.assertEqual(len(fs.list_paths(src)), 1)
+        self.assertEqual(len(list_paths(src)), 1)
 
     def test_sync_to_dir_local(self):
         path = os.path.join(self.temp_dir.name, 'lorem', 'ipsum.txt')
@@ -398,7 +397,7 @@ class TestLocalMisc(unittest.TestCase):
         fs.write_bytes(path, bytes([0x00, 0x01]))
         sync_to_dir(src, dst, delete=True)
 
-        self.assertEqual(len(fs.list_paths(dst)), 1)
+        self.assertEqual(len(list_paths(dst)), 1)
 
     def test_copy_to_local(self):
         path1 = os.path.join(self.temp_dir.name, 'lorem', 'ipsum.txt')
@@ -411,9 +410,8 @@ class TestLocalMisc(unittest.TestCase):
         with open(path1, 'w+') as file:
             file.write(self.lorem)
 
-        fs = FileSystem.get_file_system(path1, 'r')
         upload_or_copy(path1, path2)
-        self.assertEqual(len(fs.list_paths(dir2)), 1)
+        self.assertEqual(len(list_paths(dir2)), 1)
 
     def test_last_modified(self):
         path = os.path.join(self.temp_dir.name, 'lorem', 'ipsum1.txt')


### PR DESCRIPTION
## Overview

Backfilling unit tests....

The `(to|from)_proto` methods of the command configuration objects seems to be better handled in integration tests, so they are left to one side.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #505 
Depends on #497 
