### PR TITLE
Update `mask-to-polygons` to Handle Invalid Geometry

### DIFF
--- a/extras_requirements.json
+++ b/extras_requirements.json
@@ -12,6 +12,6 @@
         "awscli==1.15.*"
     ],
     "feature-extraction": [
-        "https://github.com/azavea/mask-to-polygons/archive/94739f164df1c350baa1170cac603e133f91d2cf.zip"
+        "https://github.com/jamesmcclain/mask-to-polygons/archive/ensure-valid.zip"
     ]
 }

--- a/extras_requirements.json
+++ b/extras_requirements.json
@@ -12,6 +12,6 @@
         "awscli==1.15.*"
     ],
     "feature-extraction": [
-        "https://github.com/jamesmcclain/mask-to-polygons/archive/ensure-valid.zip"
+        "https://github.com/azavea/mask-to-polygons/archive/085c022158052473dd75d278c76cfa16067fc53a.zip"
     ]
 }


### PR DESCRIPTION
## Overview

This addresses the invalid geometry bug noted in https://github.com/azavea/raster-vision/issues/658. 
 See that issue for instructions on how to replicate the bugged behavior and confirm the fixed behavior on this branch.  See also https://github.com/azavea/mask-to-polygons/pull/8 .

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes https://github.com/azavea/raster-vision/issues/658
