### PR TITLE
WIP:Correct class imbalance for chip_classification chip command

### DIFF
--- a/rastervision/protos/task.proto
+++ b/rastervision/protos/task.proto
@@ -28,6 +28,7 @@ message TaskConfig {
     message ChipClassificationConfig {
         repeated ClassItem class_items = 1;
         required int32 chip_size = 2;
+        optional float max_imbalance = 3 [default=0.0];
     }
 
     message SemanticSegmentationConfig {

--- a/rastervision/protos/task_pb2.py
+++ b/rastervision/protos/task_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/task.proto',
   package='rv.protos',
   syntax='proto2',
-  serialized_pb=_b('\n\x1erastervision/protos/task.proto\x12\trv.protos\x1a$rastervision/protos/class_item.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x80\x0b\n\nTaskConfig\x12\x11\n\ttask_type\x18\x01 \x02(\t\x12\x1e\n\x12predict_batch_size\x18\x02 \x01(\x05:\x02\x31\x30\x12\x1b\n\x13predict_package_uri\x18\x03 \x01(\t\x12\x13\n\x05\x64\x65\x62ug\x18\x04 \x01(\x08:\x04true\x12\x19\n\x11predict_debug_uri\x18\x05 \x01(\t\x12N\n\x17object_detection_config\x18\x06 \x01(\x0b\x32+.rv.protos.TaskConfig.ObjectDetectionConfigH\x00\x12T\n\x1a\x63hip_classification_config\x18\x07 \x01(\x0b\x32..rv.protos.TaskConfig.ChipClassificationConfigH\x00\x12X\n\x1csemantic_segmentation_config\x18\x08 \x01(\x0b\x32\x30.rv.protos.TaskConfig.SemanticSegmentationConfigH\x00\x12\x30\n\rcustom_config\x18\t \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xb2\x03\n\x15ObjectDetectionConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x12M\n\x0c\x63hip_options\x18\x03 \x02(\x0b\x32\x37.rv.protos.TaskConfig.ObjectDetectionConfig.ChipOptions\x12S\n\x0fpredict_options\x18\x04 \x02(\x0b\x32:.rv.protos.TaskConfig.ObjectDetectionConfig.PredictOptions\x1ao\n\x0b\x43hipOptions\x12\x11\n\tneg_ratio\x18\x01 \x02(\x02\x12\x17\n\nioa_thresh\x18\x02 \x01(\x02:\x03\x30.8\x12\x1b\n\rwindow_method\x18\x03 \x01(\t:\x04\x63hip\x12\x17\n\x0clabel_buffer\x18\x04 \x01(\x02:\x01\x30\x1a\x46\n\x0ePredictOptions\x12\x19\n\x0cmerge_thresh\x18\x02 \x01(\x02:\x03\x30.5\x12\x19\n\x0cscore_thresh\x18\x03 \x01(\x02:\x03\x30.5\x1aX\n\x18\x43hipClassificationConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x1a\xa1\x03\n\x1aSemanticSegmentationConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x12R\n\x0c\x63hip_options\x18\x03 \x02(\x0b\x32<.rv.protos.TaskConfig.SemanticSegmentationConfig.ChipOptions\x1a\xf0\x01\n\x0b\x43hipOptions\x12$\n\rwindow_method\x18\x01 \x01(\t:\rrandom_sample\x12\x16\n\x0etarget_classes\x18\x02 \x03(\x05\x12$\n\x16\x64\x65\x62ug_chip_probability\x18\x03 \x01(\x02:\x04\x30.25\x12(\n\x1dnegative_survival_probability\x18\x04 \x01(\x02:\x01\x31\x12\x1d\n\x0f\x63hips_per_scene\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12$\n\x16target_count_threshold\x18\x06 \x01(\x05:\x04\x32\x30\x34\x38\x12\x0e\n\x06stride\x18\x07 \x01(\x05\x42\r\n\x0b\x63onfig_type')
+  serialized_pb=_b('\n\x1erastervision/protos/task.proto\x12\trv.protos\x1a$rastervision/protos/class_item.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x9a\x0b\n\nTaskConfig\x12\x11\n\ttask_type\x18\x01 \x02(\t\x12\x1e\n\x12predict_batch_size\x18\x02 \x01(\x05:\x02\x31\x30\x12\x1b\n\x13predict_package_uri\x18\x03 \x01(\t\x12\x13\n\x05\x64\x65\x62ug\x18\x04 \x01(\x08:\x04true\x12\x19\n\x11predict_debug_uri\x18\x05 \x01(\t\x12N\n\x17object_detection_config\x18\x06 \x01(\x0b\x32+.rv.protos.TaskConfig.ObjectDetectionConfigH\x00\x12T\n\x1a\x63hip_classification_config\x18\x07 \x01(\x0b\x32..rv.protos.TaskConfig.ChipClassificationConfigH\x00\x12X\n\x1csemantic_segmentation_config\x18\x08 \x01(\x0b\x32\x30.rv.protos.TaskConfig.SemanticSegmentationConfigH\x00\x12\x30\n\rcustom_config\x18\t \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xb2\x03\n\x15ObjectDetectionConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x12M\n\x0c\x63hip_options\x18\x03 \x02(\x0b\x32\x37.rv.protos.TaskConfig.ObjectDetectionConfig.ChipOptions\x12S\n\x0fpredict_options\x18\x04 \x02(\x0b\x32:.rv.protos.TaskConfig.ObjectDetectionConfig.PredictOptions\x1ao\n\x0b\x43hipOptions\x12\x11\n\tneg_ratio\x18\x01 \x02(\x02\x12\x17\n\nioa_thresh\x18\x02 \x01(\x02:\x03\x30.8\x12\x1b\n\rwindow_method\x18\x03 \x01(\t:\x04\x63hip\x12\x17\n\x0clabel_buffer\x18\x04 \x01(\x02:\x01\x30\x1a\x46\n\x0ePredictOptions\x12\x19\n\x0cmerge_thresh\x18\x02 \x01(\x02:\x03\x30.5\x12\x19\n\x0cscore_thresh\x18\x03 \x01(\x02:\x03\x30.5\x1ar\n\x18\x43hipClassificationConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x12\x18\n\rmax_imbalance\x18\x03 \x01(\x02:\x01\x30\x1a\xa1\x03\n\x1aSemanticSegmentationConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x12R\n\x0c\x63hip_options\x18\x03 \x02(\x0b\x32<.rv.protos.TaskConfig.SemanticSegmentationConfig.ChipOptions\x1a\xf0\x01\n\x0b\x43hipOptions\x12$\n\rwindow_method\x18\x01 \x01(\t:\rrandom_sample\x12\x16\n\x0etarget_classes\x18\x02 \x03(\x05\x12$\n\x16\x64\x65\x62ug_chip_probability\x18\x03 \x01(\x02:\x04\x30.25\x12(\n\x1dnegative_survival_probability\x18\x04 \x01(\x02:\x01\x31\x12\x1d\n\x0f\x63hips_per_scene\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12$\n\x16target_count_threshold\x18\x06 \x01(\x05:\x04\x32\x30\x34\x38\x12\x0e\n\x06stride\x18\x07 \x01(\x05\x42\r\n\x0b\x63onfig_type')
   ,
   dependencies=[rastervision_dot_protos_dot_class__item__pb2.DESCRIPTOR,google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -189,6 +189,13 @@ _TASKCONFIG_CHIPCLASSIFICATIONCONFIG = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='max_imbalance', full_name='rv.protos.TaskConfig.ChipClassificationConfig.max_imbalance', index=2,
+      number=3, type=2, cpp_type=6, label=1,
+      has_default_value=True, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -202,7 +209,7 @@ _TASKCONFIG_CHIPCLASSIFICATIONCONFIG = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=999,
-  serialized_end=1087,
+  serialized_end=1113,
 )
 
 _TASKCONFIG_SEMANTICSEGMENTATIONCONFIG_CHIPOPTIONS = _descriptor.Descriptor(
@@ -273,8 +280,8 @@ _TASKCONFIG_SEMANTICSEGMENTATIONCONFIG_CHIPOPTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1267,
-  serialized_end=1507,
+  serialized_start=1293,
+  serialized_end=1533,
 )
 
 _TASKCONFIG_SEMANTICSEGMENTATIONCONFIG = _descriptor.Descriptor(
@@ -317,8 +324,8 @@ _TASKCONFIG_SEMANTICSEGMENTATIONCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1090,
-  serialized_end=1507,
+  serialized_start=1116,
+  serialized_end=1533,
 )
 
 _TASKCONFIG = _descriptor.Descriptor(
@@ -407,7 +414,7 @@ _TASKCONFIG = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=114,
-  serialized_end=1522,
+  serialized_end=1548,
 )
 
 _TASKCONFIG_OBJECTDETECTIONCONFIG_CHIPOPTIONS.containing_type = _TASKCONFIG_OBJECTDETECTIONCONFIG

--- a/rastervision/task/chip_classification.py
+++ b/rastervision/task/chip_classification.py
@@ -2,11 +2,19 @@ from os.path import join
 
 import numpy as np
 from PIL import Image, ImageDraw
+import logging
 
 from rastervision.rv_config import RVConfig
 from rastervision.core import Box
 from rastervision.task import Task
 from rastervision.utils.files import (get_local_path, upload_or_copy, make_dir)
+from rastervision.core.training_data import TrainingData
+
+log = logging.getLogger(__name__)
+
+# TODO: DRY... same keys as in ml_backends/tf_object_detection_api.py
+TRAIN = 'train'
+VALIDATION = 'validation'
 
 
 def draw_debug_predict_image(scene, class_map):
@@ -27,6 +35,42 @@ def draw_debug_predict_image(scene, class_map):
         draw.line(coords, fill=color, width=line_width)
     return img
 
+
+def correct_imbalance(data, max_imbalance, class_map):
+    # Assume a minimum count of 1 for each class to handle the case of
+    # there being no instances of a class.
+    class_to_count = {}
+    for class_id in class_map.get_keys():
+        class_to_count[class_id] = 1
+    class_to_data = {}
+    for chip_idx, (chip, window, labels) in enumerate(data):
+        class_id = labels.get_cell_class_id(window)
+        # If a chip is not associated with a class, don't
+        # use it in training data.
+        if class_id is None:
+            continue
+
+        class_to_count[class_id] += 1
+        class_data = class_to_data.get(class_id, [])
+        class_data.append((chip, window, labels))
+        class_to_data[class_id] = class_data
+
+    min_count = min(list(class_to_count.values()))
+    max_count = max(list(class_to_count.values()))
+    max_allowable = int(max_imbalance * min_count)
+    if max_count > max_allowable:
+        for class_id in class_to_data.keys():
+            desired_count = min(class_to_count[class_id], max_allowable)
+            class_to_data[class_id] = \
+                class_to_data[class_id][0:desired_count]
+
+    data = TrainingData()
+    for class_id, class_data in class_to_data.items():
+        for chip, window, labels in class_data:
+            data.append(chip, window, labels)
+
+    return data
+    
 
 class ChipClassification(Task):
     def get_train_windows(self, scene):
@@ -63,3 +107,55 @@ class ChipClassification(Task):
             make_dir(debug_image_path, use_dirname=True)
             img.save(debug_image_path)
             upload_or_copy(debug_image_path, debug_image_uri)
+
+    def make_chips(self, train_scenes, validation_scenes, augmentors, tmp_dir):
+        """Make training chips.
+
+        Convert Scenes with a ground_truth_label_store into training
+        chips in MLBackend-specific format, and write to URI specified in
+        options.
+
+        Args:
+            train_scenes: list of Scene
+            validation_scenes: list of Scene
+                (that is disjoint from train_scenes)
+            augmentors: Augmentors used to augment training data
+        """
+
+        def _process_scene(scene, type_, augment):
+            with scene.activate():
+                data = TrainingData()
+                log.info('Making {} chips for scene: {}'.format(
+                    type_, scene.id))
+                windows = self.get_train_windows(scene)
+                for window in windows:
+                    chip = scene.raster_source.get_chip(window)
+                    labels = self.get_train_labels(window, scene)
+                    data.append(chip, window, labels)
+
+                # Shuffle data so the first N samples which are displayed in
+                # Tensorboard are more diverse.
+                data.shuffle()
+
+                # Process augmentation
+                if augment:
+                    for augmentor in augmentors:
+                        data = augmentor.process(data, tmp_dir)
+
+                max_imbalance = self.config.max_imbalance
+                if max_imbalance != 0:
+                    data = correct_imbalance(data, max_imbalance, self.config.class_map)
+
+                return self.backend.process_scene_data(scene, data, tmp_dir)
+
+        def _process_scenes(scenes, type_, augment):
+            return [_process_scene(scene, type_, augment) for scene in scenes]
+
+        # TODO: parallel processing!
+        processed_training_results = _process_scenes(
+            train_scenes, TRAIN, augment=True)
+        processed_validation_results = _process_scenes(
+            validation_scenes, VALIDATION, augment=False)
+
+        self.backend.process_sceneset_results(
+            processed_training_results, processed_validation_results, tmp_dir)

--- a/rastervision/task/chip_classification_config.py
+++ b/rastervision/task/chip_classification_config.py
@@ -16,18 +16,21 @@ class ChipClassificationConfig(TaskConfig):
                  predict_package_uri=None,
                  debug=False,
                  predict_debug_uri=None,
-                 chip_size=300):
+                 chip_size=300,
+                 max_imbalance=0):
         super().__init__(rv.CHIP_CLASSIFICATION, predict_batch_size,
                          predict_package_uri, debug, predict_debug_uri)
         self.class_map = class_map
         self.chip_size = chip_size
+        self.max_imbalance = max_imbalance
 
     def create_task(self, backend):
         return ChipClassification(self, backend)
 
     def to_proto(self):
         conf = TaskConfigMsg.ChipClassificationConfig(
-            chip_size=self.chip_size, class_items=self.class_map.to_proto())
+            chip_size=self.chip_size, max_imbalance=self.max_imbalance,
+            class_items=self.class_map.to_proto())
         return TaskConfigMsg(
             task_type=rv.CHIP_CLASSIFICATION,
             chip_classification_config=conf,
@@ -47,6 +50,7 @@ class ChipClassificationConfigBuilder(TaskConfigBuilder):
             config = {
                 'class_map': prev.class_map,
                 'chip_size': prev.chip_size,
+                'max_imbalance': prev.max_imbalance,
                 'predict_batch_size': prev.predict_batch_size,
                 'predict_package_uri': prev.predict_package_uri,
                 'debug': prev.debug,
@@ -68,7 +72,8 @@ class ChipClassificationConfigBuilder(TaskConfigBuilder):
         conf = msg.chip_classification_config
         return b.with_classes(list(conf.class_items)) \
                 .with_predict_package_uri(msg.predict_package_uri) \
-                .with_chip_size(conf.chip_size)
+                .with_chip_size(conf.chip_size) \
+                .with_max_imbalance(conf.max_imbalance)
 
     def with_classes(
             self, classes: Union[ClassMap, List[str], List[ClassItemMsg], List[
@@ -93,4 +98,9 @@ class ChipClassificationConfigBuilder(TaskConfigBuilder):
         """
         b = deepcopy(self)
         b.config['chip_size'] = chip_size
+        return b
+
+    def with_max_imbalance(self, max_imbalance):
+        b = deepcopy(self)
+        b.config['max_imbalance'] = max_imbalance
         return b


### PR DESCRIPTION
## Overview

This PR makes it so that class imbalances are corrected in the chip command for the chip classification task. Using the follow config makes it so there is at most 2x chips of any class than the minimum number of chips for any class. (If a class is missing from a scene, then we count it as having a single chip).
```
        task = rv.TaskConfig.builder(rv.CHIP_CLASSIFICATION) \
                    .with_chip_size(200) \
                    .with_max_imbalance(2.0) \
                    .with_classes(class_map) \
                    .build()
```

### Checklist

- [ ] Updated `docs/changelog.rst`
- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
