### PR TITLE
Extricate object detection evaluation from TFOD

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -28,6 +28,7 @@ Options:
 --name sets the name of the running container
 --jupyter forwards port 8888, mounts RASTER_VISION_NOTEBOOK_DIR to /opt/notebooks, and runs Jupyter
 --docs runs the docs server and forwards port 8000
+--debug forwards port 3000 for use with remote debugger
 
 All arguments after above options are passed to 'docker run'.
 "
@@ -77,6 +78,10 @@ do
         CMD=(/bin/bash -c "cd docs && make livehtml")
         shift
         ;;
+        --debug)
+        DEBUG="-p 3000:3000"
+        shift
+        ;;
         *)    # unknown option
         POSITIONAL+=("$1") # save it in an array for later
         shift # past argument
@@ -96,6 +101,6 @@ then
         -v "${HOME}"/.rastervision:/root/.rastervision \
         -v ${REPO_ROOT}:/opt/src \
         -v ${RASTER_VISION_DATA_DIR}:/opt/data \
-        ${TENSORBOARD} ${AWS} ${JUPYTER} ${DOCS} \
+        ${TENSORBOARD} ${AWS} ${JUPYTER} ${DOCS} ${DEBUG} \
         ${IMAGE} "${CMD[@]}"
 fi

--- a/rastervision/evaluation/object_detection_evaluation.py
+++ b/rastervision/evaluation/object_detection_evaluation.py
@@ -1,104 +1,111 @@
+import numpy as np
+import shapely
+import shapely.strtree
+import shapely.geometry
+
+from rastervision.data import ObjectDetectionLabels
 from rastervision.evaluation import ClassEvaluationItem
 from rastervision.evaluation import ClassificationEvaluation
 
 
+def compute_metrics(gt_labels: ObjectDetectionLabels,
+                    pred_labels: ObjectDetectionLabels,
+                    num_classes: int,
+                    iou_thresh=0.5):
+    gt_geoms = [b.to_shapely() for b in gt_labels.get_boxes()]
+    gt_classes = gt_labels.get_class_ids() - 1
+    pred_geoms = [b.to_shapely() for b in pred_labels.get_boxes()]
+    pred_classes = pred_labels.get_class_ids() - 1
+
+    for pred, class_id in zip(pred_geoms, pred_classes):
+        pred.class_id = class_id
+    pred_tree = shapely.strtree.STRtree(pred_geoms)
+
+    def iou(a, b):
+        return a.intersection(b).area / a.union(b).area
+
+    def is_matched(geom):
+        return hasattr(geom, 'iou_matched')
+
+    tp = np.zeros((num_classes, ))
+    fp = np.zeros((num_classes, ))
+    fn = np.zeros((num_classes, ))
+
+    for gt, gt_class in zip(gt_geoms, gt_classes):
+        matches = list(
+            filter(lambda g: (not is_matched(g)) and g.class_id == gt_class,
+                   pred_tree.query(gt)))
+        scores = [iou(m, gt) for m in matches]
+        if len(scores) > 0:
+            max_ind = np.argmax(scores)
+            if scores[max_ind] > iou_thresh:
+                matches[max_ind].iou_matched = True
+                tp[gt_class] += 1
+            else:
+                fn[gt_class] += 1
+        else:
+            fn[gt_class] += 1
+
+    for class_id in range(num_classes):
+        pred_not_matched = np.array([not is_matched(g) for g in pred_geoms])
+        fp[class_id] = np.sum(pred_not_matched[pred_classes == class_id])
+
+    return tp, fp, fn
+
+
 class ObjectDetectionEvaluation(ClassificationEvaluation):
-    """Evaluation for object detection.
-
-    Requires TensorFlow Object Detection to be available as it utilizes
-    some of its evalution utility functions.
-    """
-
     def __init__(self, class_map):
         super().__init__()
         self.class_map = class_map
 
     def compute(self, ground_truth_labels, prediction_labels):
-        nb_classes = len(self.class_map)
-        od_eval = ObjectDetectionEvaluation.compute_od_eval(
-            ground_truth_labels, prediction_labels, nb_classes)
-
-        self.class_to_eval_item = ObjectDetectionEvaluation.parse_od_eval(
-            od_eval, self.class_map)
+        self.class_to_eval_item = ObjectDetectionEvaluation.compute_eval_items(
+            ground_truth_labels, prediction_labels, self.class_map)
         self.compute_avg()
 
     @staticmethod
-    def compute_od_eval(ground_truth_labels, prediction_labels, nb_classes):
-        # Lazy import of TFOD
-        from object_detection.utils import object_detection_evaluation
-
-        matching_iou_threshold = 0.5
-        od_eval = object_detection_evaluation.ObjectDetectionEvaluation(
-            nb_classes, matching_iou_threshold=matching_iou_threshold)
-        image_key = 'image'
-        od_eval.add_single_ground_truth_image_info(
-            image_key, ground_truth_labels.get_npboxes(),
-            ground_truth_labels.get_class_ids() - 1)
-        od_eval.add_single_detected_image_info(
-            image_key, prediction_labels.get_npboxes(),
-            prediction_labels.get_scores(),
-            prediction_labels.get_class_ids() - 1)
-        od_eval.evaluate()
-        return od_eval
-
-    @staticmethod
-    def parse_od_eval(od_eval, class_map):
+    def compute_eval_items(gt_labels, pred_labels, class_map):
+        iou_thresh = 0.5
+        num_classes = len(class_map)
+        tps, fps, fns = compute_metrics(gt_labels, pred_labels, num_classes,
+                                        iou_thresh)
         class_to_eval_item = {}
 
-        score_ind = -1
-        for class_id in range(1, len(class_map) + 1):
-            gt_count = int(od_eval.num_gt_instances_per_class[class_id - 1])
+        for class_ind, (tp, fp, fn) in enumerate(zip(tps, fps, fns)):
+            class_id = class_ind + 1
+            gt_count = tp + fn
+            pred_count = tp + fp
             class_name = class_map.get_by_id(class_id).name
 
             if gt_count == 0:
                 eval_item = ClassEvaluationItem(
                     class_id=class_id, class_name=class_name)
+            elif pred_count == 0:
+                eval_item = ClassEvaluationItem(
+                    precision=None,
+                    recall=0,
+                    gt_count=gt_count,
+                    class_id=class_id,
+                    class_name=class_name)
             else:
-                # precisions_per_class has an element appended to it for each
-                # class_id that has gt_count > 0. This means that the length of
-                # precision_per_class can be shorter than the total number of
-                # classes in the class_map. Therefore, we use score_ind to index
-                # into precisions_per_class instead of simply using class_id - 1.
-                score_ind += 1
+                prec = tp / (tp + fp)
+                recall = tp / (tp + fn)
+                f1 = 0.
+                if prec + recall != 0.0:
+                    f1 = 2 * (prec * recall) / (prec + recall)
+                count_err = pred_count - gt_count
+                norm_count_err = None
+                if gt_count > 0:
+                    norm_count_err = count_err / gt_count
 
-                # Precisions and recalls across a range of detection thresholds.
-                precisions = od_eval.precisions_per_class[score_ind]
-                recalls = od_eval.recalls_per_class[score_ind]
-
-                if len(precisions) == 0 or len(recalls) == 0:
-                    # No predicted boxes.
-                    eval_item = ClassEvaluationItem(
-                        precision=None,
-                        recall=0,
-                        gt_count=gt_count,
-                        class_id=class_id,
-                        class_name=class_name)
-                else:
-                    # If we use the lowest detection threshold (ie. use all
-                    # detected boxes as defined by score_thresh in the predict
-                    # protobuf), that means we use all detected boxes, or the last
-                    # element in the precisions array.
-                    precision = float(precisions[-1])
-                    recall = float(recalls[-1])
-
-                    f1 = 0.
-                    if precision + recall != 0.0:
-                        f1 = (2 * precision * recall) / (precision + recall)
-
-                    pred_count = len(recalls)
-                    count_error = pred_count - gt_count
-                    norm_count_error = None
-                    if gt_count > 0:
-                        norm_count_error = count_error / gt_count
-
-                    eval_item = ClassEvaluationItem(
-                        precision=precision,
-                        recall=recall,
-                        f1=f1,
-                        count_error=norm_count_error,
-                        gt_count=gt_count,
-                        class_id=class_id,
-                        class_name=class_name)
+                eval_item = ClassEvaluationItem(
+                    precision=prec,
+                    recall=recall,
+                    f1=f1,
+                    count_error=norm_count_err,
+                    gt_count=gt_count,
+                    class_id=class_id,
+                    class_name=class_name)
 
             class_to_eval_item[class_id] = eval_item
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ yapf==0.22.*
 unify==0.4
 sphinx==1.8.*
 sphinx-autobuild==0.7.*
+ptvsd==4.2.*

--- a/scripts/debug
+++ b/scripts/debug
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0") <python module + args>
+Run a Python module using VS code debugger.
+
+Example:
+./scripts/debug rastervision run inprocess -e examples.potsdam
+
+"
+}
+
+python -m ptvsd --host 0.0.0.0 --port 3000 --wait -m ${@:1}


### PR DESCRIPTION
This PR removes the dependence on TFOD for object detection evaluation. This was problematic because backend plugins might not have TF or TFOD installed. This replaces the calls to TFOD utility functions with a DIY evaluation function with the same behavior, at least according to the unit tests.