### PR TITLE
Force Determinism

### DIFF
--- a/.travis/test
+++ b/.travis/test
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+pushd /dev
+rm random urandom
+ln -s zero random
+ln -s zero urandom
+popd
+
 # Check no uncompiled protobufs
 docker run -w $(pwd) -v $(pwd):$(pwd) --rm -it raster-vision-cpu $(pwd)/scripts/compile
 if [ ! -z "$(git status --porcelain)" ]; then


### PR DESCRIPTION
## Overview

Force integration tests to be deterministic by removing sources of randomness.

Closes https://github.com/azavea/raster-vision/issues/584
