### PR TITLE
Add confusion matrix as metric for semantic segmentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,8 @@ Raster Vision 0.10.0
 Features
 ^^^^^^^^^^^^
 
-- Add confusion matrix to eval for semantic segmentation `#786 <https://github.com/azavea/raster-vision/pull/786>`__
+- Add confusion matrix as metric for semantic segmentation `#788 <https://github.com/azavea/raster-vision/pull/788>`__
+- Add predict_chip_size as option for semantic segmentation `#786 <https://github.com/azavea/raster-vision/pull/786>`__
 - Handle "ignore" class for semantic segmentation `#783 <https://github.com/azavea/raster-vision/pull/783>`__
 
 Bug Fixes

--- a/rastervision/evaluation/class_evaluation_item.py
+++ b/rastervision/evaluation/class_evaluation_item.py
@@ -54,15 +54,21 @@ class ClassEvaluationItem(EvaluationItem):
             self.count_error = weighted_avg(self.count_error,
                                             other.count_error)
             self.gt_count = total_gt_count
-            if other.conf_mat is not None:
-                if self.class_name == 'average':
-                    if self.conf_mat is None:
-                        self.conf_mat = np.array(other.conf_mat)
-                    else:
-                        self.conf_mat = np.stack(
-                            [self.conf_mat, other.conf_mat])
+
+        if other.conf_mat is not None:
+            if self.class_name == 'average':
+                if self.conf_mat is None:
+                    # Make first row all zeros so that the array indices
+                    # correspond to valid class ids (ie. >= 1).
+                    self.conf_mat = np.concatenate(
+                        [np.zeros_like(other.conf_mat)[np.newaxis, :],
+                            np.array(other.conf_mat)[np.newaxis, :]], axis=0)
                 else:
-                    self.conf_mat += other.conf_mat
+                    self.conf_mat = np.concatenate(
+                        [self.conf_mat, other.conf_mat[np.newaxis, :]],
+                        axis=0)
+            else:
+                self.conf_mat += other.conf_mat
 
     def to_json(self):
         new_dict = {}

--- a/rastervision/evaluation/class_evaluation_item.py
+++ b/rastervision/evaluation/class_evaluation_item.py
@@ -61,12 +61,14 @@ class ClassEvaluationItem(EvaluationItem):
                     # Make first row all zeros so that the array indices
                     # correspond to valid class ids (ie. >= 1).
                     self.conf_mat = np.concatenate(
-                        [np.zeros_like(other.conf_mat)[np.newaxis, :],
-                            np.array(other.conf_mat)[np.newaxis, :]], axis=0)
+                        [
+                            np.zeros_like(other.conf_mat)[np.newaxis, :],
+                            np.array(other.conf_mat)[np.newaxis, :]
+                        ],
+                        axis=0)
                 else:
                     self.conf_mat = np.concatenate(
-                        [self.conf_mat, other.conf_mat[np.newaxis, :]],
-                        axis=0)
+                        [self.conf_mat, other.conf_mat[np.newaxis, :]], axis=0)
             else:
                 self.conf_mat += other.conf_mat
 

--- a/rastervision/evaluation/classification_evaluator.py
+++ b/rastervision/evaluation/classification_evaluator.py
@@ -14,6 +14,7 @@ class ClassificationEvaluator(Evaluator):
     def __init__(self, class_map, output_uri):
         self.class_map = class_map
         self.output_uri = output_uri
+        self.eval = None
 
     @abstractmethod
     def create_evaluation(self):
@@ -39,3 +40,4 @@ class ClassificationEvaluator(Evaluator):
                 scene_evaluation.compute(ground_truth, predictions)
                 evaluation.merge(scene_evaluation, scene_id=scene.id)
         evaluation.save(self.output_uri)
+        self.eval = evaluation

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -66,8 +66,10 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
     def compute(self, gt_labels, pred_labels):
         self.clear()
 
-        labels = np.arange(len(self.class_map) + 1)
-        conf_mat = np.zeros((len(self.class_map) + 1, ) * 2)
+        # Ensure there is a row and column for each class_id even when
+        # class_ids are non-consecutive.
+        labels = np.arange(max(self.class_map.get_keys()) + 1)
+        conf_mat = np.zeros((len(labels), len(labels)))
         for window in pred_labels.get_windows():
             log.debug('Evaluating window: {}'.format(window))
             gt_arr = gt_labels.get_label_arr(window).ravel()

--- a/rastervision/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision/evaluation/semantic_segmentation_evaluation.py
@@ -2,6 +2,9 @@ import math
 import logging
 import json
 
+from sklearn.metrics import confusion_matrix
+import numpy as np
+
 from rastervision.evaluation import ClassEvaluationItem
 from rastervision.evaluation import ClassificationEvaluation
 
@@ -20,30 +23,21 @@ def is_geojson(data):
         return retval
 
 
-def get_class_eval_item(gt_arr, pred_arr, class_id, class_map):
+def get_class_eval_item(conf_mat, class_id, class_map):
     class_name = class_map.get_by_id(class_id).name
 
-    if gt_arr.sum() == 0:
+    if conf_mat.ravel().sum() == 0:
         return ClassEvaluationItem(None, None, None, 0, 0, class_id,
                                    class_name)
 
-    # Definitions of precision, recall, and f1 taken from
-    # http://scikit-learn.org/stable/auto_examples/model_selection/plot_precision_recall.html  # noqa
-    not_dont_care = (gt_arr != 0)  # By assumption
-    gt = (gt_arr == class_id)
-    pred = (pred_arr == class_id)
-    not_gt = (gt_arr != class_id)
-    not_pred = (pred_arr != class_id)
-
-    true_pos = (gt * pred).sum()
-    false_pos = (not_gt * pred * not_dont_care).sum()
-    false_neg = (gt * not_pred * not_dont_care).sum()
-
+    true_pos = conf_mat[class_id, class_id]
+    false_pos = conf_mat[1:, class_id].sum() - true_pos
+    false_neg = conf_mat[class_id, :].sum() - true_pos
     precision = float(true_pos) / (true_pos + false_pos)
     recall = float(true_pos) / (true_pos + false_neg)
     f1 = 2 * (precision * recall) / (precision + recall)
     count_error = int(false_pos + false_neg)
-    gt_count = int(gt.sum())
+    gt_count = conf_mat[class_id, :].sum()
 
     if math.isnan(precision):
         precision = None
@@ -59,7 +53,7 @@ def get_class_eval_item(gt_arr, pred_arr, class_id, class_map):
         f1 = float(f1)
 
     return ClassEvaluationItem(precision, recall, f1, count_error, gt_count,
-                               class_id, class_name)
+                               class_id, class_name, conf_mat[class_id, :])
 
 
 class SemanticSegmentationEvaluation(ClassificationEvaluation):
@@ -71,24 +65,20 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
 
     def compute(self, gt_labels, pred_labels):
         self.clear()
+
+        labels = np.arange(len(self.class_map) + 1)
+        conf_mat = np.zeros((len(self.class_map) + 1, ) * 2)
         for window in pred_labels.get_windows():
             log.debug('Evaluating window: {}'.format(window))
-            gt_arr = gt_labels.get_label_arr(window)
-            pred_arr = pred_labels.get_label_arr(window)
+            gt_arr = gt_labels.get_label_arr(window).ravel()
+            pred_arr = pred_labels.get_label_arr(window).ravel()
+            conf_mat += confusion_matrix(gt_arr, pred_arr, labels=labels)
 
-            eval_items = []
-            for class_id in self.class_map.get_keys():
-                if class_id > 0:
-                    eval_item = get_class_eval_item(gt_arr, pred_arr, class_id,
-                                                    self.class_map)
-                    eval_items.append(eval_item)
-
-            # Treat each window as if it was a small Scene.
-            window_eval = SemanticSegmentationEvaluation(self.class_map)
-            window_eval.set_class_to_eval_item(
-                dict(zip(self.class_map.get_keys(), eval_items)))
-            window_eval.compute_avg()
-            self.merge(window_eval)
+        for class_id in self.class_map.get_keys():
+            if class_id > 0:
+                self.class_to_eval_item[class_id] = get_class_eval_item(
+                    conf_mat, class_id, self.class_map)
+        self.compute_avg()
 
     def compute_vector(self, gt, pred, mode, class_id):
         """Compute evaluation over vector predictions.

--- a/tests/data-files/expected-eval.json
+++ b/tests/data-files/expected-eval.json
@@ -1,63 +1,143 @@
-{   "overall": [   {   "class_id": 1,
-                       "class_name": "one",
-                       "count_error": 50,
-                       "f1": 0.6666666666666666,
-                       "gt_count": 100,
-                       "precision": 1.0,
-                       "recall": 0.5},
-                   {   "class_id": 2,
-                       "class_name": "two",
-                       "count_error": 50.0,
-                       "f1": 0.6666666666666666,
-                       "gt_count": 100,
-                       "precision": 1.0,
-                       "recall": 0.5},
-                   {   "class_id": null,
-                       "class_name": "average",
-                       "count_error": 50.0,
-                       "f1": 0.6666666666666666,
-                       "gt_count": 200,
-                       "precision": 1.0,
-                       "recall": 0.5}],
-    "per_scene": {   "1": [   {   "class_id": 1,
-                                  "class_name": "one",
-                                  "count_error": 50,
-                                  "f1": 0.6666666666666666,
-                                  "gt_count": 100,
-                                  "precision": 1.0,
-                                  "recall": 0.5},
-                              {   "class_id": 2,
-                                  "class_name": "two",
-                                  "count_error": 50,
-                                  "f1": null,
-                                  "gt_count": 0,
-                                  "precision": 0.0,
-                                  "recall": null},
-                              {   "class_id": null,
-                                  "class_name": "average",
-                                  "count_error": 50.0,
-                                  "f1": 0.6666666666666666,
-                                  "gt_count": 100,
-                                  "precision": 1.0,
-                                  "recall": 0.5}],
-                     "2": [   {   "class_id": 1,
-                                  "class_name": "one",
-                                  "count_error": 50,
-                                  "f1": null,
-                                  "gt_count": 0,
-                                  "precision": 0.0,
-                                  "recall": null},
-                              {   "class_id": 2,
-                                  "class_name": "two",
-                                  "count_error": 50,
-                                  "f1": 0.6666666666666666,
-                                  "gt_count": 100,
-                                  "precision": 1.0,
-                                  "recall": 0.5},
-                              {   "class_id": null,
-                                  "class_name": "average",
-                                  "count_error": 50.0,
-                                  "f1": 0.6666666666666666,
-                                  "gt_count": 100,
-                                  "precision": 1.0,
-                                  "recall": 0.5}]}}
+{
+    "per_scene": {
+        "1": [
+            {
+                "precision": 1.0,
+                "gt_count": 100.0,
+                "count_error": 50,
+                "class_name": "one",
+                "class_id": 1,
+                "recall": 0.5,
+                "f1": 0.6666666666666666,
+                "conf_mat": [
+                    0.0,
+                    50.0,
+                    50.0
+                ]
+            },
+            {
+                "precision": 0.0,
+                "gt_count": 0.0,
+                "count_error": 50,
+                "class_name": "two",
+                "class_id": 2,
+                "recall": null,
+                "f1": null,
+                "conf_mat": [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            },
+            {
+                "precision": 1.0,
+                "gt_count": 100.0,
+                "count_error": 50.0,
+                "class_name": "average",
+                "class_id": null,
+                "recall": 0.5,
+                "f1": 0.6666666666666666,
+                "conf_mat": [
+                    0.0,
+                    50.0,
+                    50.0
+                ]
+            }
+        ],
+        "2": [
+            {
+                "precision": 0.0,
+                "gt_count": 0.0,
+                "count_error": 50,
+                "class_name": "one",
+                "class_id": 1,
+                "recall": null,
+                "f1": null,
+                "conf_mat": [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            },
+            {
+                "precision": 1.0,
+                "gt_count": 100.0,
+                "count_error": 50,
+                "class_name": "two",
+                "class_id": 2,
+                "recall": 0.5,
+                "f1": 0.6666666666666666,
+                "conf_mat": [
+                    0.0,
+                    50.0,
+                    50.0
+                ]
+            },
+            {
+                "precision": 1.0,
+                "gt_count": 100.0,
+                "count_error": 50.0,
+                "class_name": "average",
+                "class_id": null,
+                "recall": 0.5,
+                "f1": 0.6666666666666666,
+                "conf_mat": [
+                    0.0,
+                    50.0,
+                    50.0
+                ]
+            }
+        ]
+    },
+    "overall": [
+        {
+            "precision": 1.0,
+            "gt_count": 100.0,
+            "count_error": 50,
+            "class_name": "one",
+            "class_id": 1,
+            "recall": 0.5,
+            "f1": 0.6666666666666666,
+            "conf_mat": [
+                0.0,
+                50.0,
+                50.0
+            ]
+        },
+        {
+            "precision": 1.0,
+            "gt_count": 100.0,
+            "count_error": 50.0,
+            "class_name": "two",
+            "class_id": 2,
+            "recall": 0.5,
+            "f1": 0.6666666666666666,
+            "conf_mat": [
+                0.0,
+                50.0,
+                50.0
+            ]
+        },
+        {
+            "precision": 1.0,
+            "gt_count": 200.0,
+            "count_error": 50.0,
+            "class_name": "average",
+            "class_id": null,
+            "recall": 0.5,
+            "f1": 0.6666666666666666,
+            "conf_mat": [
+                [
+                    0.0,
+                    50.0,
+                    50.0
+                ],
+                [
+                    0.0,
+                    50.0,
+                    50.0
+                ]
+            ]
+        }
+    ]
+}

--- a/tests/data-files/expected-eval.json
+++ b/tests/data-files/expected-eval.json
@@ -1,132 +1,42 @@
 {
-    "per_scene": {
-        "1": [
-            {
-                "precision": 1.0,
-                "gt_count": 100.0,
-                "count_error": 50,
-                "class_name": "one",
-                "class_id": 1,
-                "recall": 0.5,
-                "f1": 0.6666666666666666,
-                "conf_mat": [
-                    0.0,
-                    50.0,
-                    50.0
-                ]
-            },
-            {
-                "precision": 0.0,
-                "gt_count": 0.0,
-                "count_error": 50,
-                "class_name": "two",
-                "class_id": 2,
-                "recall": null,
-                "f1": null,
-                "conf_mat": [
-                    0.0,
-                    0.0,
-                    0.0
-                ]
-            },
-            {
-                "precision": 1.0,
-                "gt_count": 100.0,
-                "count_error": 50.0,
-                "class_name": "average",
-                "class_id": null,
-                "recall": 0.5,
-                "f1": 0.6666666666666666,
-                "conf_mat": [
-                    0.0,
-                    50.0,
-                    50.0
-                ]
-            }
-        ],
-        "2": [
-            {
-                "precision": 0.0,
-                "gt_count": 0.0,
-                "count_error": 50,
-                "class_name": "one",
-                "class_id": 1,
-                "recall": null,
-                "f1": null,
-                "conf_mat": [
-                    0.0,
-                    0.0,
-                    0.0
-                ]
-            },
-            {
-                "precision": 1.0,
-                "gt_count": 100.0,
-                "count_error": 50,
-                "class_name": "two",
-                "class_id": 2,
-                "recall": 0.5,
-                "f1": 0.6666666666666666,
-                "conf_mat": [
-                    0.0,
-                    50.0,
-                    50.0
-                ]
-            },
-            {
-                "precision": 1.0,
-                "gt_count": 100.0,
-                "count_error": 50.0,
-                "class_name": "average",
-                "class_id": null,
-                "recall": 0.5,
-                "f1": 0.6666666666666666,
-                "conf_mat": [
-                    0.0,
-                    50.0,
-                    50.0
-                ]
-            }
-        ]
-    },
     "overall": [
         {
             "precision": 1.0,
-            "gt_count": 100.0,
+            "f1": 0.6666666666666666,
+            "conf_mat": [
+                0.0,
+                50.0,
+                50.0
+            ],
             "count_error": 50,
-            "class_name": "one",
-            "class_id": 1,
             "recall": 0.5,
-            "f1": 0.6666666666666666,
-            "conf_mat": [
-                0.0,
-                50.0,
-                50.0
-            ]
-        },
-        {
-            "precision": 1.0,
             "gt_count": 100.0,
-            "count_error": 50.0,
-            "class_name": "two",
-            "class_id": 2,
-            "recall": 0.5,
+            "class_name": "one",
+            "class_id": 1
+        },
+        {
+            "precision": 1.0,
             "f1": 0.6666666666666666,
             "conf_mat": [
                 0.0,
                 50.0,
                 50.0
-            ]
+            ],
+            "count_error": 50.0,
+            "recall": 0.5,
+            "gt_count": 100.0,
+            "class_name": "two",
+            "class_id": 2
         },
         {
             "precision": 1.0,
-            "gt_count": 200.0,
-            "count_error": 50.0,
-            "class_name": "average",
-            "class_id": null,
-            "recall": 0.5,
             "f1": 0.6666666666666666,
             "conf_mat": [
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
                 [
                     0.0,
                     50.0,
@@ -137,7 +47,126 @@
                     50.0,
                     50.0
                 ]
-            ]
+            ],
+            "count_error": 50.0,
+            "recall": 0.5,
+            "gt_count": 200.0,
+            "class_name": "average",
+            "class_id": null
         }
-    ]
+    ],
+    "per_scene": {
+        "2": [
+            {
+                "precision": 0.0,
+                "f1": null,
+                "conf_mat": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "class_id": 1,
+                "count_error": 50,
+                "gt_count": 0.0,
+                "class_name": "one",
+                "recall": null
+            },
+            {
+                "precision": 1.0,
+                "f1": 0.6666666666666666,
+                "conf_mat": [
+                    0.0,
+                    50.0,
+                    50.0
+                ],
+                "class_id": 2,
+                "count_error": 50,
+                "gt_count": 100.0,
+                "class_name": "two",
+                "recall": 0.5
+            },
+            {
+                "precision": 1.0,
+                "f1": 0.6666666666666666,
+                "conf_mat": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        50.0,
+                        50.0
+                    ]
+                ],
+                "class_id": null,
+                "count_error": 50.0,
+                "gt_count": 100.0,
+                "class_name": "average",
+                "recall": 0.5
+            }
+        ],
+        "1": [
+            {
+                "precision": 1.0,
+                "f1": 0.6666666666666666,
+                "conf_mat": [
+                    0.0,
+                    50.0,
+                    50.0
+                ],
+                "class_id": 1,
+                "count_error": 50,
+                "gt_count": 100.0,
+                "class_name": "one",
+                "recall": 0.5
+            },
+            {
+                "precision": 0.0,
+                "f1": null,
+                "conf_mat": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "class_id": 2,
+                "count_error": 50,
+                "gt_count": 0.0,
+                "class_name": "two",
+                "recall": null
+            },
+            {
+                "precision": 1.0,
+                "f1": 0.6666666666666666,
+                "conf_mat": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        50.0,
+                        50.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                ],
+                "class_id": null,
+                "count_error": 50.0,
+                "gt_count": 100.0,
+                "class_name": "average",
+                "recall": 0.5
+            }
+        ]
+    }
 }

--- a/tests/evaluation/test_semantic_segmentation_evaluation.py
+++ b/tests/evaluation/test_semantic_segmentation_evaluation.py
@@ -56,7 +56,7 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         self.assertAlmostEqual(recall2, eval.class_to_eval_item[2].recall)
         self.assertAlmostEqual(f12, eval.class_to_eval_item[2].f1)
 
-        avg_conf_mat = np.array([[1., 13, 0], [0, 1, 0]])
+        avg_conf_mat = np.array([[0, 0, 0], [1., 13, 0], [0, 1, 0]])
         avg_recall = (14 / 15) * recall1 + (1 / 15) * recall2
         self.assertTrue(np.array_equal(avg_conf_mat, eval.avg_item.conf_mat))
         self.assertEqual(avg_recall, eval.avg_item.recall)

--- a/tests/evaluation/test_semantic_segmentation_evaluation.py
+++ b/tests/evaluation/test_semantic_segmentation_evaluation.py
@@ -13,25 +13,23 @@ from tests import data_file_path
 
 class TestSemanticSegmentationEvaluation(unittest.TestCase):
     def test_compute(self):
-        class_map = ClassMap([
-            ClassItem(id=1, name='one', color='#010101'),
-            ClassItem(id=2, name='two', color='#020202')
-        ])
+        class_map = ClassMap(
+            [ClassItem(id=1, name='one'),
+             ClassItem(id=2, name='two')])
 
-        gt_array = np.ones((4, 4, 3), dtype=np.uint8)
-        gt_array[0, 0, :] = 0
-        gt_array[2, 2, :] = 2
-        gt_raster = MockRasterSource([0, 1, 2], 3)
+        # Mismatches: 0 -> 1, 2 -> 1, 1 -> 0
+        gt_array = np.ones((4, 4, 1), dtype=np.uint8)
+        gt_array[0, 0, 0] = 0
+        gt_array[2, 2, 0] = 2
+        gt_raster = MockRasterSource([0], 1)
         gt_raster.set_raster(gt_array)
-        gt_label_source = SemanticSegmentationLabelSource(
-            source=gt_raster, rgb_class_map=class_map)
+        gt_label_source = SemanticSegmentationLabelSource(source=gt_raster)
 
-        p_array = np.ones((4, 4, 3), dtype=np.uint8)
-        p_array[1, 1, :] = 0
-        p_raster = MockRasterSource([0, 1, 2], 3)
+        p_array = np.ones((4, 4, 1), dtype=np.uint8)
+        p_array[1, 1, 0] = 0
+        p_raster = MockRasterSource([0], 1)
         p_raster.set_raster(p_array)
-        p_label_source = SemanticSegmentationLabelSource(
-            source=p_raster, rgb_class_map=class_map)
+        p_label_source = SemanticSegmentationLabelSource(source=p_raster)
 
         eval = SemanticSegmentationEvaluation(class_map)
         eval.compute(gt_label_source.get_labels(), p_label_source.get_labels())
@@ -41,25 +39,37 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         fn1 = 1  # one false negative (1,1)
         precision1 = float(tp1) / (tp1 + fp1)
         recall1 = float(tp1) / (tp1 + fn1)
+        f11 = 2 * float(precision1 * recall1) / (precision1 + recall1)
 
         tp2 = 0  # 0 true positives for class 2
         fn2 = 1  # one false negative (2,2)
         precision2 = None  # float(tp2) / (tp2 + fp2) where fp2 == 0
         recall2 = float(tp2) / (tp2 + fn2)
+        f12 = None
 
         self.assertAlmostEqual(precision1,
                                eval.class_to_eval_item[1].precision)
         self.assertAlmostEqual(recall1, eval.class_to_eval_item[1].recall)
+        self.assertAlmostEqual(f11, eval.class_to_eval_item[1].f1)
+
         self.assertEqual(precision2, eval.class_to_eval_item[2].precision)
         self.assertAlmostEqual(recall2, eval.class_to_eval_item[2].recall)
+        self.assertAlmostEqual(f12, eval.class_to_eval_item[2].f1)
+
+        avg_conf_mat = np.array([[1., 13, 0], [0, 1, 0]])
+        avg_recall = (14 / 15) * recall1 + (1 / 15) * recall2
+        self.assertTrue(np.array_equal(avg_conf_mat, eval.avg_item.conf_mat))
+        self.assertEqual(avg_recall, eval.avg_item.recall)
 
     def test_compute_ignore_class(self):
+        # All ones except for a zero
         gt_array = np.ones((4, 4, 1), dtype=np.uint8)
         gt_array[0, 0, 0] = 0
         gt_raster = MockRasterSource([0], 1)
         gt_raster.set_raster(gt_array)
         gt_label_source = SemanticSegmentationLabelSource(source=gt_raster)
 
+        # All ones
         pred_array = np.ones((4, 4, 1), dtype=np.uint8)
         pred_raster = MockRasterSource([0], 1)
         pred_raster.set_raster(pred_array)
@@ -72,7 +82,8 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         eval.compute(gt_label_source.get_labels(),
                      pred_label_source.get_labels())
         self.assertAlmostEqual(1, len(eval.class_to_eval_item))
-        self.assertAlmostEqual(1.0, eval.class_to_eval_item[0].f1)
+        self.assertAlmostEqual(1.0, eval.class_to_eval_item[1].f1)
+        self.assertAlmostEqual(1.0, eval.avg_item.f1)
 
     def test_vector_compute(self):
         class_map = ClassMap([ClassItem(id=1, name='one', color='#000021')])

--- a/tests/evaluation/test_semantic_segmentation_evaluator.py
+++ b/tests/evaluation/test_semantic_segmentation_evaluator.py
@@ -27,8 +27,10 @@ class TestSemanticSegmentationEvaluator(unittest.TestCase):
         self.tmp_dir.cleanup()
 
     def get_scene(self, class_id):
+        # Make scene where ground truth is all set to class_id
+        # and predictions are set to half 1's and half 2's
         scene_id = str(class_id)
-        rs = MockRasterSource(channel_order=[0, 1, 3], num_channels=3)
+        rs = MockRasterSource(channel_order=[0, 1, 2], num_channels=3)
         rs.set_raster(np.zeros((10, 10, 3)))
 
         gt_rs = MockRasterSource(channel_order=[0], num_channels=1)


### PR DESCRIPTION
This adds a `conf_mat` field to the eval metrics generated for semantic segmentation. For each class item, `conf_mat` is the row in the confusion matrix representing that class. For the average item, `conf_mat` is the entire matrix.
