### PR TITLE
Predict zero for nodata pixels on semantic segmentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Raster Vision 0.9
 
 Raster Vision 0.9.0
 ~~~~~~~~~~~~~~~~~~~
+- Predict zero for nodata pixels on semantic segmentation `#701 <https://github.com/azavea/raster-vision/pull/701>`_
 - Add support for evaluating vector output with AOIs `#698 <https://github.com/azavea/raster-vision/pull/698>`_
 - Conserve disk space when dealing with raster files `#692 <https://github.com/azavea/raster-vision/pull/692>`_
 - Optimize StatsAnalyzer `#690 <https://github.com/azavea/raster-vision/pull/690>`_

--- a/rastervision/task/semantic_segmentation.py
+++ b/rastervision/task/semantic_segmentation.py
@@ -126,12 +126,12 @@ class SemanticSegmentation(Task):
 
         def label_fn(window):
             chip = raster_source.get_chip(window)
-            if np.any(chip):
-                chip = raster_source.get_chip(window)
-                labels = self.backend.predict([chip], [window], tmp_dir)
-                label_arr = labels.get_label_arr(window)
-            else:
-                label_arr = np.zeros((window.get_height(), window.get_width()))
+            labels = self.backend.predict([chip], [window], tmp_dir)
+            label_arr = labels.get_label_arr(window)
+
+            # Set NODATA pixels in imagery to predicted value of 0 (ie. ignore)
+            label_arr[np.sum(chip, axis=2) == 0] = 0
+
             print('.', end='', flush=True)
             return label_arr
 


### PR DESCRIPTION
## Overview

This PR makes it so that a zero (don't care value) is predicted for each pixel in the `RasterSource` that has a NODATA value. This makes it so the NODATA outlines around a scene don't have false positive "hallucinations".

## Testing Instructions

I didn't unit test this because there aren't any existing unit tests for the `Tasks`, and the integration tests don't test AOIs or NODATA handling, and that will take too much time right now. I added an issue for this https://github.com/azavea/raster-vision/issues/702  However, I did find that it has the desired effect on a client project.

Closes #703 
