### PR TITLE
Handle Rasterio crs that doesn't contain EPSG

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,7 @@ Raster Vision 0.8.2
 
 Bug Fixes
 ^^^^^^^^^
+- Handle Rasterio crs that doesn't contain EPSG `#725 <https://github.com/azavea/raster-vision/pull/725>`_
 - Fixed issue with saving semseg predictions for non-georeferenced imagery `#708 <https://github.com/azavea/raster-vision/pull/708>`_
 - Fixed issue with handling width > height in semseg eval `#627 <https://github.com/azavea/raster-vision/pull/627>`_
 - Fixed issue with experiment configs not setting key names correctly `#523 <https://github.com/azavea/raster-vision/pull/576>`_

--- a/rastervision/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision/data/crs_transformer/rasterio_crs_transformer.py
@@ -17,7 +17,7 @@ class RasterioCRSTransformer(CRSTransformer):
             map_crs: CRS code
         """
         self.map_proj = pyproj.Proj(init=map_crs)
-        self.image_proj = pyproj.Proj(init=image_crs)
+        self.image_proj = pyproj.Proj(image_crs)
 
         super().__init__(image_crs, map_crs, transform)
 
@@ -56,7 +56,7 @@ class RasterioCRSTransformer(CRSTransformer):
         if dataset.crs is None:
             return IdentityCRSTransformer()
         transform = dataset.transform
-        image_crs = dataset.crs['init']
+        image_crs = dataset.crs
         return cls(transform, image_crs, map_crs)
 
     def get_affine_transform(self):


### PR DESCRIPTION
## Overview

We tried using a GeoTIFF where the CRS is missing an EPSG value and RV crashed. This PR makes it so we can handle a wider range of CRSs.

## Testing Instructions

Closes #724
