### PR TITLE
Add semseg predict_chip_size option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Raster Vision 0.10.0
 Features
 ^^^^^^^^^^^^
 
+- Add confusion matrix to eval for semantic segmentation `#786 <https://github.com/azavea/raster-vision/pull/786>`__
 - Handle "ignore" class for semantic segmentation `#783 <https://github.com/azavea/raster-vision/pull/783>`__
 
 Bug Fixes

--- a/rastervision/backend/tf_deeplab_config.py
+++ b/rastervision/backend/tf_deeplab_config.py
@@ -219,6 +219,12 @@ class TFDeeplabConfigBuilder(BackendConfigBuilder):
             raise rv.ConfigError('Task set with with_task must be of type'
                                  ' SemanticSegmentationConfig, got {}.'.format(
                                      type(self.task)))
+
+        if self.task and (self.task.predict_chip_size != self.task.chip_size):
+            raise rv.ConfigError(
+                'TFDeepLab Backend does not currently support predict_chip_size'
+                ' that is not equal to training chip_size.')
+
         return True
 
     def build(self):

--- a/rastervision/protos/task.proto
+++ b/rastervision/protos/task.proto
@@ -44,6 +44,7 @@ message TaskConfig {
         repeated ClassItem class_items = 1;
         required int32 chip_size = 2;
         required ChipOptions chip_options = 3;
+        optional int32 predict_chip_size = 4 [default=0];
     }
 
     required string task_type = 1;

--- a/rastervision/protos/task_pb2.py
+++ b/rastervision/protos/task_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/task.proto',
   package='rv.protos',
   syntax='proto2',
-  serialized_pb=_b('\n\x1erastervision/protos/task.proto\x12\trv.protos\x1a$rastervision/protos/class_item.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x80\x0b\n\nTaskConfig\x12\x11\n\ttask_type\x18\x01 \x02(\t\x12\x1e\n\x12predict_batch_size\x18\x02 \x01(\x05:\x02\x31\x30\x12\x1b\n\x13predict_package_uri\x18\x03 \x01(\t\x12\x13\n\x05\x64\x65\x62ug\x18\x04 \x01(\x08:\x04true\x12\x19\n\x11predict_debug_uri\x18\x05 \x01(\t\x12N\n\x17object_detection_config\x18\x06 \x01(\x0b\x32+.rv.protos.TaskConfig.ObjectDetectionConfigH\x00\x12T\n\x1a\x63hip_classification_config\x18\x07 \x01(\x0b\x32..rv.protos.TaskConfig.ChipClassificationConfigH\x00\x12X\n\x1csemantic_segmentation_config\x18\x08 \x01(\x0b\x32\x30.rv.protos.TaskConfig.SemanticSegmentationConfigH\x00\x12\x30\n\rcustom_config\x18\t \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xb2\x03\n\x15ObjectDetectionConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x12M\n\x0c\x63hip_options\x18\x03 \x02(\x0b\x32\x37.rv.protos.TaskConfig.ObjectDetectionConfig.ChipOptions\x12S\n\x0fpredict_options\x18\x04 \x02(\x0b\x32:.rv.protos.TaskConfig.ObjectDetectionConfig.PredictOptions\x1ao\n\x0b\x43hipOptions\x12\x11\n\tneg_ratio\x18\x01 \x02(\x02\x12\x17\n\nioa_thresh\x18\x02 \x01(\x02:\x03\x30.8\x12\x1b\n\rwindow_method\x18\x03 \x01(\t:\x04\x63hip\x12\x17\n\x0clabel_buffer\x18\x04 \x01(\x02:\x01\x30\x1a\x46\n\x0ePredictOptions\x12\x19\n\x0cmerge_thresh\x18\x02 \x01(\x02:\x03\x30.5\x12\x19\n\x0cscore_thresh\x18\x03 \x01(\x02:\x03\x30.5\x1aX\n\x18\x43hipClassificationConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x1a\xa1\x03\n\x1aSemanticSegmentationConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x12R\n\x0c\x63hip_options\x18\x03 \x02(\x0b\x32<.rv.protos.TaskConfig.SemanticSegmentationConfig.ChipOptions\x1a\xf0\x01\n\x0b\x43hipOptions\x12$\n\rwindow_method\x18\x01 \x01(\t:\rrandom_sample\x12\x16\n\x0etarget_classes\x18\x02 \x03(\x05\x12$\n\x16\x64\x65\x62ug_chip_probability\x18\x03 \x01(\x02:\x04\x30.25\x12(\n\x1dnegative_survival_probability\x18\x04 \x01(\x02:\x01\x31\x12\x1d\n\x0f\x63hips_per_scene\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12$\n\x16target_count_threshold\x18\x06 \x01(\x05:\x04\x32\x30\x34\x38\x12\x0e\n\x06stride\x18\x07 \x01(\x05\x42\r\n\x0b\x63onfig_type')
+  serialized_pb=_b('\n\x1erastervision/protos/task.proto\x12\trv.protos\x1a$rastervision/protos/class_item.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x9e\x0b\n\nTaskConfig\x12\x11\n\ttask_type\x18\x01 \x02(\t\x12\x1e\n\x12predict_batch_size\x18\x02 \x01(\x05:\x02\x31\x30\x12\x1b\n\x13predict_package_uri\x18\x03 \x01(\t\x12\x13\n\x05\x64\x65\x62ug\x18\x04 \x01(\x08:\x04true\x12\x19\n\x11predict_debug_uri\x18\x05 \x01(\t\x12N\n\x17object_detection_config\x18\x06 \x01(\x0b\x32+.rv.protos.TaskConfig.ObjectDetectionConfigH\x00\x12T\n\x1a\x63hip_classification_config\x18\x07 \x01(\x0b\x32..rv.protos.TaskConfig.ChipClassificationConfigH\x00\x12X\n\x1csemantic_segmentation_config\x18\x08 \x01(\x0b\x32\x30.rv.protos.TaskConfig.SemanticSegmentationConfigH\x00\x12\x30\n\rcustom_config\x18\t \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x1a\xb2\x03\n\x15ObjectDetectionConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x12M\n\x0c\x63hip_options\x18\x03 \x02(\x0b\x32\x37.rv.protos.TaskConfig.ObjectDetectionConfig.ChipOptions\x12S\n\x0fpredict_options\x18\x04 \x02(\x0b\x32:.rv.protos.TaskConfig.ObjectDetectionConfig.PredictOptions\x1ao\n\x0b\x43hipOptions\x12\x11\n\tneg_ratio\x18\x01 \x02(\x02\x12\x17\n\nioa_thresh\x18\x02 \x01(\x02:\x03\x30.8\x12\x1b\n\rwindow_method\x18\x03 \x01(\t:\x04\x63hip\x12\x17\n\x0clabel_buffer\x18\x04 \x01(\x02:\x01\x30\x1a\x46\n\x0ePredictOptions\x12\x19\n\x0cmerge_thresh\x18\x02 \x01(\x02:\x03\x30.5\x12\x19\n\x0cscore_thresh\x18\x03 \x01(\x02:\x03\x30.5\x1aX\n\x18\x43hipClassificationConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x1a\xbf\x03\n\x1aSemanticSegmentationConfig\x12)\n\x0b\x63lass_items\x18\x01 \x03(\x0b\x32\x14.rv.protos.ClassItem\x12\x11\n\tchip_size\x18\x02 \x02(\x05\x12R\n\x0c\x63hip_options\x18\x03 \x02(\x0b\x32<.rv.protos.TaskConfig.SemanticSegmentationConfig.ChipOptions\x12\x1c\n\x11predict_chip_size\x18\x04 \x01(\x05:\x01\x30\x1a\xf0\x01\n\x0b\x43hipOptions\x12$\n\rwindow_method\x18\x01 \x01(\t:\rrandom_sample\x12\x16\n\x0etarget_classes\x18\x02 \x03(\x05\x12$\n\x16\x64\x65\x62ug_chip_probability\x18\x03 \x01(\x02:\x04\x30.25\x12(\n\x1dnegative_survival_probability\x18\x04 \x01(\x02:\x01\x31\x12\x1d\n\x0f\x63hips_per_scene\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12$\n\x16target_count_threshold\x18\x06 \x01(\x05:\x04\x32\x30\x34\x38\x12\x0e\n\x06stride\x18\x07 \x01(\x05\x42\r\n\x0b\x63onfig_type')
   ,
   dependencies=[rastervision_dot_protos_dot_class__item__pb2.DESCRIPTOR,google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -273,8 +273,8 @@ _TASKCONFIG_SEMANTICSEGMENTATIONCONFIG_CHIPOPTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1267,
-  serialized_end=1507,
+  serialized_start=1297,
+  serialized_end=1537,
 )
 
 _TASKCONFIG_SEMANTICSEGMENTATIONCONFIG = _descriptor.Descriptor(
@@ -305,6 +305,13 @@ _TASKCONFIG_SEMANTICSEGMENTATIONCONFIG = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='predict_chip_size', full_name='rv.protos.TaskConfig.SemanticSegmentationConfig.predict_chip_size', index=3,
+      number=4, type=5, cpp_type=1, label=1,
+      has_default_value=True, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -318,7 +325,7 @@ _TASKCONFIG_SEMANTICSEGMENTATIONCONFIG = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1090,
-  serialized_end=1507,
+  serialized_end=1537,
 )
 
 _TASKCONFIG = _descriptor.Descriptor(
@@ -407,7 +414,7 @@ _TASKCONFIG = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=114,
-  serialized_end=1522,
+  serialized_end=1552,
 )
 
 _TASKCONFIG_OBJECTDETECTIONCONFIG_CHIPOPTIONS.containing_type = _TASKCONFIG_OBJECTDETECTIONCONFIG

--- a/rastervision/task/semantic_segmentation.py
+++ b/rastervision/task/semantic_segmentation.py
@@ -179,7 +179,7 @@ class SemanticSegmentation(Task):
              An sequence of windows.
 
         """
-        chip_size = self.config.chip_size
+        chip_size = self.config.predict_chip_size
         return extent.get_windows(chip_size, chip_size)
 
     def post_process_predictions(self, labels, scene):


### PR DESCRIPTION
This adds an option for setting the size of the prediction chip size for semantic segmentation. This only works with the fastai backend.

```
with_predict_chip_size(600)
```

Tested with https://github.com/azavea/raster-vision-fastai-plugin/pull/16 and with old predict package.