### PR TITLE
Make RasterioSource the catch-all for default provider

### DIFF
--- a/rastervision/data/raster_source/default.py
+++ b/rastervision/data/raster_source/default.py
@@ -1,5 +1,4 @@
 from abc import (ABC, abstractmethod)
-import os
 
 import rastervision as rv
 
@@ -20,8 +19,10 @@ class RasterSourceDefaultProvider(ABC):
 class RasterioSourceDefaultProvider(RasterSourceDefaultProvider):
     @staticmethod
     def handles(uri):
-        ext = os.path.splitext(uri)[1]
-        return ext.lower() in ['.tif', '.tiff', '.geotiff', '.png', '.jpg']
+        # Since there are so many types handled by Rasterio/GDAL, the RasterioSource
+        # will be the catch-all. More specific types can be handled by other
+        # RasterSources.
+        return True
 
     @staticmethod
     def construct(uri, channel_order=None):

--- a/tests/data/raster_source/test_rasterio_source.py
+++ b/tests/data/raster_source/test_rasterio_source.py
@@ -8,7 +8,7 @@ from rasterio.enums import ColorInterp
 import rastervision as rv
 from rastervision.core import (RasterStats)
 from rastervision.utils.misc import save_img
-from rastervision.data.raster_source import ChannelOrderError
+from rastervision.data.raster_source import ChannelOrderError, RasterioSourceConfig
 from rastervision.rv_config import RVConfig
 from rastervision.utils.files import make_dir
 from rastervision.protos.raster_source_pb2 import RasterSourceConfig as RasterSourceMsg
@@ -349,6 +349,14 @@ class TestRasterioSource(unittest.TestCase):
                 self.fail(
                     'Creating RasterioSource with CRS with no EPSG attribute '
                     'raised an exception when it should not have.')
+
+    def test_default_provider(self):
+        # The default provider should return a RasterioSourceConfig for any uri not
+        # caught by some other default provider.
+        uri = 'x.abcdefg'
+        provider = rv._registry.get_raster_source_default_provider(uri)
+        rs_config = provider.construct(uri)
+        self.assertIsInstance(rs_config, RasterioSourceConfig)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Overview

This PR makes the `RasterioSourceDefaultProvider` the catch-all case. This brings back the previous behavior that was implemented for `ImageSource` [here](https://github.com/azavea/raster-vision/blob/3d9835285ede8fb45722c0d7e81bef304d1a7b9d/rastervision/data/raster_source/default.py)

## Testing
Added unit test for this.
