### PR TITLE
Partially Address Slow (Rio) Downloads

### DIFF
--- a/rastervision/data/label_source/chip_classification_label_source.py
+++ b/rastervision/data/label_source/chip_classification_label_source.py
@@ -10,8 +10,13 @@ from rastervision.data.label_source.utils import (
 from rastervision.data.utils import geojson_to_shapes
 
 
-def infer_cell(str_tree, shapes, cell, ioa_thresh, use_intersection_over_cell,
-               background_class_id, pick_min_class_id):
+def infer_cell(shapes,
+               cell,
+               ioa_thresh,
+               use_intersection_over_cell,
+               background_class_id,
+               pick_min_class_id,
+               str_tree=None):
     """Infer the class_id of a cell given a set of polygons.
 
     Given a cell and a set of polygons, the problem is to infer the class_id
@@ -36,7 +41,12 @@ def infer_cell(str_tree, shapes, cell, ioa_thresh, use_intersection_over_cell,
         pick_min_class_id: If true, the class_id for a cell is the minimum
             class_id of the boxes in that cell. Otherwise, pick the class_id of
             the box covering the greatest area.
+        str_tree: Either an STRtree object or None.  Used for geometric queries.
+
     """
+    if not str_tree:
+        str_tree = STRtree([shape for shape, class_id in shapes])
+
     # Monkey-patching class_id onto shapely.geom is not a good idea because
     # if you transform it, the class_id will be lost, but this works here. I wanted to
     # use a dictionary to associate shape with class_id, but couldn't because they are
@@ -108,9 +118,9 @@ def infer_labels(geojson, crs_transformer, extent, cell_size, ioa_thresh,
     cells = extent.get_windows(cell_size, cell_size)
     str_tree = STRtree([shape for shape, class_id in shapes])
     for cell in cells:
-        class_id = infer_cell(str_tree, shapes, cell, ioa_thresh,
+        class_id = infer_cell(shapes, cell, ioa_thresh,
                               use_intersection_over_cell, background_class_id,
-                              pick_min_class_id)
+                              pick_min_class_id, str_tree)
         labels.set_cell(cell, class_id)
     return labels
 


### PR DESCRIPTION
## Overview

This addresses the most acute of the performance bugs effecting the Rio example.

```
root@8688eabb6de7:/opt/src# rastervision run local chip -e spacenet.rio_chip_classification -a root_uri /tmp/XXZ
2018-12-07 14:07:29:rastervision.data.label_source.label_source_config: WARNING - LabelSource CHIP_CLASSIFICATION_GEOJSON is deprecated. Please use CHIP_CLASSIFICATION instead.
Ensuring input files exist    [####################################]  100%
Checking for existing output  [####################################]  100%
Saving command configuration to /tmp/XXZ/chip/spacenet-rio-chip-classification/command-config.json...
Making training chips...
2018-12-07 14:07:35:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232022.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232022.tif
2018-12-07 14:12:14:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223132.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223132.tif
2018-12-07 14:13:28:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223133.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223133.tif
2018-12-07 14:16:38:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232020.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232020.tif
2018-12-07 14:17:01:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223131.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223131.tif
2018-12-07 14:18:18:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223130.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223130.tif
2018-12-07 14:19:26:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232023.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232023.tif
2018-12-07 14:19:44:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232200.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232200.tif
2018-12-07 14:19:58:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223123.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022223123.tif
2018-12-07 14:20:07:rastervision.utils.files: INFO - Downloading s3://spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232021.tif to /tmp/tmpu3ifkfdu/tmp9u3zm4ix/s3/spacenet-dataset/AOI_1_Rio/srcData/mosaic_3band/013022232021.tif
2018-12-07 14:20:17:rastervision.task.task: INFO - Making train chips for scene: 013022232022
2018-12-07 14:25:14:rastervision.task.task: INFO - Making train chips for scene: 013022223132
...
```

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Connects https://github.com/azavea/raster-vision/issues/595
