### PR TITLE
Fix polygonization

### DIFF
--- a/extras_requirements.json
+++ b/extras_requirements.json
@@ -12,6 +12,6 @@
         "awscli==1.15.*"
     ],
     "feature-extraction": [
-        "https://github.com/azavea/mask-to-polygons/archive/085c022158052473dd75d278c76cfa16067fc53a.zip"
+        "https://github.com/azavea/mask-to-polygons/archive/400f118a0beb78050c48b73558c51074f2035466.zip"
     ]
 }

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -154,7 +154,8 @@ class SemanticSegmentationRasterStore(LabelStore):
                 class_mask = np.array(mask == class_id, dtype=np.uint8)
                 local_geojson_path = get_local_path(uri, self.tmp_dir)
 
-                transform = self.crs_transformer.get_affine_transform()
+                def transform(x, y):
+                    return self.crs_transformer.pixel_to_map((x, y))
 
                 if denoise_radius > 0:
                     class_mask = denoise.denoise(class_mask, denoise_radius)


### PR DESCRIPTION
## Overview

This PR makes it so we use the updates in https://github.com/azavea/mask-to-polygons/pull/9 which increase the speed of polygonization and outputs lat/lng coordinates.

## Testing Instructions
* In the `other` directory, place the code for https://github.com/azavea/mask-to-polygons/pull/9 
* In the console, run `export PYTHONPATH=$PYTHONPATH:/opt/src/other/mask-to-polygons/`
* Make this change to the Vegas example
```
diff --git a/spacenet/vegas.py b/spacenet/vegas.py
index b6c8aa5..6586114 100644
--- a/spacenet/vegas.py
+++ b/spacenet/vegas.py
@@ -139,13 +139,20 @@ def build_scene(task, spacenet_config, id, channel_order=None, vector_tile_optio
                                            .with_vector_source(vector_source) \
                                            .build()

+    vector_output = {'mode': 'polygons', 'class_id': 1}
+    label_store = rv.LabelStoreConfig.builder(rv.SEMANTIC_SEGMENTATION_RASTER) \
+                                     .with_vector_output([vector_output]) \
+                                     .build()
+
     scene = rv.SceneConfig.builder() \
                           .with_task(task) \
                           .with_id(id) \
                           .with_raster_source(raster_source) \
                           .with_label_source(label_source) \
+                          .with_label_store(label_store) \
                           .build()

+
     return scene
```
* Run the Vegas example and swap in `s3://raster-vision-lf-dev/noisy-buildings-semseg/rv/train/drop-0.0-0/model` after training is complete
* Run the predict command again and check that polygons are correct.
* To test the timing and CRS modifications, I used a custom script on the IDB data. 
```python
import json

import rasterio
import numpy as np
import numpy.ma as ma

from rastervision.data import RasterioCRSTransformer
import mask_to_polygons.vectorification as vectorification
import mask_to_polygons.processing.denoise as denoise

image_path = '/opt/data/idb/predictions/four-cities3/paramaribo-large.tif'
out_path = '/opt/data/idb/predictions/four-cities3/paramaribo-large.json'
denoise_radius = 3


with rasterio.open(image_path, 'r') as image_dataset:
    crs_transformer = RasterioCRSTransformer.from_dataset(image_dataset)
    transform = lambda x, y: crs_transformer.pixel_to_map((x, y))
    class_mask = image_dataset.read().astype(np.uint8)
    class_mask = np.transpose(class_mask, [1, 2, 0])
    print(class_mask.shape)
    print(class_mask.dtype)
    class_mask = denoise.denoise(class_mask, denoise_radius)
    geojson = vectorification.geojson_from_mask(
        mask=class_mask, transform=transform, mode='polygons')

    with open(out_path, 'w') as file_out:
        file_out.write(geojson)
```