### PR TITLE
Fix issue with saving semseg predictions for non-georeferenced imagery

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,7 @@ Raster Vision 0.8.2
 
 Bug Fixes
 ^^^^^^^^^
+- Fixed issue with saving semseg predictions for non-georeferenced imagery `#708 <https://github.com/azavea/raster-vision/pull/708>`_
 - Fixed issue with handling width > height in semseg eval `#627 <https://github.com/azavea/raster-vision/pull/627>`_
 - Fixed issue with experiment configs not setting key names correctly `#523 <https://github.com/azavea/raster-vision/pull/576>`_
 - Fixed issue with Raster Sources that have channel order `#503 <https://github.com/azavea/raster-vision/pull/576>`_

--- a/rastervision/data/crs_transformer/crs_transformer.py
+++ b/rastervision/data/crs_transformer/crs_transformer.py
@@ -3,9 +3,10 @@ class CRSTransformer(object):
 
     Each transformer is associated with a particular RasterSource."""
 
-    def __init__(self, image_crs=None, map_crs=None):
+    def __init__(self, image_crs=None, map_crs=None, transform=None):
         self.image_crs = image_crs
         self.map_crs = map_crs
+        self.transform = transform
 
     def map_to_pixel(self, map_point):
         """Transform point from map to pixel-based coordinates.
@@ -36,4 +37,4 @@ class CRSTransformer(object):
         return self.map_crs
 
     def get_affine_transform(self):
-        raise NotImplementedError()
+        return self.transform

--- a/rastervision/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision/data/crs_transformer/rasterio_crs_transformer.py
@@ -16,11 +16,10 @@ class RasterioCRSTransformer(CRSTransformer):
             image_dataset: Rasterio DatasetReader
             map_crs: CRS code
         """
-        self.transform = transform
         self.map_proj = pyproj.Proj(init=map_crs)
         self.image_proj = pyproj.Proj(init=image_crs)
 
-        super().__init__(image_crs, map_crs)
+        super().__init__(image_crs, map_crs, transform)
 
     def map_to_pixel(self, map_point):
         """Transform point from map to pixel-based coordinates.

--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -85,9 +85,7 @@ class SemanticSegmentationRasterStore(LabelStore):
         local_path = get_local_path(self.uri, self.tmp_dir)
         make_dir(local_path, use_dirname=True)
 
-        # TODO: this only works if crs_transformer is RasterioCRSTransformer.
-        # Need more general way of computing transform for the more general case.
-        transform = self.crs_transformer.transform
+        transform = self.crs_transformer.get_affine_transform()
         crs = self.crs_transformer.get_image_crs()
 
         band_count = 1


### PR DESCRIPTION
This PR fixes an issue with saving semseg predictions for non-georeferenced imagery. It does this by returning None as the transform for the IdentityCRSTransformer.

Tested with:
```
wget -O spacenet.zip https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/vegas-building-seg/predict_package.zip
wget https://content.satimagingcorp.com/static/galleryimages/vatican-city-satellite-image-ikonos-high-resolution.jpg -O example.jpg
rastervision predict spacenet.zip example.jpg out.tif
```

Closes #707 
