### PR TITLE
Parallelize Prediction Stage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Raster Vision 0.9.0
 - Add ability to shift raster images by given numbers of meters.  `#573 <https://github.com/azavea/raster-vision/pull/573>`_
 - Add ability to generate GeoJSON segmentation predictions.  `#575 <https://github.com/azavea/raster-vision/pull/575>`_
 - Add ability to run the DeepLab eval script.  `#653 <https://github.com/azavea/raster-vision/pull/653>`_
+- Add ability to split the "chipping" stage into multiple processes.  `#657 <https://github.com/azavea/raster-vision/pull/657>`_
 
 Raster Vision 0.8
 -----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Raster Vision 0.9.0
 - Add ability to generate GeoJSON segmentation predictions.  `#575 <https://github.com/azavea/raster-vision/pull/575>`_
 - Add ability to run the DeepLab eval script.  `#653 <https://github.com/azavea/raster-vision/pull/653>`_
 - Add ability to split the "chipping" stage into multiple processes.  `#657 <https://github.com/azavea/raster-vision/pull/657>`_
+- Add ability to split the "prediction" stage into multiple processes.  `#667 <https://github.com/azavea/raster-vision/pull/667>`_
 
 Raster Vision 0.8
 -----------------

--- a/rastervision/backend/backend.py
+++ b/rastervision/backend/backend.py
@@ -24,7 +24,7 @@ class Backend(ABC):
 
     @abstractmethod
     def process_sceneset_results(self, training_results, validation_results,
-                                 tmp_dir):
+                                 tmp_dir, index, count):
         """After all scenes have been processed, process the resultset
 
         Args:

--- a/rastervision/backend/backend_config.py
+++ b/rastervision/backend/backend_config.py
@@ -42,7 +42,9 @@ class BackendConfig(BundledConfigMixin, Config):
                            command_type,
                            experiment_config,
                            context=None,
-                           io_def=None):
+                           io_def=None,
+                           index: int = 0,
+                           count: int = 1):
         io_def = io_def or CommandIODefinition()
         if command_type == rv.TRAIN:
             if self.pretrained_model_uri:

--- a/rastervision/backend/backend_config.py
+++ b/rastervision/backend/backend_config.py
@@ -13,7 +13,7 @@ class BackendConfig(BundledConfigMixin, Config):
         self.pretrained_model_uri = pretrained_model_uri
 
     @abstractmethod
-    def create_backend(self, task_config):
+    def create_backend(self, task_config, index: int = 0, count: int = 1):
         """Create the Backend that this configuration represents
 
            Args:

--- a/rastervision/backend/keras_classification/backend.py
+++ b/rastervision/backend/keras_classification/backend.py
@@ -170,8 +170,12 @@ class KerasClassification(Backend):
 
         return class_dirs
 
-    def process_sceneset_results(self, training_results, validation_results,
-                                 tmp_dir):
+    def process_sceneset_results(self,
+                                 training_results,
+                                 validation_results,
+                                 tmp_dir,
+                                 index: int = 0,
+                                 count: int = 1):
         """After all scenes have been processed, collect all the images of
         each class across all scenes
 

--- a/rastervision/backend/keras_classification_config.py
+++ b/rastervision/backend/keras_classification_config.py
@@ -97,7 +97,9 @@ class KerasClassificationConfig(BackendConfig):
                            command_type,
                            experiment_config,
                            context=None,
-                           io_def=None):
+                           io_def=None,
+                           index: int = 0,
+                           count: int = 1):
         io_def = super().update_for_command(command_type, experiment_config,
                                             context, io_def)
         if command_type == rv.CHIP:

--- a/rastervision/backend/keras_classification_config.py
+++ b/rastervision/backend/keras_classification_config.py
@@ -46,7 +46,7 @@ class KerasClassificationConfig(BackendConfig):
         self.training_output_uri = training_output_uri
         self.model_uri = model_uri
 
-    def create_backend(self, task_config):
+    def create_backend(self, task_config, index: int = 0, count: int = 1):
         from rastervision.backend.keras_classification import KerasClassification
         return KerasClassification(self, task_config)
 

--- a/rastervision/backend/tf_deeplab.py
+++ b/rastervision/backend/tf_deeplab.py
@@ -455,7 +455,11 @@ class TFDeeplab(Backend):
 
     """
 
-    def __init__(self, backend_config, task_config, index: int = 0):
+    def __init__(self,
+                 backend_config,
+                 task_config,
+                 index: int = 0,
+                 count: int = 1):
         """Constructor.
 
         Args:
@@ -467,6 +471,7 @@ class TFDeeplab(Backend):
         self.task_config = task_config
         self.class_map = task_config.class_map
         self.index = index
+        self.count = count
 
     def process_scene_data(self, scene: Scene, data: TrainingData,
                            tmp_dir: str) -> str:

--- a/rastervision/backend/tf_deeplab.py
+++ b/rastervision/backend/tf_deeplab.py
@@ -455,11 +455,7 @@ class TFDeeplab(Backend):
 
     """
 
-    def __init__(self,
-                 backend_config,
-                 task_config,
-                 index: int = 0,
-                 count: int = 1):
+    def __init__(self, backend_config, task_config):
         """Constructor.
 
         Args:
@@ -470,8 +466,6 @@ class TFDeeplab(Backend):
         self.backend_config = backend_config
         self.task_config = task_config
         self.class_map = task_config.class_map
-        self.index = index
-        self.count = count
 
     def process_scene_data(self, scene: Scene, data: TrainingData,
                            tmp_dir: str) -> str:
@@ -506,9 +500,12 @@ class TFDeeplab(Backend):
 
         return record_path
 
-    def process_sceneset_results(self, training_results: List[str],
+    def process_sceneset_results(self,
+                                 training_results: List[str],
                                  validation_results: List[str],
-                                 tmp_dir: str) -> None:
+                                 tmp_dir: str,
+                                 index: int = 0,
+                                 count: int = 1) -> None:
         """Merge TFRecord files from individual scenes into two at-large files
         (one for training data and one for validation data).
 
@@ -523,11 +520,10 @@ class TFDeeplab(Backend):
 
         """
         base_uri = self.backend_config.training_data_uri
-        training_record_path = get_record_uri(base_uri, TRAIN, self.index)
+        training_record_path = get_record_uri(base_uri, TRAIN, index)
         training_record_path_local = get_local_path(training_record_path,
                                                     tmp_dir)
-        validation_record_path = get_record_uri(base_uri, VALIDATION,
-                                                self.index)
+        validation_record_path = get_record_uri(base_uri, VALIDATION, index)
         validation_record_path_local = get_local_path(validation_record_path,
                                                       tmp_dir)
 
@@ -538,7 +534,7 @@ class TFDeeplab(Backend):
         upload_or_copy(training_record_path_local, training_record_path)
         upload_or_copy(validation_record_path_local, validation_record_path)
 
-        if self.backend_config.debug and self.index == 0:
+        if self.backend_config.debug:
             training_zip_path = join(base_uri, '{}'.format(TRAIN))
             training_zip_path_local = get_local_path(training_zip_path,
                                                      tmp_dir)

--- a/rastervision/backend/tf_deeplab_config.py
+++ b/rastervision/backend/tf_deeplab_config.py
@@ -74,8 +74,8 @@ class TFDeeplabConfig(BackendConfig):
         self.index = index
         self.count = count
 
-    def create_backend(self, task_config):
-        return TFDeeplab(self, task_config)
+    def create_backend(self, task_config, index: int = 0, count: int = 1):
+        return TFDeeplab(self, task_config, index=index, count=count)
 
     def to_proto(self):
         d = {

--- a/rastervision/backend/tf_object_detection.py
+++ b/rastervision/backend/tf_object_detection.py
@@ -628,8 +628,12 @@ class TFObjectDetection(Backend):
 
         return record_path
 
-    def process_sceneset_results(self, training_results, validation_results,
-                                 tmp_dir):
+    def process_sceneset_results(self,
+                                 training_results,
+                                 validation_results,
+                                 tmp_dir,
+                                 index: int = 0,
+                                 count: int = 1):
         """After all scenes have been processed, merge all TFRecords
 
         Args:

--- a/rastervision/backend/tf_object_detection_config.py
+++ b/rastervision/backend/tf_object_detection_config.py
@@ -124,7 +124,9 @@ class TFObjectDetectionConfig(BackendConfig):
                            command_type,
                            experiment_config,
                            context=None,
-                           io_def=None):
+                           io_def=None,
+                           index: int = 0,
+                           count: int = 1):
         io_def = super().update_for_command(command_type, experiment_config,
                                             context, io_def)
         if command_type == rv.CHIP:

--- a/rastervision/backend/tf_object_detection_config.py
+++ b/rastervision/backend/tf_object_detection_config.py
@@ -65,7 +65,7 @@ class TFObjectDetectionConfig(BackendConfig):
         self.model_uri = model_uri
         self.fine_tune_checkpoint_name = fine_tune_checkpoint_name
 
-    def create_backend(self, task_config):
+    def create_backend(self, task_config, index: int = 0, count: int = 1):
         return TFObjectDetection(self, task_config)
 
     def get_num_steps(self):

--- a/rastervision/cli/main.py
+++ b/rastervision/cli/main.py
@@ -94,8 +94,14 @@ def main(profile, verbose):
     help=('Rerun commands, regardless if '
           'their output files already exist.'))
 @click.option('--tempdir', help=('Temporary directory to use for this run.'))
+@click.option(
+    '--splits',
+    '-s',
+    default=1,
+    metavar='INTEGER',
+    help=('The number of processes to attempt to split each stage into.'))
 def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
-        prefix, methods, path, filters, rerun, tempdir):
+        prefix, methods, path, filters, rerun, tempdir, splits):
     """Run Raster Vision commands from experiments, using the
     experiment runner named RUNNER."""
 
@@ -110,6 +116,9 @@ def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
                     'Must be one of: "{}"'.format(runner,
                                                   '", "'.join(valid_runners)))
         sys.exit(1)
+
+    if runner.lower() == rv.INPROCESS.lower():
+        splits = 1
 
     runner = ExperimentRunner.get_runner(runner)
 
@@ -156,7 +165,8 @@ def run(runner, commands, experiment_module, dry_run, skip_file_check, arg,
         commands_to_run=commands,
         rerun_commands=rerun,
         skip_file_check=skip_file_check,
-        dry_run=dry_run)
+        dry_run=dry_run,
+        splits=splits)
 
 
 @main.command()

--- a/rastervision/cli/main.py
+++ b/rastervision/cli/main.py
@@ -254,13 +254,26 @@ def predict(predict_package, image_uri, output_uri, update_stats,
     'run_command', short_help='Run a command from configuration file.')
 @click.argument('command_config_uri')
 @click.option('--tempdir')
-def run_command(command_config_uri, tempdir):
+@click.option(
+    '--index',
+    '-i',
+    default=0,
+    metavar='INTEGER',
+    help=('The index of this process within the overall'
+          'sequence of processes used for this stage.'))
+@click.option(
+    '--count',
+    '-N',
+    default=1,
+    metavar='INTEGER',
+    help=('The inumber of processes used for this stage.'))
+def run_command(command_config_uri, tempdir, index, count):
     """Run a command from a serialized command configuration
     at COMMAND_CONFIG_URI.
     """
     if tempdir is not None:
         RVConfig.set_tmp_dir(tempdir)
-    rv.runner.CommandRunner.run(command_config_uri)
+    rv.runner.CommandRunner.run(command_config_uri, index, count)
 
 
 if __name__ == '__main__':

--- a/rastervision/command/analyze_command.py
+++ b/rastervision/command/analyze_command.py
@@ -7,7 +7,7 @@ class AnalyzeCommand(Command):
     def __init__(self, command_config):
         self.command_config = command_config
 
-    def run(self, tmp_dir=None):
+    def run(self, tmp_dir=None, index: int = 0, count: int = 1):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
 

--- a/rastervision/command/bundle_command.py
+++ b/rastervision/command/bundle_command.py
@@ -17,7 +17,7 @@ class BundleCommand(Command):
     def __init__(self, command_config):
         self.command_config = command_config
 
-    def run(self, tmp_dir=None):
+    def run(self, tmp_dir=None, index: int = 0, count: int = 1):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
 

--- a/rastervision/command/chip_command.py
+++ b/rastervision/command/chip_command.py
@@ -7,7 +7,7 @@ class ChipCommand(Command):
     def __init__(self, command_config):
         self.command_config = command_config
 
-    def run(self, tmp_dir=None):
+    def run(self, tmp_dir=None, index: int = 0, count: int = 1):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
         msg = 'Making training chips...'
@@ -15,14 +15,16 @@ class ChipCommand(Command):
 
         cc = self.command_config
 
-        backend = cc.backend.create_backend(cc.task)
+        backend = cc.backend.create_backend(cc.task, index=index, count=count)
         task = cc.task.create_task(backend)
 
         train_scenes = list(
-            map(lambda s: s.create_scene(cc.task, tmp_dir), cc.train_scenes))
+            map(lambda s: s.create_scene(cc.task, tmp_dir),
+                cc.train_scenes[index::count]))
 
         val_scenes = list(
-            map(lambda s: s.create_scene(cc.task, tmp_dir), cc.val_scenes))
+            map(lambda s: s.create_scene(cc.task, tmp_dir),
+                cc.val_scenes[index::count]))
 
         augmentors = list(map(lambda a: a.create_augmentor(), cc.augmentors))
 

--- a/rastervision/command/chip_command.py
+++ b/rastervision/command/chip_command.py
@@ -15,7 +15,7 @@ class ChipCommand(Command):
 
         cc = self.command_config
 
-        backend = cc.backend.create_backend(cc.task, index=index, count=count)
+        backend = cc.backend.create_backend(cc.task)
         task = cc.task.create_task(backend)
 
         train_scenes = list(
@@ -28,4 +28,10 @@ class ChipCommand(Command):
 
         augmentors = list(map(lambda a: a.create_augmentor(), cc.augmentors))
 
-        task.make_chips(train_scenes, val_scenes, augmentors, tmp_dir)
+        task.make_chips(
+            train_scenes,
+            val_scenes,
+            augmentors,
+            tmp_dir,
+            index=index,
+            count=count)

--- a/rastervision/command/chip_command.py
+++ b/rastervision/command/chip_command.py
@@ -19,12 +19,10 @@ class ChipCommand(Command):
         task = cc.task.create_task(backend)
 
         train_scenes = list(
-            map(lambda s: s.create_scene(cc.task, tmp_dir),
-                cc.train_scenes[index::count]))
+            map(lambda s: s.create_scene(cc.task, tmp_dir), cc.train_scenes))
 
         val_scenes = list(
-            map(lambda s: s.create_scene(cc.task, tmp_dir),
-                cc.val_scenes[index::count]))
+            map(lambda s: s.create_scene(cc.task, tmp_dir), cc.val_scenes))
 
         augmentors = list(map(lambda a: a.create_augmentor(), cc.augmentors))
 

--- a/rastervision/command/chip_command_config.py
+++ b/rastervision/command/chip_command_config.py
@@ -103,11 +103,11 @@ class ChipCommandConfigBuilder(CommandConfigBuilder):
                         'val_scenes must be a list of class SceneConfig, '
                         'got a list of {}'.format(type(s)))
 
-    def build(self):
+    def build(self, index: int = 0, count: int = 1):
         self.validate()
-        return ChipCommandConfig(self.root_uri, self.task, self.backend,
-                                 self.augmentors, self.train_scenes,
-                                 self.val_scenes)
+        return ChipCommandConfig(
+            self.root_uri, self.task, self.backend, self.augmentors,
+            self.train_scenes[index::count], self.val_scenes[index::count])
 
     def from_proto(self, msg):
         b = super().from_proto(msg)

--- a/rastervision/command/command.py
+++ b/rastervision/command/command.py
@@ -5,7 +5,7 @@ from rastervision.rv_config import RVConfig
 
 class Command(ABC):
     @abstractmethod
-    def run(self, tmp_dir):
+    def run(self, tmp_dir, index: int = 0, count: int = 1):
         """Run the command."""
         pass
 
@@ -26,5 +26,5 @@ class NoOpCommand(Command):
     """Defines a command that does nothing.
     """
 
-    def run(self, tmp_dir):
+    def run(self, tmp_dir, index: int = 0, count: int = 1):
         pass

--- a/rastervision/command/eval_command.py
+++ b/rastervision/command/eval_command.py
@@ -7,7 +7,7 @@ class EvalCommand(Command):
     def __init__(self, command_config):
         self.command_config = command_config
 
-    def run(self, tmp_dir=None):
+    def run(self, tmp_dir=None, index: int = 0, count: int = 1):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
 

--- a/rastervision/command/predict_command.py
+++ b/rastervision/command/predict_command.py
@@ -7,7 +7,7 @@ class PredictCommand(Command):
     def __init__(self, command_config):
         self.command_config = command_config
 
-    def run(self, tmp_dir=None):
+    def run(self, tmp_dir=None, index: int = 0, count: int = 1):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
         msg = 'Making predictions...'

--- a/rastervision/command/predict_command_config.py
+++ b/rastervision/command/predict_command_config.py
@@ -74,10 +74,24 @@ class PredictCommandConfigBuilder(CommandConfigBuilder):
                 'with_backend or with_experiment')
         check_backend_type(self.backend)
 
-    def build(self):
+    def build(self, io_def=None):
         self.validate()
+
+        def predicate(scene):
+            if hasattr(scene.raster_source, 'uris'):
+                return all(
+                    map(lambda uri: uri in io_def.input_uris,
+                        scene.raster_source.uris))
+            else:
+                return True
+
+        if io_def is not None:
+            scenes = list(filter(predicate, self.scenes))
+        else:
+            scenes = self.scenes
+
         return PredictCommandConfig(self.root_uri, self.task, self.backend,
-                                    self.scenes)
+                                    scenes)
 
     def from_proto(self, msg):
         b = super().from_proto(msg)

--- a/rastervision/command/train_command.py
+++ b/rastervision/command/train_command.py
@@ -7,7 +7,7 @@ class TrainCommand(Command):
     def __init__(self, command_config):
         self.command_config = command_config
 
-    def run(self, tmp_dir=None):
+    def run(self, tmp_dir=None, index: int = 0, count: int = 1):
         if not tmp_dir:
             tmp_dir = self.get_tmp_dir()
         msg = 'Training model...'

--- a/rastervision/data/dataset_config.py
+++ b/rastervision/data/dataset_config.py
@@ -91,7 +91,9 @@ class DatasetConfig(Config):
                            command_type,
                            experiment_config,
                            context=None,
-                           io_def=None):
+                           io_def=None,
+                           index: int = 0,
+                           count: int = 1):
         verbosity = Verbosity.get()
 
         io_def = io_def or rv.core.CommandIODefinition()
@@ -138,7 +140,6 @@ class DatasetConfig(Config):
                               command_type == rv.PREDICT)
 
         if command_type in [rv.ANALYZE, rv.PREDICT, rv.EVAL, rv.BUNDLE]:
-
             log.debug(
                 'Updating test scenes for command {}'.format(command_type))
             if Verbosity.get() >= Verbosity.VERBOSE:

--- a/rastervision/experiment/experiment_config.py
+++ b/rastervision/experiment/experiment_config.py
@@ -51,7 +51,9 @@ class ExperimentConfig(Config):
                            command_type,
                            experiment_config,
                            context=None,
-                           io_def=None):
+                           io_def=None,
+                           index: int = 0,
+                           count: int = 1):
         """
         Returns a tuple (config, dependencies) with the
         """
@@ -62,12 +64,22 @@ class ExperimentConfig(Config):
                                      io_def)
 
         log.debug('Updating backend for command {}'.format(command_type))
-        self.backend.update_for_command(command_type, experiment_config,
-                                        context, io_def)
+        self.backend.update_for_command(
+            command_type,
+            experiment_config,
+            context,
+            io_def,
+            index=index,
+            count=count)
 
         log.debug('Updating dataset for command {}'.format(command_type))
-        self.dataset.update_for_command(command_type, experiment_config,
-                                        context, io_def)
+        self.dataset.update_for_command(
+            command_type,
+            experiment_config,
+            context,
+            io_def,
+            index=index,
+            count=count)
 
         log.debug('Updating analyzers for command {}'.format(command_type))
         for analyzer in self.analyzers:

--- a/rastervision/experiment/experiment_config.py
+++ b/rastervision/experiment/experiment_config.py
@@ -93,12 +93,12 @@ class ExperimentConfig(Config):
 
         return io_def
 
-    def make_command_config(self, command_type, index: int = 0,
-                            count: int = 1):
-        if command_type == 'CHIP':
+    def make_command_config(self, command_type, io_def=None):
+        parallelized = {rv.PREDICT, rv.CHIP}
+        if command_type in parallelized and io_def is not None:
             return rv._registry.get_command_config_builder(command_type)() \
                                .with_experiment(self) \
-                               .build(index=index, count=count)
+                               .build(io_def)
         else:
             return rv._registry.get_command_config_builder(command_type)() \
                                .with_experiment(self) \

--- a/rastervision/experiment/experiment_config.py
+++ b/rastervision/experiment/experiment_config.py
@@ -93,10 +93,16 @@ class ExperimentConfig(Config):
 
         return io_def
 
-    def make_command_config(self, command_type):
-        return rv._registry.get_command_config_builder(command_type)() \
-                           .with_experiment(self) \
-                           .build()
+    def make_command_config(self, command_type, index: int = 0,
+                            count: int = 1):
+        if command_type == 'CHIP':
+            return rv._registry.get_command_config_builder(command_type)() \
+                               .with_experiment(self) \
+                               .build(index=index, count=count)
+        else:
+            return rv._registry.get_command_config_builder(command_type)() \
+                               .with_experiment(self) \
+                               .build()
 
     def fully_resolve(self):
         """Returns a fully resolved copy of this  experiment.

--- a/rastervision/runner/command_definition.py
+++ b/rastervision/runner/command_definition.py
@@ -7,11 +7,20 @@ import rastervision as rv
 log = logging.getLogger(__name__)
 
 
+def semantic_segmentation_uris(uris, split):
+    retval = []
+    for uri in uris:
+        retval.append(uri.replace('0.record', '{}.record'.format(split)))
+    return set(retval)
+
+
 class CommandDefinition:
     def __init__(self, experiment_id, command_config, io_def):
         self.experiment_id = experiment_id
         self.command_config = command_config
         self.io_def = io_def
+        self.index = 0
+        self.count = 1
 
     def _key(self):
         return (self.command_config.command_type, '|'.join(

--- a/rastervision/runner/command_definition.py
+++ b/rastervision/runner/command_definition.py
@@ -50,8 +50,7 @@ class CommandDefinition:
                     command_type, e, index=index, count=count)
                 log.debug('Creating experiment configuration...'.format(
                     command_type))
-                command_config = e.make_command_config(
-                    command_type, index=index, count=count)
+                command_config = e.make_command_config(command_type, io_def)
                 command_def = cls(
                     e.id, command_config, io_def, index=index, count=count)
                 command_definitions.append(command_def)

--- a/rastervision/runner/command_definition.py
+++ b/rastervision/runner/command_definition.py
@@ -15,12 +15,17 @@ def semantic_segmentation_uris(uris, split):
 
 
 class CommandDefinition:
-    def __init__(self, experiment_id, command_config, io_def):
+    def __init__(self,
+                 experiment_id,
+                 command_config,
+                 io_def,
+                 index: int = 0,
+                 count: int = 1):
         self.experiment_id = experiment_id
         self.command_config = command_config
         self.io_def = io_def
-        self.index = 0
-        self.count = 1
+        self.index = index
+        self.count = count
 
     def _key(self):
         return (self.command_config.command_type, '|'.join(
@@ -34,7 +39,10 @@ class CommandDefinition:
         return hash(self._key())
 
     @classmethod
-    def from_experiments(cls, experiments: List[rv.ExperimentConfig]):
+    def from_experiments(cls,
+                         experiments: List[rv.ExperimentConfig],
+                         index: int = 0,
+                         count: int = 1):
         command_definitions = []
 
         for experiment in experiments:
@@ -45,11 +53,13 @@ class CommandDefinition:
             for command_type in rv.ALL_COMMANDS:
                 log.debug(
                     'Updating config for command {}...'.format(command_type))
-                io_def = e.update_for_command(command_type, e)
+                io_def = e.update_for_command(
+                    command_type, e, index=index, count=count)
                 log.debug('Creating experiment configuration...'.format(
                     command_type))
                 command_config = e.make_command_config(command_type)
-                command_def = cls(e.id, command_config, io_def)
+                command_def = cls(
+                    e.id, command_config, io_def, index=index, count=count)
                 command_definitions.append(command_def)
 
         return command_definitions

--- a/rastervision/runner/command_definition.py
+++ b/rastervision/runner/command_definition.py
@@ -7,13 +7,6 @@ import rastervision as rv
 log = logging.getLogger(__name__)
 
 
-def semantic_segmentation_uris(uris, split):
-    retval = []
-    for uri in uris:
-        retval.append(uri.replace('0.record', '{}.record'.format(split)))
-    return set(retval)
-
-
 class CommandDefinition:
     def __init__(self,
                  experiment_id,
@@ -57,7 +50,8 @@ class CommandDefinition:
                     command_type, e, index=index, count=count)
                 log.debug('Creating experiment configuration...'.format(
                     command_type))
-                command_config = e.make_command_config(command_type)
+                command_config = e.make_command_config(
+                    command_type, index=index, count=count)
                 command_def = cls(
                     e.id, command_config, io_def, index=index, count=count)
                 command_definitions.append(command_def)

--- a/rastervision/runner/command_runner.py
+++ b/rastervision/runner/command_runner.py
@@ -6,12 +6,12 @@ from rastervision.utils.files import load_json_config
 
 class CommandRunner:
     @staticmethod
-    def run(command_config_uri):
+    def run(command_config_uri, index: int = 0, count: int = 1):
         msg = load_json_config(command_config_uri, CommandConfigMsg())
-        CommandRunner.run_from_proto(msg)
+        CommandRunner.run_from_proto(msg, index=index, count=count)
 
-    def run_from_proto(msg):
+    def run_from_proto(msg, index: int = 0, count: int = 1):
         PluginRegistry.get_instance().add_plugins_from_proto(msg.plugins)
         command_config = rv.command.CommandConfig.from_proto(msg)
         command = command_config.create_command()
-        command.run()
+        command.run(index=index, count=count)

--- a/rastervision/runner/experiment_runner.py
+++ b/rastervision/runner/experiment_runner.py
@@ -52,7 +52,8 @@ class ExperimentRunner(ABC):
             commands_to_run=rv.ALL_COMMANDS,
             rerun_commands=False,
             skip_file_check=False,
-            dry_run: bool = False):
+            dry_run: bool = False,
+            splits: int = 1):
         if not isinstance(experiments, list):
             experiments = [experiments]
 

--- a/rastervision/runner/experiment_runner.py
+++ b/rastervision/runner/experiment_runner.py
@@ -61,7 +61,6 @@ class ExperimentRunner(ABC):
         command_definitions = CommandDefinition.from_experiments(experiments)
 
         # Filter  out commands we aren't running.
-
         log.debug('Filtering commands not in target command list...')
         command_definitions, not_requested = CommandDefinition.filter_to_target_commands(
             command_definitions, commands_to_run)

--- a/rastervision/runner/experiment_runner.py
+++ b/rastervision/runner/experiment_runner.py
@@ -148,7 +148,7 @@ class ExperimentRunner(ABC):
             # TODO: Replace with logging?
             s = '\t\n'.join(clashing_msgs)
 
-            raise rv.ConfigError('ERROR: Command outputs will'
+            raise rv.ConfigError('ERROR: Command outputs will '
                                  'override each other: \n{}\n'.format(s))
 
         log.debug('Constructing command DAG...')

--- a/rastervision/runner/experiment_runner.py
+++ b/rastervision/runner/experiment_runner.py
@@ -58,7 +58,10 @@ class ExperimentRunner(ABC):
             experiments = [experiments]
 
         log.debug('Generating command definitions from experiments...')
-        command_definitions = CommandDefinition.from_experiments(experiments)
+        command_definitions = []
+        for i in range(0, splits):
+            command_definitions = command_definitions + CommandDefinition.from_experiments(  # noqa
+                experiments, index=i, count=splits)
 
         # Filter  out commands we aren't running.
         log.debug('Filtering commands not in target command list...')

--- a/rastervision/runner/local_experiment_runner.py
+++ b/rastervision/runner/local_experiment_runner.py
@@ -56,7 +56,9 @@ class LocalExperimentRunner(OutOfProcessExperimentRunner):
                 print('Saving command configuration to {}...'.format(
                     command_uri))
                 save_json_config(command_config.to_proto(), command_uri)
-                run_command = make_command(command_uri, self.tmp_dir)
+                run_command = make_command(command_uri, self.tmp_dir,
+                                           command_def.index,
+                                           command_def.count)
                 makefile.write('\t{}\n\n'.format(run_command))
 
         process = Popen(['make', '-j', '-f', makefile_name])

--- a/rastervision/runner/local_experiment_runner.py
+++ b/rastervision/runner/local_experiment_runner.py
@@ -51,7 +51,9 @@ class LocalExperimentRunner(OutOfProcessExperimentRunner):
                 command_def = command_dag.get_command_definition(command_id)
                 command_config = command_def.command_config
                 command_root_uri = command_config.root_uri
-                command_uri = os.path.join(command_root_uri, 'command-config-{}.json'.format(command_def.index))
+                command_uri = os.path.join(
+                    command_root_uri,
+                    'command-config-{}.json'.format(command_def.index))
                 print('Saving command configuration to {}...'.format(
                     command_uri))
                 save_json_config(command_config.to_proto(), command_uri)

--- a/rastervision/runner/local_experiment_runner.py
+++ b/rastervision/runner/local_experiment_runner.py
@@ -51,8 +51,7 @@ class LocalExperimentRunner(OutOfProcessExperimentRunner):
                 command_def = command_dag.get_command_definition(command_id)
                 command_config = command_def.command_config
                 command_root_uri = command_config.root_uri
-                command_uri = os.path.join(command_root_uri,
-                                           'command-config.json')
+                command_uri = os.path.join(command_root_uri, 'command-config-{}.json'.format(command_def.index))
                 print('Saving command configuration to {}...'.format(
                     command_uri))
                 save_json_config(command_config.to_proto(), command_uri)

--- a/rastervision/runner/local_experiment_runner.py
+++ b/rastervision/runner/local_experiment_runner.py
@@ -1,9 +1,13 @@
 from subprocess import Popen
 import sys
 import logging
+import os
 
 from rastervision.runner import OutOfProcessExperimentRunner
+from rastervision.runner import make_command
 from rastervision.utils.misc import (terminate_at_exit)
+from rastervision.utils.files import (save_json_config, make_dir)
+from rastervision.rv_config import RVConfig
 
 log = logging.getLogger(__name__)
 
@@ -12,18 +16,50 @@ class LocalExperimentRunner(OutOfProcessExperimentRunner):
     def __init__(self, tmp_dir=None):
         super().__init__()
 
-        self.submit = self.shellout
+        self.submit = None
         self.execution_environment = 'Shell'
         self.tmp_dir = tmp_dir
 
-    def shellout(self,
-                 command_type,
-                 experiment_id,
-                 command,
-                 parent_job_ids=None,
-                 array_size=None):
-        command = list(filter(lambda s: len(s) > 0, command.split(' ')))
-        process = Popen(command)
+    def _run_experiment(self, command_dag):
+        tmp_dir = self.tmp_dir or RVConfig.get_tmp_dir().name
+        make_dir(tmp_dir)
+        makefile_name = os.path.join(tmp_dir, 'Makefile')
+        with open(makefile_name, 'w') as makefile:
+            command_ids = command_dag.get_sorted_command_ids()
+
+            # .PHONY: 0 1 2 3 4 5
+            makefile.write('.PHONY:')
+            for command_id in command_ids:
+                makefile.write(' {}'.format(command_id))
+            makefile.write('\n\n')
+
+            # all: 0 1 2 3 4 5
+            makefile.write('all:')
+            for command_id in command_ids:
+                makefile.write(' {}'.format(command_id))
+            makefile.write('\n\n')
+
+            for command_id in command_ids:
+                # 0: 1 2
+                makefile.write('{}:'.format(command_id))
+                for upstream_id in command_dag.get_upstream_command_ids(
+                        command_id):
+                    makefile.write(' {}'.format(upstream_id))
+                makefile.write('\n')
+
+                # \t rastervision ...
+                command_def = command_dag.get_command_definition(command_id)
+                command_config = command_def.command_config
+                command_root_uri = command_config.root_uri
+                command_uri = os.path.join(command_root_uri,
+                                           'command-config.json')
+                print('Saving command configuration to {}...'.format(
+                    command_uri))
+                save_json_config(command_config.to_proto(), command_uri)
+                run_command = make_command(command_uri, self.tmp_dir)
+                makefile.write('\t{}\n\n'.format(run_command))
+
+        process = Popen(['make', '-j', '-f', makefile_name])
         terminate_at_exit(process)
         exitcode = process.wait()
         if exitcode != 0:

--- a/rastervision/runner/out_of_process_experiment_runner.py
+++ b/rastervision/runner/out_of_process_experiment_runner.py
@@ -6,17 +6,20 @@ from rastervision.utils.files import save_json_config
 from rastervision.cli import Verbosity
 
 
-def make_command(command_config_uri, tmp_dir=None):
+def make_command(command_config_uri,
+                 tmp_dir=None,
+                 index: int = 0,
+                 count: int = 1):
     verbosity = Verbosity.get()
     v_flag = 'v' * max(0, verbosity - 1)
     if v_flag:
         v_flag = '-{}'.format(v_flag)
     if tmp_dir is None:
-        command = 'python -m rastervision {} run_command {}'.format(
-            v_flag, command_config_uri)
+        command = 'python -m rastervision {} run_command {} --index {} --count {}'.format(  # noqa
+            v_flag, command_config_uri, index, count)
     else:
-        command = 'python -m rastervision {} run_command {} --tempdir {}'.format(
-            v_flag, command_config_uri, tmp_dir)
+        command = 'python -m rastervision {} run_command {} --tempdir {} --index {} --count {}'.format(  # noqa
+            v_flag, command_config_uri, tmp_dir, index, count)
     return command
 
 
@@ -65,7 +68,8 @@ class OutOfProcessExperimentRunner(ExperimentRunner):
                             cur_command, upstream_command))
                 parent_job_ids.append(ids_to_job[upstream_id])
 
-            run_command = make_command(command_uri, self.tmp_dir)
+            run_command = make_command(command_uri, self.tmp_dir,
+                                       command_def.index, command_def.count)
             job_id = self.submit(command_config.command_type,
                                  command_def.experiment_id, run_command,
                                  parent_job_ids)

--- a/rastervision/task/task.py
+++ b/rastervision/task/task.py
@@ -85,7 +85,13 @@ class Task(object):
         """
         pass
 
-    def make_chips(self, train_scenes, validation_scenes, augmentors, tmp_dir):
+    def make_chips(self,
+                   train_scenes,
+                   validation_scenes,
+                   augmentors,
+                   tmp_dir,
+                   index: int = 0,
+                   count: int = 1):
         """Make training chips.
 
         Convert Scenes with a ground_truth_label_store into training
@@ -130,7 +136,11 @@ class Task(object):
             validation_scenes, VALIDATION, augment=False)
 
         self.backend.process_sceneset_results(
-            processed_training_results, processed_validation_results, tmp_dir)
+            processed_training_results,
+            processed_validation_results,
+            tmp_dir,
+            index=index,
+            count=count)
 
     def train(self, tmp_dir):
         """Train a model.

--- a/tests/data-files/plugins/noop_backend.py
+++ b/tests/data-files/plugins/noop_backend.py
@@ -11,8 +11,12 @@ class NoopBackend(Backend):
     def process_scene_data(self, scene, data, tmp_dir):
         pass
 
-    def process_sceneset_results(self, training_results, validation_results,
-                                 tmp_dir):
+    def process_sceneset_results(self,
+                                 training_results,
+                                 validation_results,
+                                 tmp_dir,
+                                 index: int = 0,
+                                 count: int = 1):
         pass
 
     def train(self, tmp_dir):
@@ -41,7 +45,9 @@ class NoopBackendConfig(BackendConfig):
                            command_type,
                            experiment_config,
                            context=None,
-                           io_def=None):
+                           io_def=None,
+                           index: int = 0,
+                           count: int = 1):
         return io_def or rv.core.CommandIODefinition()
 
     def save_bundle_files(self, bundle_dir):

--- a/tests/mock/backend.py
+++ b/tests/mock/backend.py
@@ -58,7 +58,7 @@ class MockBackendConfig(SupressDeepCopyMixin, BackendConfig):
         else:
             return result
 
-    def create_backend(self, task_config):
+    def create_backend(self, task_config, index: int = 0, count: int = 1):
         result = self.mock.create_backend(task_config)
         if result is None:
             return MockBackend()

--- a/tests/mock/backend.py
+++ b/tests/mock/backend.py
@@ -20,8 +20,12 @@ class MockBackend(Backend):
     def process_scene_data(self, scene, data, tmp_dir):
         return self.mock.process_scene_data(scene, data, tmp_dir)
 
-    def process_sceneset_results(self, training_results, validation_results,
-                                 tmp_dir):
+    def process_sceneset_results(self,
+                                 training_results,
+                                 validation_results,
+                                 tmp_dir,
+                                 index: int = 0,
+                                 count: int = 1):
         return self.mock.process_sceneset_results(training_results,
                                                   validation_results, tmp_dir)
 
@@ -69,7 +73,9 @@ class MockBackendConfig(SupressDeepCopyMixin, BackendConfig):
                            command_type,
                            experiment_config,
                            context=None,
-                           io_def=None):
+                           io_def=None,
+                           index: int = 0,
+                           count: int = 1):
         result = self.mock.update_for_command(command_type, experiment_config,
                                               context, io_def)
         if result is None:


### PR DESCRIPTION
## Overview

These changes allow multiple predictions to run in parallel.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

Add the `--splits` flag (along with some integer) to the command line of some chosen experiment.

Closes #654 
Depends on #661
Depends on #664
Depends on #657 