### PR TITLE
[BACKPORT] Change docs to `pip install rastervision==0.9.0rc1`

### DIFF
--- a/docs/qgis.rst
+++ b/docs/qgis.rst
@@ -1,6 +1,10 @@
 QGIS Plugin
 ===========
 
+.. warning::
+
+    The QGIS Plugin has not been updated yet for Raster Vision 0.9, so these instructions will not work. We plan to release the 0.9 version of the QGIS plugin soon.
+
 .. |experiment icon| image:: _static/qgis/icon-experiment.png
    :scale: 35%
 

--- a/docs/qgis.rst
+++ b/docs/qgis.rst
@@ -27,7 +27,7 @@ models.
 Installing
 ----------
 
-To install the QGIS Plugin, you must have ``rastervision`` installed in the Python 3 environment that is running QGIS. Don't worry, you won't have to install all of the deep learning frameworks just to use the plugin - you can just ``pip install rastervision`` (or ``pip3 install rastervision`` if Python 3 is not the default on your system). This has been tested with Python 3.6 and QGIS 3.2.
+To install the QGIS Plugin, you must have ``rastervision`` installed in the Python 3 environment that is running QGIS. Don't worry, you won't have to install all of the deep learning frameworks just to use the plugin - you can just ``pip install rastervision==0.9.0rc1`` (or ``pip3 install rastervision==0.9.0rc1`` if Python 3 is not the default on your system). This has been tested with Python 3.6 and QGIS 3.2.
 
 Installing from Plugin Manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -325,3 +325,7 @@ Next Steps
 
 This is just a quick example of a Raster Vision workflow. For a more complete example of how to train
 a model on SpaceNet (optionally using GPUs on AWS Batch) and view the results in QGIS, see the SpaceNet examples in the `Raster Vision Examples <https://github.com/azavea/raster-vision-examples>`_ repository.
+
+.. warning::
+
+    The QGIS Plugin has not been updated yet for Raster Vision 0.9, so the QGIS instructions will not work. We plan to release the 0.9 version of the QGIS plugin soon.

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -78,14 +78,16 @@ Rather than running Raster Vision from inside a Docker container, you can direct
 
 .. code-block:: console
 
-   > pip install rastervision
+   > pip install rastervision==0.9.0rc1
 
-.. note:: Raster Vision requires Python 3 or later. Use ``pip3 install rastervision`` if you have more than one version of Python installed.
+.. note:: Raster Vision requires Python 3 or later. Use ``pip3 install rastervision==0.9.0rc1`` if you have more than one version of Python installed.
+
+.. note:: Because 0.9 is a release candidate at the moment, it is necessary to explicitly state the version when installing via pip.
 
 Troubleshooting macOS Installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you encounter problems running ``pip install rastervision`` on macOS, you may have to manually install Cython and pyproj.
+If you encounter problems running ``pip install rastervision==0.9.0rc1`` on macOS, you may have to manually install Cython and pyproj.
 
 To circumvent a problem installing pyproj with Python 3.7, you may also have to install that library using ``git+https``:
 
@@ -93,7 +95,7 @@ To circumvent a problem installing pyproj with Python 3.7, you may also have to 
 
   > pip install cython
   > pip install git+https://github.com/jswhit/pyproj.git@e56e879438f0a1688b89b33228ebda0f0d885c19
-  > pip install rastervision
+  > pip install rastervision==0.9.0rc1
 
 Using AWS, Tensorflow, and/or Keras
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -102,7 +104,7 @@ If you'd like to use AWS, Tensorflow and/or Keras with Raster Vision, you can in
 
 .. code-block:: console
 
-   > pip install rastervision[aws,tensorflow,tensorflow-gpu]
+   > pip install rastervision[aws,tensorflow,tensorflow-gpu]==0.9.0rc1
 
 If you'd like to use Raster Vision with `Tensorflow Object Detection <https://github.com/tensorflow/models/tree/master/research/object_detection>`_ or `TensorFlow DeepLab <https://github.com/tensorflow/models/tree/master/research/deeplab>`_, you'll need to install these from `Azavea's fork <https://github.com/azavea/models/tree/AZ-v1.11-RV-v0.8.0>`_ of the models repository, since it contains some necessary changes that have not yet been merged back upstream. You will also need to install `Tippecanoe <https://github.com/mapbox/tippecanoe>`_ if you would like to do vector tile processing. For an example of setting these up, see the `Dockerfile <https://github.com/azavea/raster-vision/blob/lf/0.9/Dockerfile>`_.
 


### PR DESCRIPTION
Backport of https://github.com/azavea/raster-vision/pull/766 to 0.9 branch.