### PR TITLE
Allow type annotations with ConfigBuilders

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Bug Fixes
 ^^^^^^^^^
 
 - Fixed issue with configuration not being able to read lists `#784 <https://github.com/azavea/raster-vision/pull/784>`__
+- Fixed `ConfigBuilder`s not supporting type annotations in `__init__` `#800 <https://github.com/azavea/raster-vision/pull/800>`__
 
 Raster Vision 0.9
 -----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,7 +19,7 @@ Bug Fixes
 ^^^^^^^^^
 
 - Fixed issue with configuration not being able to read lists `#784 <https://github.com/azavea/raster-vision/pull/784>`__
-- Fixed `ConfigBuilder`s not supporting type annotations in `__init__` `#800 <https://github.com/azavea/raster-vision/pull/800>`__
+- Fixed ConfigBuilders not supporting type annotations in __init__ `#800 <https://github.com/azavea/raster-vision/pull/800>`__
 
 Raster Vision 0.9
 -----------------

--- a/rastervision/core/config.py
+++ b/rastervision/core/config.py
@@ -98,7 +98,7 @@ class ConfigBuilder(ABC):
         """Returns the configuration that is built by this builder.
         """
         self.validate()
-        arguments = set(inspect.getargspec(self.config_class).args)
+        arguments = set(inspect.getfullargspec(self.config_class).args)
         keys = set(self.config.keys())
         config = {k: self.config[k] for k in (arguments & keys)}
         return self.config_class(**config)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,29 @@
+from copy import deepcopy
+import unittest
+from rastervision.core.config import ConfigBuilder
+
+
+class DummyConfig(object):
+    def __init__(self, foo: str):
+        self.foo = foo
+
+
+class DummyConfigBuilder(ConfigBuilder):
+    config_class = DummyConfig
+    config = {'foo': 'bar'}
+
+    def __init__(self):
+        return
+
+    def with_foo(self, foo):
+        b = deepcopy(self)
+        b.foo = foo
+        return b
+
+    def from_proto(self, msg):
+        return self.with_foo(msg.foo)
+
+
+class TestConfig(unittest.TestCase):
+    def test_build_with_annotations(self):
+        self.assertTrue(DummyConfigBuilder().build().foo == 'bar')


### PR DESCRIPTION
## Overview

This PR changes `getargspec` to `getfullargspec` so that `ConfigBuilder`s can use functions with type annotations.

### Checklist

- [x] Updated `docs/changelog.rst`
- ~Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- ~Documentation updated if needed~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* tests to ensure that nothing broke

Closes #799 
