### PR TITLE
Load null channel_order correctly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,7 @@ Raster Vision 0.8.2
 
 Bug Fixes
 ^^^^^^^^^
+- Load null channel_order correctly `#733 <https://github.com/azavea/raster-vision/pull/733>`_
 - Handle Rasterio crs that doesn't contain EPSG `#725 <https://github.com/azavea/raster-vision/pull/725>`_
 - Fixed issue with saving semseg predictions for non-georeferenced imagery `#708 <https://github.com/azavea/raster-vision/pull/708>`_
 - Fixed issue with handling width > height in semseg eval `#627 <https://github.com/azavea/raster-vision/pull/627>`_

--- a/rastervision/data/raster_source/raster_source_config.py
+++ b/rastervision/data/raster_source/raster_source_config.py
@@ -119,7 +119,10 @@ class RasterSourceConfigBuilder(ConfigBuilder):
             map(lambda m: RasterTransformerConfig.from_proto(m),
                 msg.transformers))
 
-        return self.with_channel_order(list(msg.channel_order)) \
+        channel_order = list(msg.channel_order)
+        if len(channel_order) == 0:
+            channel_order = None
+        return self.with_channel_order(channel_order) \
                    .with_transformers(transformers)
 
     def with_channel_order(self, channel_order):

--- a/tests/data/raster_source/test_rasterio_source.py
+++ b/tests/data/raster_source/test_rasterio_source.py
@@ -252,6 +252,14 @@ class TestRasterioSource(unittest.TestCase):
                 expected_out_chip[:, :, :] *= np.array([1, 2]).astype(np.uint8)
                 np.testing.assert_equal(out_chip, expected_out_chip)
 
+    def test_empty_channel_order(self):
+        config = rv.RasterSourceConfig.builder(rv.RASTERIO_SOURCE) \
+                                      .with_uri('a.tif') \
+                                      .build()
+        msg = config.to_proto()
+        config = rv.RasterSourceConfig.from_proto(msg)
+        self.assertEqual(config.channel_order, None)
+
     def test_non_geo(self):
         # Check if non-georeferenced image files can be read and CRSTransformer
         # implements the identity function.


### PR DESCRIPTION
## Overview

Previously, if you saved the config for a `RasterSource` with a null `channel_order` (because it was never set) and then loaded it, the `channel_order` would be set to `[]` instead of `None` which would cause problems downstream. 

## Testing
Added unit test and checked that this fixed problem in #727 

Closes #727 