### PR TITLE
Get the docs to build: manually insert --help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build Status](https://api.travis-ci.org/azavea/raster-vision.svg?branch=master)](http://travis-ci.org/azavea/raster-vision)
 [![codecov](https://codecov.io/gh/azavea/raster-vision/branch/master/graph/badge.svg)](https://codecov.io/gh/azavea/raster-vision)
+[![Documentation Status](https://readthedocs.org/projects/raster-vision/badge/?version=0.8)](https://docs.rastervision.io/en/0.8/?badge=0.8)
 
 Raster Vision is an open source Python framework for building computer vision models on satellite, aerial, and other large imagery sets (including oblique drone imagery).
 * It allows users (who don't need to be experts in deep learning!) to quickly and repeatably configure experiments that execute a machine learning workflow including: analyzing training data, creating training chips, training models, creating predictions, evaluating models, and bundling the model files and configuration for easy deployment.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -9,7 +9,22 @@ The Raster Vision command line utility, ``rastervision``, is installed with a ``
 ``rastervision``, which is installed by default in the :ref:`docker containers`.
 It has subcommands, with some top level options:
 
-.. command-output:: rastervision --help
+.. code-block:: terminal
+
+   > rastervision --help
+    Usage: python -m rastervision [OPTIONS] COMMAND [ARGS]...
+
+    Options:
+      -p, --profile TEXT  Sets the configuration profile name to use.
+      -v, --verbose       Sets the output to  be verbose.
+      --help              Show this message and exit.
+
+    Commands:
+      ls           Print out a list of Experiment IDs.
+      predict      Make predictions using a predict package.
+      run          Run Raster Vision commands against Experiments.
+      run_command  Run a command from configuration file.
+
 
 Commands
 --------
@@ -21,7 +36,36 @@ run
 
 Run is the main interface into running ``ExperimentSet`` workflows.
 
-.. command-output:: rastervision run --help
+.. code-block:: terminal
+
+    > rastervision run --help
+    Usage: python -m rastervision run [OPTIONS] RUNNER [COMMANDS]...
+
+    Run Raster Vision commands from experiments, using the experiment runner
+    named RUNNER.
+
+    Options:
+      -e, --experiment_module TEXT  Name of an importable module to look for
+                                    experiment sets in. If not supplied,
+                                    experiments will be loaded from __main__
+      -p, --path PATTERN            Path of file containing ExprimentSet to run.
+      -n, --dry-run                 Execute a dry run, which will print out
+                                    information about the commands to be run, but
+                                    will not actually run the commands
+      -x, --skip-file-check         Skip the step that verifies that file exist.
+      -a, --arg KEY VALUE           Pass a parameter to the experiments if the
+                                    method parameter list takes in a parameter
+                                    with that key. Multiple args can be supplied
+      --prefix PREFIX               Prefix for methods containing experiments.
+                                    (default: "exp_")
+      -m, --method PATTERN          Pattern to match method names to run.
+      -f, --filter PATTERN          Pattern to match experiment names to run.
+      -r, --rerun                   Rerun commands, regardless if their output
+                                    files already exist.
+      --tempdir TEXT                Temporary directory to use for this run.
+      -s, --splits INTEGER          The number of processes to attempt to split
+                                    each stage into.
+      --help                        Show this message and exit.
 
 Some specific parameters to call out:
 
@@ -60,7 +104,23 @@ predict
 
 Use ``predict`` to make predictions on new imagery given a :ref:`predict package`.
 
-.. command-output:: rastervision predict --help
+.. code-block:: terminal
+
+    > rastervision predict --help
+    Usage: python -m rastervision predict [OPTIONS] PREDICT_PACKAGE IMAGE_URI
+                                          OUTPUT_URI
+
+      Make predictions on the image at IMAGE_URI using PREDICT_PACKAGE and store
+      the prediciton output at OUTPUT_URI.
+
+    Options:
+      -a, --update-stats    Run an analysis on this individual image, as opposed
+                            to using any analysis like statistics that exist in
+                            the prediction package
+      --channel-order TEXT  List of indices comprising channel_order. Example: 2 1
+                            0
+      --export-config PATH  Exports the configuration to the given output file.
+      --help                Show this message and exit.
 
 ls
 ^^^
@@ -69,7 +129,21 @@ The ``ls`` command very simply lists the IDs of experiments in the given module 
 This functionality is likely to expand to give more information about expriments discovered
 in a project in later versions.
 
-.. command-output:: rastervision ls --help
+.. code-block:: terminal
+
+    > rastervision ls --help
+    Usage: python -m rastervision ls [OPTIONS]
+
+      Print out a list of Experiment IDs.
+
+    Options:
+      -e, --experiment-module TEXT  Name of an importable module to look for
+                                    experiment sets in. If not supplied,
+                                    experiments will be loaded from __main__
+      -a, --arg KEY VALUE           Pass a parameter to the experiments if the
+                                    method parameter list takes in a parameter
+                                    with that key. Multiple args can be supplied
+      --help                        Show this message and exit.
 
 run_command
 ^^^^^^^^^^^
@@ -78,4 +152,14 @@ The ``run_command`` is used to run a specific command from a serialized command 
 This is likely only useful to people writing :ref:`experiment runner` that want to run
 commands remotely from serialzed command JSON.
 
-.. command-output:: rastervision run_command --help
+.. code-block:: terminal
+
+    > rastervision run_command --help
+    Usage: python -m rastervision run_command [OPTIONS] COMMAND_CONFIG_URI
+
+    Run a command from a serialized command configuration at
+    COMMAND_CONFIG_URI.
+
+    Options:
+    --tempdir TEXT
+    --help          Show this message and exit.


### PR DESCRIPTION
This PR makes some changes needed to the docs to build. We needed to stop using the `command-output` directive because that requires the "Install Project" option for `ReadTheDocs`. That option installs RV in the RTD build environment which was breaking because of trouble installing `pyproj` and `h5py` due to C dependencies. Another potentially more complex solution is to keep using `command-output`, but avoid installing the problematic dependencies when in the RTD environment and mock them.  See https://github.com/azavea/raster-vision/pull/759 for an alternative solution that didn't work.
