### PR TITLE
Fix issue with list parsing in configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 RUN add-apt-repository ppa:ubuntugis/ppa && \
     apt-get update && \
     apt-get install -y wget=1.* git=1:2.* python-protobuf=2.* python3-tk=3.* \
-                       gdal-bin=2.1.* \
+                       gdal-bin=2.2.* \
                        jq=1.5* \
                        build-essential libsqlite3-dev=3.11.* zlib1g-dev=1:1.2.* \
                        libopencv-dev=2.4.* python-opencv=2.4.* && \
@@ -38,7 +38,7 @@ RUN mkdir -p /opt/tf-models/temp/ && \
     pip install pycocotools==2.0.*
 
 # Setup GDAL_DATA directory, rasterio needs it.
-ENV GDAL_DATA=/usr/share/gdal/2.1/
+ENV GDAL_DATA=/usr/share/gdal/2.2/
 
 # See https://github.com/mapbox/rasterio/issues/1289
 ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 CHANGELOG
 =========
 
+Raster Vision 0.10
+-----------------
+
+Raster Vision 0.10.0
+~~~~~~~~~~~~~~~~~~~
+
+Bug Fixes
+^^^^^^^^^
+
+- Fixed issue with configuration not being able to read lists `#784 <https://github.com/azavea/raster-vision/pull/784>`__
+
 Raster Vision 0.9
 -----------------
 
@@ -51,6 +62,7 @@ Bug Fixes
 - Fixed issue with handling width > height in semseg eval `#627 <https://github.com/azavea/raster-vision/pull/627>`_
 - Fixed issue with experiment configs not setting key names correctly `#576 <https://github.com/azavea/raster-vision/pull/576>`_
 - Fixed issue with Raster Sources that have channel order `#576 <https://github.com/azavea/raster-vision/pull/576>`_
+
 
 Raster Vision 0.8
 -----------------

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -173,11 +173,11 @@ PLUGINS
 .. code-block:: ini
 
    [PLUGINS]
-   files=[]
-   modules=[]
+   files=analyzers.py,backends.py
+   modules=rvplugins.analyzer,rvplugins.backend
 
-* ``files`` - Optional list of Python file URIs to gather plugins from. Must be a JSON-parsable array of values, e.g. ``["analyzers.py","backends.py"]``.
-* ``modules`` - Optional list of modules to load plugins from. Must be a JSON-parsable array of values, e.g. ``["rvplugins.analyzer","rvplugins.backend"]``.
+* ``files`` - Optional list of Python file URIs to gather plugins from as a comma-separated list of values, e.g. ``analyzers.py,backends.py``.
+* ``modules`` - Optional list of modules to load plugins from as a comma-separated list of values, e.g. ``rvplugins.analyzer,rvplugins.backend``.
 
 See :ref:`plugins` for more information about the Plugin architecture.
 

--- a/rastervision/plugin.py
+++ b/rastervision/plugin.py
@@ -13,6 +13,24 @@ class PluginError(Exception):
     pass
 
 
+def load_conf_list(s):
+    """Loads a list of items from the config.
+
+    Lists should be comma separated.
+
+    This takes into account that previous versions of Raster Vision
+    allowed for a `[ "module" ]` like syntax, even though that didn't
+    work for multi-value lists.
+    """
+    try:
+        # A comma separated list of values will be transformed to
+        # having a list-like string, with ' instead of ". Replacing
+        # single quotes with double quotes lets us parse it as a JSON list.
+        return json.loads(s.replace("'", '"'))
+    except json.JSONDecodeError:
+        return list(map(lambda x: x.strip(), s.split(',')))
+
+
 class PluginRegistry:
     @staticmethod
     def get_instance():
@@ -38,11 +56,11 @@ class PluginRegistry:
         self.experiment_runners = {}
         self.filesystems = []
 
-        plugin_files = json.loads(plugin_config('files', default='[]'))
+        plugin_files = load_conf_list(plugin_config('files', default='[]'))
         self._load_from_files(plugin_files)
         self.plugin_files = plugin_files
 
-        plugin_modules = json.loads(plugin_config('modules', default='[]'))
+        plugin_modules = load_conf_list(plugin_config('modules', default='[]'))
         self._load_from_modules(plugin_modules)
         self.plugin_modules = plugin_modules
 

--- a/tests/data-files/plugins/default
+++ b/tests/data-files/plugins/default
@@ -1,2 +1,2 @@
 [PLUGINS]
-modules = [ "tests.test_plugin" ]
+modules = tests.test_plugin,tests.test_plugin_2

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,16 +10,18 @@ class TestPlugin(unittest.TestCase):
     def test_single_plugin_from_path(self):
         config = {
             'PLUGINS_files':
-            '["{}"]'.format(data_file_path('plugins/noop_augmentor.py'))
+            '["{}"]'.format(
+                data_file_path('plugins/noop_raster_transformer.py'))
         }
         rv._registry.initialize_config(config_overrides=config)
 
         try:
-            augmentor = rv.AugmentorConfig.builder('NOOP_AUGMENTOR') \
+            transformer = rv.RasterTransformerConfig.builder('NOOP_TRANSFORMER') \
                                           .build() \
-                                          .create_augmentor()
+                                          .create_transformer()
 
-            self.assertIsInstance(augmentor, rv.augmentor.Augmentor)
+            self.assertIsInstance(transformer,
+                                  rv.data.raster_transformer.RasterTransformer)
         finally:
             # Reset config
             rv._registry.initialize_config()
@@ -40,13 +42,13 @@ class TestPlugin(unittest.TestCase):
 
     def test_runs_noop_experiment_from_plugins(self):
         # set the env var to have rv pick up this configuration
-        # which adds the tests.test_plugin module as a plugin.
+        # which adds the tests.test_plugin and tests.test_plugin_2 modules
+        # as a plugin.
         old_rv_config = os.environ.get('RV_CONFIG')
         os.environ['RV_CONFIG'] = data_file_path('plugins/default')
 
         try:
             plugin_files = [
-                data_file_path('plugins/noop_augmentor.py'),
                 data_file_path('plugins/noop_task.py'),
                 data_file_path('plugins/noop_backend.py'),
                 data_file_path('plugins/noop_raster_transformer.py'),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -17,8 +17,8 @@ class TestPlugin(unittest.TestCase):
 
         try:
             transformer = rv.RasterTransformerConfig.builder('NOOP_TRANSFORMER') \
-                                          .build() \
-                                          .create_transformer()
+                                                    .build() \
+                                                    .create_transformer()
 
             self.assertIsInstance(transformer,
                                   rv.data.raster_transformer.RasterTransformer)

--- a/tests/test_plugin_2.py
+++ b/tests/test_plugin_2.py
@@ -3,14 +3,12 @@ from rastervision.augmentor import (Augmentor, AugmentorConfig,
                                     AugmentorConfigBuilder)
 from rastervision.protos.augmentor_pb2 import AugmentorConfig as AugmentorConfigMsg
 
-from .noop_utils import noop
-
 NOOP_AUGMENTOR = 'NOOP_AUGMENTOR'
 
 
 class NoopAugmentor(Augmentor):
     def process(self, training_data, tmp_dir):
-        return noop(training_data)
+        return training_data
 
 
 class NoopAugmentorConfig(AugmentorConfig):


### PR DESCRIPTION
## Overview

Fixes #782 

Depends on #785 

### Notes

This changes the way files and modules are listed in the configuration. It is backwards compatible with the old way we were doing it, which didn't work with lists of more than one value. The correct way to list multiple modules is now e.g.:

```
modules = tests.test_plugin,tests.test_plugin_2
```