### PR TITLE
Handle multiple AOI URIs

### DIFF
--- a/rastervision/protos/scene.proto
+++ b/rastervision/protos/scene.proto
@@ -22,5 +22,9 @@ message SceneConfig {
     optional LabelStoreConfig prediction_label_store = 4;
 
     // Optional AOI that describes where the scene is fully labeled.
+
+    // XXX here for backward compatibility
     optional string aoi_uri = 5;
+    
+    repeated string aoi_uris = 6;
 }

--- a/rastervision/protos/scene_pb2.py
+++ b/rastervision/protos/scene_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/scene.proto',
   package='rv.protos',
   syntax='proto2',
-  serialized_pb=_b('\n\x1frastervision/protos/scene.proto\x12\trv.protos\x1a\'rastervision/protos/raster_source.proto\x1a&rastervision/protos/label_source.proto\x1a%rastervision/protos/label_store.proto\"\xde\x01\n\x0bSceneConfig\x12\n\n\x02id\x18\x01 \x02(\t\x12\x34\n\rraster_source\x18\x02 \x02(\x0b\x32\x1d.rv.protos.RasterSourceConfig\x12?\n\x19ground_truth_label_source\x18\x03 \x01(\x0b\x32\x1c.rv.protos.LabelSourceConfig\x12;\n\x16prediction_label_store\x18\x04 \x01(\x0b\x32\x1b.rv.protos.LabelStoreConfig\x12\x0f\n\x07\x61oi_uri\x18\x05 \x01(\t')
+  serialized_pb=_b('\n\x1frastervision/protos/scene.proto\x12\trv.protos\x1a\'rastervision/protos/raster_source.proto\x1a&rastervision/protos/label_source.proto\x1a%rastervision/protos/label_store.proto\"\xf0\x01\n\x0bSceneConfig\x12\n\n\x02id\x18\x01 \x02(\t\x12\x34\n\rraster_source\x18\x02 \x02(\x0b\x32\x1d.rv.protos.RasterSourceConfig\x12?\n\x19ground_truth_label_source\x18\x03 \x01(\x0b\x32\x1c.rv.protos.LabelSourceConfig\x12;\n\x16prediction_label_store\x18\x04 \x01(\x0b\x32\x1b.rv.protos.LabelStoreConfig\x12\x0f\n\x07\x61oi_uri\x18\x05 \x01(\t\x12\x10\n\x08\x61oi_uris\x18\x06 \x03(\t')
   ,
   dependencies=[rastervision_dot_protos_dot_raster__source__pb2.DESCRIPTOR,rastervision_dot_protos_dot_label__source__pb2.DESCRIPTOR,rastervision_dot_protos_dot_label__store__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -72,6 +72,13 @@ _SCENECONFIG = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='aoi_uris', full_name='rv.protos.SceneConfig.aoi_uris', index=5,
+      number=6, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -85,7 +92,7 @@ _SCENECONFIG = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=167,
-  serialized_end=389,
+  serialized_end=407,
 )
 
 _SCENECONFIG.fields_by_name['raster_source'].message_type = rastervision_dot_protos_dot_raster__source__pb2._RASTERSOURCECONFIG

--- a/tests/data/test_scene.py
+++ b/tests/data/test_scene.py
@@ -1,0 +1,55 @@
+import unittest
+
+import rastervision as rv
+from rastervision.rv_config import RVConfig
+
+import tests.mock as mk
+from tests import data_file_path
+
+
+class TestScene(unittest.TestCase):
+    def setUp(self):
+        config = {'PLUGINS_modules': '["{}"]'.format('tests.mock')}
+        rv._registry.initialize_config(config_overrides=config)
+
+        self.temp_dir = RVConfig.get_tmp_dir()
+
+    def tearDown(self):
+        rv._registry.initialize_config()
+        self.temp_dir.cleanup()
+
+    def test_with_aois(self):
+        aoi_uri = data_file_path('evaluator/cc-label-aoi.json')
+        aoi_uris = [aoi_uri, aoi_uri]
+        task_config = rv.TaskConfig.builder(mk.MOCK_TASK).build()
+
+        scene_config = mk.create_mock_scene()
+        scene_config = scene_config.to_builder().with_aoi_uris(
+            aoi_uris).build()
+        scene = scene_config.create_scene(task_config, self.temp_dir.name)
+        self.assertEqual(2, len(scene.aoi_polygons))
+
+    def test_with_aoi(self):
+        aoi_uri = data_file_path('evaluator/cc-label-aoi.json')
+        task_config = rv.TaskConfig.builder(mk.MOCK_TASK).build()
+
+        scene_config = mk.create_mock_scene()
+        scene_config = scene_config.to_builder().with_aoi_uri(aoi_uri).build()
+        scene = scene_config.create_scene(task_config, self.temp_dir.name)
+        self.assertEqual(1, len(scene.aoi_polygons))
+
+    def test_with_aoi_back_compat(self):
+        aoi_uri = data_file_path('evaluator/cc-label-aoi.json')
+        task_config = rv.TaskConfig.builder(mk.MOCK_TASK).build()
+        scene_config = mk.create_mock_scene()
+        scene_msg = scene_config.to_proto()
+        # Use deprecated aoi_uri field.
+        del scene_msg.aoi_uris[:]
+        scene_msg.aoi_uri = aoi_uri
+        scene_config = rv.SceneConfig.from_proto(scene_msg)
+        scene = scene_config.create_scene(task_config, self.temp_dir.name)
+        self.assertEqual(1, len(scene.aoi_polygons))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

This PR adds a `with_aoi_uris` method to `SceneConfigBuilder` to handle multiple files containing AOIs. This makes it easier to select arbitrary subsets of AOIs to associate with a scene when experimenting. The original `with_aoi_uri` method, and `aoi_uri` `Scene` protobuf fields are still intact and functional for backward compatibility, 

Closes #615
