### PR TITLE
Use `make` to Manage Local Execution

### DIFF
--- a/rastervision/runner/local_experiment_runner.py
+++ b/rastervision/runner/local_experiment_runner.py
@@ -1,9 +1,13 @@
 from subprocess import Popen
 import sys
 import logging
+import os
 
 from rastervision.runner import OutOfProcessExperimentRunner
+from rastervision.runner import make_command
 from rastervision.utils.misc import (terminate_at_exit)
+from rastervision.utils.files import (save_json_config, make_dir)
+from rastervision.rv_config import RVConfig
 
 log = logging.getLogger(__name__)
 
@@ -12,18 +16,50 @@ class LocalExperimentRunner(OutOfProcessExperimentRunner):
     def __init__(self, tmp_dir=None):
         super().__init__()
 
-        self.submit = self.shellout
+        self.submit = None
         self.execution_environment = 'Shell'
         self.tmp_dir = tmp_dir
 
-    def shellout(self,
-                 command_type,
-                 experiment_id,
-                 command,
-                 parent_job_ids=None,
-                 array_size=None):
-        command = list(filter(lambda s: len(s) > 0, command.split(' ')))
-        process = Popen(command)
+    def _run_experiment(self, command_dag):
+        tmp_dir = self.tmp_dir or RVConfig.get_tmp_dir().name
+        make_dir(tmp_dir)
+        makefile_name = os.path.join(tmp_dir, 'Makefile')
+        with open(makefile_name, 'w') as makefile:
+            command_ids = command_dag.get_sorted_command_ids()
+
+            # .PHONY: 0 1 2 3 4 5
+            makefile.write('.PHONY:')
+            for command_id in command_ids:
+                makefile.write(' {}'.format(command_id))
+            makefile.write('\n\n')
+
+            # all: 0 1 2 3 4 5
+            makefile.write('all:')
+            for command_id in command_ids:
+                makefile.write(' {}'.format(command_id))
+            makefile.write('\n\n')
+
+            for command_id in command_ids:
+                # 0: 1 2
+                makefile.write('{}:'.format(command_id))
+                for upstream_id in command_dag.get_upstream_command_ids(
+                        command_id):
+                    makefile.write(' {}'.format(upstream_id))
+                makefile.write('\n')
+
+                # \t rastervision ...
+                command_def = command_dag.get_command_definition(command_id)
+                command_config = command_def.command_config
+                command_root_uri = command_config.root_uri
+                command_uri = os.path.join(command_root_uri,
+                                           'command-config.json')
+                print('Saving command configuration to {}...'.format(
+                    command_uri))
+                save_json_config(command_config.to_proto(), command_uri)
+                run_command = make_command(command_uri, self.tmp_dir)
+                makefile.write('\t{}\n\n'.format(run_command))
+
+        process = Popen(['make', '-j', '-f', makefile_name])
         terminate_at_exit(process)
         exitcode = process.wait()
         if exitcode != 0:


### PR DESCRIPTION
## Overview

GNU `make` is now used for managing local execution.  This is a prerequisite for having parallel, simultaneous processes with dependency relationships between them.  There should be no discernible difference in behavior with only this change but without stage splitting -- with stage splitting (https://github.com/azavea/raster-vision/pull/657) independent stages and parts of stages run in parallel.

GNU make is the default on virtually all Linux distributions and on OSX.  Windows users are invited to install [MinGW's version](http://www.mingw.org/wiki/msys) or to use the `inprocess` runner for local jobs.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

