### PR TITLE
Simplify/clarify/test/validate RasterSource

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Raster Vision 0.9
 
 Raster Vision 0.9.0
 ~~~~~~~~~~~~~~~~~~~
+- Simplify/clarify/test/validate RasterSource `#721 <https://github.com/azavea/raster-vision/pull/721>`_
 - Simplify and generalize geom processing `#711 <https://github.com/azavea/raster-vision/pull/711>`_
 - Predict zero for nodata pixels on semantic segmentation `#701 <https://github.com/azavea/raster-vision/pull/701>`_
 - Add support for evaluating vector output with AOIs `#698 <https://github.com/azavea/raster-vision/pull/698>`_

--- a/integration_tests/integration_tests.py
+++ b/integration_tests/integration_tests.py
@@ -197,6 +197,21 @@ def run_test(test, temp_dir):
                             'test {}, experiment {}'.format(
                                 test, experiment.id))
         else:
+            try:
+                console_info(
+                    'Checking predict package raises exception on invalid '
+                    'channel_order...')
+                pp = experiment.task.predict_package_uri
+                rv.Predictor(pp, temp_dir, channel_order=[0, 1, 7])
+                msg = (
+                    'Predictor should have raised an exception due to invalid '
+                    'channel_order but did not.')
+                details = 'for experiment {}'.format(experiment.id)
+                e = TestError(test, msg, details)
+                errors.append(e)
+            except ValueError:
+                pass
+
             console_info('Checking predict package produces same results...')
             pp = experiment.task.predict_package_uri
             predict = rv.Predictor(pp, temp_dir).predict

--- a/rastervision/data/raster_source/geotiff_source.py
+++ b/rastervision/data/raster_source/geotiff_source.py
@@ -55,10 +55,9 @@ class GeoTiffSource(RasterioRasterSource):
         self.crs_transformer = RasterioCRSTransformer.from_dataset(
             self.image_dataset)
 
-    def _get_chip(self, window):
-        no_shift = self.x_shift_meters == 0.0 and self.y_shift_meters == 0.0
-        yes_shift = not no_shift
-        if yes_shift:
+    def _get_shifted_window(self, window):
+        do_shift = self.x_shift_meters != 0.0 or self.y_shift_meters != 0.0
+        if do_shift:
             ymin, xmin, ymax, xmax = window.tuple_format()
             width = window.get_width()
             height = window.get_height()
@@ -97,8 +96,11 @@ class GeoTiffSource(RasterioRasterSource):
             xmin4, ymin4 = ~transform * (xmin3, ymin3)
 
             window = Box(ymin4, xmin4, ymin4 + height, xmin4 + width)
+        return window
 
-        return super()._get_chip(window)
+    def _get_chip(self, window):
+        shifted_window = self._get_shifted_window(window)
+        return super()._get_chip(shifted_window)
 
     def _activate(self):
         super()._activate()

--- a/rastervision/data/raster_source/raster_source.py
+++ b/rastervision/data/raster_source/raster_source.py
@@ -1,6 +1,14 @@
 from abc import ABC, abstractmethod
 
 
+class ChannelOrderError(Exception):
+    def __init__(self, channel_order, num_channels):
+        self.channel_order = channel_order
+        self.num_channels = num_channels
+        msg = 'The channel_order={} contains a channel index >= num_channels={}'
+        super().__init__(msg.format(str(channel_order), num_channels))
+
+
 class RasterSource(ABC):
     """A source of raster data.
 
@@ -12,16 +20,21 @@ class RasterSource(ABC):
         """Construct a new RasterSource.
 
         Args:
-            channel_order: numpy array of length n where n is the number of
-                channels to use and the values are channel indices.
-            num_channels: Number of channels in the raster data, before applying
+            channel_order: list of channel indices to use when extracting chip from
+                raw imagery.
+            num_channels: Number of channels in the raw imagery before applying
                 channel_order.
             raster_transformers: RasterTransformers used to transform chips
                 whenever they are retrieved.
         """
-        self.raster_transformers = raster_transformers
         self.channel_order = channel_order
         self.num_channels = num_channels
+        self.raster_transformers = raster_transformers
+
+    def validate_channel_order(self, channel_order, num_channels):
+        for c in channel_order:
+            if c >= num_channels:
+                raise ChannelOrderError(channel_order, num_channels)
 
     @abstractmethod
     def get_extent(self):

--- a/rastervision/data/raster_source/raster_source.py
+++ b/rastervision/data/raster_source/raster_source.py
@@ -44,7 +44,7 @@ class RasterSource(ABC):
 
     @abstractmethod
     def _get_chip(self, window):
-        """Return the chip located in the window.
+        """Return the raw chip located in the window.
 
         Args:
             window: Box
@@ -57,11 +57,14 @@ class RasterSource(ABC):
     def get_chip(self, window):
         """Return the transformed chip in the window.
 
+        Get a raw chip, extract subset of channels using channel_order, and then apply
+        transformations.
+
         Args:
             window: Box
 
         Returns:
-            [height, width, channels] numpy array
+            np.ndarray with shape [height, width, channels]
         """
         chip = self._get_chip(window)
 
@@ -74,13 +77,13 @@ class RasterSource(ABC):
         return chip
 
     def get_raw_chip(self, window):
-        """Return the untransformed chip in the window.
+        """Return raw chip without using channel_order or applying transforms.
 
         Args:
-            window: Box
+            window: (Box) the window for which to get the chip
 
         Returns:
-            [height, width, channels] numpy array
+            np.ndarray with shape [height, width, channels]
         """
         return self._get_chip(window)
 
@@ -92,7 +95,7 @@ class RasterSource(ABC):
         return self.get_chip(self.get_extent())
 
     def get_raw_image_array(self):
-        """Return entire untransformed image array.
+        """Return entire raw image without using channel_order or applying transforms.
 
         Not safe to call on very large RasterSources.
         """

--- a/rastervision/data/raster_source/raster_source_config.py
+++ b/rastervision/data/raster_source/raster_source_config.py
@@ -125,9 +125,11 @@ class RasterSourceConfigBuilder(ConfigBuilder):
     def with_channel_order(self, channel_order):
         """Defines the channel order for this raster source.
 
+        This defines the subset of channel indices and their order to use when extracting
+        chips from raw imagery.
+
         Args:
-            channel_order: numpy array of length n where n is the number of
-                channels to use and the values are channel indices
+            channel_order: list of channel indices
         """
         b = deepcopy(self)
         b.config['channel_order'] = channel_order

--- a/rastervision/data/raster_transformer/raster_transformer.py
+++ b/rastervision/data/raster_transformer/raster_transformer.py
@@ -9,10 +9,13 @@ class RasterTransformer(ABC):
         """Transform a chip of a raster source.
 
         Args:
-            chip: [height, width, channels] numpy array
+            chip: ndarray of shape [height, width, channels] This is assumed to already
+                have the channel_order applied to it if channel_order is set. In other
+                words, channels should be equal to len(channel_order).
+            channel_order: list of indices of channels that were extracted from the
+                raw imagery.
 
         Returns:
             [height, width, channels] numpy array
-
         """
         pass

--- a/rastervision/data/raster_transformer/stats_transformer.py
+++ b/rastervision/data/raster_transformer/stats_transformer.py
@@ -23,11 +23,15 @@ class StatsTransformer(RasterTransformer):
         Transforms non-uint8 to uint8 values using raster_stats.
 
         Args:
-            chip: [height, width, channels] numpy array
-            channel_order: The channel order to use for these statistics.
+            chip: ndarray of shape [height, width, channels] This is assumed to already
+                have the channel_order applied to it if channel_order is set. In other
+                words, channels should be equal to len(channel_order).
+            channel_order: list of indices of channels that were extracted from the
+                raw imagery.
 
         Returns:
             [height, width, channels] uint8 numpy array
+
         """
         if chip.dtype != np.uint8:
             if self.raster_stats:

--- a/rastervision/predictor.py
+++ b/rastervision/predictor.py
@@ -116,7 +116,7 @@ class Predictor():
            image_uri - URI of the image to make predictions against.
                        This can be any type of URI readable by Raster Vision
                        FileSystems.
-           label_uri - Optional URI to save labels  off into.
+           label_uri - Optional URI to save labels off into.
            config_uri - Optional URI in which to save the bundle_config,
                         which can be useful to client applications for understanding
                         how to interpret the labels.

--- a/tests/data/raster_source/test_geotiff_source.py
+++ b/tests/data/raster_source/test_geotiff_source.py
@@ -3,11 +3,12 @@ import os
 
 import numpy as np
 import rasterio
+from rasterio.enums import ColorInterp
 
 import rastervision as rv
-from rastervision.core import (Box, RasterStats)
+from rastervision.core import (RasterStats)
 from rastervision.utils.misc import save_img
-from rastervision.data.raster_source.rasterio_source import load_window
+from rastervision.data.raster_source import ChannelOrderError
 from rastervision.rv_config import RVConfig
 from rastervision.utils.files import make_dir
 
@@ -15,7 +16,7 @@ from tests import data_file_path
 
 
 class TestGeoTiffSource(unittest.TestCase):
-    def test_load_window(self):
+    def test_nodata_val(self):
         with RVConfig.get_tmp_dir() as temp_dir:
             # make geotiff filled with ones and zeros with nodata == 1
             image_path = os.path.join(temp_dir, 'temp.tif')
@@ -36,11 +37,45 @@ class TestGeoTiffSource(unittest.TestCase):
                 for channel in range(nb_channels):
                     image_dataset.write(im[:, :, channel], channel + 1)
 
-            # Should be all zeros after converting nodata values to zero.
-            window = Box.make_square(0, 0, 100).rasterio_format()
-            with rasterio.open(image_path) as image_dataset:
-                chip = load_window(image_dataset, window=window)
-            np.testing.assert_equal(chip, np.zeros(chip.shape))
+            source = rv.RasterSourceConfig.builder(rv.GEOTIFF_SOURCE) \
+                                          .with_uri(image_path) \
+                                          .build() \
+                                          .create_source(tmp_dir=temp_dir)
+            with source.activate():
+                out_chip = source.get_image_array()
+                expected_out_chip = np.zeros((height, width, nb_channels))
+                np.testing.assert_equal(out_chip, expected_out_chip)
+
+    def test_mask(self):
+        with RVConfig.get_tmp_dir() as temp_dir:
+            # make geotiff filled with ones and zeros and mask the whole image
+            image_path = os.path.join(temp_dir, 'temp.tif')
+            height = 100
+            width = 100
+            nb_channels = 3
+            with rasterio.open(
+                    image_path,
+                    'w',
+                    driver='GTiff',
+                    height=height,
+                    width=width,
+                    count=nb_channels,
+                    dtype=np.uint8) as image_dataset:
+                im = np.random.randint(
+                    0, 2, (height, width, nb_channels)).astype(np.uint8)
+                for channel in range(nb_channels):
+                    image_dataset.write(im[:, :, channel], channel + 1)
+                image_dataset.write_mask(
+                    np.zeros(im.shape[0:2]).astype(np.bool))
+
+            source = rv.RasterSourceConfig.builder(rv.GEOTIFF_SOURCE) \
+                                          .with_uri(image_path) \
+                                          .build() \
+                                          .create_source(tmp_dir=temp_dir)
+            with source.activate():
+                out_chip = source.get_image_array()
+                expected_out_chip = np.zeros((height, width, nb_channels))
+                np.testing.assert_equal(out_chip, expected_out_chip)
 
     def test_get_dtype(self):
         img_path = data_file_path('small-rgb-tile.tif')
@@ -192,6 +227,29 @@ class TestGeoTiffSource(unittest.TestCase):
                                      .with_channel_order(channel_order) \
                                      .build() \
                                      .create_source(tmp_dir=tmp_dir)
+
+    def test_detects_alpha(self):
+        # Set first channel to alpha. Expectation is that when omitting channel_order,
+        # only the second and third channels will be in output.
+        with RVConfig.get_tmp_dir() as tmp_dir:
+            img_path = os.path.join(tmp_dir, 'img.tif')
+            chip = np.ones((2, 2, 3)).astype(np.uint8)
+            chip[:, :, :] *= np.array([0, 1, 2]).astype(np.uint8)
+            save_img(chip, img_path)
+
+            ci = (ColorInterp.alpha, ColorInterp.blue, ColorInterp.green)
+            with rasterio.open(img_path, 'r+') as src:
+                src.colorinterp = ci
+
+            source = rv.RasterSourceConfig.builder(rv.GEOTIFF_SOURCE) \
+                                          .with_uri(img_path) \
+                                          .build() \
+                                          .create_source(tmp_dir=tmp_dir)
+            with source.activate():
+                out_chip = source.get_image_array()
+                expected_out_chip = np.ones((2, 2, 2)).astype(np.uint8)
+                expected_out_chip[:, :, :] *= np.array([1, 2]).astype(np.uint8)
+                np.testing.assert_equal(out_chip, expected_out_chip)
 
     def test_with_stats_transformer(self):
         config = rv.RasterSourceConfig.builder(rv.GEOTIFF_SOURCE) \

--- a/tests/data/raster_source/test_geotiff_source.py
+++ b/tests/data/raster_source/test_geotiff_source.py
@@ -178,6 +178,21 @@ class TestGeoTiffSource(unittest.TestCase):
                                                         2]).astype(np.uint8)
                 np.testing.assert_equal(out_chip, expected_out_chip)
 
+    def test_channel_order_error(self):
+        with RVConfig.get_tmp_dir() as tmp_dir:
+            img_path = os.path.join(tmp_dir, 'img.tif')
+            chip = np.ones((2, 2, 3)).astype(np.uint8)
+            chip[:, :, :] *= np.array([0, 1, 2]).astype(np.uint8)
+            save_img(chip, img_path)
+
+            channel_order = [3, 1, 0]
+            with self.assertRaises(ChannelOrderError):
+                rv.RasterSourceConfig.builder(rv.GEOTIFF_SOURCE) \
+                                     .with_uri(img_path) \
+                                     .with_channel_order(channel_order) \
+                                     .build() \
+                                     .create_source(tmp_dir=tmp_dir)
+
     def test_with_stats_transformer(self):
         config = rv.RasterSourceConfig.builder(rv.GEOTIFF_SOURCE) \
                                       .with_uri('dummy') \

--- a/tests/data/raster_source/test_image_source.py
+++ b/tests/data/raster_source/test_image_source.py
@@ -28,7 +28,7 @@ class TestImageSource(unittest.TestCase):
 
             transformers = [stats_transformer]
 
-            chip = (np.ones((2, 2, 4)) * [3, 3, 3, 0]).astype(np.uint16)
+            chip = (np.ones((2, 2, 4)) * [3, 3, 3, 3]).astype(np.uint16)
             save_img(chip, img_path)
 
             source = rv.RasterSourceConfig.builder(rv.IMAGE_SOURCE) \


### PR DESCRIPTION
## Overview

This PR does various things to simplify, clarify, test, and validate `RasterSource`. It also adds validation to the channel order for the predict command, which was the original impetus for this PR. See commits for details. 

## Testing 

Everything is tested by unit and integration tests. I also manually tested with the instructions in https://github.com/azavea/raster-vision/issues/709 which yields the error 
```
> python -m rastervision.cli.main predict potsdam.zip example.jpg out.tif

  File "/opt/src/rastervision/predictor.py", line 145, in predict
    'The predict package is using a channel_order '
ValueError: The predict package is using a channel_order with channels unavailable in the imagery.
To set a new channel_order that only uses channels available in the imagery, use the --channel-order option.
```

Closes #709 
