### PR TITLE
Switch from model to exported-model

### DIFF
--- a/rastervision/backend/keras_classification/backend.py
+++ b/rastervision/backend/keras_classification/backend.py
@@ -131,7 +131,7 @@ class ModelFiles(FileGroup):
         """
         FileGroup.__init__(self, base_uri, tmp_dir)
 
-        self.model_uri = join(self.base_uri, 'model')
+        self.model_uri = join(self.base_uri, 'exported-model')
         self.log_uri = join(self.base_uri, 'log.csv')
 
         if replace_model:

--- a/rastervision/backend/keras_classification/core/trainer.py
+++ b/rastervision/backend/keras_classification/core/trainer.py
@@ -28,7 +28,7 @@ class Trainer(object):
         self.optimizer = optimizer
         self.options = options
 
-        self.model_path = os.path.join(options.output_dir, 'model')
+        self.model_path = os.path.join(options.output_dir, 'exported-model')
         make_dir(self.model_path, use_dirname=True)
         self.weights_path = os.path.join(options.output_dir,
                                          'model-weights.hdf5')

--- a/rastervision/backend/keras_classification_config.py
+++ b/rastervision/backend/keras_classification_config.py
@@ -103,7 +103,7 @@ class KerasClassificationConfig(BackendConfig):
                 self.training_output_uri = experiment_config.train_uri
             if not self.model_uri:
                 self.model_uri = os.path.join(self.training_output_uri,
-                                              'model')
+                                              'exported-model')
 
     def report_io(self, command_type, io_def):
         super().report_io(command_type, io_def)

--- a/rastervision/backend/tf_deeplab.py
+++ b/rastervision/backend/tf_deeplab.py
@@ -30,7 +30,7 @@ from rastervision.utils.misc import (numpy_to_png, png_to_numpy, save_img,
 from rastervision.data.label_source.utils import color_to_integer
 from rastervision.rv_config import RVConfig
 
-FROZEN_INFERENCE_GRAPH = 'model'
+FROZEN_INFERENCE_GRAPH = 'exported-model'
 INPUT_TENSOR_NAME = 'ImageTensor:0'
 OUTPUT_TENSOR_NAME = 'SemanticPredictions:0'
 
@@ -692,7 +692,8 @@ class TFDeeplab(Backend):
             latest_checkpoints = get_latest_checkpoint(train_logdir_local)
             model_checkpoint_files = glob.glob(
                 '{}*'.format(latest_checkpoints))
-            inference_graph_path = os.path.join(train_logdir_local, 'model')
+            inference_graph_path = os.path.join(train_logdir_local,
+                                                'exported-model')
 
             with RVConfig.get_tmp_dir() as tmp_dir:
                 model_dir = os.path.join(tmp_dir, fine_tune_checkpoint_name)

--- a/rastervision/backend/tf_deeplab_config.py
+++ b/rastervision/backend/tf_deeplab_config.py
@@ -110,7 +110,8 @@ class TFDeeplabConfig(BackendConfig):
         if command_type == rv.TRAIN:
             self.training_output_uri = experiment_config.train_uri
 
-            self.model_uri = os.path.join(self.training_output_uri, 'model')
+            self.model_uri = os.path.join(self.training_output_uri,
+                                          'exported-model')
 
             if not self.fine_tune_checkpoint_name:
                 # Set the fine tune checkpoint name to the experiment id

--- a/rastervision/backend/tf_object_detection.py
+++ b/rastervision/backend/tf_object_detection.py
@@ -321,7 +321,7 @@ def export_inference_graph(train_root_dir,
 
         # Move frozen inference graph and clean up generated files.
 
-        output_path = join(output_dir, 'model')
+        output_path = join(output_dir, 'exported-model')
         shutil.move(inference_graph_path, output_path)
         saved_model_dir = join(output_dir, 'saved_model')
         shutil.rmtree(saved_model_dir)

--- a/rastervision/backend/tf_object_detection_config.py
+++ b/rastervision/backend/tf_object_detection_config.py
@@ -132,7 +132,7 @@ class TFObjectDetectionConfig(BackendConfig):
                 self.training_output_uri = experiment_config.train_uri
             if not self.model_uri:
                 self.model_uri = os.path.join(self.training_output_uri,
-                                              'model')
+                                              'exported-model')
             if not self.fine_tune_checkpoint_name:
                 # Set the fine tune checkpoint name to the experiment id
                 self.fine_tune_checkpoint_name = experiment_config.id

--- a/tests/backend/test_tf_deeplab_config.py
+++ b/tests/backend/test_tf_deeplab_config.py
@@ -45,7 +45,7 @@ class TestTFDeeplabConfig(MockMixin, unittest.TestCase):
         exp_id = 'exp_id'
         training_data_uri = '/chip_uri'
         train_uri = '/train_uri'
-        model_uri = '/train_uri/model'
+        model_uri = '/train_uri/exported-model'
         checkpoint_path = '/train_uri/{}.tar.gz'.format(exp_id)
 
         exp = create_mock_experiment()


### PR DESCRIPTION
## Overview

This PR switches from naming the exported model from `model` to `exported-model`. This is needed because `file_exists`, when used on S3 can't distinguish between `model` and `model-xyz`. Because of this, RV assumes that the `train` command doesn't need to be run again because model checkpoints
with a model prefix exist even though the actual model file isn't there.

### Notes

A more general solution that will avoid this problem in the future is for `report_io` to specify whether each input and output is a directory or a file, and then to set the `include_dir` argument to `file_exists` accordingly.

## Testing
Integration tests should tell if this works, and I also made sure old predict packages still work.

