### PR TITLE
Fix error when using predict packages with AOIs

### DIFF
--- a/rastervision/data/scene_config.py
+++ b/rastervision/data/scene_config.py
@@ -320,3 +320,9 @@ class SceneConfigBuilder(ConfigBuilder):
         b = deepcopy(self)
         b.config['aoi_uris'] = uris
         return b
+
+    def clear_aois(self):
+        """Clears the AOIs for this scene"""
+        b = deepcopy(self)
+        b.config['aoi_uris'] = None
+        return b

--- a/rastervision/predictor.py
+++ b/rastervision/predictor.py
@@ -58,6 +58,7 @@ class Predictor():
         scene_builder = scene_config.load_bundle_files(package_dir) \
                                     .to_builder() \
                                     .clear_label_source() \
+                                    .clear_aois() \
                                     .with_id('PREDICTOR')
 
         # If the scene does not have a label store, generate a default one.


### PR DESCRIPTION
## Overview

This PR makes it so prediction packages based on models trained on scenes containing AOIs will work. It does this by clearing the AOIs from the scene (used as a template) in the prediction package. Without this, the predictor will try to download the AOIs associated with the scene, which will cause an error.

## Testing Instructions

This is difficult to test automatically since `Predictor` is only tested with integration tests and it would require a big change to the integration tests (use of an AOI) to test it. We could also just add unit tests for `Predictor`, but I think modifying the integration tests to use an AOI is something we ought to do anyway. Added https://github.com/azavea/raster-vision/issues/675

See `raster-vision` slack for manual testing instructions.