### PR TITLE
Optimize update_for_command

### DIFF
--- a/integration_tests/integration_tests.py
+++ b/integration_tests/integration_tests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from copy import deepcopy
 import json
 import os
 import math
@@ -30,6 +31,18 @@ tensorflow.set_random_seed(5678)
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 
 TEST_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class IntegrationTestExperimentRunner(rv.runner.LocalExperimentRunner):
+    def __init__(self, tmp_dir=None):
+        super().__init__(tmp_dir)
+
+    def _run_experiment(self, command_dag):
+        """Check serialization of all commands."""
+        for command_config in command_dag.get_sorted_commands():
+            deepcopy(rv.command.CommandConfig.from_proto(command_config.to_proto()))
+
+        super()._run_experiment(command_dag)
 
 
 def console_info(msg):
@@ -139,8 +152,8 @@ def run_test(test, temp_dir):
 
     # Check that running doesn't raise any exceptions.
     try:
-        rv.runner.LocalExperimentRunner(os.path.join(temp_dir, test.lower())) \
-                 .run(experiment, rerun_commands=True)
+        IntegrationTestExperimentRunner(os.path.join(temp_dir, test.lower())) \
+            .run(experiment, rerun_commands=True)
 
     except Exception as exc:
         errors.append(

--- a/integration_tests/integration_tests.py
+++ b/integration_tests/integration_tests.py
@@ -40,7 +40,8 @@ class IntegrationTestExperimentRunner(rv.runner.LocalExperimentRunner):
     def _run_experiment(self, command_dag):
         """Check serialization of all commands."""
         for command_config in command_dag.get_sorted_commands():
-            deepcopy(rv.command.CommandConfig.from_proto(command_config.to_proto()))
+            deepcopy(
+                rv.command.CommandConfig.from_proto(command_config.to_proto()))
 
         super()._run_experiment(command_dag)
 

--- a/rastervision/analyzer/stats_analyzer_config.py
+++ b/rastervision/analyzer/stats_analyzer_config.py
@@ -44,18 +44,19 @@ class StatsAnalyzerConfig(AnalyzerConfig):
                    .with_stats_uri(local_stats_uri) \
                    .build()
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        conf = self
-        io_def = rv.core.CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or rv.core.CommandIODefinition()
         if command_type == rv.ANALYZE:
             if not self.stats_uri:
-                stats_uri = os.path.join(experiment_config.analyze_uri,
-                                         'stats.json')
-                conf = self.to_builder() \
-                           .with_stats_uri(stats_uri) \
-                           .build()
-            io_def.add_output(conf.stats_uri)
-        return (conf, io_def)
+                self.stats_uri = os.path.join(experiment_config.analyze_uri,
+                                              'stats.json')
+
+            io_def.add_output(self.stats_uri)
+        return io_def
 
 
 class StatsAnalyzerConfigBuilder(AnalyzerConfigBuilder):

--- a/rastervision/augmentor/augmentor_config.py
+++ b/rastervision/augmentor/augmentor_config.py
@@ -31,7 +31,7 @@ class AugmentorConfig(Config):
 
     def update_for_command(self, command_type, experiment_config, context=[]):
         # Generally augmentors do not have an affect on the IO.
-        return (self, rv.core.CommandIODefinition())
+        return rv.core.CommandIODefinition()
 
 
 class AugmentorConfigBuilder(ConfigBuilder):

--- a/rastervision/backend/backend_config.py
+++ b/rastervision/backend/backend_config.py
@@ -38,13 +38,16 @@ class BackendConfig(BundledConfigMixin, Config):
                            .from_proto(msg) \
                            .build()
 
-    def update_for_command(self, command_type, experiment_config,
-                           context=None):
-        io_def = CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or CommandIODefinition()
         if command_type == rv.TRAIN:
             if self.pretrained_model_uri:
                 io_def.add_input(self.pretrained_model_uri)
-        return (self, io_def)
+        return io_def
 
 
 class BackendConfigBuilder(ConfigBuilder):

--- a/rastervision/backend/keras_classification_config.py
+++ b/rastervision/backend/keras_classification_config.py
@@ -92,42 +92,45 @@ class KerasClassificationConfig(BackendConfig):
                    .with_model_uri(local_model_uri) \
                    .build()
 
-    def update_for_command(self, command_type, experiment_config,
-                           context=None):
-        conf, io_def = super().update_for_command(command_type,
-                                                  experiment_config, context)
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = super().update_for_command(command_type, experiment_config,
+                                            context, io_def)
         if command_type == rv.CHIP:
-            if not conf.training_data_uri:
-                conf.training_data_uri = experiment_config.chip_uri
+            if not self.training_data_uri:
+                self.training_data_uri = experiment_config.chip_uri
 
             outputs = list(
-                map(lambda x: os.path.join(conf.training_data_uri, x),
+                map(lambda x: os.path.join(self.training_data_uri, x),
                     CHIP_OUTPUT_FILES))
 
             io_def.add_outputs(outputs)
         if command_type == rv.TRAIN:
-            if not conf.training_data_uri:
+            if not self.training_data_uri:
                 io_def.add_missing('Missing training_data_uri.')
             else:
                 inputs = list(
-                    map(lambda x: os.path.join(conf.training_data_uri, x),
+                    map(lambda x: os.path.join(self.training_data_uri, x),
                         CHIP_OUTPUT_FILES))
                 io_def.add_inputs(inputs)
 
-            if not conf.training_output_uri:
-                conf.training_output_uri = experiment_config.train_uri
-            if not conf.model_uri:
-                conf.model_uri = os.path.join(conf.training_output_uri,
+            if not self.training_output_uri:
+                self.training_output_uri = experiment_config.train_uri
+            if not self.model_uri:
+                self.model_uri = os.path.join(self.training_output_uri,
                                               'model')
-            io_def.add_output(conf.model_uri)
+            io_def.add_output(self.model_uri)
 
         if command_type in [rv.PREDICT, rv.BUNDLE]:
-            if not conf.model_uri:
+            if not self.model_uri:
                 io_def.add_missing('Missing model_uri.')
             else:
-                io_def.add_input(conf.model_uri)
+                io_def.add_input(self.model_uri)
 
-        return (conf, io_def)
+        return io_def
 
 
 class KerasClassificationConfigBuilder(BackendConfigBuilder):

--- a/rastervision/backend/tf_deeplab_config.py
+++ b/rastervision/backend/tf_deeplab_config.py
@@ -94,37 +94,40 @@ class TFDeeplabConfig(BackendConfig):
 
         return msg
 
-    def update_for_command(self, command_type, experiment_config,
-                           context=None):
-        conf, io_def = super().update_for_command(command_type,
-                                                  experiment_config, context)
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = super().update_for_command(command_type, experiment_config,
+                                            context, io_def)
         if command_type == rv.CHIP:
-            conf.training_data_uri = experiment_config.chip_uri
+            self.training_data_uri = experiment_config.chip_uri
             outputs = list(
-                map(lambda x: os.path.join(conf.training_data_uri, x),
+                map(lambda x: os.path.join(self.training_data_uri, x),
                     CHIP_OUTPUT_FILES))
             io_def.add_outputs(outputs)
         if command_type == rv.TRAIN:
-            conf.training_output_uri = experiment_config.train_uri
+            self.training_output_uri = experiment_config.train_uri
             inputs = list(
                 map(lambda x: os.path.join(experiment_config.chip_uri, x),
                     CHIP_OUTPUT_FILES))
             io_def.add_inputs(inputs)
 
-            conf.model_uri = os.path.join(conf.training_output_uri, 'model')
-            io_def.add_output(conf.model_uri)
+            self.model_uri = os.path.join(self.training_output_uri, 'model')
+            io_def.add_output(self.model_uri)
 
             # Set the fine tune checkpoint name to the experiment id
-            if not conf.fine_tune_checkpoint_name:
-                conf.fine_tune_checkpoint_name = experiment_config.id
-            io_def.add_output(conf.fine_tune_checkpoint_name)
+            if not self.fine_tune_checkpoint_name:
+                self.fine_tune_checkpoint_name = experiment_config.id
+            io_def.add_output(self.fine_tune_checkpoint_name)
         if command_type in [rv.PREDICT, rv.BUNDLE]:
-            if not conf.model_uri:
+            if not self.model_uri:
                 io_def.add_missing('Missing model_uri.')
             else:
-                io_def.add_input(conf.model_uri)
+                io_def.add_input(self.model_uri)
 
-        return (conf, io_def)
+        return io_def
 
     def save_bundle_files(self, bundle_dir):
         if not self.model_uri:

--- a/rastervision/backend/tf_object_detection_config.py
+++ b/rastervision/backend/tf_object_detection_config.py
@@ -119,53 +119,56 @@ class TFObjectDetectionConfig(BackendConfig):
                    .with_model_uri(local_model_uri) \
                    .build()
 
-    def update_for_command(self, command_type, experiment_config,
-                           context=None):
-        conf, io_def = super().update_for_command(command_type,
-                                                  experiment_config, context)
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = super().update_for_command(command_type, experiment_config,
+                                            context, io_def)
         if command_type == rv.CHIP:
-            if not conf.training_data_uri:
-                conf.training_data_uri = experiment_config.chip_uri
+            if not self.training_data_uri:
+                self.training_data_uri = experiment_config.chip_uri
 
             outputs = list(
-                map(lambda x: os.path.join(conf.training_data_uri, x),
+                map(lambda x: os.path.join(self.training_data_uri, x),
                     CHIP_OUTPUT_FILES))
 
             if self.debug:
                 outputs.extend(
                     list(
-                        map(lambda x: os.path.join(conf.training_data_uri, x),
+                        map(lambda x: os.path.join(self.training_data_uri, x),
                             DEBUG_CHIP_OUTPUT_FILES)))
 
             io_def.add_outputs(outputs)
         if command_type == rv.TRAIN:
-            if not conf.training_data_uri:
+            if not self.training_data_uri:
                 io_def.add_missing('Missing training_data_uri.')
             else:
                 inputs = list(
-                    map(lambda x: os.path.join(conf.training_data_uri, x),
+                    map(lambda x: os.path.join(self.training_data_uri, x),
                         CHIP_OUTPUT_FILES))
                 io_def.add_inputs(inputs)
 
-            if not conf.training_output_uri:
-                conf.training_output_uri = experiment_config.train_uri
+            if not self.training_output_uri:
+                self.training_output_uri = experiment_config.train_uri
 
-            if not conf.model_uri:
-                conf.model_uri = os.path.join(conf.training_output_uri,
+            if not self.model_uri:
+                self.model_uri = os.path.join(self.training_output_uri,
                                               'model')
-            io_def.add_output(conf.model_uri)
+            io_def.add_output(self.model_uri)
 
             # Set the fine tune checkpoint name to the experiment id
-            if not conf.fine_tune_checkpoint_name:
-                conf.fine_tune_checkpoint_name = experiment_config.id
-            io_def.add_output(conf.fine_tune_checkpoint_name)
+            if not self.fine_tune_checkpoint_name:
+                self.fine_tune_checkpoint_name = experiment_config.id
+            io_def.add_output(self.fine_tune_checkpoint_name)
         if command_type in [rv.PREDICT, rv.BUNDLE]:
-            if not conf.model_uri:
+            if not self.model_uri:
                 io_def.add_missing('Missing model_uri.')
             else:
-                io_def.add_input(conf.model_uri)
+                io_def.add_input(self.model_uri)
 
-        return (conf, io_def)
+        return io_def
 
 
 class TFObjectDetectionConfigBuilder(BackendConfigBuilder):

--- a/rastervision/data/label_source/chip_classification_geojson_source_config.py
+++ b/rastervision/data/label_source/chip_classification_geojson_source_config.py
@@ -51,17 +51,18 @@ class ChipClassificationGeoJSONSourceConfig(LabelSourceConfig):
             self.pick_min_class_id, self.background_class_id, self.cell_size,
             self.infer_cells)
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        conf = self
-        io_def = rv.core.CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or rv.core.CommandIODefinition()
         io_def.add_input(self.uri)
 
         if not self.cell_size:
-            conf = conf.to_builder() \
-                       .with_cell_size(experiment_config.task.chip_size) \
-                       .build()
+            self.cell_size = experiment_config.task.chip_size
 
-        return (conf, io_def)
+        return io_def
 
 
 class ChipClassificationGeoJSONSourceConfigBuilder(LabelSourceConfigBuilder):

--- a/rastervision/data/label_source/object_detection_geojson_source_config.py
+++ b/rastervision/data/label_source/object_detection_geojson_source_config.py
@@ -21,11 +21,15 @@ class ObjectDetectionGeoJSONSourceConfig(LabelSourceConfig):
         return ObjectDetectionGeoJSONSource(self.uri, crs_transformer,
                                             task_config.class_map, extent)
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        io_def = rv.core.CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or rv.core.CommandIODefinition()
         io_def.add_input(self.uri)
 
-        return (self, io_def)
+        return io_def
 
 
 class ObjectDetectionGeoJSONSourceConfigBuilder(LabelSourceConfigBuilder):

--- a/rastervision/data/label_source/semantic_segmentation_raster_source_config.py
+++ b/rastervision/data/label_source/semantic_segmentation_raster_source_config.py
@@ -31,21 +31,20 @@ class SemanticSegmentationRasterSourceConfig(LabelSourceConfig):
             self.source.create_source(tmp_dir, extent, crs_transformer),
             self.rgb_class_map)
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
         if context is None:
             context = []
         context = context + [self]
-        io_def = rv.core.CommandIODefinition()
+        io_def = io_def or rv.core.CommandIODefinition()
 
-        b = self.to_builder()
+        self.source.update_for_command(command_type, experiment_config,
+                                       context, io_def)
 
-        (new_raster_source, sub_io_def) = self.source.update_for_command(
-            command_type, experiment_config, context)
-
-        io_def.merge(sub_io_def)
-        b = b.with_raster_source(new_raster_source)
-
-        return (b.build(), io_def)
+        return io_def
 
 
 class SemanticSegmentationRasterSourceConfigBuilder(LabelSourceConfigBuilder):

--- a/rastervision/data/label_store/chip_classification_geojson_store_config.py
+++ b/rastervision/data/label_store/chip_classification_geojson_store_config.py
@@ -26,9 +26,12 @@ class ChipClassificationGeoJSONStoreConfig(LabelStoreConfig):
         return ChipClassificationGeoJSONStore(self.uri, crs_transformer,
                                               task_config.class_map)
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        conf = self
-        io_def = rv.core.CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or rv.core.CommandIODefinition()
 
         if command_type == rv.PREDICT:
             if not self.uri:
@@ -40,16 +43,14 @@ class ChipClassificationGeoJSONStoreConfig(LabelStoreConfig):
                     if isinstance(c, rv.SceneConfig):
                         uri = os.path.join(root, '{}.json'.format(c.id))
                 if uri:
-                    conf = conf.to_builder() \
-                               .with_uri(uri) \
-                               .build()
+                    self.uri = uri
                     io_def.add_output(uri)
                 else:
                     raise rv.ConfigError(
                         'ChipClassificationGeoJSONStoreConfig has no '
                         'URI set, and is not associated with a SceneConfig.')
 
-            io_def.add_output(conf.uri)
+            io_def.add_output(self.uri)
 
         if command_type == rv.EVAL:
             if self.uri:
@@ -58,7 +59,7 @@ class ChipClassificationGeoJSONStoreConfig(LabelStoreConfig):
                 msg = 'No URI set for ChipClassificationGeoJSONStoreConfig'
                 io_def.add_missing(msg)
 
-        return (conf, io_def)
+        return io_def
 
 
 class ChipClassificationGeoJSONStoreConfigBuilder(LabelStoreConfigBuilder):

--- a/rastervision/data/label_store/object_detection_geojson_store_config.py
+++ b/rastervision/data/label_store/object_detection_geojson_store_config.py
@@ -26,9 +26,12 @@ class ObjectDetectionGeoJSONStoreConfig(LabelStoreConfig):
         return ObjectDetectionGeoJSONStore(self.uri, crs_transformer,
                                            task_config.class_map)
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        conf = self
-        io_def = rv.core.CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or rv.core.CommandIODefinition()
 
         if command_type == rv.PREDICT:
             if not self.uri:
@@ -40,16 +43,14 @@ class ObjectDetectionGeoJSONStoreConfig(LabelStoreConfig):
                     if isinstance(c, rv.SceneConfig):
                         uri = os.path.join(root, '{}.json'.format(c.id))
                 if uri:
-                    conf = conf.to_builder() \
-                               .with_uri(uri) \
-                               .build()
+                    self.uri = uri
                     io_def.add_output(uri)
                 else:
                     raise rv.ConfigError(
                         'ObjectDetectionGeoJSONStoreConfig has no '
                         'URI set, and is not associated with a SceneConfig.')
 
-            io_def.add_output(conf.uri)
+            io_def.add_output(self.uri)
 
         if command_type == rv.EVAL:
             if self.uri:
@@ -58,7 +59,7 @@ class ObjectDetectionGeoJSONStoreConfig(LabelStoreConfig):
                 msg = 'No URI set for ObjectDetectionGeoJSONStoreConfig'
                 io_def.add_missing(msg)
 
-        return (conf, io_def)
+        return io_def
 
 
 class ObjectDetectionGeoJSONStoreConfigBuilder(LabelStoreConfigBuilder):

--- a/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
@@ -31,9 +31,12 @@ class SemanticSegmentationRasterStoreConfig(LabelStoreConfig):
         return SemanticSegmentationRasterStore(
             self.uri, extent, crs_transformer, tmp_dir, class_map=class_map)
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        conf = self
-        io_def = rv.core.CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or rv.core.CommandIODefinition()
 
         if command_type == rv.PREDICT:
             if not self.uri:
@@ -45,16 +48,14 @@ class SemanticSegmentationRasterStoreConfig(LabelStoreConfig):
                     if isinstance(c, rv.SceneConfig):
                         uri = os.path.join(root, '{}.tif'.format(c.id))
                 if uri:
-                    conf = conf.to_builder() \
-                               .with_uri(uri) \
-                               .build()
+                    self.uri = uri
                     io_def.add_output(uri)
                 else:
                     raise rv.ConfigError(
                         'SemanticSegmentationRasterStoreConfig has no '
                         'URI set, and is not associated with a SceneConfig.')
 
-            io_def.add_output(conf.uri)
+            io_def.add_output(self.uri)
 
         if command_type == rv.EVAL:
             if self.uri:
@@ -63,7 +64,7 @@ class SemanticSegmentationRasterStoreConfig(LabelStoreConfig):
                 msg = 'No URI set for SemanticSegmentationRasterStoreConfig'
                 io_def.add_missing(msg)
 
-        return (conf, io_def)
+        return io_def
 
 
 class SemanticSegmentationRasterStoreConfigBuilder(LabelStoreConfigBuilder):

--- a/rastervision/data/raster_source/geojson_source_config.py
+++ b/rastervision/data/raster_source/geojson_source_config.py
@@ -76,8 +76,8 @@ class GeoJSONSourceConfig(RasterSourceConfig):
                            experiment_config,
                            context=None,
                            io_def=None):
-        io_def = super().update_for_command(command_type,
-                                            experiment_config, context, io_def)
+        io_def = super().update_for_command(command_type, experiment_config,
+                                            context, io_def)
         io_def.add_input(self.uri)
 
         return io_def

--- a/rastervision/data/raster_source/geojson_source_config.py
+++ b/rastervision/data/raster_source/geojson_source_config.py
@@ -76,8 +76,8 @@ class GeoJSONSourceConfig(RasterSourceConfig):
                            experiment_config,
                            context=None,
                            io_def=None):
-        (conf, io_def) = super().update_for_command(command_type,
-                                                    experiment_config, io_def)
+        io_def = super().update_for_command(command_type,
+                                            experiment_config, context, io_def)
         io_def.add_input(self.uri)
 
         return io_def

--- a/rastervision/data/raster_source/geojson_source_config.py
+++ b/rastervision/data/raster_source/geojson_source_config.py
@@ -71,13 +71,16 @@ class GeoJSONSourceConfig(RasterSourceConfig):
         return GeoJSONSource(self.uri, self.rasterizer_options, extent,
                              crs_transformer)
 
-    def update_for_command(self, command_type, experiment_config,
-                           context=None):
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
         (conf, io_def) = super().update_for_command(command_type,
-                                                    experiment_config)
+                                                    experiment_config, io_def)
         io_def.add_input(self.uri)
 
-        return (conf, io_def)
+        return io_def
 
 
 class GeoJSONSourceConfigBuilder(RasterSourceConfigBuilder):

--- a/rastervision/data/raster_source/geotiff_source_config.py
+++ b/rastervision/data/raster_source/geotiff_source_config.py
@@ -48,14 +48,17 @@ class GeoTiffSourceConfig(RasterSourceConfig):
         return GeoTiffSource(self.uris, transformers, tmp_dir,
                              self.channel_order)
 
-    def update_for_command(self, command_type, experiment_config,
-                           context=None):
-        (conf, io_def) = super().update_for_command(command_type,
-                                                    experiment_config, context)
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = super().update_for_command(command_type, experiment_config,
+                                            context, io_def)
         for uri in self.uris:
             io_def.add_input(uri)
 
-        return (conf, io_def)
+        return io_def
 
 
 class GeoTiffSourceConfigBuilder(RasterSourceConfigBuilder):
@@ -86,7 +89,7 @@ class GeoTiffSourceConfigBuilder(RasterSourceConfigBuilder):
     def with_uris(self, uris):
         """Set URIs for a GeoTIFFs containing as raster data."""
         b = deepcopy(self)
-        b.config['uris'] = uris
+        b.config['uris'] = list(uris)
         return b
 
     def with_uri(self, uri):

--- a/rastervision/data/raster_source/image_source_config.py
+++ b/rastervision/data/raster_source/image_source_config.py
@@ -47,13 +47,16 @@ class ImageSourceConfig(RasterSourceConfig):
         transformers = self.create_transformers()
         return ImageSource(self.uri, transformers, tmp_dir, self.channel_order)
 
-    def update_for_command(self, command_type, experiment_config,
-                           context=None):
-        (conf, io_def) = super().update_for_command(command_type,
-                                                    experiment_config)
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = super().update_for_command(command_type, experiment_config,
+                                            io_def)
         io_def.add_input(self.uri)
 
-        return (conf, io_def)
+        return io_def
 
 
 class ImageSourceConfigBuilder(RasterSourceConfigBuilder):

--- a/rastervision/data/raster_transformer/stats_transformer_config.py
+++ b/rastervision/data/raster_transformer/stats_transformer_config.py
@@ -43,19 +43,20 @@ class StatsTransformerConfig(RasterTransformerConfig):
 
         return StatsTransformer(RasterStats.load(self.stats_uri))
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        conf = self
-        io_def = rv.core.CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or rv.core.CommandIODefinition()
         if command_type != rv.ANALYZE:
-            if not conf.stats_uri:
+            if not self.stats_uri:
                 # Find the stats URI from a StatsAnalyzer
                 for analyzer in experiment_config.analyzers:
                     if analyzer.analyzer_type == rv.STATS_ANALYZER:
-                        stats_uri = analyzer.stats_uri
-                        conf = self.to_builder() \
-                                   .with_stats_uri(stats_uri) \
-                                   .build()
-            if not conf.stats_uri:
+                        self.stats_uri = analyzer.stats_uri
+
+            if not self.stats_uri:
                 io_def.add_missing(
                     "StatsTransformerConfig is missing 'stats_uri' property "
                     'in command {}. '
@@ -63,9 +64,9 @@ class StatsTransformerConfig(RasterTransformerConfig):
                     'StatsAnalyzerConfig must be added to '
                     'this experiment.'.format(command_type))
             else:
-                io_def.add_input(conf.stats_uri)
+                io_def.add_input(self.stats_uri)
 
-        return (conf, io_def)
+        return io_def
 
 
 class StatsTransformerConfigBuilder(RasterTransformerConfigBuilder):

--- a/rastervision/data/scene_config.py
+++ b/rastervision/data/scene_config.py
@@ -107,39 +107,31 @@ class SceneConfig(BundledConfigMixin, Config):
     def to_builder(self):
         return SceneConfigBuilder(self)
 
-    def update_for_command(self, command_type, experiment_config,
-                           context=None):
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
         if context is None:
             context = []
         context = context + [self]
-        io_def = rv.core.CommandIODefinition()
+        io_def = io_def or rv.core.CommandIODefinition()
 
-        b = self.to_builder()
-
-        (new_raster_source,
-         sub_io_def) = self.raster_source.update_for_command(
-             command_type, experiment_config, context)
-        io_def.merge(sub_io_def)
-        b = b.with_raster_source(new_raster_source)
+        self.raster_source.update_for_command(command_type, experiment_config,
+                                              context, io_def)
 
         if self.label_source:
-            (new_label_source,
-             sub_io_def) = self.label_source.update_for_command(
-                 command_type, experiment_config, context)
-            io_def.merge(sub_io_def)
-            b = b.with_label_source(new_label_source)
+            self.label_source.update_for_command(
+                command_type, experiment_config, context, io_def)
 
         if self.label_store:
-            (new_label_store,
-             sub_io_def) = self.label_store.update_for_command(
-                 command_type, experiment_config, context)
-            io_def.merge(sub_io_def)
-            b = b.with_label_store(new_label_store)
+            self.label_store.update_for_command(
+                command_type, experiment_config, context, io_def)
 
         if self.aoi_uri:
             io_def.add_input(self.aoi_uri)
 
-        return (b.build(), io_def)
+        return io_def
 
     @staticmethod
     def builder():

--- a/rastervision/evaluation/classification_evaluator_config.py
+++ b/rastervision/evaluation/classification_evaluator_config.py
@@ -26,18 +26,18 @@ class ClassificationEvaluatorConfig(EvaluatorConfig):
 
         return msg
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        conf = self
-        io_def = rv.core.CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or rv.core.CommandIODefinition()
         if command_type == rv.EVAL:
             if not self.output_uri:
-                output_uri = os.path.join(experiment_config.eval_uri,
-                                          'eval.json')
-                conf = conf.to_builder() \
-                           .with_output_uri(output_uri) \
-                           .build()
-            io_def.add_output(conf.output_uri)
-        return (conf, io_def)
+                self.output_uri = os.path.join(experiment_config.eval_uri,
+                                               'eval.json')
+            io_def.add_output(self.output_uri)
+        return io_def
 
 
 class ClassificationEvaluatorConfigBuilder(EvaluatorConfigBuilder):

--- a/rastervision/filesystem/local_filesystem.py
+++ b/rastervision/filesystem/local_filesystem.py
@@ -28,8 +28,7 @@ def make_dir(path, check_empty=False, force_empty=False, use_dirname=False):
 
     os.makedirs(directory, exist_ok=True)
 
-    is_empty = len(os.listdir(directory)) == 0
-    if check_empty and not is_empty:
+    if check_empty and any(os.scandir(directory)):
         raise ValueError(
             '{} needs to be an empty directory!'.format(directory))
 
@@ -80,20 +79,13 @@ class LocalFileSystem(FileSystem):
             shutil.rmtree(dest_dir_uri)
 
         # https://stackoverflow.com/a/15824216/841563
-        def recursive_overwrite(src, dest, ignore=None):
+        def recursive_overwrite(src, dest):
             if os.path.isdir(src):
                 if not os.path.isdir(dest):
                     os.makedirs(dest)
-                    files = os.listdir(src)
-                    if ignore is not None:
-                        ignored = ignore(src, files)
-                    else:
-                        ignored = set()
-                        for f in files:
-                            if f not in ignored:
-                                recursive_overwrite(
-                                    os.path.join(src, f), os.path.join(
-                                        dest, f), ignore)
+                    for entry in os.scandir(src):
+                        recursive_overwrite(entry.path,
+                                            os.path.join(dest, entry.name))
             else:
                 shutil.copyfile(src, dest)
 

--- a/rastervision/runner/command_dag.py
+++ b/rastervision/runner/command_dag.py
@@ -1,9 +1,12 @@
 import networkx as nx
+import logging
 
 import rastervision as rv
 from rastervision.utils.files import file_exists
 
 import click
+
+log = logging.getLogger(__name__)
 
 
 class CommandDAG:
@@ -26,6 +29,7 @@ class CommandDAG:
 
         uri_dag = nx.DiGraph()
 
+        log.debug('Creating command and URI DAG from command definitions...')
         for idx, command_def in enumerate(command_definitions):
             uri_dag.add_node(idx)
             for input_uri in command_def.io_def.input_uris:
@@ -36,6 +40,7 @@ class CommandDAG:
 
         # Find all source input_uris, and ensure they exist.
         if not skip_file_check:
+            log.debug('Ensuring input files exist...')
             unsolved_sources = [
                 uri for uri in uri_dag.nodes
                 if (type(uri) == str and len(uri_dag.in_edges(uri)) == 0)
@@ -58,6 +63,7 @@ class CommandDAG:
         # If we are not rerunning, remove commands that have existing outputs.
         self.skipped_commands = []
         if not rerun_commands:
+            log.debug('Checking for existing output...')
             commands_to_outputs = [(idx, edge[1]) for idx in uri_dag.nodes
                                    if type(idx) == int
                                    for edge in uri_dag.out_edges(idx)]
@@ -76,6 +82,7 @@ class CommandDAG:
         # Collapse the graph to create edges from command to command.
         command_id_dag = nx.DiGraph()
 
+        log.debug('Creating DAG of commands...')
         for idx in [idx for idx in uri_dag.nodes if (type(idx) == int)]:
             command_id_dag.add_node(idx)
             for upstream_idx in [

--- a/rastervision/runner/command_definition.py
+++ b/rastervision/runner/command_definition.py
@@ -1,6 +1,10 @@
 from typing import List
+import logging
+from copy import deepcopy
 
 import rastervision as rv
+
+log = logging.getLogger(__name__)
 
 
 class CommandDefinition:
@@ -25,9 +29,16 @@ class CommandDefinition:
         command_definitions = []
 
         for experiment in experiments:
-            e = experiment
+            e = deepcopy(experiment)
+            log.debug(
+                'Generating command definitions for experiment {}...'.format(
+                    e.id))
             for command_type in rv.ALL_COMMANDS:
-                (e, io_def) = e.update_for_command(command_type, e)
+                log.debug(
+                    'Updating config for command {}...'.format(command_type))
+                io_def = e.update_for_command(command_type, e)
+                log.debug('Creating experiment configuration...'.format(
+                    command_type))
                 command_config = e.make_command_config(command_type)
                 command_def = cls(e.id, command_config, io_def)
                 command_definitions.append(command_def)

--- a/rastervision/rv_config.py
+++ b/rastervision/rv_config.py
@@ -96,7 +96,7 @@ class RVConfig:
 
         # Set logging level
         root_log = logging.getLogger('rastervision')
-        if self.verbosity >= Verbosity.VERY_VERBOSE:
+        if self.verbosity >= Verbosity.VERBOSE:
             root_log.setLevel(logging.DEBUG)
         elif self.verbosity >= Verbosity.NORMAL:
             root_log.setLevel(logging.INFO)

--- a/rastervision/task/semantic_segmentation_config.py
+++ b/rastervision/task/semantic_segmentation_config.py
@@ -100,7 +100,7 @@ class SemanticSegmentationConfigBuilder(TaskConfigBuilder):
                 .with_chip_size(conf.chip_size) \
                 .with_chip_options(
                     window_method=conf.chip_options.window_method,
-                    target_classes=conf.chip_options.target_classes,
+                    target_classes=list(conf.chip_options.target_classes),
                     debug_chip_probability=conf.chip_options.debug_chip_probability,
                     negative_survival_probability=negative_survival_probability,
                     chips_per_scene=conf.chip_options.chips_per_scene,

--- a/rastervision/task/task_config.py
+++ b/rastervision/task/task_config.py
@@ -52,16 +52,18 @@ class TaskConfig(BundledConfigMixin, Config):
                            .from_proto(msg) \
                            .build()
 
-    def update_for_command(self, command_type, experiment_config,
-                           context=None):
-        conf = self
-        io_def = rv.core.CommandIODefinition()
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        io_def = io_def or rv.core.CommandIODefinition()
         if command_type == rv.BUNDLE:
-            if not conf.predict_package_uri:
-                conf.predict_package_uri = os.path.join(
+            if not self.predict_package_uri:
+                self.predict_package_uri = os.path.join(
                     experiment_config.bundle_uri, 'predict_package.zip')
-            io_def.add_output(conf.predict_package_uri)
-        return (conf, io_def)
+            io_def.add_output(self.predict_package_uri)
+        return io_def
 
 
 class TaskConfigBuilder(ConfigBuilder):

--- a/tests/data-files/plugins/noop_augmentor.py
+++ b/tests/data-files/plugins/noop_augmentor.py
@@ -25,8 +25,12 @@ class NoopAugmentorConfig(AugmentorConfig):
     def create_augmentor(self):
         return NoopAugmentor()
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        return (self, rv.core.CommandIODefinition())
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        return io_def or rv.core.CommandIODefinition()
 
 
 class NoopAugmentorConfigBuilder(AugmentorConfigBuilder):

--- a/tests/data-files/plugins/noop_backend.py
+++ b/tests/data-files/plugins/noop_backend.py
@@ -37,8 +37,12 @@ class NoopBackendConfig(BackendConfig):
     def create_backend(self, task_config):
         return NoopBackend()
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        return (self, rv.core.CommandIODefinition())
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        return io_def or rv.core.CommandIODefinition()
 
     def save_bundle_files(self, bundle_dir):
         return (self, [])

--- a/tests/data-files/plugins/noop_evaluator.py
+++ b/tests/data-files/plugins/noop_evaluator.py
@@ -25,8 +25,12 @@ class NoopEvaluatorConfig(EvaluatorConfig):
     def create_evaluator(self):
         return NoopEvaluator()
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        return (self, rv.core.CommandIODefinition())
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        return io_def or rv.core.CommandIODefinition()
 
 
 class NoopEvaluatorConfigBuilder(EvaluatorConfigBuilder):

--- a/tests/data-files/plugins/noop_label_source.py
+++ b/tests/data-files/plugins/noop_label_source.py
@@ -25,8 +25,12 @@ class NoopLabelSourceConfig(LabelSourceConfig):
     def create_source(self, task_config, extent, crs_transformer, tmp_dir):
         return NoopLabelSource()
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        return (self, rv.core.CommandIODefinition())
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        return io_def or rv.core.CommandIODefinition()
 
 
 class NoopLabelSourceConfigBuilder(LabelSourceConfigBuilder):

--- a/tests/data-files/plugins/noop_label_store.py
+++ b/tests/data-files/plugins/noop_label_store.py
@@ -31,8 +31,12 @@ class NoopLabelStoreConfig(LabelStoreConfig):
     def create_store(self, task_config, crs_transformer, tmp_dir):
         return NoopLabelStore()
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        return (self, rv.core.CommandIODefinition())
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        return io_def or rv.core.CommandIODefinition()
 
     def for_prediction(self, label_store_uri):
         return self

--- a/tests/data-files/plugins/noop_raster_source.py
+++ b/tests/data-files/plugins/noop_raster_source.py
@@ -38,8 +38,12 @@ class NoopRasterSourceConfig(RasterSourceConfig):
         transformers = self.create_transformers()
         return NoopRasterSource(transformers, tmp_dir)
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        return (self, rv.core.CommandIODefinition())
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        return io_def or rv.core.CommandIODefinition()
 
     def save_bundle_files(self, bundle_dir):
         return (self, [])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -175,8 +175,12 @@ class NoopAnalyzerConfig(AnalyzerConfig):
     def create_analyzer(self):
         return NoopAnalyzer()
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        return (self, rv.core.CommandIODefinition())
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        return io_def
 
     def save_bundle_files(self, bundle_dir):
         return (self, [])


### PR DESCRIPTION
## Overview

This PR refactors the update_for_command architecture to optimize the code - when using Raster Vision for experiments of lots of files (e.g. 250,000), the update_for_command chain would take way too long. It also replaces the deepcopy mechanism for configs to use pickle, which is faster than deepcopy.

Other changes:
- Use `scandir` instead of listdir when appropriate to avoid iterating over directorys with many files.
- Added debugging output for experiment running, which can be triggered with the verbose flag (`-v`)
- Don't deepcopy Datasets, just make a  copy  of the list

### Notes

Moving the config  __deepcopy__ mechanism to use pickle has the side effect of requiring that configs hold only serializable items. I've run into places  where in  `from_proto` we don't wrap a `repeated` item in a list, and that was causing serialization errors. Make sure to hold only lists and other serializable items and not raw protobuf repeated field message type. 

