### PR TITLE
Revert "Force Determinism"

### DIFF
--- a/.travis/test
+++ b/.travis/test
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-pushd /dev
-rm random urandom
-ln -s zero random
-ln -s zero urandom
-popd
-
 # Check no uncompiled protobufs
 docker run -w $(pwd) -v $(pwd):$(pwd) --rm -it raster-vision-cpu $(pwd)/scripts/compile
 if [ ! -z "$(git status --porcelain)" ]; then


### PR DESCRIPTION
This was changing device files on the host, so it would not have worked anyway.  Doing so within the docker container does not seem to limit the behavior, either.

Reverts azavea/raster-vision#589