### PR TITLE
Wrap `sync_to_dir` in Loop

### DIFF
--- a/rastervision/utils/files.py
+++ b/rastervision/utils/files.py
@@ -1,9 +1,8 @@
 import os
 import shutil
+from threading import Timer
 import time
 import logging
-
-from threading import Timer
 
 from google.protobuf import json_format
 

--- a/rastervision/utils/files.py
+++ b/rastervision/utils/files.py
@@ -1,7 +1,9 @@
 import os
 import shutil
-from threading import Timer
+import time
 import logging
+
+from threading import Timer
 
 from google.protobuf import json_format
 
@@ -87,12 +89,14 @@ def start_sync(src_dir_uri, dest_dir_uri, sync_interval=600,
     """
 
     def _sync_dir():
-        log.info('Syncing {} to {}...'.format(src_dir_uri, dest_dir_uri))
-        sync_to_dir(src_dir_uri, dest_dir_uri, delete=False, fs=fs)
+        while True:
+            time.sleep(sync_interval)
+            log.info('Syncing {} to {}...'.format(src_dir_uri, dest_dir_uri))
+            sync_to_dir(src_dir_uri, dest_dir_uri, delete=False, fs=fs)
 
     class SyncThread:
         def __init__(self):
-            thread = Timer(sync_interval, _sync_dir)
+            thread = Timer(0.68, _sync_dir)
             thread.daemon = True
             thread.start()
             self.thread = thread

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flake8==3.5.*
-moto==1.3.*
+moto<=1.3.6
 coverage==4.5.1
 codecov==2.0.15
 yapf==0.22.*


### PR DESCRIPTION
## Overview

This gives `start_sync` the correct behavior.

Note that there is still a `threading.Timer` in there instead of a `threading.Thread`.  The reason is that the latter does not have a `__cancel__` method which prevents it from (I believe) interacting well with the `with` keyword.

Note that the previous implementation seems to have never worked.  Please see the discussion [here](https://stackoverflow.com/questions/3393612/run-certain-code-every-n-seconds).  This can be further proven by typing the following into a python shell:

## Further Proof ##

Play with variations of this code in a Python interpreter:

```python
import threading

def hello():
     print("hello")

t = threading.Timer(1, hello)
t.daemon = True
t.start()
```

with the number of seconds given to `Timer` either `1` or `1000` and with the `t.daemon = True` line either absent or present.  Give a ctrl-D to the REPL 10 seconds after `t.start()` and observe the results. 
 The collective results will imply that `Timer` runs the code once and only once and there is no thread that persists after the first run.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes https://github.com/azavea/raster-vision/issues/508