### PR TITLE
Refactor commands to take in configs instead of entities. Also Mocks.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+Raster Vision 0.9
+-----------------
+
+Raster Vision 0.9.0
+~~~~~~~~~~~~~~~~~~~
+
+- Remove custom ``__deepcopy__`` implementation from ``ConfiBuilder``s. `#567 <https://github.com/azavea/raster-vision/pull/567>`_
+
+
 Raster Vision 0.8
 -----------------
 

--- a/rastervision/backend/tf_deeplab.py
+++ b/rastervision/backend/tf_deeplab.py
@@ -651,7 +651,7 @@ class TFDeeplab(Backend):
             self.sess = tf.Session(graph=graph)
 
     def predict(self, chips: np.ndarray, windows: List[Box],
-                tmp_dir: str) -> List[Tuple[Box, np.ndarray]]:
+                tmp_dir: str) -> SemanticSegmentationLabels:
         """Predict using an already-trained DeepLab model.
 
         Args:

--- a/rastervision/command/analyze_command.py
+++ b/rastervision/command/analyze_command.py
@@ -4,15 +4,21 @@ from rastervision.command import Command
 
 
 class AnalyzeCommand(Command):
-    def __init__(self, scenes, analyzers):
-        self.scenes = scenes
-        self.analyzers = analyzers
+    def __init__(self, command_config):
+        self.command_config = command_config
 
     def run(self, tmp_dir=None):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
-        for analyzer in self.analyzers:
+
+        cc = self.command_config
+
+        analyzers = list(map(lambda a: a.create_analyzer(), cc.analyzers))
+        scenes = list(
+            map(lambda s: s.create_scene(cc.task, tmp_dir), cc.scenes))
+
+        for analyzer in analyzers:
             msg = 'Running analyzer: {}...'.format(type(analyzer).__name__)
             click.echo(click.style(msg, fg='green'))
 
-            analyzer.process(self.scenes, tmp_dir)
+            analyzer.process(scenes, tmp_dir)

--- a/rastervision/command/analyze_command_config.py
+++ b/rastervision/command/analyze_command_config.py
@@ -5,7 +5,6 @@ from rastervision.command import (AnalyzeCommand, CommandConfig,
                                   CommandConfigBuilder, NoOpCommand)
 from rastervision.protos.command_pb2 \
     import CommandConfig as CommandConfigMsg
-from rastervision.rv_config import RVConfig
 
 
 class AnalyzeCommandConfig(CommandConfig):
@@ -19,17 +18,8 @@ class AnalyzeCommandConfig(CommandConfig):
         if len(self.scenes) == 0 or len(self.analyzers) == 0:
             return NoOpCommand()
 
-        if not tmp_dir:
-            _tmp_dir = RVConfig.get_tmp_dir()
-            tmp_dir = _tmp_dir.name
-        else:
-            _tmp_dir = tmp_dir
-
-        scenes = list(
-            map(lambda s: s.create_scene(self.task, tmp_dir), self.scenes))
-        analyzers = list(map(lambda a: a.create_analyzer(), self.analyzers))
-        retval = AnalyzeCommand(scenes, analyzers)
-        retval.set_tmp_dir(_tmp_dir)
+        retval = AnalyzeCommand(self)
+        retval.set_tmp_dir(tmp_dir)
         return retval
 
     def to_proto(self):

--- a/rastervision/command/bundle_command.py
+++ b/rastervision/command/bundle_command.py
@@ -14,51 +14,48 @@ log = logging.getLogger(__name__)
 class BundleCommand(Command):
     """Bundles all the necessary files together into a prediction package."""
 
-    def __init__(self, bundle_config, task_config, backend_config,
-                 scene_config, analyzer_configs):
-        self.bundle_config = bundle_config
-        self.task_config = task_config
-        self.backend_config = backend_config
-        self.scene_config = scene_config
-        self.analyzer_configs = analyzer_configs
+    def __init__(self, command_config):
+        self.command_config = command_config
 
     def run(self, tmp_dir=None):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
-        if not self.task_config.predict_package_uri:
+
+        cc = self.command_config
+
+        if not cc.task.predict_package_uri:
             msg = 'Skipping bundling of prediction package, no URI is set...'.format(
-                self.task_config.predict_package_uri)
+                cc.task.predict_package_uri)
             click.echo(click.style(msg, fg='yellow'))
             return
 
         msg = 'Bundling prediction package to {}...'.format(
-            self.task_config.predict_package_uri)
+            cc.task.predict_package_uri)
         log.info(msg)
+
         bundle_dir = os.path.join(tmp_dir, 'bundle')
         make_dir(bundle_dir)
         package_path = os.path.join(tmp_dir, 'predict_package.zip')
         bundle_files = []
-        new_task, task_files = self.task_config.save_bundle_files(bundle_dir)
+        new_task, task_files = cc.task.save_bundle_files(bundle_dir)
         bundle_files.extend(task_files)
-        new_backend, backend_files = self.backend_config.save_bundle_files(
-            bundle_dir)
+        new_backend, backend_files = cc.backend.save_bundle_files(bundle_dir)
         bundle_files.extend(backend_files)
-        new_scene, scene_files = self.scene_config.save_bundle_files(
-            bundle_dir)
+        new_scene, scene_files = cc.scene.save_bundle_files(bundle_dir)
         bundle_files.extend(scene_files)
         new_analyzers = []
-        for analyzer in self.analyzer_configs:
+        for analyzer in cc.analyzers:
             new_analyzer, analyzer_files = analyzer.save_bundle_files(
                 bundle_dir)
             new_analyzers.append(new_analyzer)
             bundle_files.extend(analyzer_files)
 
-        new_bundle_config = self.bundle_config.to_builder() \
-                                              .with_task(new_task) \
-                                              .with_backend(new_backend) \
-                                              .with_scene(new_scene) \
-                                              .with_analyzers(new_analyzers) \
-                                              .build()
+        new_bundle_config = cc.to_builder() \
+                              .with_task(new_task) \
+                              .with_backend(new_backend) \
+                              .with_scene(new_scene) \
+                              .with_analyzers(new_analyzers) \
+                              .build()
 
         # Save bundle command config
         bundle_config_path = os.path.join(tmp_dir, 'bundle_config.json')
@@ -73,4 +70,4 @@ class BundleCommand(Command):
                 bundle_config_path,
                 arcname=os.path.basename(bundle_config_path))
 
-        upload_or_copy(package_path, self.task_config.predict_package_uri)
+        upload_or_copy(package_path, cc.task.predict_package_uri)

--- a/rastervision/command/bundle_command_config.py
+++ b/rastervision/command/bundle_command_config.py
@@ -23,8 +23,7 @@ class BundleCommandConfig(CommandConfig):
         else:
             _tmp_dir = tmp_dir
 
-        retval = BundleCommand(self, self.task, self.backend, self.scene,
-                               self.analyzers)
+        retval = BundleCommand(self)
         retval.set_tmp_dir(_tmp_dir)
         return retval
 

--- a/rastervision/command/chip_command.py
+++ b/rastervision/command/chip_command.py
@@ -4,11 +4,8 @@ from rastervision.command import Command
 
 
 class ChipCommand(Command):
-    def __init__(self, task, augmentors, train_scenes, val_scenes):
-        self.task = task
-        self.augmentors = augmentors
-        self.train_scenes = train_scenes
-        self.val_scenes = val_scenes
+    def __init__(self, command_config):
+        self.command_config = command_config
 
     def run(self, tmp_dir=None):
         if not tmp_dir:
@@ -16,5 +13,17 @@ class ChipCommand(Command):
         msg = 'Making training chips...'
         click.echo(click.style(msg, fg='green'))
 
-        self.task.make_chips(self.train_scenes, self.val_scenes,
-                             self.augmentors, tmp_dir)
+        cc = self.command_config
+
+        backend = cc.backend.create_backend(cc.task)
+        task = cc.task.create_task(backend)
+
+        train_scenes = list(
+            map(lambda s: s.create_scene(cc.task, tmp_dir), cc.train_scenes))
+
+        val_scenes = list(
+            map(lambda s: s.create_scene(cc.task, tmp_dir), cc.val_scenes))
+
+        augmentors = list(map(lambda a: a.create_augmentor(), cc.augmentors))
+
+        task.make_chips(train_scenes, val_scenes, augmentors, tmp_dir)

--- a/rastervision/command/chip_command_config.py
+++ b/rastervision/command/chip_command_config.py
@@ -22,24 +22,13 @@ class ChipCommandConfig(CommandConfig):
         if len(self.train_scenes) == 0 and len(self.val_scenes) == 0:
             return NoOpCommand()
 
-        backend = self.backend.create_backend(self.task)
-        task = self.task.create_task(backend)
-
-        augmentors = list(map(lambda a: a.create_augmentor(), self.augmentors))
-
         if not tmp_dir:
             _tmp_dir = RVConfig.get_tmp_dir()
             tmp_dir = _tmp_dir.name
         else:
             _tmp_dir = tmp_dir
 
-        train_scenes = list(
-            map(lambda s: s.create_scene(self.task, tmp_dir),
-                self.train_scenes))
-        val_scenes = list(
-            map(lambda s: s.create_scene(self.task, tmp_dir), self.val_scenes))
-
-        retval = ChipCommand(task, augmentors, train_scenes, val_scenes)
+        retval = ChipCommand(self)
         retval.set_tmp_dir(_tmp_dir)
         return retval
 

--- a/rastervision/command/eval_command.py
+++ b/rastervision/command/eval_command.py
@@ -4,15 +4,21 @@ from rastervision.command import Command
 
 
 class EvalCommand(Command):
-    def __init__(self, scenes, evaluators):
-        self.scenes = scenes
-        self.evaluators = evaluators
+    def __init__(self, command_config):
+        self.command_config = command_config
 
     def run(self, tmp_dir=None):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
-        for evaluator in self.evaluators:
+
+        cc = self.command_config
+
+        scenes = list(
+            map(lambda s: s.create_scene(cc.task, tmp_dir), cc.scenes))
+        evaluators = list(map(lambda a: a.create_evaluator(), cc.evaluators))
+
+        for evaluator in evaluators:
             msg = 'Running evaluator: {}...'.format(type(evaluator).__name__)
             click.echo(click.style(msg, fg='green'))
 
-            evaluator.process(self.scenes, tmp_dir)
+            evaluator.process(scenes, tmp_dir)

--- a/rastervision/command/eval_command_config.py
+++ b/rastervision/command/eval_command_config.py
@@ -25,10 +25,7 @@ class EvalCommandConfig(CommandConfig):
         else:
             _tmp_dir = tmp_dir
 
-        scenes = list(
-            map(lambda s: s.create_scene(self.task, tmp_dir), self.scenes))
-        evaluators = list(map(lambda a: a.create_evaluator(), self.evaluators))
-        retval = EvalCommand(scenes, evaluators)
+        retval = EvalCommand(self)
         retval.set_tmp_dir(_tmp_dir)
         return retval
 

--- a/rastervision/command/predict_command.py
+++ b/rastervision/command/predict_command.py
@@ -4,13 +4,21 @@ from rastervision.command import Command
 
 
 class PredictCommand(Command):
-    def __init__(self, task, scenes):
-        self.task = task
-        self.scenes = scenes
+    def __init__(self, command_config):
+        self.command_config = command_config
 
     def run(self, tmp_dir=None):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
         msg = 'Making predictions...'
+
+        cc = self.command_config
+
+        backend = cc.backend.create_backend(cc.task)
+        task = cc.task.create_task(backend)
+
+        scenes = list(
+            map(lambda s: s.create_scene(cc.task, tmp_dir), cc.scenes))
+
         click.echo(click.style(msg, fg='green'))
-        self.task.predict(self.scenes, tmp_dir)
+        task.predict(scenes, tmp_dir)

--- a/rastervision/command/predict_command_config.py
+++ b/rastervision/command/predict_command_config.py
@@ -25,12 +25,7 @@ class PredictCommandConfig(CommandConfig):
         else:
             _tmp_dir = tmp_dir
 
-        backend = self.backend.create_backend(self.task)
-        task = self.task.create_task(backend)
-
-        scenes = list(
-            map(lambda s: s.create_scene(self.task, tmp_dir), self.scenes))
-        retval = PredictCommand(task, scenes)
+        retval = PredictCommand(self)
         retval.set_tmp_dir(_tmp_dir)
         return retval
 

--- a/rastervision/command/train_command.py
+++ b/rastervision/command/train_command.py
@@ -4,8 +4,8 @@ from rastervision.command import Command
 
 
 class TrainCommand(Command):
-    def __init__(self, task):
-        self.task = task
+    def __init__(self, command_config):
+        self.command_config = command_config
 
     def run(self, tmp_dir=None):
         if not tmp_dir:
@@ -13,4 +13,9 @@ class TrainCommand(Command):
         msg = 'Training model...'
         click.echo(click.style(msg, fg='green'))
 
-        self.task.train(tmp_dir)
+        cc = self.command_config
+
+        backend = cc.backend.create_backend(cc.task)
+        task = cc.task.create_task(backend)
+
+        task.train(tmp_dir)

--- a/rastervision/command/train_command_config.py
+++ b/rastervision/command/train_command_config.py
@@ -21,9 +21,7 @@ class TrainCommandConfig(CommandConfig):
         else:
             _tmp_dir = tmp_dir
 
-        backend = self.backend.create_backend(self.task)
-        task = self.task.create_task(backend)
-        retval = TrainCommand(task)
+        retval = TrainCommand(self)
         retval.set_tmp_dir(_tmp_dir)
         return retval
 

--- a/rastervision/core/config.py
+++ b/rastervision/core/config.py
@@ -1,6 +1,5 @@
 from abc import (ABC, abstractmethod)
 import os
-import pickle
 
 from rastervision.utils.files import download_or_copy
 
@@ -106,11 +105,6 @@ class ConfigBuilder(ABC):
         """
         pass  # pragma: no cover
 
-    def __deepcopy__(self, memodict={}):
-        """Custom deep copy that uses pickle instead of default behavior,
-        since default behavior can be extremely slow for large lists and objects"""
-        return pickle.loads(pickle.dumps(self, -1))
-
 
 class BundledConfigMixin(ABC):
     """Mixin for configurations that participate in the bundling of a
@@ -136,8 +130,3 @@ class BundledConfigMixin(ABC):
     def load_bundle_files(self, bundle_dir):
         """Load files from a prediction package bundle directory."""
         pass  # pragma: no cover
-
-    def __deepcopy__(self, memodict={}):
-        """Custom deep copy that uses pickle instead of default behavior,
-        since default behavior can be extremely slow for large lists and objects"""
-        return pickle.loads(pickle.dumps(self, -1))

--- a/rastervision/core/training_data.py
+++ b/rastervision/core/training_data.py
@@ -30,7 +30,8 @@ class TrainingData(object):
 
         This maintains the correspondence between chips and labels.
         """
-        chip_windows_labels = list(self)
-        random.shuffle(chip_windows_labels)
-        # Unzip the list.
-        self.chips, self.windows, self.labels = zip(*chip_windows_labels)
+        if len(self.chips) > 0:
+            chip_windows_labels = list(self)
+            random.shuffle(chip_windows_labels)
+            # Unzip the list.
+            self.chips, self.windows, self.labels = zip(*chip_windows_labels)

--- a/tests/command/test_analyze_command.py
+++ b/tests/command/test_analyze_command.py
@@ -3,8 +3,10 @@ import unittest
 import rastervision as rv
 from rastervision.rv_config import RVConfig
 
+import tests.mock as mk
 
-class TestAnalyzeCommand(unittest.TestCase):
+
+class TestAnalyzeCommand(mk.MockMixin, unittest.TestCase):
     def test_command_create(self):
         with RVConfig.get_tmp_dir() as tmp_dir:
             cmd = rv.command.AnalyzeCommandConfig.builder() \
@@ -48,6 +50,23 @@ class TestAnalyzeCommand(unittest.TestCase):
                                            .with_task('') \
                                            .with_scenes('') \
                                            .build()
+
+    def test_command_run_with_mocks(self):
+        task = rv.TaskConfig.builder(mk.MOCK_TASK).build()
+        scene = mk.create_mock_scene()
+        analyzer_config = rv.AnalyzerConfig.builder(mk.MOCK_ANALYZER).build()
+        analyzer = analyzer_config.create_analyzer()
+        analyzer_config.mock.create_analyzer.return_value = analyzer
+        cmd = rv.command.AnalyzeCommandConfig.builder() \
+                                             .with_task(task) \
+                                             .with_scenes([scene]) \
+                                             .with_root_uri('.') \
+                                             .with_analyzers([analyzer_config]) \
+                                             .build() \
+                                             .create_command()
+        cmd.run()
+
+        self.assertTrue(analyzer.mock.process.called)
 
 
 if __name__ == '__main__':

--- a/tests/command/test_eval_command.py
+++ b/tests/command/test_eval_command.py
@@ -3,8 +3,10 @@ import unittest
 import rastervision as rv
 from rastervision.rv_config import RVConfig
 
+import tests.mock as mk
 
-class TestEvalCommand(unittest.TestCase):
+
+class TestEvalCommand(mk.MockMixin, unittest.TestCase):
     def test_command_create(self):
         with RVConfig.get_tmp_dir() as tmp_dir:
             cmd = rv.command.EvalCommandConfig.builder() \
@@ -48,6 +50,25 @@ class TestEvalCommand(unittest.TestCase):
                                             .build()
         except rv.ConfigError:
             self.fail('rv.ConfigError raised unexpectedly')
+
+    def test_command_run_with_mocks(self):
+        task_config = rv.TaskConfig.builder(mk.MOCK_TASK).build()
+        scene = mk.create_mock_scene()
+        evaluator_config = rv.EvaluatorConfig.builder(
+            mk.MOCK_EVALUATOR).build()
+        evaluator = evaluator_config.create_evaluator()
+        evaluator_config.mock.create_evaluator.return_value = evaluator
+
+        cmd = rv.command.EvalCommandConfig.builder() \
+                                          .with_task(task_config) \
+                                          .with_scenes([scene]) \
+                                          .with_evaluators([evaluator_config]) \
+                                          .with_root_uri('.') \
+                                          .build() \
+                                          .create_command()
+        cmd.run()
+
+        self.assertTrue(evaluator.mock.process.called)
 
 
 if __name__ == '__main__':

--- a/tests/command/test_train_command.py
+++ b/tests/command/test_train_command.py
@@ -3,8 +3,10 @@ import unittest
 import rastervision as rv
 from rastervision.rv_config import RVConfig
 
+import tests.mock as mk
 
-class TrainCommand(unittest.TestCase):
+
+class TrainCommand(mk.MockMixin, unittest.TestCase):
     def test_missing_config_task(self):
         with self.assertRaises(rv.ConfigError):
             rv.command.TrainCommandConfig.builder() \
@@ -27,6 +29,22 @@ class TrainCommand(unittest.TestCase):
                                              .build()
         except rv.ConfigError:
             self.fail('rv.ConfigError raised unexpectedly')
+
+    def test_command_run_with_mocks(self):
+        task_config = rv.TaskConfig.builder(mk.MOCK_TASK).build()
+        backend_config = rv.BackendConfig.builder(mk.MOCK_BACKEND).build()
+        backend = backend_config.create_backend(task_config)
+        backend_config.mock.create_backend.return_value = backend
+
+        cmd = rv.command.TrainCommandConfig.builder() \
+                                          .with_task(task_config) \
+                                          .with_backend(backend_config) \
+                                          .with_root_uri('.') \
+                                          .build() \
+                                          .create_command()
+        cmd.run()
+
+        self.assertTrue(backend.mock.train.called)
 
 
 if __name__ == '__main__':

--- a/tests/data-files/plugins/noop_backend.py
+++ b/tests/data-files/plugins/noop_backend.py
@@ -55,9 +55,8 @@ class NoopBackendConfigBuilder(BackendConfigBuilder):
     def __init__(self, prev=None):
         super().__init__(NOOP_BACKEND, NoopBackendConfig, {})
 
-    @staticmethod
-    def from_proto(msg):
-        return NoopBackendConfigBuilder()
+    def from_proto(self, msg):
+        return self
 
     def _applicable_tasks(self):
         return [NOOP_TASK]

--- a/tests/data-files/plugins/noop_label_store.py
+++ b/tests/data-files/plugins/noop_label_store.py
@@ -28,7 +28,7 @@ class NoopLabelStoreConfig(LabelStoreConfig):
         msg.MergeFrom(LabelStoreConfigMsg(custom_config={}))
         return msg
 
-    def create_store(self, task_config, crs_transformer, tmp_dir):
+    def create_store(self, task_config, extent, crs_transformer, tmp_dir):
         return NoopLabelStore()
 
     def update_for_command(self,

--- a/tests/data-files/plugins/noop_raster_transformer.py
+++ b/tests/data-files/plugins/noop_raster_transformer.py
@@ -20,8 +20,12 @@ class NoopRasterTransformerConfig(RasterTransformerConfig):
     def create_transformer(self):
         return NoopTransformer()
 
-    def update_for_command(self, command_type, experiment_config, context=[]):
-        return (self, rv.core.CommandIODefinition())
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        return io_def or rv.core.CommandIODefinition()
 
     def save_bundle_files(self, bundle_dir):
         return (self, [])

--- a/tests/data-files/plugins/noop_task.py
+++ b/tests/data-files/plugins/noop_task.py
@@ -53,9 +53,8 @@ class NoopTaskConfigBuilder(TaskConfigBuilder):
     def __init__(self, prev=None):
         super().__init__(NoopTaskConfig, {})
 
-    @staticmethod
-    def from_proto(msg):
-        return NoopTaskConfigBuilder()
+    def from_proto(self, msg):
+        return self
 
 
 def register_plugin(plugin_registry):

--- a/tests/mock/__init__.py
+++ b/tests/mock/__init__.py
@@ -1,4 +1,12 @@
-from unittest.mock import Mock
+# flake8: noqa
+
+
+class SupressDeepCopyMixin:
+    """Supress deep copy in mock objects, since we want to check mocks after processing."""
+
+    def __deepcopy__(self, memodict={}):
+        return self
+
 
 from tests.mock.task import *
 from tests.mock.backend import *
@@ -10,7 +18,8 @@ from tests.mock.augmentor import *
 from tests.mock.analyzer import *
 from tests.mock.evaluator import *
 
-class MockMixin():
+
+class MockMixin:
     def setUp(self):
         config = {'PLUGINS_modules': '["{}"]'.format(__name__)}
         rv._registry.initialize_config(config_overrides=config)
@@ -19,6 +28,7 @@ class MockMixin():
     def tearDown(self):
         rv._registry.initialize_config()
         super().tearDown()
+
 
 def create_mock_scene():
     raster_transformer_config = rv.RasterTransformerConfig.builder(MOCK_TRANSFORMER) \
@@ -35,7 +45,7 @@ def create_mock_scene():
                                                 .build()
 
     return rv.SceneConfig.builder() \
-                         .with_id("test") \
+                         .with_id('test') \
                          .with_raster_source(raster_source_config) \
                          .with_label_source(label_source_config) \
                          .with_label_store(label_store_config) \
@@ -53,8 +63,9 @@ def register_plugin(plugin_registry):
                                             MockLabelSourceConfigBuilder)
     plugin_registry.register_config_builder(rv.LABEL_STORE, MOCK_STORE,
                                             MockLabelStoreConfigBuilder)
-    plugin_registry.register_config_builder(rv.RASTER_TRANSFORMER, MOCK_TRANSFORMER,
-                                            MockRasterTransformerConfigBuilder)
+    plugin_registry.register_config_builder(
+        rv.RASTER_TRANSFORMER, MOCK_TRANSFORMER,
+        MockRasterTransformerConfigBuilder)
     plugin_registry.register_config_builder(rv.AUGMENTOR, MOCK_AUGMENTOR,
                                             MockAugmentorConfigBuilder)
     plugin_registry.register_config_builder(rv.ANALYZER, MOCK_ANALYZER,

--- a/tests/mock/__init__.py
+++ b/tests/mock/__init__.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock
+
+from tests.mock.task import *
+from tests.mock.backend import *
+from tests.mock.raster_source import *
+from tests.mock.label_source import *
+from tests.mock.label_store import *
+from tests.mock.raster_transformer import *
+from tests.mock.augmentor import *
+from tests.mock.analyzer import *
+from tests.mock.evaluator import *
+
+class MockMixin():
+    def setUp(self):
+        config = {'PLUGINS_modules': '["{}"]'.format(__name__)}
+        rv._registry.initialize_config(config_overrides=config)
+        super().setUp()
+
+    def tearDown(self):
+        rv._registry.initialize_config()
+        super().tearDown()
+
+def create_mock_scene():
+    raster_transformer_config = rv.RasterTransformerConfig.builder(MOCK_TRANSFORMER) \
+                                                          .build()
+
+    raster_source_config = rv.RasterSourceConfig.builder(MOCK_SOURCE) \
+                                                .with_transformer(raster_transformer_config) \
+                                                .build()
+
+    label_source_config = rv.LabelSourceConfig.builder(MOCK_SOURCE) \
+                                                .build()
+
+    label_store_config = rv.LabelStoreConfig.builder(MOCK_STORE) \
+                                                .build()
+
+    return rv.SceneConfig.builder() \
+                         .with_id("test") \
+                         .with_raster_source(raster_source_config) \
+                         .with_label_source(label_source_config) \
+                         .with_label_store(label_store_config) \
+                         .build()
+
+
+def register_plugin(plugin_registry):
+    plugin_registry.register_config_builder(rv.TASK, MOCK_TASK,
+                                            MockTaskConfigBuilder)
+    plugin_registry.register_config_builder(rv.BACKEND, MOCK_BACKEND,
+                                            MockBackendConfigBuilder)
+    plugin_registry.register_config_builder(rv.RASTER_SOURCE, MOCK_SOURCE,
+                                            MockRasterSourceConfigBuilder)
+    plugin_registry.register_config_builder(rv.LABEL_SOURCE, MOCK_SOURCE,
+                                            MockLabelSourceConfigBuilder)
+    plugin_registry.register_config_builder(rv.LABEL_STORE, MOCK_STORE,
+                                            MockLabelStoreConfigBuilder)
+    plugin_registry.register_config_builder(rv.RASTER_TRANSFORMER, MOCK_TRANSFORMER,
+                                            MockRasterTransformerConfigBuilder)
+    plugin_registry.register_config_builder(rv.AUGMENTOR, MOCK_AUGMENTOR,
+                                            MockAugmentorConfigBuilder)
+    plugin_registry.register_config_builder(rv.ANALYZER, MOCK_ANALYZER,
+                                            MockAnalyzerConfigBuilder)
+    plugin_registry.register_config_builder(rv.EVALUATOR, MOCK_EVALUATOR,
+                                            MockEvaluatorConfigBuilder)

--- a/tests/mock/analyzer.py
+++ b/tests/mock/analyzer.py
@@ -1,9 +1,12 @@
 from unittest.mock import Mock
 
+import rastervision as rv
 from rastervision.analyzer import (Analyzer, AnalyzerConfig,
                                    AnalyzerConfigBuilder)  # noqa
 from rastervision.protos.analyzer_pb2 \
     import AnalyzerConfig as AnalyzerConfigMsg # noqa
+
+from tests.mock import SupressDeepCopyMixin
 
 MOCK_ANALYZER = 'MOCK_ANALYZER'
 
@@ -16,7 +19,7 @@ class MockAnalyzer(Analyzer):
         self.mock.process(training_data, tmp_dir)
 
 
-class MockAnalyzerConfig(AnalyzerConfig):
+class MockAnalyzerConfig(SupressDeepCopyMixin, AnalyzerConfig):
     def __init__(self):
         super().__init__(MOCK_ANALYZER)
         self.mock = Mock()
@@ -46,7 +49,8 @@ class MockAnalyzerConfig(AnalyzerConfig):
                            experiment_config,
                            context=None,
                            io_def=None):
-        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        result = self.mock.update_for_command(command_type, experiment_config,
+                                              context, io_def)
         if result is None:
             return io_def or rv.core.CommandIODefinition()
         else:
@@ -59,7 +63,7 @@ class MockAnalyzerConfig(AnalyzerConfig):
         return self.mock.load_bundle_files(bundle_dir)
 
 
-class MockAnalyzerConfigBuilder(AnalyzerConfigBuilder):
+class MockAnalyzerConfigBuilder(SupressDeepCopyMixin, AnalyzerConfigBuilder):
     def __init__(self, prev=None):
         super().__init__(MockAnalyzerConfig, {})
         self.mock = Mock()

--- a/tests/mock/analyzer.py
+++ b/tests/mock/analyzer.py
@@ -1,0 +1,73 @@
+from unittest.mock import Mock
+
+from rastervision.analyzer import (Analyzer, AnalyzerConfig,
+                                   AnalyzerConfigBuilder)  # noqa
+from rastervision.protos.analyzer_pb2 \
+    import AnalyzerConfig as AnalyzerConfigMsg # noqa
+
+MOCK_ANALYZER = 'MOCK_ANALYZER'
+
+
+class MockAnalyzer(Analyzer):
+    def __init__(self):
+        self.mock = Mock()
+
+    def process(self, training_data, tmp_dir):
+        self.mock.process(training_data, tmp_dir)
+
+
+class MockAnalyzerConfig(AnalyzerConfig):
+    def __init__(self):
+        super().__init__(MOCK_ANALYZER)
+        self.mock = Mock()
+
+        self.mock.to_proto.return_value = None
+        self.mock.create_analyzer.return_value = None
+        self.mock.update_for_command.return_value = None
+        self.mock.save_bundle_files.return_value = (self, [])
+        self.mock.load_bundle_files.return_value = self
+
+    def to_proto(self):
+        result = self.mock.to_proto()
+        if result is None:
+            return AnalyzerConfigMsg(analyzer_type=self.analyzer_type)
+        else:
+            return result
+
+    def create_analyzer(self):
+        result = self.mock.create_analyzer()
+        if result is None:
+            return MockAnalyzer()
+        else:
+            return result
+
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        if result is None:
+            return io_def or rv.core.CommandIODefinition()
+        else:
+            return result
+
+    def save_bundle_files(self, bundle_dir):
+        return self.mock.save_bundle_files(bundle_dir)
+
+    def load_bundle_files(self, bundle_dir):
+        return self.mock.load_bundle_files(bundle_dir)
+
+
+class MockAnalyzerConfigBuilder(AnalyzerConfigBuilder):
+    def __init__(self, prev=None):
+        super().__init__(MockAnalyzerConfig, {})
+        self.mock = Mock()
+        self.mock.from_proto.return_value = None
+
+    def from_proto(self, msg):
+        result = self.mock.from_proto(msg)
+        if result is None:
+            return self
+        else:
+            return result

--- a/tests/mock/augmentor.py
+++ b/tests/mock/augmentor.py
@@ -5,6 +5,8 @@ from rastervision.augmentor import (Augmentor, AugmentorConfig,
                                     AugmentorConfigBuilder)
 from rastervision.protos.augmentor_pb2 import AugmentorConfig as AugmentorConfigMsg
 
+from tests.mock import SupressDeepCopyMixin
+
 MOCK_AUGMENTOR = 'MOCK_AUGMENTOR'
 
 
@@ -22,7 +24,7 @@ class MockAugmentor(Augmentor):
             return result
 
 
-class MockAugmentorConfig(AugmentorConfig):
+class MockAugmentorConfig(SupressDeepCopyMixin, AugmentorConfig):
     def __init__(self):
         super().__init__(MOCK_AUGMENTOR)
         self.mock = Mock()
@@ -51,14 +53,15 @@ class MockAugmentorConfig(AugmentorConfig):
                            experiment_config,
                            context=None,
                            io_def=None):
-        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        result = self.mock.update_for_command(command_type, experiment_config,
+                                              context, io_def)
         if result is None:
             return io_def or rv.core.CommandIODefinition()
         else:
             return result
 
 
-class MockAugmentorConfigBuilder(AugmentorConfigBuilder):
+class MockAugmentorConfigBuilder(SupressDeepCopyMixin, AugmentorConfigBuilder):
     def __init__(self, prev=None):
         super().__init__(MockAugmentorConfig, {})
         self.mock = Mock()

--- a/tests/mock/augmentor.py
+++ b/tests/mock/augmentor.py
@@ -1,0 +1,73 @@
+from unittest.mock import Mock
+
+import rastervision as rv
+from rastervision.augmentor import (Augmentor, AugmentorConfig,
+                                    AugmentorConfigBuilder)
+from rastervision.protos.augmentor_pb2 import AugmentorConfig as AugmentorConfigMsg
+
+MOCK_AUGMENTOR = 'MOCK_AUGMENTOR'
+
+
+class MockAugmentor(Augmentor):
+    def __init__(self):
+        self.mock = Mock()
+
+        self.mock.process.return_value = None
+
+    def process(self, training_data, tmp_dir):
+        result = self.mock.process(training_data, tmp_dir)
+        if result is None:
+            return training_data
+        else:
+            return result
+
+
+class MockAugmentorConfig(AugmentorConfig):
+    def __init__(self):
+        super().__init__(MOCK_AUGMENTOR)
+        self.mock = Mock()
+
+        self.mock.to_proto.return_value = None
+        self.mock.create_augmentor.return_value = None
+        self.mock.update_for_command.return_value = None
+
+    def to_proto(self):
+        result = self.mock.to_proto()
+        if result is None:
+            return AugmentorConfigMsg(
+                augmentor_type=self.augmentor_type, custom_config={})
+        else:
+            return result
+
+    def create_augmentor(self):
+        result = self.mock.create_augmentor()
+        if result is None:
+            return MockAugmentor()
+        else:
+            return result
+
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        if result is None:
+            return io_def or rv.core.CommandIODefinition()
+        else:
+            return result
+
+
+class MockAugmentorConfigBuilder(AugmentorConfigBuilder):
+    def __init__(self, prev=None):
+        super().__init__(MockAugmentorConfig, {})
+        self.mock = Mock()
+
+        self.mock.from_proto = None
+
+    def from_proto(self, msg):
+        result = self.mock.from_proto(msg)
+        if result is None:
+            return self
+        else:
+            return result

--- a/tests/mock/backend.py
+++ b/tests/mock/backend.py
@@ -1,0 +1,107 @@
+from unittest.mock import Mock
+
+import rastervision as rv
+from rastervision.backend import (Backend, BackendConfig, BackendConfigBuilder)
+from rastervision.protos.backend_pb2 import BackendConfig as BackendConfigMsg
+
+from .task import MOCK_TASK
+
+
+MOCK_BACKEND = 'MOCK_BACKEND'
+
+
+class MockBackend(Backend):
+    def __init__(self):
+        self.mock = Mock()
+
+        self.mock.predict.return_value = None
+
+    def process_scene_data(self, scene, data, tmp_dir):
+        return self.mock.process_scene_data(scene, data, tmp_dir)
+
+    def process_sceneset_results(self, training_results, validation_results,
+                                 tmp_dir):
+        return self.mock.process_sceneset_results(training_results, validation_results, tmp_dir)
+
+    def train(self, tmp_dir):
+        return self.mock.train(tmp_dir)
+
+    def load_model(self, tmp_dir):
+        return self.mock.load_model(tmp_dir)
+
+    def predict(self, chips, windows, tmp_dir):
+        result = self.mock.predict(chips, windows, tmp_dir)
+        if result is None:
+            return rv.data.ChipClassificationLabels()
+        else:
+            return result
+
+
+class MockBackendConfig(BackendConfig):
+    def __init__(self):
+        super().__init__(MOCK_BACKEND)
+        self.mock = Mock()
+
+        self.mock.to_proto.return_value = None
+        self.mock.create_backend.return_value = None
+        self.mock.update_for_command.return_value = None
+        self.mock.save_bundle_files.return_value = (self, [])
+        self.mock.load_bundle_files.return_value = self
+
+    def to_proto(self):
+        result = self.mock.to_proto()
+        if result is None:
+            return BackendConfigMsg(backend_type=self.backend_type, custom_config={})
+        else:
+            return result
+
+    def create_backend(self, task_config):
+        result = self.mock.create_backend(task_config)
+        if result is None:
+            return MockBackend()
+        else:
+            return result
+
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        if result is None:
+            return io_def or rv.core.CommandIODefinition()
+        else:
+            return result
+
+    def save_bundle_files(self, bundle_dir):
+        return self.mock.save_bundle_files(bundle_dir)
+
+    def load_bundle_files(self, bundle_dir):
+        return self.mock.load_bundle_files(bundle_dir)
+
+
+class MockBackendConfigBuilder(BackendConfigBuilder):
+    def __init__(self, prev=None):
+        super().__init__(MOCK_BACKEND, MockBackendConfig, {})
+        self.mock = Mock()
+
+        self.mock.from_proto.return_value = None
+        self.mock._applicable_tasks.return_value = None
+
+    @staticmethod
+    def from_proto(msg):
+        result = self.mock.from_proto(msg)
+        if result is None:
+            return NoopBackendConfigBuilder()
+        else:
+            return result
+
+    def _applicable_tasks(self):
+        result = self.mock._applicable_tasks
+        if result is None:
+            return [MOCK_TASK]
+        else:
+            return result
+
+    def _process_task(self, task):
+        self.mock._process_task(task)

--- a/tests/mock/evaluator.py
+++ b/tests/mock/evaluator.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock
+
+from rastervision.evaluation import (Evaluator, EvaluatorConfig,
+                                   EvaluatorConfigBuilder)
+from rastervision.protos.evaluator_pb2 \
+    import EvaluatorConfig as EvaluatorConfigMsg
+
+MOCK_EVALUATOR = 'MOCK_EVALUATOR'
+
+
+class MockEvaluator(Evaluator):
+    def __init__(self):
+        self.mock = Mock()
+
+    def process(self, scenes, tmp_dir):
+        self.mock.process(scenes, tmp_dir)
+
+
+class MockEvaluatorConfig(EvaluatorConfig):
+    def __init__(self):
+        super().__init__(MOCK_EVALUATOR)
+        self.mock = Mock()
+
+        self.mock.to_proto.return_value = None
+        self.mock.create_evaluator.return_value = None
+        self.mock.update_for_command.return_value = None
+
+    def to_proto(self):
+        result = self.mock.to_proto()
+        if result is None:
+            return EvaluatorConfigMsg(evaluator_type=self.evaluator_type)
+        else:
+            return result
+
+    def create_evaluator(self):
+        result = self.mock.create_evaluator()
+        if result is None:
+            return MockEvaluator()
+        else:
+            return result
+
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        if result is None:
+            return io_def or rv.core.CommandIODefinition()
+        else:
+            return result
+
+
+class MockEvaluatorConfigBuilder(EvaluatorConfigBuilder):
+    def __init__(self, prev=None):
+        super().__init__(MockEvaluatorConfig, {})
+        self.mock = Mock()
+        self.mock.from_proto.return_value = None
+
+    def from_proto(self, msg):
+        result = self.mock.from_proto(msg)
+        if result is None:
+            return self
+        else:
+            return result

--- a/tests/mock/evaluator.py
+++ b/tests/mock/evaluator.py
@@ -1,9 +1,12 @@
 from unittest.mock import Mock
 
+import rastervision as rv
 from rastervision.evaluation import (Evaluator, EvaluatorConfig,
-                                   EvaluatorConfigBuilder)
+                                     EvaluatorConfigBuilder)
 from rastervision.protos.evaluator_pb2 \
     import EvaluatorConfig as EvaluatorConfigMsg
+
+from tests.mock import SupressDeepCopyMixin
 
 MOCK_EVALUATOR = 'MOCK_EVALUATOR'
 
@@ -16,7 +19,7 @@ class MockEvaluator(Evaluator):
         self.mock.process(scenes, tmp_dir)
 
 
-class MockEvaluatorConfig(EvaluatorConfig):
+class MockEvaluatorConfig(SupressDeepCopyMixin, EvaluatorConfig):
     def __init__(self):
         super().__init__(MOCK_EVALUATOR)
         self.mock = Mock()
@@ -44,14 +47,15 @@ class MockEvaluatorConfig(EvaluatorConfig):
                            experiment_config,
                            context=None,
                            io_def=None):
-        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        result = self.mock.update_for_command(command_type, experiment_config,
+                                              context, io_def)
         if result is None:
             return io_def or rv.core.CommandIODefinition()
         else:
             return result
 
 
-class MockEvaluatorConfigBuilder(EvaluatorConfigBuilder):
+class MockEvaluatorConfigBuilder(SupressDeepCopyMixin, EvaluatorConfigBuilder):
     def __init__(self, prev=None):
         super().__init__(MockEvaluatorConfig, {})
         self.mock = Mock()

--- a/tests/mock/label_source.py
+++ b/tests/mock/label_source.py
@@ -7,6 +7,7 @@ from rastervision.data import (LabelSource, LabelSourceConfig,
 from rastervision.protos.label_source_pb2 \
     import LabelSourceConfig as LabelSourceConfigMsg
 
+from tests.mock import SupressDeepCopyMixin
 from tests.mock.raster_source import MOCK_SOURCE
 
 
@@ -24,7 +25,7 @@ class MockLabelSource(LabelSource):
             return result
 
 
-class MockLabelSourceConfig(LabelSourceConfig):
+class MockLabelSourceConfig(SupressDeepCopyMixin, LabelSourceConfig):
     def __init__(self):
         super().__init__(MOCK_SOURCE)
         self.mock = Mock()
@@ -43,7 +44,8 @@ class MockLabelSourceConfig(LabelSourceConfig):
             return result
 
     def create_source(self, task_config, extent, crs_transformer, tmp_dir):
-        result = self.mock.create_source(task_config, extent, crs_transformer, tmp_dir)
+        result = self.mock.create_source(task_config, extent, crs_transformer,
+                                         tmp_dir)
         if result is None:
             return MockLabelSource()
         else:
@@ -54,14 +56,16 @@ class MockLabelSourceConfig(LabelSourceConfig):
                            experiment_config,
                            context=None,
                            io_def=None):
-        result = self.mock.update_for_command(command_type, experiment_config,  context, io_def)
+        result = self.mock.update_for_command(command_type, experiment_config,
+                                              context, io_def)
         if result is None:
             return io_def or rv.core.CommandIODefinition()
         else:
             return result
 
 
-class MockLabelSourceConfigBuilder(LabelSourceConfigBuilder):
+class MockLabelSourceConfigBuilder(SupressDeepCopyMixin,
+                                   LabelSourceConfigBuilder):
     def __init__(self, prev=None):
         super().__init__(MockLabelSourceConfig, {})
         self.mock = Mock()

--- a/tests/mock/label_source.py
+++ b/tests/mock/label_source.py
@@ -1,0 +1,76 @@
+from unittest.mock import Mock
+
+import rastervision as rv
+from rastervision.data import (LabelSource, LabelSourceConfig,
+                               LabelSourceConfigBuilder,
+                               ChipClassificationLabels)
+from rastervision.protos.label_source_pb2 \
+    import LabelSourceConfig as LabelSourceConfigMsg
+
+from tests.mock.raster_source import MOCK_SOURCE
+
+
+class MockLabelSource(LabelSource):
+    def __init__(self):
+        self.mock = Mock()
+
+        self.mock.get_labels.return_value = None
+
+    def get_labels(self, window=None):
+        result = self.mock.get_labels(window)
+        if result is None:
+            return ChipClassificationLabels()
+        else:
+            return result
+
+
+class MockLabelSourceConfig(LabelSourceConfig):
+    def __init__(self):
+        super().__init__(MOCK_SOURCE)
+        self.mock = Mock()
+
+        self.mock.to_proto.return_value = None
+        self.mock.create_source.return_value = None
+        self.mock.update_for_command.return_value = None
+
+    def to_proto(self):
+        result = self.mock.to_proto()
+        if result is None:
+            msg = super().to_proto()
+            msg.MergeFrom(LabelSourceConfigMsg(custom_config={}))
+            return msg
+        else:
+            return result
+
+    def create_source(self, task_config, extent, crs_transformer, tmp_dir):
+        result = self.mock.create_source(task_config, extent, crs_transformer, tmp_dir)
+        if result is None:
+            return MockLabelSource()
+        else:
+            return result
+
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        result = self.mock.update_for_command(command_type, experiment_config,  context, io_def)
+        if result is None:
+            return io_def or rv.core.CommandIODefinition()
+        else:
+            return result
+
+
+class MockLabelSourceConfigBuilder(LabelSourceConfigBuilder):
+    def __init__(self, prev=None):
+        super().__init__(MockLabelSourceConfig, {})
+        self.mock = Mock()
+
+        self.mock.from_proto.return_value = None
+
+    def from_proto(self, msg):
+        result = self.mock.from_proto(msg)
+        if result is None:
+            return self
+        else:
+            return result

--- a/tests/mock/label_store.py
+++ b/tests/mock/label_store.py
@@ -7,6 +7,8 @@ from rastervision.data import (LabelStore, LabelStoreConfig,
 from rastervision.protos.label_store_pb2 \
     import LabelStoreConfig as LabelStoreConfigMsg
 
+from tests.mock import SupressDeepCopyMixin
+
 MOCK_STORE = 'MOCK_STORE'
 
 
@@ -35,13 +37,13 @@ class MockLabelStore(LabelStore):
             return result
 
 
-class MockLabelStoreConfig(LabelStoreConfig):
+class MockLabelStoreConfig(SupressDeepCopyMixin, LabelStoreConfig):
     def __init__(self):
         super().__init__(MOCK_STORE)
         self.mock = Mock()
 
         self.mock.to_proto.return_value = None
-        self.mock.create_store.return_value  = None
+        self.mock.create_store.return_value = None
         self.mock.update_for_command.return_value = None
         self.mock.for_prediction.return_value = None
 
@@ -55,7 +57,8 @@ class MockLabelStoreConfig(LabelStoreConfig):
             return result
 
     def create_store(self, task_config, extent, crs_transformer, tmp_dir):
-        result = self.mock.create_store(task_config, extent, crs_transformer, tmp_dir)
+        result = self.mock.create_store(task_config, extent, crs_transformer,
+                                        tmp_dir)
         if result is None:
             return MockLabelStore()
         else:
@@ -66,7 +69,8 @@ class MockLabelStoreConfig(LabelStoreConfig):
                            experiment_config,
                            context=None,
                            io_def=None):
-        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        result = self.mock.update_for_command(command_type, experiment_config,
+                                              context, io_def)
         if result is None:
             return io_def or rv.core.CommandIODefinition()
         else:
@@ -80,7 +84,8 @@ class MockLabelStoreConfig(LabelStoreConfig):
             return result
 
 
-class MockLabelStoreConfigBuilder(LabelStoreConfigBuilder):
+class MockLabelStoreConfigBuilder(SupressDeepCopyMixin,
+                                  LabelStoreConfigBuilder):
     def __init__(self, prev=None):
         super().__init__(MockLabelStoreConfig, {})
         self.mock = Mock()

--- a/tests/mock/label_store.py
+++ b/tests/mock/label_store.py
@@ -1,0 +1,95 @@
+from unittest.mock import Mock
+
+import rastervision as rv
+from rastervision.data import (LabelStore, LabelStoreConfig,
+                               LabelStoreConfigBuilder,
+                               ChipClassificationLabels)
+from rastervision.protos.label_store_pb2 \
+    import LabelStoreConfig as LabelStoreConfigMsg
+
+MOCK_STORE = 'MOCK_STORE'
+
+
+class MockLabelStore(LabelStore):
+    def __init__(self):
+        self.mock = Mock()
+
+        self.mock.get_labels.return_value = None
+        self.mock.empty_labels.return_value = None
+
+    def save(self, labels):
+        self.mock.save(labels)
+
+    def get_labels(self):
+        result = self.mock.get_labels()
+        if result is None:
+            return ChipClassificationLabels()
+        else:
+            return result
+
+    def empty_labels(self):
+        result = self.mock.empty_labels()
+        if result is None:
+            return ChipClassificationLabels()
+        else:
+            return result
+
+
+class MockLabelStoreConfig(LabelStoreConfig):
+    def __init__(self):
+        super().__init__(MOCK_STORE)
+        self.mock = Mock()
+
+        self.mock.to_proto.return_value = None
+        self.mock.create_store.return_value  = None
+        self.mock.update_for_command.return_value = None
+        self.mock.for_prediction.return_value = None
+
+    def to_proto(self):
+        result = self.mock.to_proto()
+        if result is None:
+            msg = super().to_proto()
+            msg.MergeFrom(LabelStoreConfigMsg(custom_config={}))
+            return msg
+        else:
+            return result
+
+    def create_store(self, task_config, extent, crs_transformer, tmp_dir):
+        result = self.mock.create_store(task_config, extent, crs_transformer, tmp_dir)
+        if result is None:
+            return MockLabelStore()
+        else:
+            return result
+
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        if result is None:
+            return io_def or rv.core.CommandIODefinition()
+        else:
+            return result
+
+    def for_prediction(self, label_store_uri):
+        result = self.mock.for_prediction(label_store_uri)
+        if result is None:
+            return self
+        else:
+            return result
+
+
+class MockLabelStoreConfigBuilder(LabelStoreConfigBuilder):
+    def __init__(self, prev=None):
+        super().__init__(MockLabelStoreConfig, {})
+        self.mock = Mock()
+
+        self.mock.from_proto.return_value = None
+
+    def from_proto(self, msg):
+        result = self.mock.from_proto(msg)
+        if result is None:
+            return self
+        else:
+            return result

--- a/tests/mock/raster_source.py
+++ b/tests/mock/raster_source.py
@@ -1,0 +1,104 @@
+from unittest.mock import Mock
+import numpy as np
+
+import rastervision as rv
+from rastervision.core import Box
+from rastervision.data import (RasterSource, RasterSourceConfig,
+                               RasterSourceConfigBuilder,
+                               IdentityCRSTransformer)
+from rastervision.protos.raster_source_pb2 \
+    import RasterSourceConfig as RasterSourceConfigMsg
+
+MOCK_SOURCE = 'MOCK_SOURCE'
+
+
+class MockRasterSource(RasterSource):
+    def __init__(self, channel_order, num_channels, raster_transformers=[]):
+        super().__init__(channel_order, num_channels, raster_transformers)
+        self.mock = Mock()
+
+        # Set default return values
+        self.mock.get_extent.return_value = Box.make_square(0, 0, 2)
+        self.mock.get_dtype.return_value = np.uint8
+        self.mock.get_crs_transformer.return_value = IdentityCRSTransformer()
+        self.mock._get_chip.return_value = np.random.rand(1, 2, 2, 3)
+
+    def get_extent(self):
+        return self.mock.get_extent()
+
+    def get_dtype(self):
+        return self.mock.get_dtype()
+
+    def get_crs_transformer(self):
+        return self.mock.get_crs_transformer()
+
+    def _get_chip(self, window):
+        return self.mock._get_chip(window)
+
+
+class MockRasterSourceConfig(RasterSourceConfig):
+    def __init__(self, transformers=None, channel_order=None):
+        super().__init__(MOCK_SOURCE, transformers, channel_order)
+        self.mock = Mock()
+        self.mock.to_proto.return_value = None
+        self.mock.create_source.return_value = None
+        self.mock.update_for_command.return_value = None
+        self.mock.save_bundle_files.return_value = (self, [])
+        self.mock.load_bundle_files.return_value = self
+        self.mock.for_prediction.return_value = self
+        self.mock.create_local.return_value = self
+
+    def to_proto(self):
+        result = self.mock.to_proto()
+        if result is None:
+            msg = super().to_proto()
+            msg.MergeFrom(RasterSourceConfigMsg(custom_config={}))
+            return msg
+        else:
+            return result
+
+    def create_source(self, tmp_dir):
+        result =  self.mock.create_source(tmp_dir)
+        if result is None:
+            self.mock.create_source(tmp_dir)
+            transformers = self.create_transformers()
+            return MockRasterSource(self.channel_order, 3, transformers)
+        else:
+            return result
+
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        if result is None:
+            return io_def or rv.core.CommandIODefinition()
+        else:
+            return result
+
+    def save_bundle_files(self, bundle_dir):
+        return self.mock.save_bundle_files(bundle_dir)
+
+    def load_bundle_files(self, bundle_dir):
+        return self.mock.load_bundle_files(bundle_dir)
+
+    def for_prediction(self, image_uri):
+        return self.mock.for_prediction(image_uri)
+
+    def create_local(self, tmp_dir):
+        return self.mock.create_local(tmp_dir)
+
+
+class MockRasterSourceConfigBuilder(RasterSourceConfigBuilder):
+    def __init__(self, prev=None):
+        super().__init__(MockRasterSourceConfig, {})
+        self.mock = Mock()
+        self.mock.from_proto.return_value = None
+
+    def from_proto(self, msg):
+        result = self.mock.from_proto(msg)
+        if result is None:
+            return super().from_proto(msg)
+        else:
+            return result

--- a/tests/mock/raster_source.py
+++ b/tests/mock/raster_source.py
@@ -9,6 +9,8 @@ from rastervision.data import (RasterSource, RasterSourceConfig,
 from rastervision.protos.raster_source_pb2 \
     import RasterSourceConfig as RasterSourceConfigMsg
 
+from tests.mock import SupressDeepCopyMixin
+
 MOCK_SOURCE = 'MOCK_SOURCE'
 
 
@@ -36,7 +38,7 @@ class MockRasterSource(RasterSource):
         return self.mock._get_chip(window)
 
 
-class MockRasterSourceConfig(RasterSourceConfig):
+class MockRasterSourceConfig(SupressDeepCopyMixin, RasterSourceConfig):
     def __init__(self, transformers=None, channel_order=None):
         super().__init__(MOCK_SOURCE, transformers, channel_order)
         self.mock = Mock()
@@ -58,7 +60,7 @@ class MockRasterSourceConfig(RasterSourceConfig):
             return result
 
     def create_source(self, tmp_dir):
-        result =  self.mock.create_source(tmp_dir)
+        result = self.mock.create_source(tmp_dir)
         if result is None:
             self.mock.create_source(tmp_dir)
             transformers = self.create_transformers()
@@ -71,7 +73,8 @@ class MockRasterSourceConfig(RasterSourceConfig):
                            experiment_config,
                            context=None,
                            io_def=None):
-        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        result = self.mock.update_for_command(command_type, experiment_config,
+                                              context, io_def)
         if result is None:
             return io_def or rv.core.CommandIODefinition()
         else:
@@ -90,7 +93,8 @@ class MockRasterSourceConfig(RasterSourceConfig):
         return self.mock.create_local(tmp_dir)
 
 
-class MockRasterSourceConfigBuilder(RasterSourceConfigBuilder):
+class MockRasterSourceConfigBuilder(SupressDeepCopyMixin,
+                                    RasterSourceConfigBuilder):
     def __init__(self, prev=None):
         super().__init__(MockRasterSourceConfig, {})
         self.mock = Mock()

--- a/tests/mock/raster_transformer.py
+++ b/tests/mock/raster_transformer.py
@@ -1,0 +1,92 @@
+from unittest.mock import Mock
+
+import rastervision as rv
+from rastervision.data import (
+    RasterTransformerConfig, RasterTransformerConfigBuilder,
+    RasterTransformer)
+from rastervision.protos.raster_transformer_pb2 \
+    import RasterTransformerConfig as RasterTransformerConfigMsg
+
+MOCK_TRANSFORMER = 'MOCK_TRANSFORMER'
+
+class MockRasterTransformer(RasterTransformer):
+    def __init__(self):
+        self.mock = Mock()
+
+        self.mock.transform.return_value = None
+
+    def transform(self, chip, channel_order=None):
+        result = self.mock.transform(chip, channel_order)
+        if result is None:
+            return chip
+        else:
+            return result
+
+
+class MockRasterTransformerConfig(RasterTransformerConfig):
+    def __init__(self):
+        super().__init__(MOCK_TRANSFORMER)
+        self.mock = Mock()
+
+        self.mock.to_proto.return_value = None
+        self.mock.create_transformer.return_value  = None
+        self.mock.update_for_command.return_value = None
+        self.mock.save_bundle_files.return_value = (self, [])
+        self.mock.load_bundle_files.return_value = self
+        self.mock.for_prediction.return_value = self
+        self.mock.create_local.return_value = self
+
+
+    def to_proto(self):
+        result = self.mock.to_proto()
+        if result is None:
+            msg = RasterTransformerConfigMsg(
+                transformer_type=self.transformer_type, custom_config={})
+            return msg
+        else:
+            return result
+
+    def create_transformer(self):
+        result = self.mock.create_transformer()
+        if result is None:
+            return MockRasterTransformer()
+        else:
+            return result
+
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        if result is None:
+            return io_def or rv.core.CommandIODefinition()
+        else:
+            return result
+
+    def save_bundle_files(self, bundle_dir):
+        return self.mock.save_bundle_files(bundle_dir)
+
+    def load_bundle_files(self, bundle_dir):
+        return self.mock.load_bundle_files(bundle_dir)
+
+    def for_prediction(self, image_uri):
+        return self.mock.for_prediction(image_uri)
+
+    def create_local(self, tmp_dir):
+        return self.mock.create_local(tmp_dir)
+
+
+class MockRasterTransformerConfigBuilder(RasterTransformerConfigBuilder):
+    def __init__(self, prev=None):
+        super().__init__(MockRasterTransformerConfig, {})
+        self.mock = Mock()
+
+        self.mock.from_proto.return_value = None
+
+    def from_proto(self, msg):
+        result = self.mock.from_proto(msg)
+        if result is None:
+            return super().from_proto(msg)
+        else:
+            return result

--- a/tests/mock/raster_transformer.py
+++ b/tests/mock/raster_transformer.py
@@ -2,12 +2,14 @@ from unittest.mock import Mock
 
 import rastervision as rv
 from rastervision.data import (
-    RasterTransformerConfig, RasterTransformerConfigBuilder,
-    RasterTransformer)
+    RasterTransformerConfig, RasterTransformerConfigBuilder, RasterTransformer)
 from rastervision.protos.raster_transformer_pb2 \
     import RasterTransformerConfig as RasterTransformerConfigMsg
 
+from tests.mock import SupressDeepCopyMixin
+
 MOCK_TRANSFORMER = 'MOCK_TRANSFORMER'
+
 
 class MockRasterTransformer(RasterTransformer):
     def __init__(self):
@@ -23,19 +25,19 @@ class MockRasterTransformer(RasterTransformer):
             return result
 
 
-class MockRasterTransformerConfig(RasterTransformerConfig):
+class MockRasterTransformerConfig(SupressDeepCopyMixin,
+                                  RasterTransformerConfig):
     def __init__(self):
         super().__init__(MOCK_TRANSFORMER)
         self.mock = Mock()
 
         self.mock.to_proto.return_value = None
-        self.mock.create_transformer.return_value  = None
+        self.mock.create_transformer.return_value = None
         self.mock.update_for_command.return_value = None
         self.mock.save_bundle_files.return_value = (self, [])
         self.mock.load_bundle_files.return_value = self
         self.mock.for_prediction.return_value = self
         self.mock.create_local.return_value = self
-
 
     def to_proto(self):
         result = self.mock.to_proto()
@@ -58,7 +60,8 @@ class MockRasterTransformerConfig(RasterTransformerConfig):
                            experiment_config,
                            context=None,
                            io_def=None):
-        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        result = self.mock.update_for_command(command_type, experiment_config,
+                                              context, io_def)
         if result is None:
             return io_def or rv.core.CommandIODefinition()
         else:
@@ -77,7 +80,8 @@ class MockRasterTransformerConfig(RasterTransformerConfig):
         return self.mock.create_local(tmp_dir)
 
 
-class MockRasterTransformerConfigBuilder(RasterTransformerConfigBuilder):
+class MockRasterTransformerConfigBuilder(SupressDeepCopyMixin,
+                                         RasterTransformerConfigBuilder):
     def __init__(self, prev=None):
         super().__init__(MockRasterTransformerConfig, {})
         self.mock = Mock()

--- a/tests/mock/task.py
+++ b/tests/mock/task.py
@@ -1,0 +1,108 @@
+from unittest.mock import Mock
+
+import rastervision as rv
+from rastervision.task import (Task, TaskConfig, TaskConfigBuilder)
+from rastervision.protos.task_pb2 import TaskConfig as TaskConfigMsg
+
+MOCK_TASK = 'MOCK_TASK'
+
+class MockTask(Task):
+    def __init__(self, task_config, backend):
+        self.config = task_config
+        self.backend = backend
+        self.mock = Mock()
+
+        self.mock.get_train_windows.return_value = None
+        self.mock.get_train_labels.return_value = None
+        self.mock.get_predict_windows.return_value = None
+
+    def get_train_windows(self, scene):
+        result = self.mock.get_train_windows(scene)
+        if result is None:
+            return []
+        else:
+            return result
+
+    def get_train_labels(self, window, scene):
+        result = self.mock.get_train_labels(window, scene)
+        if result is None:
+            return []
+        else:
+            return result
+
+    def post_process_predictions(self, labels, scene):
+        return self.mock.post_process_predictions(labels, scene)
+
+    def get_predict_windows(self, extent):
+        result = self.mock.get_predict_windows(extent)
+        if result is None:
+            return []
+        else:
+            return result
+
+    def save_debug_predict_image(self, scene, debug_dir_uri):
+        return self.mock.save_debug_predict_image(scene, debug_dir_uri)
+
+class MockTaskConfig(TaskConfig):
+    def __init__(self):
+        super().__init__(MOCK_TASK)
+        self.mock = Mock()
+
+        self.mock.create_task.return_value = None
+        self.mock.to_proto.return_value = None
+        self.mock.update_for_command.return_value = None
+        self.mock.save_bundle_files.return_value = (self, [])
+        self.mock.load_bundle_files.return_value = self
+
+    def create_task(self, backend):
+        result = self.mock.create_task(backend)
+        if result is None:
+            return MockTask(self, backend)
+        else:
+            return result
+
+    def to_proto(self):
+        result = self.mock.to_proto()
+        if result is None:
+            return TaskConfigMsg(task_type=self.task_type, custom_config={})
+        else:
+            return result
+
+    def save_bundle_files(self, bundle_dir):
+        return self.mock.save_bundle_files(bundle_dir)
+
+    def load_bundle_files(self, bundle_dir):
+        return self.mock.load_bundle_files(bundle_dir)
+
+    def update_for_command(self,
+                           command_type,
+                           experiment_config,
+                           context=None,
+                           io_def=None):
+        result = self.mock.update_for_command(command_type, experiment_config, context, io_def)
+        if result is None:
+            # Have input always be this file, and output be a non-existant file,
+            # so commands always run
+
+            io_def = super().update_for_command(command_type, experiment_config, context, io_def)
+            io_def.add_input(__file__)
+            io_def.add_output("{}{}".format(__file__, 'xxxx'))
+            return io_def
+        else:
+            return result
+
+
+class MockTaskConfigBuilder(TaskConfigBuilder):
+    def __init__(self, prev=None):
+        super().__init__(MockTaskConfig, {})
+        self.mock = Mock()
+
+        self.mock.from_proto.return_value = None
+
+    @staticmethod
+    def from_proto(msg):
+        result = self.mock.from_proto(msg)
+        if result is None:
+            return MockTaskConfigBuilder()
+        else:
+            return result

--- a/tests/mock/test_mocks.py
+++ b/tests/mock/test_mocks.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 import tempfile
 
@@ -17,11 +16,12 @@ class TestPlugin(mk.MockMixin, unittest.TestCase):
         backend_config = rv.BackendConfig.builder(mk.MOCK_BACKEND) \
                                          .build()
 
-        raster_transformer_config = rv.RasterTransformerConfig.builder(mk.MOCK_TRANSFORMER) \
-                                                              .build()
+        raster_transformer_config = rv.RasterTransformerConfig.builder(
+            mk.MOCK_TRANSFORMER).build()
 
         raster_source_config = rv.RasterSourceConfig.builder(mk.MOCK_SOURCE) \
-                                                    .with_transformer(raster_transformer_config) \
+                                                    .with_transformer(
+                                                        raster_transformer_config) \
                                                     .build()
 
         label_source_config = rv.LabelSourceConfig.builder(mk.MOCK_SOURCE) \
@@ -31,7 +31,7 @@ class TestPlugin(mk.MockMixin, unittest.TestCase):
                                                     .build()
 
         scene_config = rv.SceneConfig.builder() \
-                                     .with_id("test") \
+                                     .with_id('test') \
                                      .with_raster_source(raster_source_config) \
                                      .with_label_source(label_source_config) \
                                      .with_label_store(label_store_config) \
@@ -47,36 +47,38 @@ class TestPlugin(mk.MockMixin, unittest.TestCase):
                                   .build()
 
         analyzer_config = rv.AnalyzerConfig.builder(mk.MOCK_ANALYZER).build()
-        evaluator_config = rv.EvaluatorConfig.builder(mk.MOCK_EVALUATOR).build()
+        evaluator_config = rv.EvaluatorConfig.builder(
+            mk.MOCK_EVALUATOR).build()
 
         # Create entities from configuration
 
         backend = backend_config.create_backend(task_config)
         task = task_config.create_task(backend)
-        scene  = scene_config.create_scene(task_config, '.')
-        augmentor = augmentor_config.create_augmentor()
-        analyzer = analyzer_config.create_analyzer()
-        evaluator = evaluator_config.create_evaluator()
+        scene = scene_config.create_scene(task_config, '.')
+        _ = augmentor_config.create_augmentor()  # noqa
+        _ = analyzer_config.create_analyzer()  # noqa
+        _ = evaluator_config.create_evaluator()  # noqa
 
         # Assert some things
 
         task_config.mock.create_task.assert_called_once_with(backend)
-        self.assertEqual(task.get_predict_windows(Box(0,0,1,1)), [])
+        self.assertEqual(task.get_predict_windows(Box(0, 0, 1, 1)), [])
 
-        chip = scene.raster_source.get_chip(Box(0,0,1,1))
-        self.assertTrue(scene.raster_source.raster_transformers[0].mock.transform.called)
+        _ = scene.raster_source.get_chip(Box(0, 0, 1, 1))  # noqa
+        self.assertTrue(
+            scene.raster_source.raster_transformers[0].mock.transform.called)
 
         # Create and run experiment
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            e =  rv.ExperimentConfig.builder() \
-                                    .with_task(task_config) \
-                                    .with_backend(backend_config) \
-                                    .with_dataset(dataset) \
-                                    .with_analyzer(analyzer_config) \
-                                    .with_evaluator(evaluator_config) \
-                                    .with_root_uri(tmp_dir) \
-                                    .with_id('test') \
-                                    .build()
+            e = rv.ExperimentConfig.builder() \
+                                   .with_task(task_config) \
+                                   .with_backend(backend_config) \
+                                   .with_dataset(dataset) \
+                                   .with_analyzer(analyzer_config) \
+                                   .with_evaluator(evaluator_config) \
+                                   .with_root_uri(tmp_dir) \
+                                   .with_id('test') \
+                                   .build()
 
             rv.ExperimentRunner.get_runner(rv.LOCAL).run(e)

--- a/tests/mock/test_mocks.py
+++ b/tests/mock/test_mocks.py
@@ -1,0 +1,82 @@
+import os
+import unittest
+import tempfile
+
+import rastervision as rv
+from rastervision.core import Box
+
+import tests.mock as mk
+
+
+class TestPlugin(mk.MockMixin, unittest.TestCase):
+    def test_mocks(self):
+        """Test to ensure all mocks are working as expected."""
+        task_config = rv.TaskConfig.builder(mk.MOCK_TASK) \
+                                   .build()
+
+        backend_config = rv.BackendConfig.builder(mk.MOCK_BACKEND) \
+                                         .build()
+
+        raster_transformer_config = rv.RasterTransformerConfig.builder(mk.MOCK_TRANSFORMER) \
+                                                              .build()
+
+        raster_source_config = rv.RasterSourceConfig.builder(mk.MOCK_SOURCE) \
+                                                    .with_transformer(raster_transformer_config) \
+                                                    .build()
+
+        label_source_config = rv.LabelSourceConfig.builder(mk.MOCK_SOURCE) \
+                                                    .build()
+
+        label_store_config = rv.LabelStoreConfig.builder(mk.MOCK_STORE) \
+                                                    .build()
+
+        scene_config = rv.SceneConfig.builder() \
+                                     .with_id("test") \
+                                     .with_raster_source(raster_source_config) \
+                                     .with_label_source(label_source_config) \
+                                     .with_label_store(label_store_config) \
+                                     .build()
+
+        augmentor_config = rv.AugmentorConfig.builder(mk.MOCK_AUGMENTOR) \
+                                             .build()
+
+        dataset = rv.DatasetConfig.builder() \
+                                  .with_train_scene(scene_config) \
+                                  .with_validation_scene(scene_config) \
+                                  .with_augmentor(augmentor_config)  \
+                                  .build()
+
+        analyzer_config = rv.AnalyzerConfig.builder(mk.MOCK_ANALYZER).build()
+        evaluator_config = rv.EvaluatorConfig.builder(mk.MOCK_EVALUATOR).build()
+
+        # Create entities from configuration
+
+        backend = backend_config.create_backend(task_config)
+        task = task_config.create_task(backend)
+        scene  = scene_config.create_scene(task_config, '.')
+        augmentor = augmentor_config.create_augmentor()
+        analyzer = analyzer_config.create_analyzer()
+        evaluator = evaluator_config.create_evaluator()
+
+        # Assert some things
+
+        task_config.mock.create_task.assert_called_once_with(backend)
+        self.assertEqual(task.get_predict_windows(Box(0,0,1,1)), [])
+
+        chip = scene.raster_source.get_chip(Box(0,0,1,1))
+        self.assertTrue(scene.raster_source.raster_transformers[0].mock.transform.called)
+
+        # Create and run experiment
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            e =  rv.ExperimentConfig.builder() \
+                                    .with_task(task_config) \
+                                    .with_backend(backend_config) \
+                                    .with_dataset(dataset) \
+                                    .with_analyzer(analyzer_config) \
+                                    .with_evaluator(evaluator_config) \
+                                    .with_root_uri(tmp_dir) \
+                                    .with_id('test') \
+                                    .build()
+
+            rv.ExperimentRunner.get_runner(rv.LOCAL).run(e)


### PR DESCRIPTION
## Overview

This PR is a refactor that is part of #551. It makes space for commands to implement logic that determines how configurations will turn into entities themselves and takes the entity creation logic out of the `create_command` method of the `CommandConfig` objects.

It also adds a `tests/mock` package, which is useful for testing entities and commands. Prior to this we didn't have a good way to run commands and experiments in unit tests in a way that we could check what happened - this new package allows for that.

Also - this removes the `__deepcopy__` override on config builders that was happening as a performance booster. I realized during this that the deep copy override wasn't even happening on configs, where it could really make a difference, but on config builders - so I don't see a huge loss here. I removed because this is the second time I've seen it cause problems with un-pickle-able things.

