### PR TITLE
Change batch repo name back to raster-vision-aws

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,7 @@ html_context = {
         ProjectLink('Gitter Channel', 'https://gitter.im/azavea/raster-vision'),
         ProjectLink('Raster Vision Examples', 'https://github.com/azavea/raster-vision-examples'),
         ProjectLink('QGIS Plugin', 'https://github.com/azavea/raster-vision-qgis'),
-        ProjectLink('AWS Batch Setup', 'https://github.com/azavea/raster-vision-batch'),
+        ProjectLink('AWS Batch Setup', 'https://github.com/azavea/raster-vision-aws'),
         ProjectLink('Issue Tracker', 'https://github.com/azavea/raster-vision/issues/'),
         ProjectLink('CHANGELOG', 'changelog.html'),
         ProjectLink('Azavea', 'https://www.azavea.com/'),

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -196,7 +196,7 @@ If you have `nvidia-smi <https://developer.nvidia.com/nvidia-system-management-i
 Setting up AWS Batch
 --------------------
 
-If you want to run code against AWS, you'll need a specific Raster Vision AWS Batch setup on your account, which you can accomplish by following the instructions found in the `CloudFormation-based Raster Vision for AWS Batch setup repository <https://github.com/azavea/raster-vision-batch>`_.
+If you want to run code against AWS, you'll need a specific Raster Vision AWS Batch setup on your account, which you can accomplish by following the instructions found in the `CloudFormation-based Raster Vision for AWS Batch setup repository <https://github.com/azavea/raster-vision-aws>`_.
 
 .. _aws batch config section:
 


### PR DESCRIPTION
This is the original name of the repo, and changing it back will allow people to avoid 404s who had that cloned or bookmarked.