### PR TITLE
Add Stochastic Gradient Descent to Chip Classification

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Features
 - Add confusion matrix as metric for semantic segmentation `#788 <https://github.com/azavea/raster-vision/pull/788>`__
 - Add predict_chip_size as option for semantic segmentation `#786 <https://github.com/azavea/raster-vision/pull/786>`__
 - Handle "ignore" class for semantic segmentation `#783 <https://github.com/azavea/raster-vision/pull/783>`__
+- Add stochastic gradient descent ("SGD") as an optimizer option for chip classification `#792 <https://github.com/azavea/raster-vision/pull/792>`__
 
 Bug Fixes
 ^^^^^^^^^

--- a/rastervision/backend/keras_classification/builders/optimizer_builder.py
+++ b/rastervision/backend/keras_classification/builders/optimizer_builder.py
@@ -5,6 +5,8 @@ from rastervision.protos.keras_classification.optimizer_pb2 import Optimizer
 def build(optimizer_options):
     if optimizer_options.type == Optimizer.Type.Value('ADAM'):
         optimizer = keras.optimizers.Adam(lr=optimizer_options.init_lr)
+    elif optimizer_options.type == Optimizer.Type.Value('SGD'):
+        optimizer = keras.optimizers.SGD(lr=optimizer_options.init_lr)
     else:
         raise ValueError((Optimizer.Type.Name(optimizer_options.type) +
                           ' is not a valid optimizer type'))

--- a/rastervision/protos/keras_classification/optimizer.proto
+++ b/rastervision/protos/keras_classification/optimizer.proto
@@ -5,6 +5,7 @@ package keras_classification.protos;
 message Optimizer {
     enum Type {
         ADAM = 1;
+        SGD = 2;
     }
 
     required Type type = 4;

--- a/rastervision/protos/keras_classification/optimizer_pb2.py
+++ b/rastervision/protos/keras_classification/optimizer_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/keras_classification/optimizer.proto',
   package='keras_classification.protos',
   syntax='proto2',
-  serialized_pb=_b('\n8rastervision/protos/keras_classification/optimizer.proto\x12\x1bkeras_classification.protos\"i\n\tOptimizer\x12\x39\n\x04type\x18\x04 \x02(\x0e\x32+.keras_classification.protos.Optimizer.Type\x12\x0f\n\x07init_lr\x18\x05 \x02(\x02\"\x10\n\x04Type\x12\x08\n\x04\x41\x44\x41M\x10\x01')
+  serialized_pb=_b('\n8rastervision/protos/keras_classification/optimizer.proto\x12\x1bkeras_classification.protos\"r\n\tOptimizer\x12\x39\n\x04type\x18\x04 \x02(\x0e\x32+.keras_classification.protos.Optimizer.Type\x12\x0f\n\x07init_lr\x18\x05 \x02(\x02\"\x19\n\x04Type\x12\x08\n\x04\x41\x44\x41M\x10\x01\x12\x07\n\x03SGD\x10\x02')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -35,11 +35,15 @@ _OPTIMIZER_TYPE = _descriptor.EnumDescriptor(
       name='ADAM', index=0, number=1,
       options=None,
       type=None),
+    _descriptor.EnumValueDescriptor(
+      name='SGD', index=1, number=2,
+      options=None,
+      type=None),
   ],
   containing_type=None,
   options=None,
   serialized_start=178,
-  serialized_end=194,
+  serialized_end=203,
 )
 _sym_db.RegisterEnumDescriptor(_OPTIMIZER_TYPE)
 
@@ -79,7 +83,7 @@ _OPTIMIZER = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=89,
-  serialized_end=194,
+  serialized_end=203,
 )
 
 _OPTIMIZER.fields_by_name['type'].enum_type = _OPTIMIZER_TYPE


### PR DESCRIPTION
## Overview

Adds the ability to use the SGD optimizer for chip classification.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes https://github.com/azavea/raster-vision/issues/790
