### PR TITLE
Make and save predictions and do eval chip-by-chip

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Raster Vision 0.9
 
 Raster Vision 0.9.0
 ~~~~~~~~~~~~~~~~~~~
+- Make and save predictions and do eval chip-by-chip `#635 <https://github.com/azavea/raster-vision/pull/635>`_
 - Decrease semseg memory usage `#630 <https://github.com/azavea/raster-vision/pull/630>`_
 - Add support for vector tiles in .mbtiles files `#601 <https://github.com/azavea/raster-vision/pull/601>`_
 - Add support for getting labels from zxy vector tiles `#532 <https://github.com/azavea/raster-vision/pull/532>`_

--- a/rastervision/backend/backend.py
+++ b/rastervision/backend/backend.py
@@ -52,5 +52,8 @@ class Backend(ABC):
         Args:
             chips: [[height, width, channels], ...] numpy array of chips
             windows: List of boxes that are the windows aligned with the chips.
+
+        Return:
+            Labels object containing predictions
         """
         pass

--- a/rastervision/backend/tf_deeplab.py
+++ b/rastervision/backend/tf_deeplab.py
@@ -52,8 +52,8 @@ def make_tf_examples(training_data: TrainingData, class_map: ClassMap) -> List:
     tf_examples = []
     log.info('Creating TFRecord')
     for chip, window, labels in training_data:
-        tf_example = create_tf_example(chip, window, labels.to_array(),
-                                       class_map)
+        tf_example = create_tf_example(chip, window,
+                                       labels.get_label_arr(window), class_map)
         tf_examples.append(tf_example)
     return tf_examples
 

--- a/rastervision/backend/tf_deeplab.py
+++ b/rastervision/backend/tf_deeplab.py
@@ -657,24 +657,24 @@ class TFDeeplab(Backend):
         """Predict using an already-trained DeepLab model.
 
         Args:
-            chips: An np.ndarray containing the image data.
-            windows: A list of windows corresponding to the respective
-                 training chips.
-             tmp_dir: (str) temporary directory to use
-        Returns:
-             A list of Box × np.ndarray pairs.
+            chips: An np.ndarray containing the image data in a batch of size 1.
+            tmp_dir: (str) temporary directory to use
 
+        Returns:
+             SemanticSegmentationLabels object with predictions for a single chip
         """
         self.load_model(tmp_dir)
-        labels = SemanticSegmentationLabels()
+        label_arr = self.sess.run(
+            OUTPUT_TENSOR_NAME, feed_dict={INPUT_TENSOR_NAME: [chips[0]]})[0]
 
-        # Feeding in one chip at a time because the model doesn't seem to
-        # accept > 1.
-        # TODO fix this
-        for ind, window in enumerate(windows):
-            class_labels = self.sess.run(
-                OUTPUT_TENSOR_NAME,
-                feed_dict={INPUT_TENSOR_NAME: [chips[ind]]})[0]
-            labels.add_label_pair(window, class_labels)
+        # Return "trivial" instance of SemanticSegmentationLabels that holds a single
+        # window and has ability to get labels for that one window.
+        def label_fn(_window):
+            if _window == windows[0]:
+                return label_arr
+            else:
+                raise ValueError('Trying to get labels for unknown window.')
+
+        labels = SemanticSegmentationLabels(windows, label_fn)
 
         return labels

--- a/rastervision/data/label/labels.py
+++ b/rastervision/data/label/labels.py
@@ -3,17 +3,15 @@ from abc import (ABC, abstractmethod)
 
 class Labels(ABC):
     """A set of spatially referenced labels.
+
     A set of labels predicted by a model or provided by human labelers for the
-    sake of training. Every label is associated with a spatial location and a
-    class. For object detection, a label is a bounding box surrounding an
-    object and the associated class. For classification, a label is a bounding
-    box representing a cell/chip within a spatial grid and its class.
-    For segmentation, a label is a pixel and its class.
+    sake of training.
     """
 
     @abstractmethod
     def __add__(self, other):
         """Add labels to these labels.
+
         Returns a concatenation of this and the other labels.
         """
         pass
@@ -25,4 +23,8 @@ class Labels(ABC):
         Args:
           aoi_polygons - A list of AOI polygons to filter by, in pixel coordinates.
         """
+        pass
+
+    @abstractmethod
+    def __eq__(self, other):
         pass

--- a/rastervision/data/label/semantic_segmentation_labels.py
+++ b/rastervision/data/label/semantic_segmentation_labels.py
@@ -38,6 +38,13 @@ class SemanticSegmentationLabels(Labels):
             self.label_fn,
             aoi_polygons=self.aoi_polygons)
 
+    def __eq__(self, other):
+        for window in self.get_windows():
+            if not np.array_equal(
+                    self.get_label_arr(window), other.get_label_arr(window)):
+                return False
+        return True
+
     def filter_by_aoi(self, aoi_polygons):
         """Returns a new SemanticSegmentationLabels object with aoi_polygons set."""
         return SemanticSegmentationLabels(

--- a/rastervision/data/label_store/label_store.py
+++ b/rastervision/data/label_store/label_store.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 
+from rastervision.data import ActivateMixin
 
-class LabelStore(ABC):
+
+class LabelStore(ABC, ActivateMixin):
     """This defines how to store prediction labels are stored for a scene.
     """
 
@@ -23,4 +25,13 @@ class LabelStore(ABC):
     @abstractmethod
     def empty_labels(self):
         """Produces an empty Labels"""
+        pass
+
+    def _subcomponents_to_activate(self):
+        pass
+
+    def _activate(self):
+        pass
+
+    def _deactivate(self):
         pass

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -93,7 +93,6 @@ class SemanticSegmentationRasterStore(LabelStore):
         dtype = np.uint8
         if self.class_trans:
             band_count = 3
-            dtype = np.uint8
 
         if self.vector_output:
             # We need to store the whole output mask to run feature extraction.

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -126,7 +126,8 @@ class SemanticSegmentationRasterStore(LabelStore):
                                    window.xmin + class_labels.shape[1]))
                 if mask is not None:
                     mask[clipped_window[0][0]:clipped_window[0][1],
-                         clipped_window[1][0]:clipped_window[1][1]] = class_labels
+                         clipped_window[1][0]:clipped_window[1][
+                             1]] = class_labels
                 if self.class_trans:
                     rgb_labels = self.class_trans.class_to_rgb(class_labels)
                     for chan in range(3):
@@ -168,7 +169,6 @@ class SemanticSegmentationRasterStore(LabelStore):
                     with open(local_geojson_path, 'w') as file_out:
                         file_out.write(geojson)
                         upload_or_copy(local_geojson_path, uri)
-
 
     def empty_labels(self):
         """Returns an empty SemanticSegmentationLabels object."""

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -2,7 +2,8 @@ import numpy as np
 import rasterio
 
 import rastervision as rv
-from rastervision.utils.files import (get_local_path, make_dir, upload_or_copy)
+from rastervision.utils.files import (get_local_path, make_dir, upload_or_copy,
+                                      file_exists)
 from rastervision.data.label import SemanticSegmentationLabels
 from rastervision.data.label_store import LabelStore
 from rastervision.data.label_source import SegmentationClassTransformer
@@ -42,23 +43,37 @@ class SemanticSegmentationRasterStore(LabelStore):
         else:
             self.class_trans = None
 
-    def get_labels(self):
+        self.source = None
+        if file_exists(uri):
+            self.source = rv.RasterSourceConfig.builder(rv.GEOTIFF_SOURCE) \
+                                               .with_uri(self.uri) \
+                                               .build() \
+                                               .create_source(self.tmp_dir)
+
+    def _subcomponents_to_activate(self):
+        if self.source is not None:
+            return [self.source]
+        return []
+
+    def get_labels(self, chip_size=1000):
         """Get all labels.
 
         Returns:
-            SemanticSegmentationLabels
+            SemanticSegmentationLabels with windows of size chip_size covering the
+                scene with no overlap.
         """
-        source = rv.RasterSourceConfig.builder(rv.GEOTIFF_SOURCE) \
-                                      .with_uri(self.uri) \
-                                      .build() \
-                                      .create_source(self.tmp_dir)
-        with source.activate():
-            raw_labels = source.get_raw_image_array()
+
+        def label_fn(window):
+            raw_labels = self.source.get_raw_chip(window)
             if self.class_trans:
                 labels = self.class_trans.rgb_to_class(raw_labels)
             else:
                 labels = np.squeeze(raw_labels)
-            return SemanticSegmentationLabels.from_array(labels)
+            return labels
+
+        extent = self.source.get_extent()
+        windows = extent.get_windows(chip_size, chip_size)
+        return SemanticSegmentationLabels(windows, label_fn)
 
     def save(self, labels):
         """Save.
@@ -73,7 +88,6 @@ class SemanticSegmentationRasterStore(LabelStore):
         # Need more general way of computing transform for the more general case.
         transform = self.crs_transformer.transform
         crs = self.crs_transformer.get_image_crs()
-        clipped_labels = labels.get_clipped_labels(self.extent)
 
         band_count = 1
         dtype = np.uint8
@@ -82,6 +96,11 @@ class SemanticSegmentationRasterStore(LabelStore):
             dtype = np.uint8
 
         if self.vector_output:
+            # We need to store the whole output mask to run feature extraction.
+            # If the raster is large, this will result in running out of memory, so
+            # more work will be needed to get this to work in a scalable way. But this
+            # is complicated because of the need to merge features that are split
+            # across windows.
             mask = np.zeros(
                 (self.extent.ymax, self.extent.xmax), dtype=np.uint8)
         else:
@@ -99,19 +118,26 @@ class SemanticSegmentationRasterStore(LabelStore):
                 dtype=dtype,
                 transform=transform,
                 crs=crs) as dataset:
-            for (window, class_labels) in clipped_labels.get_label_pairs():
-                window = (window.ymin, window.ymax), (window.xmin, window.xmax)
+            for window in labels.get_windows():
+                class_labels = labels.get_label_arr(
+                    window, clip_extent=self.extent)
+                clipped_window = ((window.ymin,
+                                   window.ymin + class_labels.shape[0]),
+                                  (window.xmin,
+                                   window.xmin + class_labels.shape[1]))
                 if mask is not None:
-                    mask[window[0][0]:window[0][1], window[1][0]:window[1][
-                        1]] = class_labels
+                    mask[clipped_window[0][0]:clipped_window[0][1],
+                         clipped_window[1][0]:clipped_window[1][1]] = class_labels
                 if self.class_trans:
                     rgb_labels = self.class_trans.class_to_rgb(class_labels)
                     for chan in range(3):
                         dataset.write_band(
-                            chan + 1, rgb_labels[:, :, chan], window=window)
+                            chan + 1,
+                            rgb_labels[:, :, chan],
+                            window=clipped_window)
                 else:
                     img = class_labels.astype(dtype)
-                    dataset.write_band(1, img, window=window)
+                    dataset.write_band(1, img, window=clipped_window)
 
         upload_or_copy(local_path, self.uri)
 
@@ -143,6 +169,7 @@ class SemanticSegmentationRasterStore(LabelStore):
                     with open(local_geojson_path, 'w') as file_out:
                         file_out.write(geojson)
                         upload_or_copy(local_geojson_path, uri)
+
 
     def empty_labels(self):
         """Returns an empty SemanticSegmentationLabels object."""

--- a/rastervision/evaluation/classification_evaluation.py
+++ b/rastervision/evaluation/classification_evaluation.py
@@ -20,6 +20,9 @@ class ClassificationEvaluation(ABC):
         self.class_to_eval_item = {}
         self.avg_item = None
 
+    def set_class_to_eval_item(self, class_to_eval_item):
+        self.class_to_eval_item = class_to_eval_item
+
     def get_by_id(self, key):
         """Gets the evaluation for a particular EvaluationItem key"""
         return self.class_to_eval_item[key]

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -24,7 +24,8 @@ def get_class_eval_item(gt_arr, pred_arr, class_id, class_map):
     class_name = class_map.get_by_id(class_id).name
 
     if gt_arr.sum() == 0:
-        return ClassEvaluationItem(None, None, None, 0, 0, class_id, class_name)
+        return ClassEvaluationItem(None, None, None, 0, 0, class_id,
+                                   class_name)
 
     # Definitions of precision, recall, and f1 taken from
     # http://scikit-learn.org/stable/auto_examples/model_selection/plot_precision_recall.html  # noqa

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -20,17 +20,76 @@ def is_geojson(data):
         return retval
 
 
+def get_class_eval_item(gt_arr, pred_arr, class_id, class_map):
+    class_name = class_map.get_by_id(class_id).name
+
+    if gt_arr.sum() == 0:
+        return ClassEvaluationItem(None, None, None, 0, 0, class_id, class_name)
+
+    # Definitions of precision, recall, and f1 taken from
+    # http://scikit-learn.org/stable/auto_examples/model_selection/plot_precision_recall.html  # noqa
+    not_dont_care = (gt_arr != 0)  # By assumption
+    gt = (gt_arr == class_id)
+    pred = (pred_arr == class_id)
+    not_gt = (gt_arr != class_id)
+    not_pred = (pred_arr != class_id)
+
+    true_pos = (gt * pred).sum()
+    false_pos = (not_gt * pred * not_dont_care).sum()
+    false_neg = (gt * not_pred * not_dont_care).sum()
+
+    precision = float(true_pos) / (true_pos + false_pos)
+    recall = float(true_pos) / (true_pos + false_neg)
+    f1 = 2 * (precision * recall) / (precision + recall)
+    count_error = int(false_pos + false_neg)
+    gt_count = int(gt.sum())
+
+    if math.isnan(precision):
+        precision = None
+    else:
+        precision = float(precision)
+    if math.isnan(recall):
+        recall = None
+    else:
+        recall = float(recall)
+    if math.isnan(f1):
+        f1 = None
+    else:
+        f1 = float(f1)
+
+    return ClassEvaluationItem(precision, recall, f1, count_error, gt_count,
+                               class_id, class_name)
+
+
 class SemanticSegmentationEvaluation(ClassificationEvaluation):
-    """Evaluation for semantic segmentation.
-    """
+    """Evaluation for semantic segmentation."""
 
     def __init__(self, class_map):
         super().__init__()
         self.class_map = class_map
 
+    def compute(self, gt_labels, pred_labels):
+        self.clear()
+        for window in pred_labels.get_windows():
+            log.debug('Evaluating window: {}'.format(window))
+            gt_arr = gt_labels.get_label_arr(window)
+            pred_arr = pred_labels.get_label_arr(window)
+
+            eval_items = []
+            for class_id in self.class_map.get_keys():
+                eval_item = get_class_eval_item(gt_arr, pred_arr, class_id,
+                                                self.class_map)
+                eval_items.append(eval_item)
+
+            # Treat each window as if it was a small Scene.
+            window_eval = SemanticSegmentationEvaluation(self.class_map)
+            window_eval.set_class_to_eval_item(
+                dict(zip(self.class_map.get_keys(), eval_items)))
+            window_eval.compute_avg()
+            self.merge(window_eval)
+
     def compute_vector(self, gt, pred, mode, class_id):
         """Compute evaluation over vectorized predictions.
-
             Args:
                 gt: Ground-truth GeoJSON.  Either a string (containing
                     unparsed GeoJSON or a file name), or a dictionary
@@ -42,7 +101,6 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
                     'polygons'.
                 class_id: An integer containing the class id of
                     interest.
-
         """
         import mask_to_polygons.vectorification as vectorification
         import mask_to_polygons.processing.score as score
@@ -96,62 +154,3 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
             else:
                 self.class_to_eval_item = {-class_id: evaluation_item}
             self.compute_avg()
-
-    def compute(self, ground_truth_labels, prediction_labels):
-        # Definitions of precision, recall, and f1 taken from
-        # http://scikit-learn.org/stable/auto_examples/model_selection/plot_precision_recall.html  # noqa
-        ground_truth_labels = ground_truth_labels.to_array()
-        prediction_labels = prediction_labels.to_array()
-
-        log.debug('Type of ground truth labels: {}'.format(
-            ground_truth_labels.dtype))
-        log.debug('Type of prediction labels: {}'.format(
-            prediction_labels.dtype))
-
-        # This shouldn't happen, but just in case...
-        if ground_truth_labels.shape != prediction_labels.shape:
-            raise ValueError(
-                'ground_truth_labels and prediction_labels need to '
-                'have the same shape.')
-
-        evaluation_items = []
-        for class_id in self.class_map.get_keys():
-            not_dont_care = (ground_truth_labels != 0)  # By assumption
-            gt = (ground_truth_labels == class_id)
-            pred = (prediction_labels == class_id)
-            not_gt = (ground_truth_labels != class_id)
-            not_pred = (prediction_labels != class_id)
-
-            true_positives = (gt * pred).sum()
-            false_positives = (not_gt * pred * not_dont_care).sum()
-            false_negatives = (gt * not_pred * not_dont_care).sum()
-
-            precision = float(true_positives) / (
-                true_positives + false_positives)
-            recall = float(true_positives) / (true_positives + false_negatives)
-            f1 = 2 * (precision * recall) / (precision + recall)
-            count_error = int(false_positives + false_negatives)
-            gt_count = int(gt.sum())
-            class_name = self.class_map.get_by_id(class_id).name
-
-            if math.isnan(precision):
-                precision = None
-            else:
-                precision = float(precision)
-            if math.isnan(recall):
-                recall = None
-            else:
-                recall = float(recall)
-            if math.isnan(f1):
-                f1 = None
-            else:
-                f1 = float(f1)
-
-            evaluation_item = ClassEvaluationItem(precision, recall, f1,
-                                                  count_error, gt_count,
-                                                  class_id, class_name)
-            evaluation_items.append(evaluation_item)
-
-        self.class_to_eval_item = dict(
-            zip(self.class_map.get_keys(), evaluation_items))
-        self.compute_avg()

--- a/rastervision/predictor.py
+++ b/rastervision/predictor.py
@@ -137,9 +137,10 @@ class Predictor():
             # Reload scene to refresh any new analyzer config
             scene = scene_config.create_scene(self.task_config, self.tmp_dir)
 
-        labels = self.task.predict_scene(scene, self.tmp_dir)
-        if label_uri:
-            scene.prediction_label_store.save(labels)
+        with scene.activate():
+            labels = self.task.predict_scene(scene, self.tmp_dir)
+            if label_uri:
+                scene.prediction_label_store.save(labels)
 
         if config_uri:
             msg = self.bundle_config.to_builder() \

--- a/rastervision/protos/scene.proto
+++ b/rastervision/protos/scene.proto
@@ -23,8 +23,8 @@ message SceneConfig {
 
     // Optional AOI that describes where the scene is fully labeled.
 
-    // XXX here for backward compatibility
+    // here for backward compatibility
     optional string aoi_uri = 5;
-    
+
     repeated string aoi_uris = 6;
 }

--- a/rastervision/task/task.py
+++ b/rastervision/task/task.py
@@ -155,8 +155,8 @@ class Task(object):
                 label_store.save(labels)
 
                 if self.config.debug and self.config.predict_debug_uri:
-                    self.save_debug_predict_image(scene,
-                                                  self.config.predict_debug_uri)
+                    self.save_debug_predict_image(
+                        scene, self.config.predict_debug_uri)
 
     def predict_scene(self, scene, tmp_dir):
         """Predict on a single scene, and return the labels."""

--- a/rastervision/task/task.py
+++ b/rastervision/task/task.py
@@ -149,13 +149,14 @@ class Task(object):
         self.backend.load_model(tmp_dir)
 
         for scene in scenes:
-            labels = self.predict_scene(scene, tmp_dir)
-            label_store = scene.prediction_label_store
-            label_store.save(labels)
+            with scene.activate():
+                labels = self.predict_scene(scene, tmp_dir)
+                label_store = scene.prediction_label_store
+                label_store.save(labels)
 
-            if self.config.debug and self.config.predict_debug_uri:
-                self.save_debug_predict_image(scene,
-                                              self.config.predict_debug_uri)
+                if self.config.debug and self.config.predict_debug_uri:
+                    self.save_debug_predict_image(scene,
+                                                  self.config.predict_debug_uri)
 
     def predict_scene(self, scene, tmp_dir):
         """Predict on a single scene, and return the labels."""
@@ -164,31 +165,30 @@ class Task(object):
         label_store = scene.prediction_label_store
         labels = label_store.empty_labels()
 
-        with scene.activate():
-            windows = self.get_predict_windows(raster_source.get_extent())
+        windows = self.get_predict_windows(raster_source.get_extent())
 
-            def predict_batch(predict_chips, predict_windows):
-                nonlocal labels
-                new_labels = self.backend.predict(
-                    np.array(predict_chips), predict_windows, tmp_dir)
-                labels += new_labels
-                print('.' * len(predict_chips), end='', flush=True)
+        def predict_batch(predict_chips, predict_windows):
+            nonlocal labels
+            new_labels = self.backend.predict(
+                np.array(predict_chips), predict_windows, tmp_dir)
+            labels += new_labels
+            print('.' * len(predict_chips), end='', flush=True)
 
-            batch_chips, batch_windows = [], []
-            for window in windows:
-                chip = raster_source.get_chip(window)
-                if np.any(chip):
-                    batch_chips.append(chip)
-                    batch_windows.append(window)
+        batch_chips, batch_windows = [], []
+        for window in windows:
+            chip = raster_source.get_chip(window)
+            if np.any(chip):
+                batch_chips.append(chip)
+                batch_windows.append(window)
 
-                # Predict on batch
-                if len(batch_chips) >= self.config.predict_batch_size:
-                    predict_batch(batch_chips, batch_windows)
-                    batch_chips, batch_windows = [], []
-            print()
-
-            # Predict on remaining batch
-            if len(batch_chips) > 0:
+            # Predict on batch
+            if len(batch_chips) >= self.config.predict_batch_size:
                 predict_batch(batch_chips, batch_windows)
+                batch_chips, batch_windows = [], []
+        print()
 
-            return self.post_process_predictions(labels, scene)
+        # Predict on remaining batch
+        if len(batch_chips) > 0:
+            predict_batch(batch_chips, batch_windows)
+
+        return self.post_process_predictions(labels, scene)

--- a/tests/data/label_source/test_semantic_segmentation_label_source.py
+++ b/tests/data/label_source/test_semantic_segmentation_label_source.py
@@ -5,52 +5,17 @@ import numpy as np
 import rastervision as rv
 from rastervision.core.box import Box
 from rastervision.core.class_map import ClassMap, ClassItem
-from rastervision.data import (ActivateMixin, ActivationError)
 from rastervision.data.label_source.semantic_segmentation_label_source import (
     SemanticSegmentationLabelSource)
-from rastervision.data.raster_source.raster_source import RasterSource
-
-
-class MockRasterSource(ActivateMixin, RasterSource):
-    def __init__(self, data):
-        self.data = data
-        (self.height, self.width, self.channels) = data.shape
-        self.activated = False
-
-    def get_extent(self):
-        return Box(0, 0, self.height, self.width)
-
-    def _get_chip(self, window):
-        if not self.activated:
-            raise ActivationError('MockRasterSource should be activated')
-
-        ymin = window.ymin
-        xmin = window.xmin
-        ymax = window.ymax
-        xmax = window.xmax
-        return self.data[ymin:ymax, xmin:xmax, :]
-
-    def get_chip(self, window):
-        return self.get_chip(window)
-
-    def get_crs_transformer(self, window):
-        return None
-
-    def get_dtype(self):
-        return np.uint8
-
-    def _activate(self):
-        self.activated = True
-
-    def _deactivate(self):
-        self.activated = False
+from tests.mock import MockRasterSource
 
 
 class TestSemanticSegmentationLabelSource(unittest.TestCase):
     def test_enough_target_pixels_true(self):
         data = np.zeros((10, 10, 3), dtype=np.uint8)
         data[4:, 4:, :] = [1, 1, 1]
-        raster_source = MockRasterSource(data)
+        raster_source = MockRasterSource([0, 1, 2], 3)
+        raster_source.set_raster(data)
         rgb_class_map = ClassMap([ClassItem(id=1, color='#010101')])
         label_source = SemanticSegmentationLabelSource(
             source=raster_source, rgb_class_map=rgb_class_map)
@@ -61,7 +26,8 @@ class TestSemanticSegmentationLabelSource(unittest.TestCase):
     def test_enough_target_pixels_false(self):
         data = np.zeros((10, 10, 3), dtype=np.uint8)
         data[7:, 7:, :] = [1, 1, 1]
-        raster_source = MockRasterSource(data)
+        raster_source = MockRasterSource([0, 1, 2], 3)
+        raster_source.set_raster(data)
         rgb_class_map = ClassMap([ClassItem(id=1, color='#010101')])
         label_source = SemanticSegmentationLabelSource(
             source=raster_source, rgb_class_map=rgb_class_map)
@@ -73,36 +39,30 @@ class TestSemanticSegmentationLabelSource(unittest.TestCase):
     def test_get_labels(self):
         data = np.zeros((10, 10, 1), dtype=np.uint8)
         data[7:, 7:, 0] = 1
-        raster_source = MockRasterSource(data)
+        raster_source = MockRasterSource([0, 1, 2], 3)
+        raster_source.set_raster(data)
         label_source = SemanticSegmentationLabelSource(source=raster_source)
         with label_source.activate():
-            labels = label_source.get_labels().to_array()
-            expected_labels = np.zeros((10, 10))
-            expected_labels[7:, 7:] = 1
-            np.testing.assert_array_equal(labels, expected_labels)
-
             window = Box.make_square(7, 7, 3)
-            labels = label_source.get_labels(window=window).to_array()
-            expected_labels = np.ones((3, 3))
-            np.testing.assert_array_equal(labels, expected_labels)
+            labels = label_source.get_labels(window=window)
+            label_arr = labels.get_label_arr(window)
+            expected_label_arr = np.ones((3, 3))
+            np.testing.assert_array_equal(label_arr, expected_label_arr)
 
     def test_get_labels_rgb(self):
         data = np.zeros((10, 10, 3), dtype=np.uint8)
         data[7:, 7:, :] = [1, 1, 1]
-        raster_source = MockRasterSource(data)
+        raster_source = MockRasterSource([0, 1, 2], 3)
+        raster_source.set_raster(data)
         rgb_class_map = ClassMap([ClassItem(id=1, color='#010101')])
         label_source = SemanticSegmentationLabelSource(
             source=raster_source, rgb_class_map=rgb_class_map)
         with label_source.activate():
-            labels = label_source.get_labels().to_array()
-            expected_labels = np.zeros((10, 10))
-            expected_labels[7:, 7:] = 1
-            np.testing.assert_array_equal(labels, expected_labels)
-
             window = Box.make_square(7, 7, 3)
-            labels = label_source.get_labels(window=window).to_array()
-            expected_labels = np.ones((3, 3))
-            np.testing.assert_array_equal(labels, expected_labels)
+            labels = label_source.get_labels(window=window)
+            label_arr = labels.get_label_arr(window)
+            expected_label_arr = np.ones((3, 3))
+            np.testing.assert_array_equal(label_arr, expected_label_arr)
 
     def test_build_missing(self):
         with self.assertRaises(rv.ConfigError):

--- a/tests/data/raster_source/test_rasterized_source.py
+++ b/tests/data/raster_source/test_rasterized_source.py
@@ -86,11 +86,15 @@ class TestRasterizedSource(unittest.TestCase):
 
         source = self.build_source(geojson)
         with source.activate():
+            # Get chip that partially overlaps extent. Expect that chip has zeros
+            # outside of extent, and background_class_id otherwise.
             self.assertEqual(source.get_extent(), self.extent)
-            chip = source.get_image_array()
+            chip = source.get_chip(Box.make_square(5, 5, 10))
             self.assertEqual(chip.shape, (10, 10, 1))
 
-            expected_chip = self.background_class_id * np.ones((10, 10, 1))
+            expected_chip = np.zeros((10, 10, 1))
+            expected_chip[0:5, 0:5, :] = self.background_class_id
+
             np.testing.assert_array_equal(chip, expected_chip)
 
 

--- a/tests/evaluation/test_semantic_segmentation_evaluation.py
+++ b/tests/evaluation/test_semantic_segmentation_evaluation.py
@@ -7,58 +7,7 @@ from rastervision.evaluation.semantic_segmentation_evaluation import (
     SemanticSegmentationEvaluation)
 from rastervision.data.label_source.semantic_segmentation_label_source import (
     SemanticSegmentationLabelSource)
-from rastervision.data.raster_source.raster_source import RasterSource
-from rastervision.core.box import Box
-
-# from ..data.label_source.test_semantic_segmentation_label_source import (
-#    MockRasterSource)
-
-
-# This class was copied from test_semantic_segmentation_label_source
-# because it can't be imported because
-# SystemError: Parent module '' not loaded, cannot perform relative import
-# TODO: solve this problem
-class MockRasterSource(RasterSource):
-    def __init__(self, zeros=False, data=None):
-        if data is not None:
-            self.data = data
-            (self.height, self.width, self.channels) = data.shape
-        elif zeros and data is None:
-            self.width = 4
-            self.height = 4
-            self.channels = 3
-            self.data = np.zeros(
-                (self.height, self.width, self.channels), dtype=np.uint8)
-        elif not zeros and data is None:
-            self.width = 4
-            self.height = 4
-            self.channels = 3
-            self.data = np.random.randint(
-                0,
-                2,
-                size=(self.width, self.height, self.channels),
-                dtype=np.uint8)
-            self.data[:, :, 0:(self.channels - 1)] = np.zeros(
-                (self.height, self.width, self.channels - 1), dtype=np.uint8)
-
-    def get_extent(self):
-        return Box(0, 0, self.height, self.width)
-
-    def _get_chip(self, window):
-        ymin = window.ymin
-        xmin = window.xmin
-        ymax = window.ymax
-        xmax = window.xmax
-        return self.data[ymin:ymax, xmin:xmax, :]
-
-    def get_chip(self, window):
-        return self.get_chip(window)
-
-    def get_crs_transformer(self, window):
-        return None
-
-    def get_dtype(self):
-        return np.uint8
+from tests.mock import MockRasterSource
 
 
 class TestSemanticSegmentationEvaluation(unittest.TestCase):
@@ -71,13 +20,15 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         gt_array = np.ones((4, 4, 3), dtype=np.uint8)
         gt_array[0, 0, :] = 0
         gt_array[2, 2, :] = 2
-        gt_raster = MockRasterSource(data=gt_array)
+        gt_raster = MockRasterSource([0, 1, 2], 3)
+        gt_raster.set_raster(gt_array)
         gt_label_source = SemanticSegmentationLabelSource(
             source=gt_raster, rgb_class_map=class_map)
 
         p_array = np.ones((4, 4, 3), dtype=np.uint8)
         p_array[1, 1, :] = 0
-        p_raster = MockRasterSource(data=p_array)
+        p_raster = MockRasterSource([0, 1, 2], 3)
+        p_raster.set_raster(p_array)
         p_label_source = SemanticSegmentationLabelSource(
             source=p_raster, rgb_class_map=class_map)
 

--- a/tests/mock/raster_source.py
+++ b/tests/mock/raster_source.py
@@ -25,6 +25,7 @@ class MockRasterSource(RasterSource):
         self.mock.get_dtype.return_value = np.uint8
         self.mock.get_crs_transformer.return_value = IdentityCRSTransformer()
         self.mock._get_chip.return_value = np.random.rand(1, 2, 2, 3)
+        self.raster = None
 
     def get_extent(self):
         return self.mock.get_extent()
@@ -36,7 +37,12 @@ class MockRasterSource(RasterSource):
         return self.mock.get_crs_transformer()
 
     def _get_chip(self, window):
-        return self.mock._get_chip(window)
+        if self.raster is None:
+            return self.mock._get_chip(window)
+        return self.raster[window.ymin:window.ymax, window.xmin:window.xmax, :]
+
+    def set_raster(self, raster):
+        self.raster = raster
 
 
 class MockRasterSourceConfig(SupressDeepCopyMixin, RasterSourceConfig):


### PR DESCRIPTION
## Overview

Currently, the predict command makes predictions for each chip in a scene, holding all the predictions in memory and then saves them to disk. This uses too much RAM for very large scenes. The same happens for the eval command. This PR makes it so that each prediction (for a chip) is written to disk immediately, and so that the eval is done one window at a time, and not over the whole scene. 

The main change supporting this is making the `SemanticSegmentationLabels` class compute labels dynamically rather than storing them all for the set of windows. This is accomplished by making `label_fn` a parameter of the constructor for `SemanticSegmentationLabels`. The `label_fn` converts a window to a label array, and can implemented in different ways depending on the context. It calls the backend `predict` method for the `predict` command, and Rasterio windowed read operations during `eval`.

## Notes

The vectorification process involves loading the whole prediction array into RAM, which means that won't work on very large scenes. If that is a priority, we can fix it in a separate PR.

## Testing Instructions

* I tested this on a private experiment with very large scenes, that previously would crash during each of chip, predict, and eval, and it now works.
* The correctness of the changes should be captured by the unit and integration tests.
* I also tested this by running on the Vegas example and checked that the vectorification still works. (Tested using instructions in https://github.com/azavea/raster-vision/issues/658. That bug seems to be coming from the vectorification code. I got it to work by swapping in a known good model into the train dir after the training step completes.)

Closes #632 
Closes #651 