### PR TITLE
Handle width > height in semseg eval

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Raster Vision 0.9.0
 ~~~~~~~~~~~~~~~~~~~
 - Add support for vector tiles in .mbtiles files `#601 <https://github.com/azavea/raster-vision/pull/601>`_
 - Add support for getting labels from zxy vector tiles `#532 <https://github.com/azavea/raster-vision/pull/532>`_
-- Remove custom ``__deepcopy__`` implementation from ``ConfiBuilder``s. `#567 <https://github.com/azavea/raster-vision/pull/567>`_
+- Remove custom ``__deepcopy__`` implementation from ``ConfigBuilder``s. `#567 <https://github.com/azavea/raster-vision/pull/567>`_
 - Add ability to shift raster images by given numbers of meters.  `#573 <https://github.com/azavea/raster-vision/pull/573>`_
 
 Raster Vision 0.8
@@ -19,6 +19,7 @@ Raster Vision 0.8.2
 
 Bug Fixes
 ^^^^^^^^^
+- Fixed issue with handling width > height in semseg eval `#627 <https://github.com/azavea/raster-vision/pull/627>`_
 - Fixed issue with experiment configs not setting key names correctly `#523 <https://github.com/azavea/raster-vision/pull/576>`_
 - Fixed issue with Raster Sources that have channel order `#503 <https://github.com/azavea/raster-vision/pull/576>`_
 

--- a/rastervision/data/label/semantic_segmentation_labels.py
+++ b/rastervision/data/label/semantic_segmentation_labels.py
@@ -61,7 +61,7 @@ class SemanticSegmentationLabels(Labels):
 
     def to_array(self):
         extent = self.get_extent()
-        arr = np.zeros((extent.ymax, extent.ymax))
+        arr = np.zeros((extent.ymax, extent.xmax))
         for window, label_array in self.label_pairs:
             arr[window.ymin:window.ymax, window.xmin:window.xmax] = label_array
         return arr

--- a/tests/data/label/test_semantic_segmentation_labels.py
+++ b/tests/data/label/test_semantic_segmentation_labels.py
@@ -9,31 +9,36 @@ from rastervision.data.label import SemanticSegmentationLabels
 class TestSemanticSegmentationLabels(unittest.TestCase):
     def setUp(self):
         labels = np.zeros((100, 100))
-        # Make 2x2 grid that spans 200x200
+        # Make 2x3 grid that spans 200x300
         # yapf: disable
         label_pairs = [
             (Box.make_square(0, 0, 100), labels),
             (Box.make_square(0, 100, 100), labels),
+            (Box.make_square(0, 200, 100), labels),
             (Box.make_square(100, 0, 100), labels),
-            (Box.make_square(100, 100, 100), labels)
+            (Box.make_square(100, 100, 100), labels),
+            (Box.make_square(100, 200, 100), labels)
         ]
         # yapf: enable
         self.labels = SemanticSegmentationLabels(label_pairs)
 
     def test_get_extent(self):
         extent = self.labels.get_extent()
-        self.assertTrue(extent == Box.make_square(0, 0, 200))
+        self.assertEqual(extent.get_width(), 300)
+        self.assertEqual(extent.get_height(), 200)
 
     def test_get_clipped_labels(self):
-        extent = Box.make_square(0, 0, 150)
+        extent = Box.make_square(0, 0, 250)
         clipped = self.labels.get_clipped_labels(extent)
         pairs = clipped.get_label_pairs()
         # yapf: disable
         expected_pairs = [
-            (Box.make_square(0, 0, 100), np.zeros((100, 100))),
-            (Box(0, 100, 100, 150), np.zeros((100, 50))),
-            (Box(100, 0, 150, 100), np.zeros((50, 100))),
-            (Box(100, 100, 150, 150), np.zeros((50, 50)))
+            (Box(0, 0, 100, 100), np.zeros((100, 100))),
+            (Box(0, 100, 100, 200), np.zeros((100, 100))),
+            (Box(0, 200, 100, 250), np.zeros((100, 50))),
+            (Box(100, 0, 200, 100), np.zeros((100, 100))),
+            (Box(100, 100, 200, 200), np.zeros((100, 100))),
+            (Box(100, 200, 200, 250), np.zeros((100, 50)))
         ]
         # yapf: enable
 
@@ -55,7 +60,7 @@ class TestSemanticSegmentationLabels(unittest.TestCase):
 
     def test_to_array(self):
         arr = self.labels.to_array()
-        expected_arr = np.zeros((200, 200))
+        expected_arr = np.zeros((200, 300))
         np.testing.assert_array_equal(arr, expected_arr)
 
     def test_filter_by_aoi(self):


### PR DESCRIPTION
## Overview

This fixes a bug in the semantic segmentation evaluation that causing a failure when the width of the scene was greater than the height. This issue was first noted by @naf140230. This is covered by unit tests and I also tested it on a real world problem.

