### PR TITLE
Remove validation on semseg label source that is too restrictive.

### DIFF
--- a/rastervision/data/label_source/semantic_segmentation_raster_source_config.py
+++ b/rastervision/data/label_source/semantic_segmentation_raster_source_config.py
@@ -6,7 +6,7 @@ from rastervision.data.label_source import (LabelSourceConfig,
                                             LabelSourceConfigBuilder,
                                             SemanticSegmentationRasterSource)
 from rastervision.protos.label_source_pb2 import LabelSourceConfig as LabelSourceConfigMsg
-from rastervision.data.raster_source import RasterSourceConfig, GeoJSONSourceConfig
+from rastervision.data.raster_source import RasterSourceConfig
 
 
 class SemanticSegmentationRasterSourceConfig(LabelSourceConfig):
@@ -113,15 +113,8 @@ class SemanticSegmentationRasterSourceConfigBuilder(LabelSourceConfigBuilder):
 
     def validate(self):
         source = self.config.get('source')
-        rgb_class_map = self.config.get('rgb_class_map')
 
         if source is None:
             raise rv.ConfigError(
                 'You must set the source for SemanticSegmentationRasterSourceConfig'
                 ' Use "with_raster_source".')
-
-        if type(source) != GeoJSONSourceConfig and rgb_class_map is None:
-            raise rv.ConfigError(
-                'You must set the rgb_class_map for '
-                'SemanticSegmentationRasterSourceConfig. Use "with_rgb_class_map".'
-            )


### PR DESCRIPTION
This PR removes some validation that invalidates what are actually valid use cases.

Fixes #535, but also other instances where we have raster sources that are class ID based and not RGB.