### PR TITLE
Eval Script

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Raster Vision 0.9.0
 - Remove custom ``__deepcopy__`` implementation from ``ConfigBuilder``s. `#567 <https://github.com/azavea/raster-vision/pull/567>`_
 - Add ability to shift raster images by given numbers of meters.  `#573 <https://github.com/azavea/raster-vision/pull/573>`_
 - Add ability to generate GeoJSON segmentation predictions.  `#575 <https://github.com/azavea/raster-vision/pull/575>`_
+- Add ability to run the DeepLab eval script.  `#653 <https://github.com/azavea/raster-vision/pull/653>`_
 
 Raster Vision 0.8
 -----------------

--- a/rastervision/backend/tf_deeplab.py
+++ b/rastervision/backend/tf_deeplab.py
@@ -653,18 +653,12 @@ class TFDeeplab(Backend):
             if self.backend_config.train_options.do_eval:
                 # Start eval script
                 log.info('Starting eval script')
-                eval_logdir = os.path.join(tmp_dir, 'eval_logdir')
+                eval_logdir = train_logdir_local
                 eval_args = get_evaluation_args(eval_py, train_logdir_local,
                                                 dataset_dir_local, eval_logdir,
                                                 tfdl_config)
                 eval_process = Popen(eval_args, env=train_env)
                 terminate_at_exit(eval_process)
-
-                tensorboard_process2 = Popen([
-                    'tensorboard', '--logdir={}'.format(eval_logdir),
-                    '--port=6007'
-                ])
-                terminate_at_exit(tensorboard_process2)
 
             # Wait for training and tensorboard
             log.info('Waiting for training and tensorboard processes')

--- a/rastervision/backend/tf_deeplab.py
+++ b/rastervision/backend/tf_deeplab.py
@@ -176,7 +176,7 @@ def create_tf_example(image: np.ndarray,
                       labels: np.ndarray,
                       class_map: ClassMap,
                       chip_id: str = ''):
-    """Create a TensorFlow from an image, the labels, &c.
+    """Create a TensorFlow Example from an image, the labels, &c.
 
     Args:
          image: An np.ndarray containing the image data.
@@ -294,7 +294,7 @@ def get_evaluation_args(eval_py: str, train_logdir_local: str,
 
     multi_fields = [
         'atrous_rates',
-        'train_crop_size',
+        'eval_crop_size',
     ]
 
     args = ['python', eval_py]

--- a/rastervision/backend/tf_deeplab_config.py
+++ b/rastervision/backend/tf_deeplab_config.py
@@ -258,7 +258,8 @@ class TFDeeplabConfigBuilder(BackendConfigBuilder):
     def _process_task(self):
         return self.with_config(
             {
-                'trainCropSize': [self.task.chip_size, self.task.chip_size]
+                'trainCropSize': [self.task.chip_size, self.task.chip_size],
+                'evalCropSize': [self.task.chip_size, self.task.chip_size]
             },
             ignore_missing_keys=True)
 

--- a/rastervision/backend/tf_deeplab_config.py
+++ b/rastervision/backend/tf_deeplab_config.py
@@ -12,6 +12,7 @@ from rastervision.task import SemanticSegmentationConfig
 
 # Default location to Tensorflow Deeplab's scripts.
 DEFAULT_SCRIPT_TRAIN = '/opt/tf-models/deeplab/train.py'
+DEFAULT_SCRIPT_EVAL = '/opt/tf-models/deeplab/eval.py'
 DEFAULT_SCRIPT_EXPORT = '/opt/tf-models/deeplab/export_model.py'
 CHIP_OUTPUT_FILES = ['train-{}.record', 'validation-{}.record']
 DEBUG_CHIP_OUTPUT_FILES = ['train.zip', 'validation.zip']
@@ -34,8 +35,10 @@ class TFDeeplabConfig(BackendConfig):
     class ScriptLocations:
         def __init__(self,
                      train_py=DEFAULT_SCRIPT_TRAIN,
-                     export_py=DEFAULT_SCRIPT_EXPORT):
+                     export_py=DEFAULT_SCRIPT_EXPORT,
+                     eval_py=DEFAULT_SCRIPT_EVAL):
             self.train_py = train_py
+            self.eval_py = eval_py
             self.export_py = export_py
 
     def __init__(self,
@@ -77,6 +80,7 @@ class TFDeeplabConfig(BackendConfig):
     def to_proto(self):
         d = {
             'train_py': self.script_locations.train_py,
+            'eval_py': self.script_locations.eval_py,
             'export_py': self.script_locations.export_py,
             'train_restart_dir': self.train_options.train_restart_dir,
             'sync_interval': self.train_options.sync_interval,
@@ -198,7 +202,7 @@ class TFDeeplabConfigBuilder(BackendConfigBuilder):
             replace_model=conf.replace_model,
             do_eval=conf.do_eval)
         b = b.with_script_locations(
-            train_py=conf.train_py, export_py=conf.export_py)
+            train_py=conf.train_py, export_py=conf.export_py, eval_py=conf.eval_py)
         b = b.with_training_data_uri(conf.training_data_uri)
         b = b.with_training_output_uri(conf.training_output_uri)
         b = b.with_model_uri(conf.model_uri)
@@ -404,9 +408,10 @@ class TFDeeplabConfigBuilder(BackendConfigBuilder):
 
     def with_script_locations(self,
                               train_py=DEFAULT_SCRIPT_TRAIN,
-                              export_py=DEFAULT_SCRIPT_EXPORT):
+                              export_py=DEFAULT_SCRIPT_EXPORT,
+                              eval_py=DEFAULT_SCRIPT_EVAL):
         script_locs = TFDeeplabConfig.ScriptLocations(
-            train_py=train_py, export_py=export_py)
+            train_py=train_py, export_py=export_py, eval_py=eval_py)
         b = deepcopy(self)
         b.config['script_locations'] = script_locs
         return b

--- a/rastervision/backend/tf_deeplab_config.py
+++ b/rastervision/backend/tf_deeplab_config.py
@@ -202,7 +202,9 @@ class TFDeeplabConfigBuilder(BackendConfigBuilder):
             replace_model=conf.replace_model,
             do_eval=conf.do_eval)
         b = b.with_script_locations(
-            train_py=conf.train_py, export_py=conf.export_py, eval_py=conf.eval_py)
+            train_py=conf.train_py,
+            export_py=conf.export_py,
+            eval_py=conf.eval_py)
         b = b.with_training_data_uri(conf.training_data_uri)
         b = b.with_training_output_uri(conf.training_output_uri)
         b = b.with_model_uri(conf.model_uri)

--- a/rastervision/backend/tf_deeplab_config.py
+++ b/rastervision/backend/tf_deeplab_config.py
@@ -23,11 +23,13 @@ class TFDeeplabConfig(BackendConfig):
                      train_restart_dir=None,
                      sync_interval=600,
                      do_monitoring=True,
-                     replace_model=False):
+                     replace_model=False,
+                     do_eval=False):
             self.train_restart_dir = train_restart_dir
             self.sync_interval = sync_interval
             self.do_monitoring = do_monitoring
             self.replace_model = replace_model
+            self.do_eval = do_eval
 
     class ScriptLocations:
         def __init__(self,
@@ -79,6 +81,7 @@ class TFDeeplabConfig(BackendConfig):
             'train_restart_dir': self.train_options.train_restart_dir,
             'sync_interval': self.train_options.sync_interval,
             'do_monitoring': self.train_options.do_monitoring,
+            'do_eval': self.train_options.do_eval,
             'replace_model': self.train_options.replace_model,
             'debug': self.debug,
             'training_data_uri': self.training_data_uri,
@@ -192,7 +195,8 @@ class TFDeeplabConfigBuilder(BackendConfigBuilder):
             train_restart_dir=conf.train_restart_dir,
             sync_interval=conf.sync_interval,
             do_monitoring=conf.do_monitoring,
-            replace_model=conf.replace_model)
+            replace_model=conf.replace_model,
+            do_eval=conf.do_eval)
         b = b.with_script_locations(
             train_py=conf.train_py, export_py=conf.export_py)
         b = b.with_training_data_uri(conf.training_data_uri)
@@ -327,25 +331,28 @@ class TFDeeplabConfigBuilder(BackendConfigBuilder):
                            train_restart_dir=None,
                            sync_interval=600,
                            do_monitoring=True,
-                           replace_model=False):
+                           replace_model=False,
+                           do_eval=False):
         """Sets the train options for this backend.
 
            Args:
               sync_interval: How often to sync output of training to the cloud
                 (in seconds).
-
               do_monitoring: Run process to monitor training (eg. Tensorboard)
-
               replace_model: Replace the model checkpoint if exists.
                              If false, this will continue training from
                              checkpoing if exists, if the backend allows for this.
+              do_eval: Boolean determining whether to run the eval
+                   script.
+
         """
         b = deepcopy(self)
         b.config['train_options'] = TFDeeplabConfig.TrainOptions(
             train_restart_dir=train_restart_dir,
             sync_interval=sync_interval,
             do_monitoring=do_monitoring,
-            replace_model=replace_model)
+            replace_model=replace_model,
+            do_eval=do_eval)
 
         return b.with_config(
             {

--- a/rastervision/protos/backend.proto
+++ b/rastervision/protos/backend.proto
@@ -47,6 +47,7 @@ message BackendConfig {
         optional string train_restart_dir = 3;
         optional int32 sync_interval = 4 [default=600];
         optional bool do_monitoring = 5 [default=true];
+	optional bool do_eval = 13 [default=false];
         optional bool replace_model = 6 [default=false];
 
         optional string training_data_uri = 7;

--- a/rastervision/protos/backend.proto
+++ b/rastervision/protos/backend.proto
@@ -42,6 +42,7 @@ message BackendConfig {
 
     message TFDeeplabConfig {
         optional string train_py = 1 [default="/opt/tf-models/deeplab/train.py"];
+        optional string eval_py = 14 [default="/opt/tf-models/deeplab/eval.py"];
         optional string export_py = 2 [default="/opt/tf-models/deeplab/export_model.py"];
 
         optional string train_restart_dir = 3;

--- a/rastervision/protos/backend_pb2.py
+++ b/rastervision/protos/backend_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/backend.proto',
   package='rv.protos',
   syntax='proto2',
-  serialized_pb=_b('\n!rastervision/protos/backend.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xfa\x0b\n\rBackendConfig\x12\x14\n\x0c\x62\x61\x63kend_type\x18\x01 \x02(\t\x12\x1c\n\x14pretrained_model_uri\x18\x03 \x01(\t\x12V\n\x1atf_object_detection_config\x18\x04 \x01(\x0b\x32\x30.rv.protos.BackendConfig.TFObjectDetectionConfigH\x00\x12Y\n\x1bkeras_classification_config\x18\x05 \x01(\x0b\x32\x32.rv.protos.BackendConfig.KerasClassificationConfigH\x00\x12\x45\n\x11tf_deeplab_config\x18\x07 \x01(\x0b\x32(.rv.protos.BackendConfig.TFDeeplabConfigH\x00\x12\x30\n\rcustom_config\x18\x06 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xb6\x03\n\x17TFObjectDetectionConfig\x12\x1a\n\rsync_interval\x18\x01 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x02 \x01(\x08:\x04true\x12\x1c\n\rreplace_model\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x44\n\rmodel_main_py\x18\x04 \x01(\t:-/opt/tf-models/object_detection/model_main.py\x12L\n\texport_py\x18\x05 \x01(\t:9/opt/tf-models/object_detection/export_inference_graph.py\x12\x19\n\x11training_data_uri\x18\x06 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x07 \x01(\t\x12\x11\n\tmodel_uri\x18\x08 \x01(\t\x12!\n\x19\x66ine_tune_checkpoint_name\x18\t \x01(\t\x12\x14\n\x05\x64\x65\x62ug\x18\n \x01(\x08:\x05\x66\x61lse\x12,\n\x0btfod_config\x18\x0b \x02(\x0b\x32\x17.google.protobuf.Struct\x1a\xff\x01\n\x19KerasClassificationConfig\x12\x1a\n\rsync_interval\x18\x01 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x02 \x01(\x08:\x04true\x12\x1c\n\rreplace_model\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11training_data_uri\x18\x04 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x05 \x01(\t\x12\x11\n\tmodel_uri\x18\x06 \x01(\t\x12\x14\n\x05\x64\x65\x62ug\x18\x07 \x01(\x08:\x05\x66\x61lse\x12*\n\tkc_config\x18\x08 \x02(\x0b\x32\x17.google.protobuf.Struct\x1a\xbb\x03\n\x0fTFDeeplabConfig\x12\x31\n\x08train_py\x18\x01 \x01(\t:\x1f/opt/tf-models/deeplab/train.py\x12\x39\n\texport_py\x18\x02 \x01(\t:&/opt/tf-models/deeplab/export_model.py\x12\x19\n\x11train_restart_dir\x18\x03 \x01(\t\x12\x1a\n\rsync_interval\x18\x04 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x05 \x01(\x08:\x04true\x12\x16\n\x07\x64o_eval\x18\r \x01(\x08:\x05\x66\x61lse\x12\x1c\n\rreplace_model\x18\x06 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11training_data_uri\x18\x07 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x08 \x01(\t\x12\x11\n\tmodel_uri\x18\t \x01(\t\x12!\n\x19\x66ine_tune_checkpoint_name\x18\n \x01(\t\x12,\n\x0btfdl_config\x18\x0b \x02(\x0b\x32\x17.google.protobuf.Struct\x12\x14\n\x05\x64\x65\x62ug\x18\x0c \x01(\x08:\x05\x66\x61lseB\x10\n\x0e\x62\x61\x63kend_config')
+  serialized_pb=_b('\n!rastervision/protos/backend.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xab\x0c\n\rBackendConfig\x12\x14\n\x0c\x62\x61\x63kend_type\x18\x01 \x02(\t\x12\x1c\n\x14pretrained_model_uri\x18\x03 \x01(\t\x12V\n\x1atf_object_detection_config\x18\x04 \x01(\x0b\x32\x30.rv.protos.BackendConfig.TFObjectDetectionConfigH\x00\x12Y\n\x1bkeras_classification_config\x18\x05 \x01(\x0b\x32\x32.rv.protos.BackendConfig.KerasClassificationConfigH\x00\x12\x45\n\x11tf_deeplab_config\x18\x07 \x01(\x0b\x32(.rv.protos.BackendConfig.TFDeeplabConfigH\x00\x12\x30\n\rcustom_config\x18\x06 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xb6\x03\n\x17TFObjectDetectionConfig\x12\x1a\n\rsync_interval\x18\x01 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x02 \x01(\x08:\x04true\x12\x1c\n\rreplace_model\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x44\n\rmodel_main_py\x18\x04 \x01(\t:-/opt/tf-models/object_detection/model_main.py\x12L\n\texport_py\x18\x05 \x01(\t:9/opt/tf-models/object_detection/export_inference_graph.py\x12\x19\n\x11training_data_uri\x18\x06 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x07 \x01(\t\x12\x11\n\tmodel_uri\x18\x08 \x01(\t\x12!\n\x19\x66ine_tune_checkpoint_name\x18\t \x01(\t\x12\x14\n\x05\x64\x65\x62ug\x18\n \x01(\x08:\x05\x66\x61lse\x12,\n\x0btfod_config\x18\x0b \x02(\x0b\x32\x17.google.protobuf.Struct\x1a\xff\x01\n\x19KerasClassificationConfig\x12\x1a\n\rsync_interval\x18\x01 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x02 \x01(\x08:\x04true\x12\x1c\n\rreplace_model\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11training_data_uri\x18\x04 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x05 \x01(\t\x12\x11\n\tmodel_uri\x18\x06 \x01(\t\x12\x14\n\x05\x64\x65\x62ug\x18\x07 \x01(\x08:\x05\x66\x61lse\x12*\n\tkc_config\x18\x08 \x02(\x0b\x32\x17.google.protobuf.Struct\x1a\xec\x03\n\x0fTFDeeplabConfig\x12\x31\n\x08train_py\x18\x01 \x01(\t:\x1f/opt/tf-models/deeplab/train.py\x12/\n\x07\x65val_py\x18\x0e \x01(\t:\x1e/opt/tf-models/deeplab/eval.py\x12\x39\n\texport_py\x18\x02 \x01(\t:&/opt/tf-models/deeplab/export_model.py\x12\x19\n\x11train_restart_dir\x18\x03 \x01(\t\x12\x1a\n\rsync_interval\x18\x04 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x05 \x01(\x08:\x04true\x12\x16\n\x07\x64o_eval\x18\r \x01(\x08:\x05\x66\x61lse\x12\x1c\n\rreplace_model\x18\x06 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11training_data_uri\x18\x07 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x08 \x01(\t\x12\x11\n\tmodel_uri\x18\t \x01(\t\x12!\n\x19\x66ine_tune_checkpoint_name\x18\n \x01(\t\x12,\n\x0btfdl_config\x18\x0b \x02(\x0b\x32\x17.google.protobuf.Struct\x12\x14\n\x05\x64\x65\x62ug\x18\x0c \x01(\x08:\x05\x66\x61lseB\x10\n\x0e\x62\x61\x63kend_config')
   ,
   dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -222,84 +222,91 @@ _BACKENDCONFIG_TFDEEPLABCONFIG = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='export_py', full_name='rv.protos.BackendConfig.TFDeeplabConfig.export_py', index=1,
+      name='eval_py', full_name='rv.protos.BackendConfig.TFDeeplabConfig.eval_py', index=1,
+      number=14, type=9, cpp_type=9, label=1,
+      has_default_value=True, default_value=_b("/opt/tf-models/deeplab/eval.py").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='export_py', full_name='rv.protos.BackendConfig.TFDeeplabConfig.export_py', index=2,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=True, default_value=_b("/opt/tf-models/deeplab/export_model.py").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='train_restart_dir', full_name='rv.protos.BackendConfig.TFDeeplabConfig.train_restart_dir', index=2,
+      name='train_restart_dir', full_name='rv.protos.BackendConfig.TFDeeplabConfig.train_restart_dir', index=3,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='sync_interval', full_name='rv.protos.BackendConfig.TFDeeplabConfig.sync_interval', index=3,
+      name='sync_interval', full_name='rv.protos.BackendConfig.TFDeeplabConfig.sync_interval', index=4,
       number=4, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=600,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='do_monitoring', full_name='rv.protos.BackendConfig.TFDeeplabConfig.do_monitoring', index=4,
+      name='do_monitoring', full_name='rv.protos.BackendConfig.TFDeeplabConfig.do_monitoring', index=5,
       number=5, type=8, cpp_type=7, label=1,
       has_default_value=True, default_value=True,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='do_eval', full_name='rv.protos.BackendConfig.TFDeeplabConfig.do_eval', index=5,
+      name='do_eval', full_name='rv.protos.BackendConfig.TFDeeplabConfig.do_eval', index=6,
       number=13, type=8, cpp_type=7, label=1,
       has_default_value=True, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='replace_model', full_name='rv.protos.BackendConfig.TFDeeplabConfig.replace_model', index=6,
+      name='replace_model', full_name='rv.protos.BackendConfig.TFDeeplabConfig.replace_model', index=7,
       number=6, type=8, cpp_type=7, label=1,
       has_default_value=True, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='training_data_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.training_data_uri', index=7,
+      name='training_data_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.training_data_uri', index=8,
       number=7, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='training_output_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.training_output_uri', index=8,
+      name='training_output_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.training_output_uri', index=9,
       number=8, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='model_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.model_uri', index=9,
+      name='model_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.model_uri', index=10,
       number=9, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='fine_tune_checkpoint_name', full_name='rv.protos.BackendConfig.TFDeeplabConfig.fine_tune_checkpoint_name', index=10,
+      name='fine_tune_checkpoint_name', full_name='rv.protos.BackendConfig.TFDeeplabConfig.fine_tune_checkpoint_name', index=11,
       number=10, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='tfdl_config', full_name='rv.protos.BackendConfig.TFDeeplabConfig.tfdl_config', index=11,
+      name='tfdl_config', full_name='rv.protos.BackendConfig.TFDeeplabConfig.tfdl_config', index=12,
       number=11, type=11, cpp_type=10, label=2,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='debug', full_name='rv.protos.BackendConfig.TFDeeplabConfig.debug', index=12,
+      name='debug', full_name='rv.protos.BackendConfig.TFDeeplabConfig.debug', index=13,
       number=12, type=8, cpp_type=7, label=1,
       has_default_value=True, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -318,7 +325,7 @@ _BACKENDCONFIG_TFDEEPLABCONFIG = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1148,
-  serialized_end=1591,
+  serialized_end=1640,
 )
 
 _BACKENDCONFIG = _descriptor.Descriptor(
@@ -386,7 +393,7 @@ _BACKENDCONFIG = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=79,
-  serialized_end=1609,
+  serialized_end=1658,
 )
 
 _BACKENDCONFIG_TFOBJECTDETECTIONCONFIG.fields_by_name['tfod_config'].message_type = google_dot_protobuf_dot_struct__pb2._STRUCT

--- a/rastervision/protos/backend_pb2.py
+++ b/rastervision/protos/backend_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/backend.proto',
   package='rv.protos',
   syntax='proto2',
-  serialized_pb=_b('\n!rastervision/protos/backend.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xe2\x0b\n\rBackendConfig\x12\x14\n\x0c\x62\x61\x63kend_type\x18\x01 \x02(\t\x12\x1c\n\x14pretrained_model_uri\x18\x03 \x01(\t\x12V\n\x1atf_object_detection_config\x18\x04 \x01(\x0b\x32\x30.rv.protos.BackendConfig.TFObjectDetectionConfigH\x00\x12Y\n\x1bkeras_classification_config\x18\x05 \x01(\x0b\x32\x32.rv.protos.BackendConfig.KerasClassificationConfigH\x00\x12\x45\n\x11tf_deeplab_config\x18\x07 \x01(\x0b\x32(.rv.protos.BackendConfig.TFDeeplabConfigH\x00\x12\x30\n\rcustom_config\x18\x06 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xb6\x03\n\x17TFObjectDetectionConfig\x12\x1a\n\rsync_interval\x18\x01 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x02 \x01(\x08:\x04true\x12\x1c\n\rreplace_model\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x44\n\rmodel_main_py\x18\x04 \x01(\t:-/opt/tf-models/object_detection/model_main.py\x12L\n\texport_py\x18\x05 \x01(\t:9/opt/tf-models/object_detection/export_inference_graph.py\x12\x19\n\x11training_data_uri\x18\x06 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x07 \x01(\t\x12\x11\n\tmodel_uri\x18\x08 \x01(\t\x12!\n\x19\x66ine_tune_checkpoint_name\x18\t \x01(\t\x12\x14\n\x05\x64\x65\x62ug\x18\n \x01(\x08:\x05\x66\x61lse\x12,\n\x0btfod_config\x18\x0b \x02(\x0b\x32\x17.google.protobuf.Struct\x1a\xff\x01\n\x19KerasClassificationConfig\x12\x1a\n\rsync_interval\x18\x01 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x02 \x01(\x08:\x04true\x12\x1c\n\rreplace_model\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11training_data_uri\x18\x04 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x05 \x01(\t\x12\x11\n\tmodel_uri\x18\x06 \x01(\t\x12\x14\n\x05\x64\x65\x62ug\x18\x07 \x01(\x08:\x05\x66\x61lse\x12*\n\tkc_config\x18\x08 \x02(\x0b\x32\x17.google.protobuf.Struct\x1a\xa3\x03\n\x0fTFDeeplabConfig\x12\x31\n\x08train_py\x18\x01 \x01(\t:\x1f/opt/tf-models/deeplab/train.py\x12\x39\n\texport_py\x18\x02 \x01(\t:&/opt/tf-models/deeplab/export_model.py\x12\x19\n\x11train_restart_dir\x18\x03 \x01(\t\x12\x1a\n\rsync_interval\x18\x04 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x05 \x01(\x08:\x04true\x12\x1c\n\rreplace_model\x18\x06 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11training_data_uri\x18\x07 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x08 \x01(\t\x12\x11\n\tmodel_uri\x18\t \x01(\t\x12!\n\x19\x66ine_tune_checkpoint_name\x18\n \x01(\t\x12,\n\x0btfdl_config\x18\x0b \x02(\x0b\x32\x17.google.protobuf.Struct\x12\x14\n\x05\x64\x65\x62ug\x18\x0c \x01(\x08:\x05\x66\x61lseB\x10\n\x0e\x62\x61\x63kend_config')
+  serialized_pb=_b('\n!rastervision/protos/backend.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\"\xfa\x0b\n\rBackendConfig\x12\x14\n\x0c\x62\x61\x63kend_type\x18\x01 \x02(\t\x12\x1c\n\x14pretrained_model_uri\x18\x03 \x01(\t\x12V\n\x1atf_object_detection_config\x18\x04 \x01(\x0b\x32\x30.rv.protos.BackendConfig.TFObjectDetectionConfigH\x00\x12Y\n\x1bkeras_classification_config\x18\x05 \x01(\x0b\x32\x32.rv.protos.BackendConfig.KerasClassificationConfigH\x00\x12\x45\n\x11tf_deeplab_config\x18\x07 \x01(\x0b\x32(.rv.protos.BackendConfig.TFDeeplabConfigH\x00\x12\x30\n\rcustom_config\x18\x06 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xb6\x03\n\x17TFObjectDetectionConfig\x12\x1a\n\rsync_interval\x18\x01 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x02 \x01(\x08:\x04true\x12\x1c\n\rreplace_model\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x44\n\rmodel_main_py\x18\x04 \x01(\t:-/opt/tf-models/object_detection/model_main.py\x12L\n\texport_py\x18\x05 \x01(\t:9/opt/tf-models/object_detection/export_inference_graph.py\x12\x19\n\x11training_data_uri\x18\x06 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x07 \x01(\t\x12\x11\n\tmodel_uri\x18\x08 \x01(\t\x12!\n\x19\x66ine_tune_checkpoint_name\x18\t \x01(\t\x12\x14\n\x05\x64\x65\x62ug\x18\n \x01(\x08:\x05\x66\x61lse\x12,\n\x0btfod_config\x18\x0b \x02(\x0b\x32\x17.google.protobuf.Struct\x1a\xff\x01\n\x19KerasClassificationConfig\x12\x1a\n\rsync_interval\x18\x01 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x02 \x01(\x08:\x04true\x12\x1c\n\rreplace_model\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11training_data_uri\x18\x04 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x05 \x01(\t\x12\x11\n\tmodel_uri\x18\x06 \x01(\t\x12\x14\n\x05\x64\x65\x62ug\x18\x07 \x01(\x08:\x05\x66\x61lse\x12*\n\tkc_config\x18\x08 \x02(\x0b\x32\x17.google.protobuf.Struct\x1a\xbb\x03\n\x0fTFDeeplabConfig\x12\x31\n\x08train_py\x18\x01 \x01(\t:\x1f/opt/tf-models/deeplab/train.py\x12\x39\n\texport_py\x18\x02 \x01(\t:&/opt/tf-models/deeplab/export_model.py\x12\x19\n\x11train_restart_dir\x18\x03 \x01(\t\x12\x1a\n\rsync_interval\x18\x04 \x01(\x05:\x03\x36\x30\x30\x12\x1b\n\rdo_monitoring\x18\x05 \x01(\x08:\x04true\x12\x16\n\x07\x64o_eval\x18\r \x01(\x08:\x05\x66\x61lse\x12\x1c\n\rreplace_model\x18\x06 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11training_data_uri\x18\x07 \x01(\t\x12\x1b\n\x13training_output_uri\x18\x08 \x01(\t\x12\x11\n\tmodel_uri\x18\t \x01(\t\x12!\n\x19\x66ine_tune_checkpoint_name\x18\n \x01(\t\x12,\n\x0btfdl_config\x18\x0b \x02(\x0b\x32\x17.google.protobuf.Struct\x12\x14\n\x05\x64\x65\x62ug\x18\x0c \x01(\x08:\x05\x66\x61lseB\x10\n\x0e\x62\x61\x63kend_config')
   ,
   dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -250,49 +250,56 @@ _BACKENDCONFIG_TFDEEPLABCONFIG = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='replace_model', full_name='rv.protos.BackendConfig.TFDeeplabConfig.replace_model', index=5,
+      name='do_eval', full_name='rv.protos.BackendConfig.TFDeeplabConfig.do_eval', index=5,
+      number=13, type=8, cpp_type=7, label=1,
+      has_default_value=True, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='replace_model', full_name='rv.protos.BackendConfig.TFDeeplabConfig.replace_model', index=6,
       number=6, type=8, cpp_type=7, label=1,
       has_default_value=True, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='training_data_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.training_data_uri', index=6,
+      name='training_data_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.training_data_uri', index=7,
       number=7, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='training_output_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.training_output_uri', index=7,
+      name='training_output_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.training_output_uri', index=8,
       number=8, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='model_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.model_uri', index=8,
+      name='model_uri', full_name='rv.protos.BackendConfig.TFDeeplabConfig.model_uri', index=9,
       number=9, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='fine_tune_checkpoint_name', full_name='rv.protos.BackendConfig.TFDeeplabConfig.fine_tune_checkpoint_name', index=9,
+      name='fine_tune_checkpoint_name', full_name='rv.protos.BackendConfig.TFDeeplabConfig.fine_tune_checkpoint_name', index=10,
       number=10, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='tfdl_config', full_name='rv.protos.BackendConfig.TFDeeplabConfig.tfdl_config', index=10,
+      name='tfdl_config', full_name='rv.protos.BackendConfig.TFDeeplabConfig.tfdl_config', index=11,
       number=11, type=11, cpp_type=10, label=2,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='debug', full_name='rv.protos.BackendConfig.TFDeeplabConfig.debug', index=11,
+      name='debug', full_name='rv.protos.BackendConfig.TFDeeplabConfig.debug', index=12,
       number=12, type=8, cpp_type=7, label=1,
       has_default_value=True, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -311,7 +318,7 @@ _BACKENDCONFIG_TFDEEPLABCONFIG = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1148,
-  serialized_end=1567,
+  serialized_end=1591,
 )
 
 _BACKENDCONFIG = _descriptor.Descriptor(
@@ -379,7 +386,7 @@ _BACKENDCONFIG = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=79,
-  serialized_end=1585,
+  serialized_end=1609,
 )
 
 _BACKENDCONFIG_TFOBJECTDETECTIONCONFIG.fields_by_name['tfod_config'].message_type = google_dot_protobuf_dot_struct__pb2._STRUCT

--- a/rastervision/protos/deeplab/train.proto
+++ b/rastervision/protos/deeplab/train.proto
@@ -36,6 +36,7 @@ message TrainingParameters {
 
         // Dataset (DeepLab)
         optional string train_split = 22 [default = "train"];
+	optional string eval_split = 33 [default = "validation"];
         optional string dataset = 23 [default = "custom"];
         required int32 train_batch_size = 24;
         required int32 training_number_of_steps = 25;

--- a/rastervision/protos/deeplab/train.proto
+++ b/rastervision/protos/deeplab/train.proto
@@ -41,6 +41,7 @@ message TrainingParameters {
         required int32 train_batch_size = 24;
         required int32 training_number_of_steps = 25;
         repeated int32 train_crop_size = 26;
+        repeated int32 eval_crop_size = 34;
 
         // Dataset (RasterVision)
         optional int32 dl_custom_train = 27 [default = 1333];

--- a/rastervision/protos/deeplab/train_pb2.py
+++ b/rastervision/protos/deeplab/train_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/deeplab/train.proto',
   package='deeplab.protos',
   syntax='proto2',
-  serialized_pb=_b('\n\'rastervision/protos/deeplab/train.proto\x12\x0e\x64\x65\x65plab.protos\"\xd3\x07\n\x12TrainingParameters\x12\x1d\n\x15initialize_last_layer\x18\x01 \x01(\t\x12\'\n\x1flast_layers_contain_logits_only\x18\x02 \x01(\t\x12\x17\n\x0fupsample_logits\x18\x03 \x01(\t\x12\x1c\n\x14\x66ine_tune_batch_norm\x18\x04 \x01(\t\x12\x1a\n\x12\x62\x61se_learning_rate\x18\x05 \x01(\t\x12&\n\x1elast_layer_gradient_multiplier\x18\x06 \x01(\t\x12\x16\n\x0elearning_power\x18\x07 \x01(\t\x12\"\n\x1alearning_rate_decay_factor\x18\x08 \x01(\t\x12\x10\n\x08momentum\x18\t \x01(\t\x12 \n\x18slow_start_learning_rate\x18\n \x01(\t\x12\x14\n\x0cweight_decay\x18\x0b \x01(\t\x12 \n\x18learning_rate_decay_step\x18\x0c \x01(\t\x12\x17\n\x0fslow_start_step\x18\r \x01(\t\x12\x17\n\x0flearning_policy\x18\x0e \x01(\t\x12\x18\n\x10max_scale_factor\x18\x0f \x01(\t\x12\x18\n\x10min_scale_factor\x18\x10 \x01(\t\x12\x1e\n\x16scale_factor_step_size\x18\x11 \x01(\t\x12\x1d\n\x15\x64\x65\x63oder_output_stride\x18\x12 \x02(\x05\x12\x15\n\routput_stride\x18\x13 \x02(\x05\x12\x15\n\rmodel_variant\x18\x14 \x02(\t\x12\x14\n\x0c\x61trous_rates\x18\x15 \x03(\x05\x12\x1a\n\x0btrain_split\x18\x16 \x01(\t:\x05train\x12\x1e\n\neval_split\x18! \x01(\t:\nvalidation\x12\x17\n\x07\x64\x61taset\x18\x17 \x01(\t:\x06\x63ustom\x12\x18\n\x10train_batch_size\x18\x18 \x02(\x05\x12 \n\x18training_number_of_steps\x18\x19 \x02(\x05\x12\x17\n\x0ftrain_crop_size\x18\x1a \x03(\x05\x12\x1d\n\x0f\x64l_custom_train\x18\x1b \x01(\x05:\x04\x31\x33\x33\x33\x12\"\n\x14\x64l_custom_validation\x18\x1c \x01(\x05:\x04\x31\x33\x33\x33\x12#\n\x15save_summaries_images\x18\x1d \x01(\x08:\x04true\x12\x1f\n\x12save_interval_secs\x18\x1e \x01(\x05:\x03\x36\x30\x30\x12\x1f\n\x13save_summaries_secs\x18\x1f \x01(\x05:\x02\x36\x30\x12\x15\n\nnum_clones\x18  \x01(\x05:\x01\x31')
+  serialized_pb=_b('\n\'rastervision/protos/deeplab/train.proto\x12\x0e\x64\x65\x65plab.protos\"\xeb\x07\n\x12TrainingParameters\x12\x1d\n\x15initialize_last_layer\x18\x01 \x01(\t\x12\'\n\x1flast_layers_contain_logits_only\x18\x02 \x01(\t\x12\x17\n\x0fupsample_logits\x18\x03 \x01(\t\x12\x1c\n\x14\x66ine_tune_batch_norm\x18\x04 \x01(\t\x12\x1a\n\x12\x62\x61se_learning_rate\x18\x05 \x01(\t\x12&\n\x1elast_layer_gradient_multiplier\x18\x06 \x01(\t\x12\x16\n\x0elearning_power\x18\x07 \x01(\t\x12\"\n\x1alearning_rate_decay_factor\x18\x08 \x01(\t\x12\x10\n\x08momentum\x18\t \x01(\t\x12 \n\x18slow_start_learning_rate\x18\n \x01(\t\x12\x14\n\x0cweight_decay\x18\x0b \x01(\t\x12 \n\x18learning_rate_decay_step\x18\x0c \x01(\t\x12\x17\n\x0fslow_start_step\x18\r \x01(\t\x12\x17\n\x0flearning_policy\x18\x0e \x01(\t\x12\x18\n\x10max_scale_factor\x18\x0f \x01(\t\x12\x18\n\x10min_scale_factor\x18\x10 \x01(\t\x12\x1e\n\x16scale_factor_step_size\x18\x11 \x01(\t\x12\x1d\n\x15\x64\x65\x63oder_output_stride\x18\x12 \x02(\x05\x12\x15\n\routput_stride\x18\x13 \x02(\x05\x12\x15\n\rmodel_variant\x18\x14 \x02(\t\x12\x14\n\x0c\x61trous_rates\x18\x15 \x03(\x05\x12\x1a\n\x0btrain_split\x18\x16 \x01(\t:\x05train\x12\x1e\n\neval_split\x18! \x01(\t:\nvalidation\x12\x17\n\x07\x64\x61taset\x18\x17 \x01(\t:\x06\x63ustom\x12\x18\n\x10train_batch_size\x18\x18 \x02(\x05\x12 \n\x18training_number_of_steps\x18\x19 \x02(\x05\x12\x17\n\x0ftrain_crop_size\x18\x1a \x03(\x05\x12\x16\n\x0e\x65val_crop_size\x18\" \x03(\x05\x12\x1d\n\x0f\x64l_custom_train\x18\x1b \x01(\x05:\x04\x31\x33\x33\x33\x12\"\n\x14\x64l_custom_validation\x18\x1c \x01(\x05:\x04\x31\x33\x33\x33\x12#\n\x15save_summaries_images\x18\x1d \x01(\x08:\x04true\x12\x1f\n\x12save_interval_secs\x18\x1e \x01(\x05:\x03\x36\x30\x30\x12\x1f\n\x13save_summaries_secs\x18\x1f \x01(\x05:\x02\x36\x30\x12\x15\n\nnum_clones\x18  \x01(\x05:\x01\x31')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -223,42 +223,49 @@ _TRAININGPARAMETERS = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='dl_custom_train', full_name='deeplab.protos.TrainingParameters.dl_custom_train', index=27,
+      name='eval_crop_size', full_name='deeplab.protos.TrainingParameters.eval_crop_size', index=27,
+      number=34, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='dl_custom_train', full_name='deeplab.protos.TrainingParameters.dl_custom_train', index=28,
       number=27, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=1333,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='dl_custom_validation', full_name='deeplab.protos.TrainingParameters.dl_custom_validation', index=28,
+      name='dl_custom_validation', full_name='deeplab.protos.TrainingParameters.dl_custom_validation', index=29,
       number=28, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=1333,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='save_summaries_images', full_name='deeplab.protos.TrainingParameters.save_summaries_images', index=29,
+      name='save_summaries_images', full_name='deeplab.protos.TrainingParameters.save_summaries_images', index=30,
       number=29, type=8, cpp_type=7, label=1,
       has_default_value=True, default_value=True,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='save_interval_secs', full_name='deeplab.protos.TrainingParameters.save_interval_secs', index=30,
+      name='save_interval_secs', full_name='deeplab.protos.TrainingParameters.save_interval_secs', index=31,
       number=30, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=600,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='save_summaries_secs', full_name='deeplab.protos.TrainingParameters.save_summaries_secs', index=31,
+      name='save_summaries_secs', full_name='deeplab.protos.TrainingParameters.save_summaries_secs', index=32,
       number=31, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=60,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='num_clones', full_name='deeplab.protos.TrainingParameters.num_clones', index=32,
+      name='num_clones', full_name='deeplab.protos.TrainingParameters.num_clones', index=33,
       number=32, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=1,
       message_type=None, enum_type=None, containing_type=None,
@@ -277,7 +284,7 @@ _TRAININGPARAMETERS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=60,
-  serialized_end=1039,
+  serialized_end=1063,
 )
 
 DESCRIPTOR.message_types_by_name['TrainingParameters'] = _TRAININGPARAMETERS

--- a/rastervision/protos/deeplab/train_pb2.py
+++ b/rastervision/protos/deeplab/train_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/deeplab/train.proto',
   package='deeplab.protos',
   syntax='proto2',
-  serialized_pb=_b('\n\'rastervision/protos/deeplab/train.proto\x12\x0e\x64\x65\x65plab.protos\"\xb3\x07\n\x12TrainingParameters\x12\x1d\n\x15initialize_last_layer\x18\x01 \x01(\t\x12\'\n\x1flast_layers_contain_logits_only\x18\x02 \x01(\t\x12\x17\n\x0fupsample_logits\x18\x03 \x01(\t\x12\x1c\n\x14\x66ine_tune_batch_norm\x18\x04 \x01(\t\x12\x1a\n\x12\x62\x61se_learning_rate\x18\x05 \x01(\t\x12&\n\x1elast_layer_gradient_multiplier\x18\x06 \x01(\t\x12\x16\n\x0elearning_power\x18\x07 \x01(\t\x12\"\n\x1alearning_rate_decay_factor\x18\x08 \x01(\t\x12\x10\n\x08momentum\x18\t \x01(\t\x12 \n\x18slow_start_learning_rate\x18\n \x01(\t\x12\x14\n\x0cweight_decay\x18\x0b \x01(\t\x12 \n\x18learning_rate_decay_step\x18\x0c \x01(\t\x12\x17\n\x0fslow_start_step\x18\r \x01(\t\x12\x17\n\x0flearning_policy\x18\x0e \x01(\t\x12\x18\n\x10max_scale_factor\x18\x0f \x01(\t\x12\x18\n\x10min_scale_factor\x18\x10 \x01(\t\x12\x1e\n\x16scale_factor_step_size\x18\x11 \x01(\t\x12\x1d\n\x15\x64\x65\x63oder_output_stride\x18\x12 \x02(\x05\x12\x15\n\routput_stride\x18\x13 \x02(\x05\x12\x15\n\rmodel_variant\x18\x14 \x02(\t\x12\x14\n\x0c\x61trous_rates\x18\x15 \x03(\x05\x12\x1a\n\x0btrain_split\x18\x16 \x01(\t:\x05train\x12\x17\n\x07\x64\x61taset\x18\x17 \x01(\t:\x06\x63ustom\x12\x18\n\x10train_batch_size\x18\x18 \x02(\x05\x12 \n\x18training_number_of_steps\x18\x19 \x02(\x05\x12\x17\n\x0ftrain_crop_size\x18\x1a \x03(\x05\x12\x1d\n\x0f\x64l_custom_train\x18\x1b \x01(\x05:\x04\x31\x33\x33\x33\x12\"\n\x14\x64l_custom_validation\x18\x1c \x01(\x05:\x04\x31\x33\x33\x33\x12#\n\x15save_summaries_images\x18\x1d \x01(\x08:\x04true\x12\x1f\n\x12save_interval_secs\x18\x1e \x01(\x05:\x03\x36\x30\x30\x12\x1f\n\x13save_summaries_secs\x18\x1f \x01(\x05:\x02\x36\x30\x12\x15\n\nnum_clones\x18  \x01(\x05:\x01\x31')
+  serialized_pb=_b('\n\'rastervision/protos/deeplab/train.proto\x12\x0e\x64\x65\x65plab.protos\"\xd3\x07\n\x12TrainingParameters\x12\x1d\n\x15initialize_last_layer\x18\x01 \x01(\t\x12\'\n\x1flast_layers_contain_logits_only\x18\x02 \x01(\t\x12\x17\n\x0fupsample_logits\x18\x03 \x01(\t\x12\x1c\n\x14\x66ine_tune_batch_norm\x18\x04 \x01(\t\x12\x1a\n\x12\x62\x61se_learning_rate\x18\x05 \x01(\t\x12&\n\x1elast_layer_gradient_multiplier\x18\x06 \x01(\t\x12\x16\n\x0elearning_power\x18\x07 \x01(\t\x12\"\n\x1alearning_rate_decay_factor\x18\x08 \x01(\t\x12\x10\n\x08momentum\x18\t \x01(\t\x12 \n\x18slow_start_learning_rate\x18\n \x01(\t\x12\x14\n\x0cweight_decay\x18\x0b \x01(\t\x12 \n\x18learning_rate_decay_step\x18\x0c \x01(\t\x12\x17\n\x0fslow_start_step\x18\r \x01(\t\x12\x17\n\x0flearning_policy\x18\x0e \x01(\t\x12\x18\n\x10max_scale_factor\x18\x0f \x01(\t\x12\x18\n\x10min_scale_factor\x18\x10 \x01(\t\x12\x1e\n\x16scale_factor_step_size\x18\x11 \x01(\t\x12\x1d\n\x15\x64\x65\x63oder_output_stride\x18\x12 \x02(\x05\x12\x15\n\routput_stride\x18\x13 \x02(\x05\x12\x15\n\rmodel_variant\x18\x14 \x02(\t\x12\x14\n\x0c\x61trous_rates\x18\x15 \x03(\x05\x12\x1a\n\x0btrain_split\x18\x16 \x01(\t:\x05train\x12\x1e\n\neval_split\x18! \x01(\t:\nvalidation\x12\x17\n\x07\x64\x61taset\x18\x17 \x01(\t:\x06\x63ustom\x12\x18\n\x10train_batch_size\x18\x18 \x02(\x05\x12 \n\x18training_number_of_steps\x18\x19 \x02(\x05\x12\x17\n\x0ftrain_crop_size\x18\x1a \x03(\x05\x12\x1d\n\x0f\x64l_custom_train\x18\x1b \x01(\x05:\x04\x31\x33\x33\x33\x12\"\n\x14\x64l_custom_validation\x18\x1c \x01(\x05:\x04\x31\x33\x33\x33\x12#\n\x15save_summaries_images\x18\x1d \x01(\x08:\x04true\x12\x1f\n\x12save_interval_secs\x18\x1e \x01(\x05:\x03\x36\x30\x30\x12\x1f\n\x13save_summaries_secs\x18\x1f \x01(\x05:\x02\x36\x30\x12\x15\n\nnum_clones\x18  \x01(\x05:\x01\x31')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -188,70 +188,77 @@ _TRAININGPARAMETERS = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='dataset', full_name='deeplab.protos.TrainingParameters.dataset', index=22,
+      name='eval_split', full_name='deeplab.protos.TrainingParameters.eval_split', index=22,
+      number=33, type=9, cpp_type=9, label=1,
+      has_default_value=True, default_value=_b("validation").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='dataset', full_name='deeplab.protos.TrainingParameters.dataset', index=23,
       number=23, type=9, cpp_type=9, label=1,
       has_default_value=True, default_value=_b("custom").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='train_batch_size', full_name='deeplab.protos.TrainingParameters.train_batch_size', index=23,
+      name='train_batch_size', full_name='deeplab.protos.TrainingParameters.train_batch_size', index=24,
       number=24, type=5, cpp_type=1, label=2,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='training_number_of_steps', full_name='deeplab.protos.TrainingParameters.training_number_of_steps', index=24,
+      name='training_number_of_steps', full_name='deeplab.protos.TrainingParameters.training_number_of_steps', index=25,
       number=25, type=5, cpp_type=1, label=2,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='train_crop_size', full_name='deeplab.protos.TrainingParameters.train_crop_size', index=25,
+      name='train_crop_size', full_name='deeplab.protos.TrainingParameters.train_crop_size', index=26,
       number=26, type=5, cpp_type=1, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='dl_custom_train', full_name='deeplab.protos.TrainingParameters.dl_custom_train', index=26,
+      name='dl_custom_train', full_name='deeplab.protos.TrainingParameters.dl_custom_train', index=27,
       number=27, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=1333,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='dl_custom_validation', full_name='deeplab.protos.TrainingParameters.dl_custom_validation', index=27,
+      name='dl_custom_validation', full_name='deeplab.protos.TrainingParameters.dl_custom_validation', index=28,
       number=28, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=1333,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='save_summaries_images', full_name='deeplab.protos.TrainingParameters.save_summaries_images', index=28,
+      name='save_summaries_images', full_name='deeplab.protos.TrainingParameters.save_summaries_images', index=29,
       number=29, type=8, cpp_type=7, label=1,
       has_default_value=True, default_value=True,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='save_interval_secs', full_name='deeplab.protos.TrainingParameters.save_interval_secs', index=29,
+      name='save_interval_secs', full_name='deeplab.protos.TrainingParameters.save_interval_secs', index=30,
       number=30, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=600,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='save_summaries_secs', full_name='deeplab.protos.TrainingParameters.save_summaries_secs', index=30,
+      name='save_summaries_secs', full_name='deeplab.protos.TrainingParameters.save_summaries_secs', index=31,
       number=31, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=60,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='num_clones', full_name='deeplab.protos.TrainingParameters.num_clones', index=31,
+      name='num_clones', full_name='deeplab.protos.TrainingParameters.num_clones', index=32,
       number=32, type=5, cpp_type=1, label=1,
       has_default_value=True, default_value=1,
       message_type=None, enum_type=None, containing_type=None,
@@ -270,7 +277,7 @@ _TRAININGPARAMETERS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=60,
-  serialized_end=1007,
+  serialized_end=1039,
 )
 
 DESCRIPTOR.message_types_by_name['TrainingParameters'] = _TRAININGPARAMETERS

--- a/rastervision/task/task.py
+++ b/rastervision/task/task.py
@@ -93,8 +93,8 @@ class Task(object):
         options.
 
         Args:
-            train_scenes: list of Scene
-            validation_scenes: list of Scene
+            train_scenes: list of Scenes
+            validation_scenes: list of Scenes
                 (that is disjoint from train_scenes)
             augmentors: Augmentors used to augment training data
         """


### PR DESCRIPTION
## Overview

Run DeepLab evaluation script upon request.

Test with [this](https://github.com/jamesmcclain/raster-vision-examples/tree/eval) branch.

~~Note: this current logs evaluation events to a directory other than the training log directory.  This is because logging to that directory appears to disrupt the normal logging behavior of the training script (it might be a problem caused by the slow computer that I am using, I will have to investigate more later).~~

The eval script seems to add these:
![screenshot_2019-01-07_07-19-48](https://user-images.githubusercontent.com/11281373/50774988-f2233780-1262-11e9-9a83-4763a7ccd099.png)


### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes #647 
