### PR TITLE
Fix Deeplab resume bug: update path in checkpoint file

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,6 +38,7 @@ Features
 
 Bug Fixes
 ^^^^^^^^^
+- Fix Deeplab resume bug: update path in checkpoint file `#756 <https://github.com/azavea/raster-vision/pull/756>`_
 - Allow Spaces in ``--channel-order`` Argument `#731 <https://github.com/azavea/raster-vision/pull/731>`_
 - Fix error when using predict packages with AOIs `#674 <https://github.com/azavea/raster-vision/pull/674>`_
 - Correct checkpoint name `#624 <https://github.com/azavea/raster-vision/pull/624>`_

--- a/rastervision/backend/tf_deeplab.py
+++ b/rastervision/backend/tf_deeplab.py
@@ -620,6 +620,17 @@ class TFDeeplab(Backend):
                 train_restart_dir
         ) > 0 and not self.backend_config.train_options.replace_model:
             sync_from_dir(train_restart_dir, train_logdir_local)
+
+            # Need to update model_checkpoint_path in the checkpoint file,
+            # since it has the absolute paths from the previous run which
+            # was using a different temporary directory on another machine.
+            # If Deeplab could save relative paths instead (like the Object
+            # Detection API does), then we wouldn't need to do this.
+            latest_checkpoint = get_latest_checkpoint(train_logdir_local)
+            checkpoint_path = join(train_logdir_local, 'checkpoint')
+            with open(checkpoint_path, 'w') as cf:
+                cf.write(
+                    'model_checkpoint_path: \"{}\"'.format(latest_checkpoint))
         else:
             if self.backend_config.train_options.replace_model:
                 if os.path.exists(train_logdir_local):


### PR DESCRIPTION
This PR allows you to resume training using Deeplab. Previously, it would crash because the `checkpoint` file contained absolute paths to the model checkpoints which were specific to the temporary directory that was used when running remotely. I tested this by downloading the `train` directory from a remote run that did not complete, ran it locally, and saw that it resumed training from the latest checkpoint.

TODO: make an issue to make an issue to deeplab about this

<img width="804" alt="Screen Shot 2019-04-09 at 5 57 34 PM" src="https://user-images.githubusercontent.com/1896461/55839150-e3b01a80-5af4-11e9-9a31-2855d01d2d8c.png">
