### PR TITLE
Fix filter_by_aoi for ObjectDetectionLabels

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,7 @@ Raster Vision 0.8.2
 
 Bug Fixes
 ^^^^^^^^^
+- Fix filter_by_aoi for ObjectDetectionLabels `#746 <https://github.com/azavea/raster-vision/pull/746>`_
 - Load null channel_order correctly `#733 <https://github.com/azavea/raster-vision/pull/733>`_
 - Handle Rasterio crs that doesn't contain EPSG `#725 <https://github.com/azavea/raster-vision/pull/725>`_
 - Fixed issue with saving semseg predictions for non-georeferenced imagery `#708 <https://github.com/azavea/raster-vision/pull/708>`_

--- a/rastervision/data/label/object_detection_labels.py
+++ b/rastervision/data/label/object_detection_labels.py
@@ -61,10 +61,13 @@ class ObjectDetectionLabels(Labels):
             box_poly = box.to_shapely()
             for aoi in aoi_polygons:
                 if box_poly.within(aoi):
-                    new_boxes.append(box)
+                    new_boxes.append(box.npbox_format())
                     new_class_ids.append(class_id)
                     new_scores.append(score)
                     break
+
+        if len(new_boxes) == 0:
+            return ObjectDetectionLabels.make_empty()
 
         return ObjectDetectionLabels(
             np.array(new_boxes), np.array(new_class_ids), np.array(new_scores))

--- a/tests/data/label/test_chip_classification_labels.py
+++ b/tests/data/label/test_chip_classification_labels.py
@@ -63,6 +63,22 @@ class TestChipClassificationLabels(unittest.TestCase):
         self.assertEqual(len(cells), 3)
         self.assertTrue(cell3 in cells)
 
+    def test_filter_by_aoi(self):
+        aois = [Box.make_square(0, 0, 2).to_shapely()]
+        filt_labels = self.labels.filter_by_aoi(aois)
+
+        exp_labels = ChipClassificationLabels()
+        cell1 = Box.make_square(0, 0, 2)
+        class_id1 = 1
+        exp_labels.set_cell(cell1, class_id1)
+        self.assertEqual(filt_labels, exp_labels)
+
+        aois = [Box.make_square(4, 4, 2).to_shapely()]
+        filt_labels = self.labels.filter_by_aoi(aois)
+
+        exp_labels = ChipClassificationLabels()
+        self.assertEqual(filt_labels, exp_labels)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/data/label/test_object_detection_labels.py
+++ b/tests/data/label/test_object_detection_labels.py
@@ -182,6 +182,21 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
             scores=expected_scores[pruned_inds])
         pruned_labels.assert_equal(expected_labels)
 
+    def test_filter_by_aoi(self):
+        aois = [Box.make_square(0, 0, 2).to_shapely()]
+        filt_labels = self.labels.filter_by_aoi(aois)
+
+        npboxes = np.array([[0., 0., 2., 2.]])
+        class_ids = np.array([1])
+        scores = np.array([0.9])
+        exp_labels = ObjectDetectionLabels(npboxes, class_ids, scores=scores)
+        self.assertEqual(filt_labels, exp_labels)
+
+        aois = [Box.make_square(4, 4, 2).to_shapely()]
+        filt_labels = self.labels.filter_by_aoi(aois)
+        exp_labels = ObjectDetectionLabels.make_empty()
+        self.assertEqual(filt_labels, exp_labels)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

This PR fixes a bug, enabling using AOIs with object detection tasks, and adds two unit tests for this functionality.

## Testing 
* Modified the Vegas buildings object detection to use a single scene with an AOI overlapping it (and then again with an AOI that does not overlap). This motivates me to do #675 even more.

Closes #740
