### PR TITLE
WIP: Conserve disk space when dealing with raster files

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Raster Vision 0.9
 
 Raster Vision 0.9.0
 ~~~~~~~~~~~~~~~~~~~
+- Conserve disk space when dealing with raster files `#692 <https://github.com/azavea/raster-vision/pull/692>`_
 - Optimize StatsAnalyzer `#690 <https://github.com/azavea/raster-vision/pull/690>`_
 - Include per-scene eval metrics `#641 <https://github.com/azavea/raster-vision/pull/641>`_
 - Make and save predictions and do eval chip-by-chip `#635 <https://github.com/azavea/raster-vision/pull/635>`_

--- a/rastervision/command/command.py
+++ b/rastervision/command/command.py
@@ -19,7 +19,9 @@ class Command(ABC):
             else:
                 return self._tmp_dir.name
         else:
-            return RVConfig.get_tmp_dir().name
+            tmp_dir = RVConfig.get_tmp_dir()
+            self.set_tmp_dir(tmp_dir)
+            return tmp_dir.name
 
 
 class NoOpCommand(Command):

--- a/rastervision/data/raster_source/image_source.py
+++ b/rastervision/data/raster_source/image_source.py
@@ -11,7 +11,7 @@ class ImageSource(RasterioRasterSource):
         super().__init__(raster_transformers, temp_dir, channel_order)
 
     def _download_data(self, temp_dir):
-        return download_if_needed(self.uri, self.temp_dir)
+        return download_if_needed(self.uri, temp_dir)
 
     def _set_crs_transformer(self):
         self.crs_transformer = IdentityCRSTransformer()


### PR DESCRIPTION
## Overview

Currently, we download all raster files in one go. This leads to running out of disk space on large datasets. This PR avoids this by downloading an individual raster (on activation), using it, and then deleting it (on deactivation). With this change, you shouldn't run out of disk space as long as the biggest scene fits onto disk. However, if multiple jobs are running on a multi-core instance, then you could still run out of disk space. We should keep that in mind when deciding how much disk space to allocate.

### Notes

An unfortunate consequence of this PR is that we now have to download each raster twice: once when we read metadata and a test chip in the `RasterioRasterSource` constructor, and then again when we actually use it for chipping, prediction, etc. To get around this, I tried to read the metadata and test chip directly off S3 in the constructor using GDAL/Rasterio's ability to do this, but there were problems documented in #691 I'm hoping this won't present a big performance issues since downloads from S3 are fast on EC2.

## Testing Instructions
* I tested the Vegas workflow with local and remote data.
* In progress: I tested the analyze command remotely using the IDB dataset duplicated 4 times which has 60GB+ of imagery on a 50GB disk. (25 mins)
* In progress: I compared times for running analyze with the IDB dataset with this branch (10mins) and develop (8mins). 

Closes #689
