### PR TITLE
Correct Checkpoint Name

### DIFF
--- a/rastervision/backend/tf_deeplab_config.py
+++ b/rastervision/backend/tf_deeplab_config.py
@@ -121,7 +121,10 @@ class TFDeeplabConfig(BackendConfig):
             # Set the fine tune checkpoint name to the experiment id
             if not self.fine_tune_checkpoint_name:
                 self.fine_tune_checkpoint_name = experiment_config.id
-            io_def.add_output(self.fine_tune_checkpoint_name)
+            full_checkpoint_path = '{}.tar.gz'.format(
+                os.path.join(self.training_output_uri,
+                             self.fine_tune_checkpoint_name))
+            io_def.add_output(full_checkpoint_path)
         if command_type in [rv.PREDICT, rv.BUNDLE]:
             if not self.model_uri:
                 io_def.add_missing('Missing model_uri.')


### PR DESCRIPTION
## Overview

Fixes dependency checking by noting the correct fine-tuning checkpoint name as a product of the `TRAIN` stage.

### Checklist

- [x] Ran scripts/format_code and commited any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

To Test: Run the Vegas experiment twice in a row both with and without these changes.
```bash
rastervision run local -e spacenet.vegas -a test True -a use_remote_data True -a root_uri s3://my-bucket/vegas
rastervision run local -e spacenet.vegas -a test True -a use_remote_data True -a root_uri s3://my-bucket/vegas
```

Closes #608
