### PR TITLE
Feature Extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN add-apt-repository ppa:ubuntugis/ppa && \
     apt-get update && \
     apt-get install -y wget=1.* git=1:2.* python-protobuf=2.* python3-tk=3.* \
                        gdal-bin=2.1.* \
-                       jq \
-                       build-essential libsqlite3-dev zlib1g-dev \
-                       libopencv-dev python-opencv && \
+                       jq=1.5* \
+                       build-essential libsqlite3-dev=3.11.* zlib1g-dev=1:1.2.* \
+                       libopencv-dev=2.4.* python-opencv=2.4.* && \
     apt-get autoremove && apt-get autoclean && apt-get clean
 
 # Install protoc

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,3 +73,7 @@ RUN cat extras_requirements.json | jq  '.[][]' | grep -v 'tensorflow' | sort -u 
 # Install requirements.txt
 COPY ./requirements.txt /opt/src/requirements.txt
 RUN pip install -r requirements.txt
+
+# Install optional-requirements.txt
+COPY ./optional-requirements.txt /opt/src/optional-requirements.txt
+RUN pip install -r optional-requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ FROM tensorflow/tensorflow:1.10.1-gpu-py3
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
-# Install misc. packages, GDAL, jq (for parsing extra-requirements.json), and Tippecanoe
+# Install misc. packages, GDAL, jq (for parsing extra-requirements.json), Tippecanoe dependencies, and OpenCV
 RUN add-apt-repository ppa:ubuntugis/ppa && \
     apt-get update && \
     apt-get install -y wget=1.* git=1:2.* python-protobuf=2.* python3-tk=3.* \
-            gdal-bin=2.1.* \
-            jq \
-            build-essential libsqlite3-dev zlib1g-dev && \
+                       gdal-bin=2.1.* \
+                       jq \
+                       build-essential libsqlite3-dev zlib1g-dev \
+                       libopencv-dev python-opencv && \
     apt-get autoremove && apt-get autoclean && apt-get clean
 
 # Install protoc
@@ -46,6 +47,7 @@ ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 RUN rm -f /usr/bin/pip && ln -s /usr/bin/pip3 /usr/bin/pip
 RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 
+# Install Tippecanoe
 RUN cd /tmp && \
     wget https://github.com/mapbox/tippecanoe/archive/1.32.5.zip && \
     unzip 1.32.5.zip && \

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Raster Vision 0.9.0
 - Add support for getting labels from zxy vector tiles `#532 <https://github.com/azavea/raster-vision/pull/532>`_
 - Remove custom ``__deepcopy__`` implementation from ``ConfigBuilder``s. `#567 <https://github.com/azavea/raster-vision/pull/567>`_
 - Add ability to shift raster images by given numbers of meters.  `#573 <https://github.com/azavea/raster-vision/pull/573>`_
+- Add ability to generate GeoJSON segmentation predictions.  `#575 <https://github.com/azavea/raster-vision/pull/575>`_
 
 Raster Vision 0.8
 -----------------

--- a/extras_requirements.json
+++ b/extras_requirements.json
@@ -10,5 +10,8 @@
     "aws": [
         "boto3==1.7.*",
         "awscli==1.15.*"
+    ],
+    "feature-extraction": [
+        "https://github.com/jamesmcclain/mask-to-polygons/archive/5446751caeaa7f99368d264184be3926ffdd6a4e.zip"
     ]
 }

--- a/extras_requirements.json
+++ b/extras_requirements.json
@@ -12,6 +12,6 @@
         "awscli==1.15.*"
     ],
     "feature-extraction": [
-        "https://github.com/jamesmcclain/mask-to-polygons/archive/94739f164df1c350baa1170cac603e133f91d2cf.zip"
+        "https://github.com/azavea/mask-to-polygons/archive/94739f164df1c350baa1170cac603e133f91d2cf.zip"
     ]
 }

--- a/extras_requirements.json
+++ b/extras_requirements.json
@@ -12,6 +12,6 @@
         "awscli==1.15.*"
     ],
     "feature-extraction": [
-        "https://github.com/jamesmcclain/mask-to-polygons/archive/62965bb50ba94a35e59fb6171bcd1dcaed357d31.zip"
+        "https://github.com/jamesmcclain/mask-to-polygons/archive/cb1d563ca8c84da2b2f524e8f183180fc80164a8.zip"
     ]
 }

--- a/extras_requirements.json
+++ b/extras_requirements.json
@@ -12,6 +12,6 @@
         "awscli==1.15.*"
     ],
     "feature-extraction": [
-        "https://github.com/jamesmcclain/mask-to-polygons/archive/5446751caeaa7f99368d264184be3926ffdd6a4e.zip"
+        "https://github.com/jamesmcclain/mask-to-polygons/archive/62965bb50ba94a35e59fb6171bcd1dcaed357d31.zip"
     ]
 }

--- a/extras_requirements.json
+++ b/extras_requirements.json
@@ -12,6 +12,6 @@
         "awscli==1.15.*"
     ],
     "feature-extraction": [
-        "https://github.com/jamesmcclain/mask-to-polygons/archive/cb1d563ca8c84da2b2f524e8f183180fc80164a8.zip"
+        "https://github.com/jamesmcclain/mask-to-polygons/archive/94739f164df1c350baa1170cac603e133f91d2cf.zip"
     ]
 }

--- a/integration_tests/semantic_segmentation_tests/experiment.py
+++ b/integration_tests/semantic_segmentation_tests/experiment.py
@@ -55,7 +55,7 @@ class SemanticSegmentationIntegrationTest(rv.ExperimentSet):
                                            .with_raster_source(label_path) \
                                            .build()
 
-        vector_output = {'mode': 'buildings', 'class_id': 1}
+        vector_output = {'denoise': 1, 'mode': 'buildings', 'class_id': 1}
         label_store = rv.LabelStoreConfig.builder(rv.SEMANTIC_SEGMENTATION_RASTER) \
                                          .with_vector_output([vector_output]) \
                                          .with_rgb(True) \

--- a/integration_tests/semantic_segmentation_tests/experiment.py
+++ b/integration_tests/semantic_segmentation_tests/experiment.py
@@ -55,9 +55,16 @@ class SemanticSegmentationIntegrationTest(rv.ExperimentSet):
                                            .with_raster_source(label_path) \
                                            .build()
 
-        vector_output = {'denoise': 1, 'mode': 'buildings', 'class_id': 1}
+        vector_output = [{
+            'mode': 'buildings',
+            'class_id': 1
+        }, {
+            'denoise': 50,
+            'mode': 'polygons',
+            'class_id': 1
+        }]
         label_store = rv.LabelStoreConfig.builder(rv.SEMANTIC_SEGMENTATION_RASTER) \
-                                         .with_vector_output([vector_output]) \
+                                         .with_vector_output(vector_output) \
                                          .with_rgb(True) \
                                          .build()
 

--- a/integration_tests/semantic_segmentation_tests/experiment.py
+++ b/integration_tests/semantic_segmentation_tests/experiment.py
@@ -55,7 +55,9 @@ class SemanticSegmentationIntegrationTest(rv.ExperimentSet):
                                            .with_raster_source(label_path) \
                                            .build()
 
+        vector_output = {'uri': '*', 'mode': 'buildings'}
         label_store = rv.LabelStoreConfig.builder(rv.SEMANTIC_SEGMENTATION_RASTER) \
+                                         .with_vector_output([vector_output]) \
                                          .with_rgb(True) \
                                          .build()
 

--- a/integration_tests/semantic_segmentation_tests/experiment.py
+++ b/integration_tests/semantic_segmentation_tests/experiment.py
@@ -37,7 +37,7 @@ class SemanticSegmentationIntegrationTest(rv.ExperimentSet):
                                                debug_chip_probability=1.0) \
                             .build()
 
-        # .with_config belowe needed to copy final layer from pretrained model.
+        # .with_config below needed to copy final layer from pretrained model.
         backend = rv.BackendConfig.builder(rv.TF_DEEPLAB) \
                                   .with_task(task) \
                                   .with_model_defaults(rv.MOBILENET_V2) \
@@ -55,7 +55,7 @@ class SemanticSegmentationIntegrationTest(rv.ExperimentSet):
                                            .with_raster_source(label_path) \
                                            .build()
 
-        vector_output = {'uri': '*', 'mode': 'buildings'}
+        vector_output = {'mode': 'buildings', 'class_id': 1}
         label_store = rv.LabelStoreConfig.builder(rv.SEMANTIC_SEGMENTATION_RASTER) \
                                          .with_vector_output([vector_output]) \
                                          .with_rgb(True) \

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,0 +1,2 @@
+geojson>=2.4.0
+opencv-python>=3.4.0

--- a/rastervision/data/crs_transformer/crs_transformer.py
+++ b/rastervision/data/crs_transformer/crs_transformer.py
@@ -34,3 +34,6 @@ class CRSTransformer(object):
 
     def get_map_crs(self):
         return self.map_crs
+
+    def get_affine_transform(self):
+        raise NotImplementedError()

--- a/rastervision/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision/data/crs_transformer/rasterio_crs_transformer.py
@@ -59,3 +59,6 @@ class RasterioCRSTransformer(CRSTransformer):
         transform = dataset.transform
         image_crs = dataset.crs['init']
         return cls(transform, image_crs, map_crs)
+
+    def get_affine_transform(self):
+        return self.transform

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -116,9 +116,11 @@ class SemanticSegmentationRasterStore(LabelStore):
         upload_or_copy(local_path, self.uri)
 
         if self.vector_output:
-            import mask_to_polygons.vectorification as m2p
+            import mask_to_polygons.vectorification as vectorification
+            import mask_to_polygons.processing.denoise as denoise
 
             for vo in self.vector_output:
+                denoise_radius = vo['denoise']
                 uri = vo['uri']
                 mode = vo['mode']
                 class_id = vo['class_id']
@@ -127,8 +129,11 @@ class SemanticSegmentationRasterStore(LabelStore):
 
                 transform = self.crs_transformer.get_affine_transform()
 
+                if denoise_radius > 0:
+                    class_mask = denoise.denoise(class_mask, denoise_radius)
+
                 if uri and mode == 'buildings':
-                    geojson = m2p.geojson_from_mask(class_mask, transform)
+                    geojson = vectorification.geojson_from_mask(class_mask, transform)
 
                 if local_geojson_path:
                     with open(local_geojson_path, 'w') as file_out:

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -12,21 +12,32 @@ class SemanticSegmentationRasterStore(LabelStore):
     """A prediction label store for segmentation raster files.
     """
 
-    def __init__(self, uri, geojson_uri, extent, affine_tranform, crs_transformer, tmp_dir, class_map=None):
+    def __init__(self,
+                 uri,
+                 geojson_uri,
+                 extent,
+                 affine_tranform,
+                 crs_transformer,
+                 tmp_dir,
+                 class_map=None):
         """Constructor.
 
         Args:
             uri: (str) URI of GeoTIFF file used for storing predictions as RGB values
             geojson_uri: (str or None) URI of GeoJSON polygons derived from the mask
             extent: (Box) The extent of the scene
-            affine_tranform: (affine.Affine) The mapping from mask coordintes to world coordinates
+            affine_tranform: (affine.Affine) The mapping from mask
+                 image coordintes to world coordinates
             crs_transformer: (CRSTransformer)
             tmp_dir: (str) temp directory to use
             class_map: (ClassMap) with color values used to convert class ids to
                 RGB values
+
         """
         self.uri = uri
+        self.geojson_uri = geojson_uri
         self.extent = extent
+        self.affine_transform = affine_tranform
         self.crs_transformer = crs_transformer
         self.tmp_dir = tmp_dir
         # Note: can't name this class_transformer due to Python using that attribute
@@ -59,7 +70,10 @@ class SemanticSegmentationRasterStore(LabelStore):
         Args:
             labels - (SemanticSegmentationLabels) labels to be saved
         """
+        import pdb
+        pdb.set_trace()
         local_path = get_local_path(self.uri, self.tmp_dir)
+        # local_geojson_path = get_local_path(self.geojson_uri, self.tmp_dir)
         make_dir(local_path, use_dirname=True)
 
         # TODO: this only works if crs_transformer is RasterioCRSTransformer.
@@ -98,6 +112,9 @@ class SemanticSegmentationRasterStore(LabelStore):
                     dataset.write_band(1, img, window=window)
 
         upload_or_copy(local_path, self.uri)
+
+        if self.geojson_uri:
+            pass  # XXX
 
     def empty_labels(self):
         """Returns an empty SemanticSegmentationLabels object."""

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -6,8 +6,6 @@ from rastervision.utils.files import (get_local_path, make_dir, upload_or_copy)
 from rastervision.data.label import SemanticSegmentationLabels
 from rastervision.data.label_store import LabelStore
 from rastervision.data.label_source import SegmentationClassTransformer
-from rastervision.data.crs_transformer.rasterio_crs_transformer import (
-    RasterioCRSTransformer)
 
 
 class SemanticSegmentationRasterStore(LabelStore):
@@ -119,7 +117,6 @@ class SemanticSegmentationRasterStore(LabelStore):
 
         if self.vector_output:
             import mask_to_polygons.vectorification as m2p
-            from affine import Affine
 
             for vo in self.vector_output:
                 uri = vo['uri']
@@ -128,10 +125,7 @@ class SemanticSegmentationRasterStore(LabelStore):
                 class_mask = np.array(mask == class_id, dtype=np.uint8)
                 local_geojson_path = get_local_path(uri, self.tmp_dir)
 
-                if isinstance(self.crs_transformer, RasterioCRSTransformer):
-                    transform = self.crs_transformer.transform
-                else:
-                    transform = Affine.identity()
+                transform = self.crs_transformer.get_affine_transform()
 
                 if uri and mode == 'buildings':
                     geojson = m2p.geojson_from_mask(class_mask, transform)

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -12,11 +12,14 @@ class SemanticSegmentationRasterStore(LabelStore):
     """A prediction label store for segmentation raster files.
     """
 
-    def __init__(self, uri, extent, crs_transformer, tmp_dir, class_map=None):
+    def __init__(self, uri, geojson_uri, extent, affine_tranform, crs_transformer, tmp_dir, class_map=None):
         """Constructor.
 
         Args:
             uri: (str) URI of GeoTIFF file used for storing predictions as RGB values
+            geojson_uri: (str or None) URI of GeoJSON polygons derived from the mask
+            extent: (Box) The extent of the scene
+            affine_tranform: (affine.Affine) The mapping from mask coordintes to world coordinates
             crs_transformer: (CRSTransformer)
             tmp_dir: (str) temp directory to use
             class_map: (ClassMap) with color values used to convert class ids to

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -133,7 +133,11 @@ class SemanticSegmentationRasterStore(LabelStore):
                     class_mask = denoise.denoise(class_mask, denoise_radius)
 
                 if uri and mode == 'buildings':
-                    geojson = vectorification.geojson_from_mask(class_mask, transform)
+                    geojson = vectorification.geojson_from_mask(
+                        mask=class_mask, transform=transform, mode=mode)
+                elif uri and mode == 'polygons':
+                    geojson = vectorification.geojson_from_mask(
+                        mask=class_mask, transform=transform, mode=mode)
 
                 if local_geojson_path:
                     with open(local_geojson_path, 'w') as file_out:

--- a/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
@@ -7,15 +7,18 @@ from rastervision.data.label_store import (
 
 
 class SemanticSegmentationRasterStoreConfig(LabelStoreConfig):
-    def __init__(self, uri=None, rgb=False):
+    def __init__(self, uri=None, geojson_uri=None, rgb=False):
         super().__init__(store_type=rv.SEMANTIC_SEGMENTATION_RASTER)
         self.uri = uri
+        self.geojson_uri = geojson_uri
         self.rgb = rgb
 
     def to_proto(self):
         msg = super().to_proto()
         if self.uri:
             msg.semantic_segmentation_raster_store.uri = self.uri
+        if self.geojson_uri:
+            msg.semantic_segmentation_raster_store.geojson_uri = self.geojson_uri
         msg.semantic_segmentation_raster_store.rgb = self.rgb
         return msg
 
@@ -24,12 +27,20 @@ class SemanticSegmentationRasterStoreConfig(LabelStoreConfig):
                    .with_uri(label_uri) \
                    .build()
 
-    def create_store(self, task_config, extent, affine_transform, crs_transformer, tmp_dir):
+    def create_store(self, task_config, extent, crs_transformer, tmp_dir):
         class_map = None
         if self.rgb:
             class_map = task_config.class_map
+        affine_transform = task_config.affine_transform
+
         return SemanticSegmentationRasterStore(
-            self.uri, self.geojson_uri, extent, affine_transform, crs_transformer, tmp_dir, class_map=class_map)
+            self.uri,
+            self.geojson_uri,
+            extent,
+            affine_transform,
+            crs_transformer,
+            tmp_dir,
+            class_map=class_map)
 
     def update_for_command(self,
                            command_type,
@@ -54,13 +65,37 @@ class SemanticSegmentationRasterStoreConfig(LabelStoreConfig):
                     raise rv.ConfigError(
                         'SemanticSegmentationRasterStoreConfig has no '
                         'URI set, and is not associated with a SceneConfig.')
+            if not self.geojson_uri:  # XXX and SOMETHING
+                # Construct the URI for this prediction store,
+                # using the scene ID.
+                root = experiment_config.predict_uri
+                uri = None
+                for c in context:
+                    if isinstance(c, rv.SceneConfig):
+                        uri = os.path.join(root, '{}.geojson'.format(c.id))
+                if uri:
+                    self.geojson_uri = uri
+                    io_def.add_output(uri)
+                else:
+                    raise rv.ConfigError(
+                        'SemanticSegmentationRasterStoreConfig has no '
+                        'GeoJSON URI set, and is not associated with a SceneConfig.'
+                    )
 
             io_def.add_output(self.uri)
+            if self.geojson_uri:
+                io_def.add_output(self.geojson_uri)
 
         if command_type == rv.EVAL:
             if self.uri:
                 io_def.add_input(self.uri)
             else:
+                msg = 'No URI set for SemanticSegmentationRasterStoreConfig'
+                io_def.add_missing(msg)
+
+            if self.geojson_uri:
+                io_def.add_input(self.geojson_uri)
+            else:  # XXX
                 msg = 'No URI set for SemanticSegmentationRasterStoreConfig'
                 io_def.add_missing(msg)
 
@@ -71,18 +106,29 @@ class SemanticSegmentationRasterStoreConfigBuilder(LabelStoreConfigBuilder):
     def __init__(self, prev=None):
         config = {}
         if prev:
-            config = {'uri': prev.uri, 'rgb': prev.rgb}
+            config = {
+                'uri': prev.uri,
+                'geojson_uri': prev.geojson_uri,
+                'rgb': prev.rgb,
+            }
 
         super().__init__(SemanticSegmentationRasterStoreConfig, config)
 
     def from_proto(self, msg):
         return self.with_uri(msg.semantic_segmentation_raster_store.uri) \
+                   .with_geojson_uri(msg.semantic_segmentation_raster_store.geojson_uri) \
                    .with_rgb(msg.semantic_segmentation_raster_store.rgb)
 
     def with_uri(self, uri):
         """Set URI for a GeoTIFF used to read/write predictions."""
         b = deepcopy(self)
         b.config['uri'] = uri
+        return b
+
+    def with_geojson_uri(self, geojson_uri):
+        """Set URI for a GeoJSON used to write predictions."""
+        b = deepcopy(self)
+        b.config['geojson_uri'] = geojson_uri
         return b
 
     def with_rgb(self, rgb):

--- a/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
@@ -23,6 +23,7 @@ class SemanticSegmentationRasterStoreConfig(LabelStoreConfig):
             for vo in self.vector_output:
                 msg2 = LabelStoreConfigMsg.SemanticSegmentationRasterStore.VectorOutput(
                 )
+                msg2.denoise = vo['denoise'] if 'denoise' in vo.keys() else 0
                 msg2.uri = vo['uri'] if 'uri' in vo.keys() else ''
                 msg2.mode = vo['mode']
                 msg2.class_id = vo['class_id']
@@ -137,12 +138,13 @@ class SemanticSegmentationRasterStoreConfigBuilder(LabelStoreConfigBuilder):
                 vector_output: Either a list of dictionaries or a
                     protobuf object.  The dictionary or the object
                     contain (respectively) keys (attributes) called
-                    'uri', 'class_id', and 'mode.  The 'uri' key is
-                    either a file where the GeoJSON prediction will be
-                    written, or "" indicating that the filename should
-                    be auto-generated.  'class_id' is the integer
-                    prediction class that is of interest.  The 'mode'
-                    key must be set to 'buildings'.
+                    'denoise', 'uri', 'class_id', and 'mode.  The
+                    'uri' key is either a file where the GeoJSON
+                    prediction will be written, or "" indicating that
+                    the filename should be auto-generated.  'class_id'
+                    is the integer prediction class that is of
+                    interest.  The 'mode' key must be set to
+                    'buildings'.
 
         """
         b = deepcopy(self)
@@ -154,6 +156,7 @@ class SemanticSegmentationRasterStoreConfigBuilder(LabelStoreConfigBuilder):
         else:
             for vo in vector_output:
                 ar.append({
+                    'denoise': vo.denoise,
                     'uri': vo.uri,
                     'mode': vo.mode,
                     'class_id': vo.class_id

--- a/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
@@ -135,7 +135,6 @@ class SemanticSegmentationRasterStoreConfigBuilder(LabelStoreConfigBuilder):
         """Configure vector output for predictions.
 
             Args:
-
                 vector_output: Either a list of dictionaries or a
                     protobuf object.  The dictionary or the object
                     contain (respectively) keys (attributes) called

--- a/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
@@ -135,16 +135,22 @@ class SemanticSegmentationRasterStoreConfigBuilder(LabelStoreConfigBuilder):
         """Configure vector output for predictions.
 
             Args:
+
                 vector_output: Either a list of dictionaries or a
                     protobuf object.  The dictionary or the object
                     contain (respectively) keys (attributes) called
-                    'denoise', 'uri', 'class_id', and 'mode.  The
-                    'uri' key is either a file where the GeoJSON
-                    prediction will be written, or "" indicating that
-                    the filename should be auto-generated.  'class_id'
-                    is the integer prediction class that is of
-                    interest.  The 'mode' key must be set to
-                    'buildings' or 'polygons'.
+                    'denoise', 'uri', 'class_id', and 'mode'.  The
+                    value associated with the 'denoise' key specifies
+                    the radius of the structural element used to
+                    perform a low-pass filtering process on the mask
+                    (see
+                    https://en.wikipedia.org/wiki/Mathematical_morphology#Opening).
+                    The value associated with the 'uri' key is either
+                    a file where the GeoJSON prediction will be
+                    written, or "" indicating that the filename should
+                    be auto-generated.  'class_id' is the integer
+                    prediction class that is of interest.  The 'mode'
+                    key must be set to 'buildings' or 'polygons'.
 
         """
         b = deepcopy(self)

--- a/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
@@ -24,12 +24,12 @@ class SemanticSegmentationRasterStoreConfig(LabelStoreConfig):
                    .with_uri(label_uri) \
                    .build()
 
-    def create_store(self, task_config, extent, crs_transformer, tmp_dir):
+    def create_store(self, task_config, extent, affine_transform, crs_transformer, tmp_dir):
         class_map = None
         if self.rgb:
             class_map = task_config.class_map
         return SemanticSegmentationRasterStore(
-            self.uri, extent, crs_transformer, tmp_dir, class_map=class_map)
+            self.uri, self.geojson_uri, extent, affine_transform, crs_transformer, tmp_dir, class_map=class_map)
 
     def update_for_command(self,
                            command_type,

--- a/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
@@ -114,7 +114,7 @@ class SemanticSegmentationRasterStoreConfigBuilder(LabelStoreConfigBuilder):
             }
 
         super().__init__(SemanticSegmentationRasterStoreConfig, config)
-        self.valid_modes = set(['buildings'])
+        self.valid_modes = set(['buildings', 'polygons'])
 
     def from_proto(self, msg):
         uri = msg.semantic_segmentation_raster_store.uri
@@ -144,7 +144,7 @@ class SemanticSegmentationRasterStoreConfigBuilder(LabelStoreConfigBuilder):
                     the filename should be auto-generated.  'class_id'
                     is the integer prediction class that is of
                     interest.  The 'mode' key must be set to
-                    'buildings'.
+                    'buildings' or 'polygons'.
 
         """
         b = deepcopy(self)

--- a/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store_config.py
@@ -126,7 +126,20 @@ class SemanticSegmentationRasterStoreConfigBuilder(LabelStoreConfigBuilder):
         return b
 
     def with_vector_output(self, msg):
-        """Vector output for predictions."""
+        """Configure vector output for predictions.
+
+            Args:
+                msg: Either a list of dictionaries or a protobuf
+                    object.  The dictionary or the object contain
+                    (respectively) key (attributes) called 'uri' and
+                    'mode.  The 'uri' key is either a file where the
+                    GeoJSON prediction will be written, or "*"
+                    indicating that the filename should be
+                    auto-generated.  The 'mode' key currently must be
+                    set to 'buildings', indicating that the
+                    building-specific feature extractor is to be used.
+
+        """
         b = deepcopy(self)
         ar = []
 

--- a/rastervision/data/raster_source/geotiff_source.py
+++ b/rastervision/data/raster_source/geotiff_source.py
@@ -108,3 +108,8 @@ class GeoTiffSource(RasterioRasterSource):
         else:
             self.proj = None
         self.crs = str(self.crs)
+
+    def get_affine_transform(self):
+        with self.activate():
+            transform = self.image_dataset.transform
+        return transform

--- a/rastervision/data/raster_source/geotiff_source.py
+++ b/rastervision/data/raster_source/geotiff_source.py
@@ -108,8 +108,3 @@ class GeoTiffSource(RasterioRasterSource):
         else:
             self.proj = None
         self.crs = str(self.crs)
-
-    def get_affine_transform(self):
-        with self.activate():
-            transform = self.image_dataset.transform
-        return transform

--- a/rastervision/data/scene_config.py
+++ b/rastervision/data/scene_config.py
@@ -36,7 +36,10 @@ class SceneConfig(BundledConfigMixin, Config):
         raster_source = self.raster_source.create_source(tmp_dir)
 
         extent = raster_source.get_extent()
-        affine_transform = raster_source.get_affine_transform()  # XXX
+        if False:  # self.geojson_uri:
+            task_config.affine_transform = raster_source.get_affine_transform()
+        else:
+            task_config.affine_transform = None
         crs_transformer = raster_source.get_crs_transformer()
 
         label_source = None

--- a/rastervision/data/scene_config.py
+++ b/rastervision/data/scene_config.py
@@ -34,14 +34,7 @@ class SceneConfig(BundledConfigMixin, Config):
               tmp_dir - Temporary directory to use
         """
         raster_source = self.raster_source.create_source(tmp_dir)
-
         extent = raster_source.get_extent()
-        if self.label_store and hasattr(
-                self.label_store,
-                'vector_output') and self.label_store.vector_output:
-            task_config.affine_transform = raster_source.get_affine_transform()
-        else:
-            task_config.affine_transform = None
         crs_transformer = raster_source.get_crs_transformer()
 
         label_source = None

--- a/rastervision/data/scene_config.py
+++ b/rastervision/data/scene_config.py
@@ -36,7 +36,9 @@ class SceneConfig(BundledConfigMixin, Config):
         raster_source = self.raster_source.create_source(tmp_dir)
 
         extent = raster_source.get_extent()
-        if False:  # self.geojson_uri:
+        if self.label_store and hasattr(
+                self.label_store,
+                'vector_output') and self.label_store.vector_output:
             task_config.affine_transform = raster_source.get_affine_transform()
         else:
             task_config.affine_transform = None

--- a/rastervision/data/scene_config.py
+++ b/rastervision/data/scene_config.py
@@ -36,6 +36,7 @@ class SceneConfig(BundledConfigMixin, Config):
         raster_source = self.raster_source.create_source(tmp_dir)
 
         extent = raster_source.get_extent()
+        affine_transform = raster_source.get_affine_transform()  # XXX
         crs_transformer = raster_source.get_crs_transformer()
 
         label_source = None
@@ -46,7 +47,6 @@ class SceneConfig(BundledConfigMixin, Config):
         if self.label_store:
             label_store = self.label_store.create_store(
                 task_config, extent, crs_transformer, tmp_dir)
-
         aoi_polygons = None
         if self.aoi_uris:
             aoi_polygons = []

--- a/rastervision/evaluation/classification_evaluation.py
+++ b/rastervision/evaluation/classification_evaluation.py
@@ -24,6 +24,10 @@ class ClassificationEvaluation(ABC):
         """Gets the evaluation for a particular EvaluationItem key"""
         return self.class_to_eval_item[key]
 
+    def has_id(self, key):
+        """Answers whether or not the EvaluationItem key is represented"""
+        return key in self.class_to_eval_item
+
     def to_json(self):
         json_rep = []
         for eval_item in self.class_to_eval_item.values():
@@ -54,7 +58,10 @@ class ClassificationEvaluation(ABC):
         else:
             for key, other_eval_item in \
                     evaluation.class_to_eval_item.items():
-                self.get_by_id(key).merge(other_eval_item)
+                if self.has_id(key):
+                    self.get_by_id(key).merge(other_eval_item)
+                else:
+                    self.class_to_eval_item[key] = other_eval_item
 
         self.compute_avg()
 

--- a/rastervision/evaluation/classification_evaluator.py
+++ b/rastervision/evaluation/classification_evaluator.py
@@ -3,8 +3,6 @@ import logging
 
 from rastervision.evaluation import Evaluator
 from rastervision.data import ActivateMixin
-from rastervision.rv_config import RVConfig
-from rastervision.utils.files import (download_if_needed)
 
 log = logging.getLogger(__name__)
 
@@ -39,22 +37,5 @@ class ClassificationEvaluator(Evaluator):
                 scene_evaluation = self.create_evaluation()
                 scene_evaluation.compute(ground_truth, predictions)
                 evaluation.merge(scene_evaluation)
-
-            if hasattr(label_source, 'source') and hasattr(
-                    label_source.source, 'vector_source') and hasattr(
-                        label_store, 'vector_output'):
-                tmp_dir = RVConfig.get_tmp_dir().name
-                gt_geojson = label_source.source.vector_source.uri
-                gt_geojson_local = download_if_needed(gt_geojson, tmp_dir)
-                for vo in label_store.vector_output:
-                    pred_geojson = vo['uri']
-                    mode = vo['mode']
-                    class_id = vo['class_id']
-                    pred_geojson_local = download_if_needed(
-                        pred_geojson, tmp_dir)
-                    scene_evaluation = self.create_evaluation()
-                    scene_evaluation.compute_vector(
-                        gt_geojson_local, pred_geojson_local, mode, class_id)
-                    evaluation.merge(scene_evaluation)
 
         evaluation.save(self.output_uri)

--- a/rastervision/evaluation/classification_evaluator.py
+++ b/rastervision/evaluation/classification_evaluator.py
@@ -3,6 +3,10 @@ import logging
 
 from rastervision.evaluation import Evaluator
 from rastervision.data import ActivateMixin
+from rastervision.rv_config import RVConfig
+from rastervision.utils.files import (download_if_needed, get_local_path,
+                                      make_dir, start_sync, upload_or_copy,
+                                      sync_to_dir, sync_from_dir)
 
 log = logging.getLogger(__name__)
 
@@ -37,4 +41,19 @@ class ClassificationEvaluator(Evaluator):
                 scene_evaluation = self.create_evaluation()
                 scene_evaluation.compute(ground_truth, predictions)
                 evaluation.merge(scene_evaluation)
+
+            if hasattr(label_source.source, 'vector_source') and hasattr(label_store, 'vector_output'):
+                tmp_dir = RVConfig.get_tmp_dir().name
+                gt_geojson = label_source.source.vector_source.uri
+                gt_geojson_local = download_if_needed(gt_geojson, tmp_dir)
+                for vo in label_store.vector_output:
+                    pred_geojson = vo['uri']
+                    mode = vo['mode']
+                    class_id = vo['class_id']
+                    pred_geojson_local = download_if_needed(pred_geojson, tmp_dir)
+                    scene_evaluation = self.create_evaluation()
+                    scene_evaluation.compute_vector(gt_geojson_local, pred_geojson_local, mode, class_id)
+                    # import pdb ; pdb.set_trace()
+                    evaluation.merge(scene_evaluation)
+
         evaluation.save(self.output_uri)

--- a/rastervision/evaluation/classification_evaluator.py
+++ b/rastervision/evaluation/classification_evaluator.py
@@ -4,9 +4,7 @@ import logging
 from rastervision.evaluation import Evaluator
 from rastervision.data import ActivateMixin
 from rastervision.rv_config import RVConfig
-from rastervision.utils.files import (download_if_needed, get_local_path,
-                                      make_dir, start_sync, upload_or_copy,
-                                      sync_to_dir, sync_from_dir)
+from rastervision.utils.files import (download_if_needed)
 
 log = logging.getLogger(__name__)
 
@@ -42,8 +40,9 @@ class ClassificationEvaluator(Evaluator):
                 scene_evaluation.compute(ground_truth, predictions)
                 evaluation.merge(scene_evaluation)
 
-            if hasattr(label_source.source, 'vector_source') and hasattr(
-                    label_store, 'vector_output'):
+            if hasattr(label_source, 'source') and hasattr(
+                    label_source.source, 'vector_source') and hasattr(
+                        label_store, 'vector_output'):
                 tmp_dir = RVConfig.get_tmp_dir().name
                 gt_geojson = label_source.source.vector_source.uri
                 gt_geojson_local = download_if_needed(gt_geojson, tmp_dir)
@@ -56,7 +55,6 @@ class ClassificationEvaluator(Evaluator):
                     scene_evaluation = self.create_evaluation()
                     scene_evaluation.compute_vector(
                         gt_geojson_local, pred_geojson_local, mode, class_id)
-                    # import pdb ; pdb.set_trace()
                     evaluation.merge(scene_evaluation)
 
         evaluation.save(self.output_uri)

--- a/rastervision/evaluation/classification_evaluator.py
+++ b/rastervision/evaluation/classification_evaluator.py
@@ -42,7 +42,8 @@ class ClassificationEvaluator(Evaluator):
                 scene_evaluation.compute(ground_truth, predictions)
                 evaluation.merge(scene_evaluation)
 
-            if hasattr(label_source.source, 'vector_source') and hasattr(label_store, 'vector_output'):
+            if hasattr(label_source.source, 'vector_source') and hasattr(
+                    label_store, 'vector_output'):
                 tmp_dir = RVConfig.get_tmp_dir().name
                 gt_geojson = label_source.source.vector_source.uri
                 gt_geojson_local = download_if_needed(gt_geojson, tmp_dir)
@@ -50,9 +51,11 @@ class ClassificationEvaluator(Evaluator):
                     pred_geojson = vo['uri']
                     mode = vo['mode']
                     class_id = vo['class_id']
-                    pred_geojson_local = download_if_needed(pred_geojson, tmp_dir)
+                    pred_geojson_local = download_if_needed(
+                        pred_geojson, tmp_dir)
                     scene_evaluation = self.create_evaluation()
-                    scene_evaluation.compute_vector(gt_geojson_local, pred_geojson_local, mode, class_id)
+                    scene_evaluation.compute_vector(
+                        gt_geojson_local, pred_geojson_local, mode, class_id)
                     # import pdb ; pdb.set_trace()
                     evaluation.merge(scene_evaluation)
 

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -29,6 +29,21 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
         self.class_map = class_map
 
     def compute_vector(self, gt, pred, mode, class_id):
+        """Compute evaluation over vectorized predictions.
+
+            Args:
+                gt: Ground-truth GeoJSON.  Either a string (containing
+                    unparsed GeoJSON or a file name), or a dictionary
+                    containing parsed GeoJSON.
+                pred: GeoJSON for predictions.  Either a string
+                    (containing unparsed GeoJSON or a file name), or a
+                    dictionary containing parsed GeoJSON.
+                mode: A string containing either 'buildings' or
+                    'polygons'.
+                class_id: An integer containing the class id of
+                    interest.
+
+        """
         import mask_to_polygons.vectorification as vectorification
         import mask_to_polygons.processing.score as score
 

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -3,7 +3,6 @@ import logging
 
 from rastervision.evaluation import ClassEvaluationItem
 from rastervision.evaluation import ClassificationEvaluation
-from rastervision.rv_config import RVConfig
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +21,6 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
 
         ground_truth = vectorification.geometries_from_geojson(gt_filename)
         predictions = vectorification.geometries_from_geojson(pred_filename)
-        # import pdb ; pdb.set_trace()
         if len(ground_truth) > 0 and len(predictions) > 0:
             results = score.spacenet(predictions, ground_truth)
 
@@ -44,7 +42,6 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
                                                   count_error, gt_count,
                                                   -class_id, class_name)
 
-            # XXX
             if hasattr(self, 'class_to_eval_item') and isinstance(
                     self.class_to_eval_item, dict):
                 self.class_to_eval_item[-class_id] = evaluation_item

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -82,7 +82,9 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
                 f1 = 0.0
             count_error = int(false_positives + false_negatives)
             gt_count = len(ground_truth)
-            class_name = 'vector-{}'.format(mode)
+            class_name = 'vector-{}-{}'.format(
+                mode,
+                self.class_map.get_by_id(class_id).name)
 
             evaluation_item = ClassEvaluationItem(precision, recall, f1,
                                                   count_error, gt_count,

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -45,7 +45,8 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
                                                   -class_id, class_name)
 
             # XXX
-            if hasattr(self, 'class_to_eval_item') and isinstance(self.class_to_eval_item, dict):
+            if hasattr(self, 'class_to_eval_item') and isinstance(
+                    self.class_to_eval_item, dict):
                 self.class_to_eval_item[-class_id] = evaluation_item
             else:
                 self.class_to_eval_item = {-class_id: evaluation_item}

--- a/rastervision/evaluation/semantic_segmentation_evaluator.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluator.py
@@ -42,8 +42,7 @@ class SemanticSegmentationEvaluator(ClassificationEvaluator):
                     label_source.source, 'vector_source') and hasattr(
                         label_store, 'vector_output'):
                 tmp_dir = RVConfig.get_tmp_dir().name
-                gt_geojson = label_source.source.vector_source.uri
-                gt_geojson_local = download_if_needed(gt_geojson, tmp_dir)
+                gt_geojson = label_source.source.vector_source.get_geojson()
                 for vo in label_store.vector_output:
                     pred_geojson = vo['uri']
                     mode = vo['mode']
@@ -52,7 +51,7 @@ class SemanticSegmentationEvaluator(ClassificationEvaluator):
                         pred_geojson, tmp_dir)
                     scene_evaluation = self.create_evaluation()
                     scene_evaluation.compute_vector(
-                        gt_geojson_local, pred_geojson_local, mode, class_id)
+                        gt_geojson, pred_geojson_local, mode, class_id)
                     evaluation.merge(scene_evaluation)
 
         evaluation.save(self.output_uri)

--- a/rastervision/evaluation/semantic_segmentation_evaluator.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluator.py
@@ -1,5 +1,12 @@
+import logging
+
+from rastervision.data import ActivateMixin
+from rastervision.rv_config import RVConfig
+from rastervision.utils.files import (download_if_needed)
 from rastervision.evaluation import (ClassificationEvaluator,
                                      SemanticSegmentationEvaluation)
+
+log = logging.getLogger(__name__)
 
 
 class SemanticSegmentationEvaluator(ClassificationEvaluator):
@@ -11,3 +18,41 @@ class SemanticSegmentationEvaluator(ClassificationEvaluator):
 
     def create_evaluation(self):
         return SemanticSegmentationEvaluation(self.class_map)
+
+    def process(self, scenes, tmp_dir):
+        evaluation = self.create_evaluation()
+        for scene in scenes:
+            log.info('Computing evaluation for scene {}...'.format(scene.id))
+            label_source = scene.ground_truth_label_source
+            label_store = scene.prediction_label_store
+            with ActivateMixin.compose(label_source, label_store):
+                ground_truth = label_source.get_labels()
+                predictions = label_store.get_labels()
+
+                if scene.aoi_polygons:
+                    # Filter labels based on AOI.
+                    ground_truth = ground_truth.filter_by_aoi(
+                        scene.aoi_polygons)
+                    predictions = predictions.filter_by_aoi(scene.aoi_polygons)
+                scene_evaluation = self.create_evaluation()
+                scene_evaluation.compute(ground_truth, predictions)
+                evaluation.merge(scene_evaluation)
+
+            if hasattr(label_source, 'source') and hasattr(
+                    label_source.source, 'vector_source') and hasattr(
+                        label_store, 'vector_output'):
+                tmp_dir = RVConfig.get_tmp_dir().name
+                gt_geojson = label_source.source.vector_source.uri
+                gt_geojson_local = download_if_needed(gt_geojson, tmp_dir)
+                for vo in label_store.vector_output:
+                    pred_geojson = vo['uri']
+                    mode = vo['mode']
+                    class_id = vo['class_id']
+                    pred_geojson_local = download_if_needed(
+                        pred_geojson, tmp_dir)
+                    scene_evaluation = self.create_evaluation()
+                    scene_evaluation.compute_vector(
+                        gt_geojson_local, pred_geojson_local, mode, class_id)
+                    evaluation.merge(scene_evaluation)
+
+        evaluation.save(self.output_uri)

--- a/rastervision/protos/label_store.proto
+++ b/rastervision/protos/label_store.proto
@@ -6,12 +6,19 @@ import "google/protobuf/struct.proto";
 
 message LabelStoreConfig {
     message SemanticSegmentationRasterStore {
+        message VectorOutput {
+            required string uri = 1;
+            required string mode = 2;
+        }
+
         optional string uri = 1;
 
         // Flag that determines whether or not the values in this
         // raster are RGB values. If so, the RGB values will be
         // translated into class IDs based on the class map.
         optional bool rgb = 2 [default=false];
+
+        repeated VectorOutput vector_output = 3;
     }
 
     required string store_type = 1;

--- a/rastervision/protos/label_store.proto
+++ b/rastervision/protos/label_store.proto
@@ -7,8 +7,9 @@ import "google/protobuf/struct.proto";
 message LabelStoreConfig {
     message SemanticSegmentationRasterStore {
         message VectorOutput {
-            required string uri = 1;
+            optional string uri = 1 [default=""];
             required string mode = 2;
+            required int32 class_id = 3;
         }
 
         optional string uri = 1;

--- a/rastervision/protos/label_store.proto
+++ b/rastervision/protos/label_store.proto
@@ -7,9 +7,10 @@ import "google/protobuf/struct.proto";
 message LabelStoreConfig {
     message SemanticSegmentationRasterStore {
         message VectorOutput {
-            optional string uri = 1 [default=""];
-            required string mode = 2;
-            required int32 class_id = 3;
+            optional int32 denoise = 1 [default=0];
+            optional string uri = 2 [default=""];
+            required string mode = 3;
+            required int32 class_id = 4;
         }
 
         optional string uri = 1;

--- a/rastervision/protos/label_store_pb2.py
+++ b/rastervision/protos/label_store_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/label_store.proto',
   package='rv.protos',
   syntax='proto2',
-  serialized_pb=_b('\n%rastervision/protos/label_store.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xcd\x03\n\x10LabelStoreConfig\x12\x12\n\nstore_type\x18\x01 \x02(\t\x12\r\n\x03uri\x18\x02 \x01(\tH\x00\x12i\n\"semantic_segmentation_raster_store\x18\x03 \x01(\x0b\x32;.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStoreH\x00\x12\x30\n\rcustom_config\x18\x04 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xe2\x01\n\x1fSemanticSegmentationRasterStore\x12\x0b\n\x03uri\x18\x01 \x01(\t\x12\x12\n\x03rgb\x18\x02 \x01(\x08:\x05\x66\x61lse\x12_\n\rvector_output\x18\x03 \x03(\x0b\x32H.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput\x1a=\n\x0cVectorOutput\x12\r\n\x03uri\x18\x01 \x01(\t:\x00\x12\x0c\n\x04mode\x18\x02 \x02(\t\x12\x10\n\x08\x63lass_id\x18\x03 \x02(\x05\x42\x14\n\x12label_store_config')
+  serialized_pb=_b('\n%rastervision/protos/label_store.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xe1\x03\n\x10LabelStoreConfig\x12\x12\n\nstore_type\x18\x01 \x02(\t\x12\r\n\x03uri\x18\x02 \x01(\tH\x00\x12i\n\"semantic_segmentation_raster_store\x18\x03 \x01(\x0b\x32;.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStoreH\x00\x12\x30\n\rcustom_config\x18\x04 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xf6\x01\n\x1fSemanticSegmentationRasterStore\x12\x0b\n\x03uri\x18\x01 \x01(\t\x12\x12\n\x03rgb\x18\x02 \x01(\x08:\x05\x66\x61lse\x12_\n\rvector_output\x18\x03 \x03(\x0b\x32H.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput\x1aQ\n\x0cVectorOutput\x12\x12\n\x07\x64\x65noise\x18\x01 \x01(\x05:\x01\x30\x12\r\n\x03uri\x18\x02 \x01(\t:\x00\x12\x0c\n\x04mode\x18\x03 \x02(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x02(\x05\x42\x14\n\x12label_store_config')
   ,
   dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -36,22 +36,29 @@ _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT = _descriptor.Des
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='uri', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.uri', index=0,
-      number=1, type=9, cpp_type=9, label=1,
+      name='denoise', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.denoise', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=True, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='uri', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.uri', index=1,
+      number=2, type=9, cpp_type=9, label=1,
       has_default_value=True, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='mode', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.mode', index=1,
-      number=2, type=9, cpp_type=9, label=2,
+      name='mode', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.mode', index=2,
+      number=3, type=9, cpp_type=9, label=2,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='class_id', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.class_id', index=2,
-      number=3, type=5, cpp_type=1, label=2,
+      name='class_id', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.class_id', index=3,
+      number=4, type=5, cpp_type=1, label=2,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -69,7 +76,7 @@ _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT = _descriptor.Des
   oneofs=[
   ],
   serialized_start=461,
-  serialized_end=522,
+  serialized_end=542,
 )
 
 _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE = _descriptor.Descriptor(
@@ -113,7 +120,7 @@ _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=296,
-  serialized_end=522,
+  serialized_end=542,
 )
 
 _LABELSTORECONFIG = _descriptor.Descriptor(
@@ -167,7 +174,7 @@ _LABELSTORECONFIG = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=83,
-  serialized_end=544,
+  serialized_end=564,
 )
 
 _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT.containing_type = _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE

--- a/rastervision/protos/label_store_pb2.py
+++ b/rastervision/protos/label_store_pb2.py
@@ -20,13 +20,50 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/label_store.proto',
   package='rv.protos',
   syntax='proto2',
-  serialized_pb=_b('\n%rastervision/protos/label_store.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xac\x02\n\x10LabelStoreConfig\x12\x12\n\nstore_type\x18\x01 \x02(\t\x12\r\n\x03uri\x18\x02 \x01(\tH\x00\x12i\n\"semantic_segmentation_raster_store\x18\x03 \x01(\x0b\x32;.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStoreH\x00\x12\x30\n\rcustom_config\x18\x04 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\x42\n\x1fSemanticSegmentationRasterStore\x12\x0b\n\x03uri\x18\x01 \x01(\t\x12\x12\n\x03rgb\x18\x02 \x01(\x08:\x05\x66\x61lseB\x14\n\x12label_store_config')
+  serialized_pb=_b('\n%rastervision/protos/label_store.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xb9\x03\n\x10LabelStoreConfig\x12\x12\n\nstore_type\x18\x01 \x02(\t\x12\r\n\x03uri\x18\x02 \x01(\tH\x00\x12i\n\"semantic_segmentation_raster_store\x18\x03 \x01(\x0b\x32;.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStoreH\x00\x12\x30\n\rcustom_config\x18\x04 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xce\x01\n\x1fSemanticSegmentationRasterStore\x12\x0b\n\x03uri\x18\x01 \x01(\t\x12\x12\n\x03rgb\x18\x02 \x01(\x08:\x05\x66\x61lse\x12_\n\rvector_output\x18\x03 \x03(\x0b\x32H.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput\x1a)\n\x0cVectorOutput\x12\x0b\n\x03uri\x18\x01 \x02(\t\x12\x0c\n\x04mode\x18\x02 \x02(\tB\x14\n\x12label_store_config')
   ,
   dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
+
+_LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT = _descriptor.Descriptor(
+  name='VectorOutput',
+  full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='uri', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.uri', index=0,
+      number=1, type=9, cpp_type=9, label=2,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='mode', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.mode', index=1,
+      number=2, type=9, cpp_type=9, label=2,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=461,
+  serialized_end=502,
+)
 
 _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE = _descriptor.Descriptor(
   name='SemanticSegmentationRasterStore',
@@ -49,10 +86,17 @@ _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='vector_output', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.vector_output', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
-  nested_types=[],
+  nested_types=[_LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT, ],
   enum_types=[
   ],
   options=None,
@@ -61,8 +105,8 @@ _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=295,
-  serialized_end=361,
+  serialized_start=296,
+  serialized_end=502,
 )
 
 _LABELSTORECONFIG = _descriptor.Descriptor(
@@ -116,9 +160,11 @@ _LABELSTORECONFIG = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=83,
-  serialized_end=383,
+  serialized_end=524,
 )
 
+_LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT.containing_type = _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE
+_LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE.fields_by_name['vector_output'].message_type = _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT
 _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE.containing_type = _LABELSTORECONFIG
 _LABELSTORECONFIG.fields_by_name['semantic_segmentation_raster_store'].message_type = _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE
 _LABELSTORECONFIG.fields_by_name['custom_config'].message_type = google_dot_protobuf_dot_struct__pb2._STRUCT
@@ -136,6 +182,13 @@ DESCRIPTOR.message_types_by_name['LabelStoreConfig'] = _LABELSTORECONFIG
 LabelStoreConfig = _reflection.GeneratedProtocolMessageType('LabelStoreConfig', (_message.Message,), dict(
 
   SemanticSegmentationRasterStore = _reflection.GeneratedProtocolMessageType('SemanticSegmentationRasterStore', (_message.Message,), dict(
+
+    VectorOutput = _reflection.GeneratedProtocolMessageType('VectorOutput', (_message.Message,), dict(
+      DESCRIPTOR = _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT,
+      __module__ = 'rastervision.protos.label_store_pb2'
+      # @@protoc_insertion_point(class_scope:rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput)
+      ))
+    ,
     DESCRIPTOR = _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE,
     __module__ = 'rastervision.protos.label_store_pb2'
     # @@protoc_insertion_point(class_scope:rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore)
@@ -147,6 +200,7 @@ LabelStoreConfig = _reflection.GeneratedProtocolMessageType('LabelStoreConfig', 
   ))
 _sym_db.RegisterMessage(LabelStoreConfig)
 _sym_db.RegisterMessage(LabelStoreConfig.SemanticSegmentationRasterStore)
+_sym_db.RegisterMessage(LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput)
 
 
 # @@protoc_insertion_point(module_scope)

--- a/rastervision/protos/label_store_pb2.py
+++ b/rastervision/protos/label_store_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/label_store.proto',
   package='rv.protos',
   syntax='proto2',
-  serialized_pb=_b('\n%rastervision/protos/label_store.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xb9\x03\n\x10LabelStoreConfig\x12\x12\n\nstore_type\x18\x01 \x02(\t\x12\r\n\x03uri\x18\x02 \x01(\tH\x00\x12i\n\"semantic_segmentation_raster_store\x18\x03 \x01(\x0b\x32;.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStoreH\x00\x12\x30\n\rcustom_config\x18\x04 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xce\x01\n\x1fSemanticSegmentationRasterStore\x12\x0b\n\x03uri\x18\x01 \x01(\t\x12\x12\n\x03rgb\x18\x02 \x01(\x08:\x05\x66\x61lse\x12_\n\rvector_output\x18\x03 \x03(\x0b\x32H.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput\x1a)\n\x0cVectorOutput\x12\x0b\n\x03uri\x18\x01 \x02(\t\x12\x0c\n\x04mode\x18\x02 \x02(\tB\x14\n\x12label_store_config')
+  serialized_pb=_b('\n%rastervision/protos/label_store.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xcd\x03\n\x10LabelStoreConfig\x12\x12\n\nstore_type\x18\x01 \x02(\t\x12\r\n\x03uri\x18\x02 \x01(\tH\x00\x12i\n\"semantic_segmentation_raster_store\x18\x03 \x01(\x0b\x32;.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStoreH\x00\x12\x30\n\rcustom_config\x18\x04 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xe2\x01\n\x1fSemanticSegmentationRasterStore\x12\x0b\n\x03uri\x18\x01 \x01(\t\x12\x12\n\x03rgb\x18\x02 \x01(\x08:\x05\x66\x61lse\x12_\n\rvector_output\x18\x03 \x03(\x0b\x32H.rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput\x1a=\n\x0cVectorOutput\x12\r\n\x03uri\x18\x01 \x01(\t:\x00\x12\x0c\n\x04mode\x18\x02 \x02(\t\x12\x10\n\x08\x63lass_id\x18\x03 \x02(\x05\x42\x14\n\x12label_store_config')
   ,
   dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -37,8 +37,8 @@ _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT = _descriptor.Des
   fields=[
     _descriptor.FieldDescriptor(
       name='uri', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.uri', index=0,
-      number=1, type=9, cpp_type=9, label=2,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=True, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -46,6 +46,13 @@ _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT = _descriptor.Des
       name='mode', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.mode', index=1,
       number=2, type=9, cpp_type=9, label=2,
       has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='class_id', full_name='rv.protos.LabelStoreConfig.SemanticSegmentationRasterStore.VectorOutput.class_id', index=2,
+      number=3, type=5, cpp_type=1, label=2,
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -62,7 +69,7 @@ _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT = _descriptor.Des
   oneofs=[
   ],
   serialized_start=461,
-  serialized_end=502,
+  serialized_end=522,
 )
 
 _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE = _descriptor.Descriptor(
@@ -106,7 +113,7 @@ _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=296,
-  serialized_end=502,
+  serialized_end=522,
 )
 
 _LABELSTORECONFIG = _descriptor.Descriptor(
@@ -160,7 +167,7 @@ _LABELSTORECONFIG = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=83,
-  serialized_end=524,
+  serialized_end=544,
 )
 
 _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE_VECTOROUTPUT.containing_type = _LABELSTORECONFIG_SEMANTICSEGMENTATIONRASTERSTORE

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flake8==3.5.*
-moto<=1.3.6
+moto==1.3.*,<=1.3.6
 coverage==4.5.1
 codecov==2.0.15
 yapf==0.22.*


### PR DESCRIPTION
## Overview

Adds ability to produce a GeoJSON file containing semantic segmentation predictions.

The ProtoBuf schema has been updated to include a [list of vector outputs](https://github.com/azavea/raster-vision/pull/575/files#diff-ba58680523016964b2532a3779c09392).

The segmentation integration test gives the following results:

![mask](https://user-images.githubusercontent.com/11281373/49242802-a9619e80-f3d9-11e8-9a2d-617576f77708.png)
![screenshot from 2018-12-05 14-38-44](https://user-images.githubusercontent.com/11281373/49539467-b67c0300-f89b-11e8-8bee-4d7ee0053d3e.png)

Evaluation of vector outputs has been left for future work (see https://github.com/azavea/raster-vision/issues/611 ).

`polygon` output mode left for future work (see https://github.com/azavea/raster-vision/issues/612 ).

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes https://github.com/azavea/raster-vision/issues/544
Closes #611
Closes #612
Closes #564