### PR TITLE
Add requester_pays RV config option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Raster Vision 0.9.0
 
 Features
 ^^^^^^^^
+- Add requester_pays RV config option `#762 <https://github.com/azavea/raster-vision/pull/762>`_
 - Unify Docker scripts `#743 <https://github.com/azavea/raster-vision/pull/743>`_
 - Switch default branch to master `#726 <https://github.com/azavea/raster-vision/pull/726>`_
 - Merge GeoTiffSource and ImageSource into RasterioSource `#723 <https://github.com/azavea/raster-vision/pull/723>`_

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -151,6 +151,18 @@ RV
 
 * ``model_defaults_uri`` - Specifies the URI of the :ref:`model defaults` JSON. Leave this option out to use the Raster Vision supplied model defaults.
 
+.. _s3 config section:
+
+AWS_S3
+^^^^^^
+
+.. code-block:: ini
+
+   [AWS_S3]
+   requester_pays = False
+
+* ``requester_pays`` - Set to True if you would like to allow using `requester pays <https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html>`_ S3 buckets. The default value is False.
+
 .. _plugins config section:
 
 PLUGINS

--- a/rastervision/rv_config.py
+++ b/rastervision/rv_config.py
@@ -8,9 +8,9 @@ from everett.manager import (ConfigManager, ConfigDictEnv, ConfigEnvFileEnv,
                              ConfigIniEnv, ConfigOSEnv)
 
 import rastervision as rv
-from rastervision.utils.files import file_to_str
 from rastervision.cli import Verbosity
 from rastervision.filesystem.local_filesystem import make_dir
+from rastervision.utils.files import file_to_str
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Overview

This PR adds a `requester_pays` option the RV config, which adds support for using requester pays S3 buckets.

```
[AWS_S3]
requester_pays=True
```

TODO: See if it's possible to unit test this using `moto`.

## Testing
I tested this by creating a [test experiment](https://github.com/azavea/raster-vision/files/3074218/naip.py.txt) using NAIP data which is requester pays. I tested it using with `requester_pays` set to True and False, and did the same with a test project using a non-requester pays S3 bucket.

Closes #682 
