### PR TITLE
Decrease semseg memory usage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,8 @@ Brief description of what this PR does, and why it is needed.
 ### Checklist
 
 - [ ] Updated `docs/changelog.rst`
-- [ ] Ran scripts/format_code and commited any changes
+- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
+- [ ] Ran scripts/format_code and committed any changes
 - [ ] Documentation updated if needed
 - [ ] PR has a name that won't get you publicly shamed for vagueness
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Raster Vision 0.9
 
 Raster Vision 0.9.0
 ~~~~~~~~~~~~~~~~~~~
+- Decrease semseg memory usage `#630 <https://github.com/azavea/raster-vision/pull/630>`_
 - Add support for vector tiles in .mbtiles files `#601 <https://github.com/azavea/raster-vision/pull/601>`_
 - Add support for getting labels from zxy vector tiles `#532 <https://github.com/azavea/raster-vision/pull/532>`_
 - Remove custom ``__deepcopy__`` implementation from ``ConfigBuilder``s. `#567 <https://github.com/azavea/raster-vision/pull/567>`_

--- a/rastervision/data/label/semantic_segmentation_labels.py
+++ b/rastervision/data/label/semantic_segmentation_labels.py
@@ -43,7 +43,7 @@ class SemanticSegmentationLabels(Labels):
         """
         arr = self.to_array()
         mask = rasterize(
-            [(p, 1) for p in aoi_polygons], out_shape=arr.shape, fill=0)
+            [(p, 1) for p in aoi_polygons], out_shape=arr.shape, fill=0, dtype=np.uint8)
         arr = arr * mask
         return SemanticSegmentationLabels.from_array(arr)
 

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -66,7 +66,7 @@ class SemanticSegmentationRasterStore(LabelStore):
         clipped_labels = labels.get_clipped_labels(self.extent)
 
         band_count = 1
-        dtype = np.int32
+        dtype = np.uint8
         if self.class_trans:
             band_count = 3
             dtype = np.uint8

--- a/rastervision/data/raster_source/rasterized_source.py
+++ b/rastervision/data/raster_source/rasterized_source.py
@@ -26,19 +26,26 @@ def geojson_to_raster(str_tree, rasterizer_options, extent, crs_transformer):
     shapes = [(s.buffer(line_buffer), c)
               if type(s) is shapely.geometry.LineString else (s, c)
               for s, c in shapes]
-    shapes = [(shapely.ops.transform(lambda x, y, z=None: (x - extent.xmin, y - extent.ymin), s),
-               c)
+
+    def transform_shape(x, y, z=None):
+        return (x - extent.xmin, y - extent.ymin)
+
+    shapes = [(shapely.ops.transform(transform_shape, s), c)
               for s, c in shapes]
     log.debug('# of shapes in extent: {}'.format(len(shapes)))
 
     out_shape = (extent.get_height(), extent.get_width())
+
     # rasterize needs to be passed >= 1 shapes.
     if shapes:
         log.debug('rasterio.rasterize()...')
         raster = rasterize(
-            shapes, out_shape=out_shape, fill=background_class_id)
+            shapes,
+            out_shape=out_shape,
+            fill=background_class_id,
+            dtype=np.uint8)
     else:
-        raster = np.full(out_shape, background_class_id)
+        raster = np.full(out_shape, background_class_id, dtype=np.uint8)
 
     return raster
 

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -1,7 +1,10 @@
 import math
+import logging
 
 from rastervision.evaluation import ClassEvaluationItem
 from rastervision.evaluation import ClassificationEvaluation
+
+log = logging.getLogger(__name__)
 
 
 class SemanticSegmentationEvaluation(ClassificationEvaluation):
@@ -17,6 +20,12 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
         # http://scikit-learn.org/stable/auto_examples/model_selection/plot_precision_recall.html  # noqa
         ground_truth_labels = ground_truth_labels.to_array()
         prediction_labels = prediction_labels.to_array()
+
+        log.debug('Type of ground truth labels: {}'.format(
+            ground_truth_labels.dtype))
+        log.debug('Type of prediction labels: {}'.format(
+            prediction_labels.dtype))
+
         # This shouldn't happen, but just in case...
         if ground_truth_labels.shape != prediction_labels.shape:
             raise ValueError(

--- a/rastervision/task/semantic_segmentation_config.py
+++ b/rastervision/task/semantic_segmentation_config.py
@@ -109,6 +109,16 @@ class SemanticSegmentationConfigBuilder(TaskConfigBuilder):
                     target_count_threshold=conf.chip_options.target_count_threshold,
                     stride=conf.chip_options.stride)
 
+    def validate(self):
+        super().validate()
+        # Segmentation masks are stored as uint8 to save space, so can only handle 256
+        # classes. If this is really needed, we can add an option for saving with uint16.
+        max_classes = 256
+        if len(self.config['class_map']) > max_classes:
+            raise rv.ConfigError(
+                'Cannot use more than {} classes with semantic segmentation.'.
+                format(max_classes))
+
     def with_classes(
             self, classes: Union[ClassMap, List[str], List[ClassItemMsg], List[
                 ClassItem], Dict[str, int], Dict[str, Tuple[int, str]]]):


### PR DESCRIPTION
## Overview

This PR decreases memory usage on semantic segmentation problems. Previously, we were rasterizing the entire scene, which would lead to running out of memory on large scenes. Now, we rasterize on the fly for individual chips which allows us to chip large scenes. 

The predict and eval steps still store the entire label array in RAM, which will be fixed in another PR. (See unchecked bullet points in #616)  But, as a step forward this PR switches to using uint8's to store the labels, and avoids some redundant copies. 

## Testing

* Using the Spacenet [Vegas](https://github.com/azavea/raster-vision-examples/blob/master/spacenet/vegas.py) example, I verified that it produced uint8 prediction GeoTIFFs. I also timed it on `chip` to make sure that it didn't get slower as a result of this change.
```
export ROOT_URI=/opt/data/lf-dev/rv-output/vegas-spacenet
time rastervision run local -e spacenet.vegas \
    -a test True \
    -a use_remote_data False \
    -a root_uri ${ROOT_URI} \
    -a target buildings \
    -a task_type semantic_segmentation \
    -r chip

vegas with this PR:
real	0m42.827s
user	0m32.920s
sys	0m1.840s

vegas using develop branch:
real	0m45.460s
user	0m35.560s
sys	0m1.790s
```
* I verified that the chip command ran successfully on a large ~8GB scene that previously failed. I also timed it, and it ran slightly faster with these changes which was a little surprising since for each chip, it has to intersect geoms for the whole scene with the chip extent. (This was done on a private project and doesn't need to be replicated, but details are available upon request.)

Closes #629 
Connects #616 