### PR TITLE
[wip] miscellaneous changes to config builders

### DIFF
--- a/rastervision/task/semantic_segmentation_config.py
+++ b/rastervision/task/semantic_segmentation_config.py
@@ -88,24 +88,23 @@ class SemanticSegmentationConfigBuilder(TaskConfigBuilder):
 
     def from_proto(self, msg):
         conf = msg.semantic_segmentation_config
-        b = SemanticSegmentationConfigBuilder()
 
         negative_survival_probability = conf.chip_options \
                                             .negative_survival_probability
 
-        return b.with_classes(list(conf.class_items)) \
-                .with_predict_batch_size(msg.predict_batch_size) \
-                .with_predict_package_uri(msg.predict_package_uri) \
-                .with_debug(msg.debug) \
-                .with_chip_size(conf.chip_size) \
-                .with_chip_options(
-                    window_method=conf.chip_options.window_method,
-                    target_classes=conf.chip_options.target_classes,
-                    debug_chip_probability=conf.chip_options.debug_chip_probability,
-                    negative_survival_probability=negative_survival_probability,
-                    chips_per_scene=conf.chip_options.chips_per_scene,
-                    target_count_threshold=conf.chip_options.target_count_threshold,
-                    stride=conf.chip_options.stride)
+        return self.with_classes(list(conf.class_items)) \
+            .with_predict_batch_size(msg.predict_batch_size) \
+            .with_predict_package_uri(msg.predict_package_uri) \
+            .with_debug(msg.debug) \
+            .with_chip_size(conf.chip_size) \
+            .with_chip_options(
+            window_method=conf.chip_options.window_method,
+            target_classes=conf.chip_options.target_classes,
+            debug_chip_probability=conf.chip_options.debug_chip_probability,
+            negative_survival_probability=negative_survival_probability,
+            chips_per_scene=conf.chip_options.chips_per_scene,
+            target_count_threshold=conf.chip_options.target_count_threshold,
+            stride=conf.chip_options.stride)
 
     def with_classes(
             self, classes: Union[ClassMap, List[str], List[ClassItemMsg], List[


### PR DESCRIPTION
## Overview

Use `self` in `from_proto()` method rather than instantiating a new TaskConfigBuilder subclass.

### Checklist

- [x ] Ran scripts/format_code and commited any changes
- [ ] Documentation updated if needed
- [ ] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* Run integration tests

Closes #537 
