### PR TITLE
Implement activation to avoid keeping files open.

### DIFF
--- a/rastervision/core/raster_stats.py
+++ b/rastervision/core/raster_stats.py
@@ -17,20 +17,18 @@ class RasterStats():
 
         def chip_stream(channel):
             for raster_source in raster_sources:
-                windows = raster_source.get_extent().get_windows(
-                    chip_size, stride)
-                for window in windows:
-                    chip = raster_source.get_raw_chip(window).astype(
-                        np.float32)
-                    chip = chip[:, :, channel].ravel()
-                    # Ignore NODATA values.
-                    chip[chip == 0.0] = np.nan
-                    yield chip
+                with raster_source.activate():
+                    windows = raster_source.get_extent().get_windows(
+                        chip_size, stride)
+                    for window in windows:
+                        chip = raster_source.get_raw_chip(window).astype(
+                            np.float32)
+                        chip = chip[:, :, channel].ravel()
+                        # Ignore NODATA values.
+                        chip[chip == 0.0] = np.nan
+                        yield chip
 
-        # Sniff the number of channels.
-        window = raster_sources[0].get_extent().get_windows(chip_size,
-                                                            stride)[0]
-        nb_channels = raster_sources[0].get_raw_chip(window).shape[2]
+        nb_channels = len(raster_sources[0].channel_order)
 
         self.means = []
         self.stds = []

--- a/rastervision/data/__init__.py
+++ b/rastervision/data/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+from rastervision.data.activate_mixin import *
 from rastervision.data.raster_transformer import *
 from rastervision.data.raster_source import *
 from rastervision.data.crs_transformer import *

--- a/rastervision/data/activate_mixin.py
+++ b/rastervision/data/activate_mixin.py
@@ -1,0 +1,98 @@
+from abc import abstractmethod
+
+
+class ActivationError(Exception):
+    pass
+
+
+class ActivateMixin:
+    """Defines a mixin for data that can activate and deactivate.
+    These methods can open and close files, download files, and do
+    whatever has to be done to make the entity usable, and cleanup
+    after the entity is not needed anymore.
+    """
+
+    class ActivateContextManager:
+        def __init__(self, activate, deactivate):
+            self.activate = activate
+            self.deactivate = deactivate
+
+        def __enter__(self):
+            self.activate()
+            return self
+
+        def __exit__(self, type, value, traceback):
+            self.deactivate()
+
+        @classmethod
+        def dummy(cls):
+            def noop():
+                pass
+
+            return cls(noop, noop)
+
+    class CompositContextManager:
+        def __init__(self, *managers):
+            self.managers = managers
+
+        def __enter__(self):
+            for manager in self.managers:
+                manager.__enter__()
+
+        def __exit__(self, type, value, traceback):
+            for manager in self.managers:
+                manager.__exit__(type, value, traceback)
+
+    def activate(self):
+        if hasattr(self, '_mixin_activated'):
+            if self._mixin_activated:
+                raise ActivationError('This {} is already activated'.format(
+                    type(self)))
+
+        def do_activate():
+            self._mixin_activated = True
+            self._activate()
+
+        def do_deactivate():
+            self._deactivate()
+            self._mixin_activated = False
+
+        a = ActivateMixin.ActivateContextManager(do_activate, do_deactivate)
+        subcomponents = self._subcomponents_to_activate()
+        if subcomponents:
+            return ActivateMixin.CompositContextManager(
+                a, ActivateMixin.compose(*subcomponents))
+        else:
+            return a
+
+    @abstractmethod
+    def _activate(self):
+        pass
+
+    @abstractmethod
+    def _deactivate(self):
+        pass
+
+    def _subcomponents_to_activate(self):
+        """Subclasses override this if they have subcomponents
+        that may need to be activated when this class is activated
+        """
+        return []
+
+    @staticmethod
+    def with_activation(obj):
+        """Method will give activate an object if it mixes in  the ActivateMixin and
+        return the context manager, or else return a dummy context manager.
+        """
+        if obj is None or not isinstance(obj, ActivateMixin):
+            return ActivateMixin.dummy()
+        else:
+            return obj.activate()
+
+    @staticmethod
+    def compose(*objs):
+        managers = [
+            obj.activate() for obj in objs
+            if obj is not None and isinstance(obj, ActivateMixin)
+        ]
+        return ActivateMixin.CompositContextManager(*managers)

--- a/rastervision/data/label_source/semantic_segmentation_raster_source.py
+++ b/rastervision/data/label_source/semantic_segmentation_raster_source.py
@@ -4,12 +4,13 @@ import numpy as np
 
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap
+from rastervision.data import ActivateMixin
 from rastervision.data.label import SemanticSegmentationLabels
 from rastervision.data.label_source import LabelSource, SegmentationClassTransformer
 from rastervision.data.raster_source import RasterSource
 
 
-class SemanticSegmentationRasterSource(LabelSource):
+class SemanticSegmentationRasterSource(ActivateMixin, LabelSource):
     """A read-only label source for segmentation raster files.
     """
 
@@ -17,10 +18,12 @@ class SemanticSegmentationRasterSource(LabelSource):
         """Constructor.
 
         Args:
-            source: (RasterSource) assumed to have RGB values that are mapped to
-                class_ids using the rgb_class_map
+            source: (RasterSource) A raster source that returns a single channel
+                raster with class_ids as values, or a 3 channel raster with
+                RGB values that are mapped to class_ids using the rgb_class_map
             rgb_class_map: (ClassMap) with color values filled in. Optional and used to
-                transform RGB values to class ids.
+                transform RGB values to class ids. Only use if the raster source
+                is RGB.
         """
         self.source = source
         self.class_transformer = None
@@ -77,3 +80,12 @@ class SemanticSegmentationRasterSource(LabelSource):
             labels = np.squeeze(raw_labels)
 
         return SemanticSegmentationLabels.from_array(labels)
+
+    def _subcomponents_to_activate(self):
+        return [self.source]
+
+    def _activate(self):
+        pass
+
+    def _deactivate(self):
+        pass

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -42,12 +42,13 @@ class SemanticSegmentationRasterStore(LabelStore):
                                       .with_uri(self.uri) \
                                       .build() \
                                       .create_source(self.tmp_dir)
-        raw_labels = source.get_raw_image_array()
-        if self.class_trans:
-            labels = self.class_trans.rgb_to_class(raw_labels)
-        else:
-            labels = np.squeeze(raw_labels)
-        return SemanticSegmentationLabels.from_array(labels)
+        with source.activate():
+            raw_labels = source.get_raw_image_array()
+            if self.class_trans:
+                labels = self.class_trans.rgb_to_class(raw_labels)
+            else:
+                labels = np.squeeze(raw_labels)
+            return SemanticSegmentationLabels.from_array(labels)
 
     def save(self, labels):
         """Save.
@@ -60,7 +61,7 @@ class SemanticSegmentationRasterStore(LabelStore):
 
         # TODO: this only works if crs_transformer is RasterioCRSTransformer.
         # Need more general way of computing transform for the more general case.
-        transform = self.crs_transformer.image_dataset.transform
+        transform = self.crs_transformer.transform
         crs = self.crs_transformer.get_image_crs()
         clipped_labels = labels.get_clipped_labels(self.extent)
 

--- a/rastervision/data/raster_source/image_source.py
+++ b/rastervision/data/raster_source/image_source.py
@@ -1,5 +1,3 @@
-import rasterio
-
 from rastervision.data.raster_source.rasterio_source import (
     RasterioRasterSource)
 from rastervision.data.crs_transformer.identity_crs_transformer import (
@@ -12,9 +10,8 @@ class ImageSource(RasterioRasterSource):
         self.uri = uri
         super().__init__(raster_transformers, temp_dir, channel_order)
 
-    def build_image_dataset(self, temp_dir):
-        imagery_path = download_if_needed(self.uri, self.temp_dir)
-        return rasterio.open(imagery_path)
+    def _download_data(self, temp_dir):
+        return download_if_needed(self.uri, self.temp_dir)
 
-    def get_crs_transformer(self):
-        return IdentityCRSTransformer()
+    def _set_crs_transformer(self):
+        self.crs_transformer = IdentityCRSTransformer()

--- a/rastervision/data/raster_source/raster_source.py
+++ b/rastervision/data/raster_source/raster_source.py
@@ -8,7 +8,7 @@ class RasterSource(ABC):
     a set of files, an API, a TMS URI schema, etc.
     """
 
-    def __init__(self, raster_transformers=[], channel_order=None):
+    def __init__(self, channel_order, raster_transformers=[]):
         """Construct a new RasterSource.
 
         Args:
@@ -16,8 +16,6 @@ class RasterSource(ABC):
                 whenever they are retrieved.
             channel_order: numpy array of length n where n is the number of
                 channels to use and the values are channel indices.
-                Default: None, which will take all the raster's bands as is.
-
         """
         self.raster_transformers = raster_transformers
         self.channel_order = channel_order

--- a/rastervision/data/raster_source/rasterio_source.py
+++ b/rastervision/data/raster_source/rasterio_source.py
@@ -1,8 +1,10 @@
 from abc import abstractmethod
 
 import numpy as np
+import rasterio
 from rasterio.enums import (ColorInterp, MaskFlags)
 
+from rastervision.data import (ActivateMixin, ActivationError)
 from rastervision.data.raster_source import RasterSource
 from rastervision.core.box import Box
 
@@ -33,35 +35,62 @@ def load_window(image_dataset, window=None, channels=None, is_masked=False):
     return im
 
 
-class RasterioRasterSource(RasterSource):
+class RasterioRasterSource(ActivateMixin, RasterSource):
     def __init__(self, raster_transformers, temp_dir, channel_order=None):
+        super().__init__(channel_order, raster_transformers)
+
         self.temp_dir = temp_dir
-        self.image_dataset = self.build_image_dataset(temp_dir)
-        super().__init__(raster_transformers, channel_order)
+        self.imagery_path = self._download_data(temp_dir)
 
-        colorinterp = self.image_dataset.colorinterp
-        self.channels = [
-            i for i, color_interp in enumerate(colorinterp)
-            if color_interp != ColorInterp.alpha
-        ]
+        # Activate in order to get information out of the raster
+        with self.activate():
+            colorinterp = self.image_dataset.colorinterp
+            self.channels = [
+                i for i, color_interp in enumerate(colorinterp)
+                if color_interp != ColorInterp.alpha
+            ]
 
-        mask_flags = self.image_dataset.mask_flag_enums
-        self.is_masked = any(
-            [m for m in mask_flags if m != MaskFlags.all_valid])
+            mask_flags = self.image_dataset.mask_flag_enums
+            self.is_masked = any(
+                [m for m in mask_flags if m != MaskFlags.all_valid])
+
+            self.height = self.image_dataset.height
+            self.width = self.image_dataset.width
+            # Get 1x1 chip (after applying raster transformers) to test dtype
+            # and channel order if needed
+            test_chip = self.get_chip(Box.make_square(0, 0, 1))
+            self.dtype = test_chip.dtype
+
+            self.channel_order = self.channel_order or list(
+                range(0, test_chip.shape[2]))
+
+            self._set_crs_transformer()
 
     @abstractmethod
-    def build_image_dataset(self, temp_dir):
+    def _download_data(self, tmp_dir):
+        """Download any data needed for this Raster Source.
+        Return a single local path representing the image or a VRT of the data."""
         pass
 
+    def get_crs_transformer(self):
+        return self.crs_transformer
+
     def get_extent(self):
-        return Box(0, 0, self.image_dataset.height, self.image_dataset.width)
+        return Box(0, 0, self.height, self.width)
 
     def get_dtype(self):
         """Return the numpy.dtype of this scene"""
-        # Get 1x1 chip (after applying raster transformers) to test dtype.
-        chip = self.get_chip(window=Box.make_square(0, 0, 1))
-        return chip.dtype
+        return self.dtype
 
     def _get_chip(self, window):
+        if self.image_dataset is None:
+            raise ActivationError('RasterSource must be activated before use')
         return load_window(self.image_dataset, window.rasterio_format(),
                            self.channels)
+
+    def _activate(self):
+        self.image_dataset = rasterio.open(self.imagery_path)
+
+    def _deactivate(self):
+        self.image_dataset.close()
+        self.image_dataset = None

--- a/rastervision/data/scene.py
+++ b/rastervision/data/scene.py
@@ -1,4 +1,7 @@
-class Scene():
+from rastervision.data import ActivateMixin
+
+
+class Scene(ActivateMixin):
     """The raster data and labels associated with an area of interest."""
 
     def __init__(self,
@@ -24,3 +27,15 @@ class Scene():
             self.aoi_polygons = []
         else:
             self.aoi_polygons = aoi_polygons
+
+    def _subcomponents_to_activate(self):
+        return [
+            self.raster_source, self.ground_truth_label_source,
+            self.prediction_label_store
+        ]
+
+    def _activate(self):
+        pass
+
+    def _deactivate(self):
+        pass

--- a/rastervision/evaluation/classification_evaluator.py
+++ b/rastervision/evaluation/classification_evaluator.py
@@ -2,6 +2,7 @@ from abc import (abstractmethod)
 import logging
 
 from rastervision.evaluation import Evaluator
+from rastervision.data import ActivateMixin
 
 log = logging.getLogger(__name__)
 
@@ -22,14 +23,18 @@ class ClassificationEvaluator(Evaluator):
         evaluation = self.create_evaluation()
         for scene in scenes:
             log.info('Computing evaluation for scene {}...'.format(scene.id))
-            ground_truth = scene.ground_truth_label_source.get_labels()
-            predictions = scene.prediction_label_store.get_labels()
+            label_source = scene.ground_truth_label_source
+            label_store = scene.prediction_label_store
+            with ActivateMixin.compose(label_source, label_store):
+                ground_truth = label_source.get_labels()
+                predictions = label_store.get_labels()
 
-            if scene.aoi_polygons:
-                # Filter labels based on AOI.
-                ground_truth = ground_truth.filter_by_aoi(scene.aoi_polygons)
-                predictions = predictions.filter_by_aoi(scene.aoi_polygons)
-            scene_evaluation = self.create_evaluation()
-            scene_evaluation.compute(ground_truth, predictions)
-            evaluation.merge(scene_evaluation)
+                if scene.aoi_polygons:
+                    # Filter labels based on AOI.
+                    ground_truth = ground_truth.filter_by_aoi(
+                        scene.aoi_polygons)
+                    predictions = predictions.filter_by_aoi(scene.aoi_polygons)
+                scene_evaluation = self.create_evaluation()
+                scene_evaluation.compute(ground_truth, predictions)
+                evaluation.merge(scene_evaluation)
         evaluation.save(self.output_uri)

--- a/tests/data/raster_source/test_geojson_source.py
+++ b/tests/data/raster_source/test_geojson_source.py
@@ -70,25 +70,27 @@ class TestGeoJSONSource(unittest.TestCase):
         }
 
         source = self.build_source(geojson)
-        self.assertEqual(source.get_extent(), self.extent)
-        chip = source.get_image_array()
-        self.assertEqual(chip.shape, (10, 10, 1))
+        with source.activate():
+            self.assertEqual(source.get_extent(), self.extent)
+            chip = source.get_image_array()
+            self.assertEqual(chip.shape, (10, 10, 1))
 
-        expected_chip = self.background_class_id * np.ones((10, 10, 1))
-        expected_chip[0:5, 0:5, 0] = self.class_id
-        expected_chip[0:10, 6:8] = self.class_id
-        np.testing.assert_array_equal(chip, expected_chip)
+            expected_chip = self.background_class_id * np.ones((10, 10, 1))
+            expected_chip[0:5, 0:5, 0] = self.class_id
+            expected_chip[0:10, 6:8] = self.class_id
+            np.testing.assert_array_equal(chip, expected_chip)
 
     def test_get_chip_no_polygons(self):
         geojson = {'type': 'FeatureCollection', 'features': []}
 
         source = self.build_source(geojson)
-        self.assertEqual(source.get_extent(), self.extent)
-        chip = source.get_image_array()
-        self.assertEqual(chip.shape, (10, 10, 1))
+        with source.activate():
+            self.assertEqual(source.get_extent(), self.extent)
+            chip = source.get_image_array()
+            self.assertEqual(chip.shape, (10, 10, 1))
 
-        expected_chip = self.background_class_id * np.ones((10, 10, 1))
-        np.testing.assert_array_equal(chip, expected_chip)
+            expected_chip = self.background_class_id * np.ones((10, 10, 1))
+            np.testing.assert_array_equal(chip, expected_chip)
 
 
 if __name__ == '__main__':

--- a/tests/data/raster_source/test_geotiff_source.py
+++ b/tests/data/raster_source/test_geotiff_source.py
@@ -57,8 +57,9 @@ class TestGeoTiffSource(unittest.TestCase):
                                              channel_order=channel_order) \
                         .create_source(tmp_dir=None)
 
-        out_chip = source.get_raw_image_array()
-        self.assertEqual(out_chip.shape[2], 3)
+        with source.activate():
+            out_chip = source.get_raw_image_array()
+            self.assertEqual(out_chip.shape[2], 3)
 
     def test_gets_raw_chip_from_proto(self):
         img_path = data_file_path('small-rgb-tile.tif')
@@ -71,8 +72,9 @@ class TestGeoTiffSource(unittest.TestCase):
         source = rv.RasterSourceConfig.from_proto(msg) \
                                       .create_source(tmp_dir=None)
 
-        out_chip = source.get_raw_image_array()
-        self.assertEqual(out_chip.shape[2], 3)
+        with source.activate():
+            out_chip = source.get_raw_image_array()
+            self.assertEqual(out_chip.shape[2], 3)
 
     def test_uses_channel_order(self):
         with RVConfig.get_tmp_dir() as tmp_dir:
@@ -87,11 +89,12 @@ class TestGeoTiffSource(unittest.TestCase):
                                           .with_channel_order(channel_order) \
                                           .build() \
                                           .create_source(tmp_dir=tmp_dir)
-
-            out_chip = source.get_image_array()
-            expected_out_chip = np.ones((2, 2, 3)).astype(np.uint8)
-            expected_out_chip[:, :, :] *= np.array([0, 1, 2]).astype(np.uint8)
-            np.testing.assert_equal(out_chip, expected_out_chip)
+            with source.activate():
+                out_chip = source.get_image_array()
+                expected_out_chip = np.ones((2, 2, 3)).astype(np.uint8)
+                expected_out_chip[:, :, :] *= np.array([0, 1,
+                                                        2]).astype(np.uint8)
+                np.testing.assert_equal(out_chip, expected_out_chip)
 
     def test_with_stats_transformer(self):
         config = rv.RasterSourceConfig.builder(rv.GEOTIFF_SOURCE) \

--- a/tests/data/raster_source/test_image_source.py
+++ b/tests/data/raster_source/test_image_source.py
@@ -38,9 +38,10 @@ class TestImageSource(unittest.TestCase):
                                           .build() \
                                           .create_source(tmp_dir)
 
-            out_chip = source.get_image_array()
-            expected_out_chip = np.ones((2, 2, 3)) * 170
-            np.testing.assert_equal(out_chip, expected_out_chip)
+            with source.activate():
+                out_chip = source.get_image_array()
+                expected_out_chip = np.ones((2, 2, 3)) * 170
+                np.testing.assert_equal(out_chip, expected_out_chip)
 
     def test_missing_config_uri(self):
         with self.assertRaises(rv.ConfigError):

--- a/tests/data/test_activate_mixin.py
+++ b/tests/data/test_activate_mixin.py
@@ -1,0 +1,54 @@
+import unittest
+
+from rastervision.data import (ActivateMixin, ActivationError)
+
+
+class TestActivateMixin(unittest.TestCase):
+    class Foo(ActivateMixin):
+        def __init__(self):
+            self.activated = False
+
+        def _activate(self):
+            self.activated = True
+
+        def _deactivate(self):
+            self.activated = False
+
+    class Bar(ActivateMixin):
+        def __init__(self):
+            self.activated = False
+            self.foo = TestActivateMixin.Foo()
+
+        def _activate(self):
+            self.activated = True
+
+        def _deactivate(self):
+            self.activated = False
+
+        def _subcomponents_to_activate(self):
+            return [self.foo]
+
+    def test_activates_and_deactivates(self):
+        foo = TestActivateMixin.Foo()
+        self.assertFalse(foo.activated)
+        with foo.activate():
+            self.assertTrue(foo.activated)
+        self.assertFalse(foo.activated)
+
+    def test_activated_and_deactivates_subcomponents(self):
+        bar = TestActivateMixin.Bar()
+        self.assertFalse(bar.activated)
+        self.assertFalse(bar.foo.activated)
+        with bar.activate():
+            self.assertTrue(bar.activated)
+            self.assertTrue(bar.foo.activated)
+        self.assertFalse(bar.activated)
+        self.assertFalse(bar.foo.activated)
+
+    def test_no_activate_twice(self):
+        bar = TestActivateMixin.Bar()
+        with self.assertRaises(ActivationError):
+            with bar.activate():
+                with bar.activate():
+                    pass
+        self.assertFalse(bar.activated)

--- a/tests/task/test_chip_classification.py
+++ b/tests/task/test_chip_classification.py
@@ -47,7 +47,9 @@ class TestChipClassification(unittest.TestCase):
             scene = s.create_scene(task_config, tmp_dir)
             backend = backend_config.create_backend(task_config)
             task = task_config.create_task(backend)
-            windows = task.get_train_windows(scene)
+
+            with scene.activate():
+                windows = task.get_train_windows(scene)
 
             from rastervision.data import (ChipClassificationLabels,
                                            ChipClassificationGeoJSONStore)


### PR DESCRIPTION
## Overview

This  PR implements  an 'activation' architecture that allows for scene components to be opened and closed as needed. This  change arises from seeing "Too many files open" errors when dealing with a large number of files - the way the code works currently is that files (like the GeoTIFFs of a raster source) remain open for the duration of the lifetime of the entity. This uses  context managers to allow  code control over when things are opened and closed.

### Notes

One thing I was hoping would work out is to put off downloading until the raster source was activated. We need information from the raster up front (like it's crs transform and how many channels), and trying to do that through VSI functionality seemed like a secondary change.

