### PR TITLE
Get docs to build: mock problematic dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build Status](https://api.travis-ci.org/azavea/raster-vision.svg?branch=master)](http://travis-ci.org/azavea/raster-vision)
 [![codecov](https://codecov.io/gh/azavea/raster-vision/branch/master/graph/badge.svg)](https://codecov.io/gh/azavea/raster-vision)
+[![Documentation Status](https://readthedocs.org/projects/raster-vision/badge/?version=0.8)](https://docs.rastervision.io/en/0.8/?badge=0.8)
 
 Raster Vision is an open source Python framework for building computer vision models on satellite, aerial, and other large imagery sets (including oblique drone imagery).
 * It allows users (who don't need to be experts in deep learning!) to quickly and repeatably configure experiments that execute a machine learning workflow including: analyzing training data, creating training chips, training models, creating predictions, evaluating models, and bundling the model files and configuration for easy deployment.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,18 @@ extensions = [
     'sphinxcontrib.programoutput'
 ]
 
+# https://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
+import sys
+from unittest.mock import MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return MagicMock()
+
+MOCK_MODULES = ['pyproj', 'h5py']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 intersphinx_mapping = {'python': ('https://docs.python.org/3/', None)}
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 
 from os import path as op
+import os
 import json
 import io
 import re
@@ -15,6 +16,11 @@ here = op.abspath(op.dirname(__file__))
 # get the dependencies and installs
 with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
     all_reqs = f.read().split('\n')
+
+# The RTD build environment fails with the reqs in bad_reqs.
+if 'READTHEDOCS' in os.environ:
+    bad_reqs = ['pyproj', 'h5py']
+    all_reqs = list(filter(lambda r: r.split('==')[0] not in bad_reqs, all_reqs))
 
 install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
 dependency_links = [
@@ -35,10 +41,10 @@ def replace_images(readme):
 with io.open(op.join(here, 'extras_requirements.json'), encoding='utf-8') as f:
     extras_require = json.loads(f.read())
 
-# Uncomment this line if we are using a commit of mask-to-polygons 
+# Uncomment this line if we are using a commit of mask-to-polygons
 # (as opposed to released version) to avoid error.
 # del extras_require['feature-extraction']
-    
+
 setup(
     name='rastervision',
     version=__version__,


### PR DESCRIPTION
This is an alternative approach to https://github.com/azavea/raster-vision/pull/758 that follows the advice in https://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
 
I couldn't get it to work, but I'm making this PR and closing it so we have a record of it.