### PR TITLE
Handle "ignore" class for semantic segmentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Raster Vision 0.10
 Raster Vision 0.10.0
 ~~~~~~~~~~~~~~~~~~~
 
+Features
+^^^^^^^^^^^^
+
+- Handle "ignore" class for semantic segmentation `#783 <https://github.com/azavea/raster-vision/pull/783>`__
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/rastervision/core/class_map.py
+++ b/rastervision/core/class_map.py
@@ -46,6 +46,7 @@ class ClassMap(object):
     the class 0 is reserved for use as an "ignore" class, which denotes
     pixels that should not be used for training the model or evaluating it.
     """
+
     def __init__(self, class_items):
         """Construct a new ClassMap.
 

--- a/rastervision/core/class_map.py
+++ b/rastervision/core/class_map.py
@@ -40,8 +40,12 @@ class ClassItem(object):
 
 
 class ClassMap(object):
-    """A map from class_id to ClassItem."""
+    """A map from class_id to ClassItem.
 
+    The class ids should be integers >= 1. For semantic segmentation,
+    the class 0 is reserved for use as an "ignore" class, which denotes
+    pixels that should not be used for training the model or evaluating it.
+    """
     def __init__(self, class_items):
         """Construct a new ClassMap.
 

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -78,9 +78,10 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
 
             eval_items = []
             for class_id in self.class_map.get_keys():
-                eval_item = get_class_eval_item(gt_arr, pred_arr, class_id,
-                                                self.class_map)
-                eval_items.append(eval_item)
+                if class_id > 0:
+                    eval_item = get_class_eval_item(gt_arr, pred_arr, class_id,
+                                                    self.class_map)
+                    eval_items.append(eval_item)
 
             # Treat each window as if it was a small Scene.
             window_eval = SemanticSegmentationEvaluation(self.class_map)

--- a/rastervision/task/semantic_segmentation.py
+++ b/rastervision/task/semantic_segmentation.py
@@ -144,7 +144,6 @@ class SemanticSegmentation(Task):
         def _process_scenes(scenes, type_, augment):
             return [_process_scene(scene, type_, augment) for scene in scenes]
 
-        # TODO: parallel processing!
         processed_training_results = _process_scenes(
             train_scenes, TRAIN, augment=True)
         processed_validation_results = _process_scenes(

--- a/rastervision/task/task.py
+++ b/rastervision/task/task.py
@@ -123,7 +123,6 @@ class Task(object):
         def _process_scenes(scenes, type_, augment):
             return [_process_scene(scene, type_, augment) for scene in scenes]
 
-        # TODO: parallel processing!
         processed_training_results = _process_scenes(
             train_scenes, TRAIN, augment=True)
         processed_validation_results = _process_scenes(

--- a/tests/evaluation/test_semantic_segmentation_evaluation.py
+++ b/tests/evaluation/test_semantic_segmentation_evaluation.py
@@ -65,10 +65,9 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         pred_raster.set_raster(pred_array)
         pred_label_source = SemanticSegmentationLabelSource(source=pred_raster)
 
-        class_map = ClassMap([
-            ClassItem(id=0, name='ignore'),
-            ClassItem(id=1, name='one')
-        ])
+        class_map = ClassMap(
+            [ClassItem(id=0, name='ignore'),
+             ClassItem(id=1, name='one')])
         eval = SemanticSegmentationEvaluation(class_map)
         eval.compute(gt_label_source.get_labels(),
                      pred_label_source.get_labels())

--- a/tests/evaluation/test_semantic_segmentation_evaluation.py
+++ b/tests/evaluation/test_semantic_segmentation_evaluation.py
@@ -53,6 +53,28 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         self.assertEqual(precision2, eval.class_to_eval_item[2].precision)
         self.assertAlmostEqual(recall2, eval.class_to_eval_item[2].recall)
 
+    def test_compute_ignore_class(self):
+        gt_array = np.ones((4, 4, 1), dtype=np.uint8)
+        gt_array[0, 0, 0] = 0
+        gt_raster = MockRasterSource([0], 1)
+        gt_raster.set_raster(gt_array)
+        gt_label_source = SemanticSegmentationLabelSource(source=gt_raster)
+
+        pred_array = np.ones((4, 4, 1), dtype=np.uint8)
+        pred_raster = MockRasterSource([0], 1)
+        pred_raster.set_raster(pred_array)
+        pred_label_source = SemanticSegmentationLabelSource(source=pred_raster)
+
+        class_map = ClassMap([
+            ClassItem(id=0, name='ignore'),
+            ClassItem(id=1, name='one')
+        ])
+        eval = SemanticSegmentationEvaluation(class_map)
+        eval.compute(gt_label_source.get_labels(),
+                     pred_label_source.get_labels())
+        self.assertAlmostEqual(1, len(eval.class_to_eval_item))
+        self.assertAlmostEqual(1.0, eval.class_to_eval_item[0].f1)
+
     def test_vector_compute(self):
         class_map = ClassMap([ClassItem(id=1, name='one', color='#000021')])
         gt_uri = data_file_path('3-gt-polygons.geojson')


### PR DESCRIPTION
## Overview
This PR makes it so we handle an "ignore" class in a more sensible way for semantic segmentation. This establishes a convention that class 0 represents an "ignore" class of pixels that should be ignored for the sake of training and evaluation. Imagery pixels with label class 0 are now set to 0 (NODATA) to prevent the model from associating good imagery with the ignore class. Chips that only contain class 0 aren't saved since they are a waste of time to train on. And, the eval does not generate metrics for class 0.

## Testing
This is tested with a unit test and also in an experiment that used class 0, where debug chips were inspected for correctness.
