### PR TITLE
[BACKPORT] Ensure compatable moto

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flake8==3.5.*
-moto==1.3.*
+moto<=1.3.6
 coverage==4.5.1
 codecov==2.0.15
 yapf==0.22.*


### PR DESCRIPTION
This change was made as part of  #555. This should fix the build errors we've been seeing on the 0.8 branch.