### PR TITLE
Don't assume `train_uri` is in `BackendConfig`

### DIFF
--- a/rastervision/backend/backend_config.py
+++ b/rastervision/backend/backend_config.py
@@ -47,8 +47,6 @@ class BackendConfigBuilder(ConfigBuilder):
     def __init__(self, backend_type, config_class, config=None, prev=None):
         if config is None:
             config = {}
-        if prev:
-            config['train_options'] = prev.train_options
         super().__init__(config_class, config)
         self.task = None
         self.backend_type = backend_type


### PR DESCRIPTION
The removed line is unnecessary, and makes it so you need a `train_uri` field in all `BackendConfigs`. This caused a problem when implementing the fastai plugin.