### PR TITLE
Add CHANGELOG to docs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,15 @@
+CHANGELOG
+=========
+
+Raster Vision 0.8
+-----------------
+
+Raster Vision 0.8.1
+~~~~~~~~~~~~~~~~~~~
+
+Bug Fixes
+^^^^^^^^^
+- Allow multiploygon for chip classification `#523 <https://github.com/azavea/raster-vision/pull/523>`_
+- Remove unused args for AWS Batch runner `#503 <https://github.com/azavea/raster-vision/pull/503>`_
+- Skip over lines when doing chip classification, Use background_class_id for scenes with no polygons `#507 <https://github.com/azavea/raster-vision/pull/507>`_
+- Fix issue where ``get_matching_s3_keys`` fails when ``suffix`` is ``None`` `#497 <https://github.com/azavea/raster-vision/pull/497>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,7 @@ html_context = {
         ProjectLink('QGIS Plugin', 'https://github.com/azavea/raster-vision-qgis'),
         ProjectLink('AWS Batch Setup', 'https://github.com/azavea/raster-vision-aws'),
         ProjectLink('Issue Tracker', 'https://github.com/azavea/raster-vision/issues/'),
+        ProjectLink('CHANGELOG', 'changelog.html'),
         ProjectLink('Azavea', 'https://www.azavea.com/'),
     ],
     'css_files': [

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -165,3 +165,11 @@ method, this part of the documentation is for you.
    :maxdepth: 10
 
    api
+
+CHANGELOG
+---------
+
+.. toctree::
+   :maxdepth: 3
+
+   changelog


### PR DESCRIPTION
This PR adds a CHANGELOG to the documentation.

This changelog should be added to whenever there is a new bug fix or feature added to Raster Vision, so that we can keep track of what versions have what features and inform users of what is contained in new releases.

Fixes #525 