### PR TITLE
Add option to determine if all touched pixels should be rasterized.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 Raster Vision 0.10
------------------
+------------------
 
 Raster Vision 0.10.0
 ~~~~~~~~~~~~~~~~~~~
@@ -14,6 +14,7 @@ Features
 - Add predict_chip_size as option for semantic segmentation `#786 <https://github.com/azavea/raster-vision/pull/786>`__
 - Handle "ignore" class for semantic segmentation `#783 <https://github.com/azavea/raster-vision/pull/783>`__
 - Add stochastic gradient descent ("SGD") as an optimizer option for chip classification `#792 <https://github.com/azavea/raster-vision/pull/792>`__
+- Add option to determine if all touched pixels should be rasterized for rasterized RasterSource `#803 <https://github.com/azavea/raster-vision/pull/803>`_
 
 Bug Fixes
 ^^^^^^^^^

--- a/rastervision/data/raster_source/rasterized_source.py
+++ b/rastervision/data/raster_source/rasterized_source.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 def geoms_to_raster(str_tree, rasterizer_options, window, extent):
     background_class_id = rasterizer_options.background_class_id
+    all_touched = rasterizer_options.all_touched
 
     log.debug('Cropping shapes to window...')
     # Crop shapes against window, remove empty shapes, and put in window frame of
@@ -41,7 +42,8 @@ def geoms_to_raster(str_tree, rasterizer_options, window, extent):
             shapes,
             out_shape=out_shape,
             fill=background_class_id,
-            dtype=np.uint8)
+            dtype=np.uint8,
+            all_touched=all_touched)
     else:
         raster = np.full(out_shape, background_class_id, dtype=np.uint8)
 

--- a/rastervision/data/raster_source/rasterized_source_config.py
+++ b/rastervision/data/raster_source/rasterized_source_config.py
@@ -20,16 +20,17 @@ class RasterizedSourceConfig(RasterSourceConfig):
                 background_class_id: The class_id to use for background pixels that don't
                     overlap with any shapes in the GeoJSON file.
                 all_touched: If True, all pixels touched by geometries will be burned in.
-                             If false, only pixels whose center is within the polygon or that
-                             are selected by Bresenham’s line algorithm will be burned in. (See
-                             rasterio.features.rasterize).
+                             If false, only pixels whose center is within the polygon or
+                             that are selected by Bresenham’s line algorithm will be
+                             burned in. (See rasterio.features.rasterize).
             """
             self.background_class_id = background_class_id
             self.all_touched = all_touched
 
         def to_proto(self):
             return RasterSourceConfigMsg.RasterizedSource.RasterizerOptions(
-                background_class_id=self.background_class_id, all_touched=self.all_touched)
+                background_class_id=self.background_class_id,
+                all_touched=self.all_touched)
 
     def __init__(self,
                  vector_source,
@@ -181,8 +182,8 @@ class RasterizedSourceConfigBuilder(RasterSourceConfigBuilder):
                 overlap with any shapes in the GeoJSON file.
             all_touched: If True, all pixels touched by geometries will be burned in.
                          If false, only pixels whose center is within the polygon or that
-                         are selected by Bresenham’s line algorithm will be burned in. (See
-                         rasterio.features.rasterize).
+                         are selected by Bresenham’s line algorithm will be burned in.
+                         (See rasterio.features.rasterize).
 
         """
         b = deepcopy(self)

--- a/rastervision/data/raster_source/rasterized_source_config.py
+++ b/rastervision/data/raster_source/rasterized_source_config.py
@@ -13,18 +13,23 @@ from rastervision.utils.files import download_if_needed
 
 class RasterizedSourceConfig(RasterSourceConfig):
     class RasterizerOptions(object):
-        def __init__(self, background_class_id):
+        def __init__(self, background_class_id, all_touched=False):
             """Constructor.
 
             Args:
                 background_class_id: The class_id to use for background pixels that don't
                     overlap with any shapes in the GeoJSON file.
+                all_touched: If True, all pixels touched by geometries will be burned in.
+                             If false, only pixels whose center is within the polygon or that
+                             are selected by Bresenham’s line algorithm will be burned in. (See
+                             rasterio.features.rasterize).
             """
             self.background_class_id = background_class_id
+            self.all_touched = all_touched
 
         def to_proto(self):
             return RasterSourceConfigMsg.RasterizedSource.RasterizerOptions(
-                background_class_id=self.background_class_id)
+                background_class_id=self.background_class_id, all_touched=self.all_touched)
 
     def __init__(self,
                  vector_source,
@@ -140,7 +145,8 @@ class RasterizedSourceConfigBuilder(RasterSourceConfigBuilder):
         return b \
             .with_vector_source(vector_source) \
             .with_rasterizer_options(
-                rasterizer_options.background_class_id)
+                rasterizer_options.background_class_id,
+                rasterizer_options.all_touched)
 
     def with_vector_source(self, vector_source):
         """Set the vector_source.
@@ -167,15 +173,20 @@ class RasterizedSourceConfigBuilder(RasterSourceConfigBuilder):
         b.config['vector_source'] = provider.construct(uri)
         return b
 
-    def with_rasterizer_options(self, background_class_id):
+    def with_rasterizer_options(self, background_class_id, all_touched=False):
         """Specify options for converting GeoJSON to raster.
 
         Args:
             background_class_id: The class_id to use for background pixels that don't
                 overlap with any shapes in the GeoJSON file.
+            all_touched: If True, all pixels touched by geometries will be burned in.
+                         If false, only pixels whose center is within the polygon or that
+                         are selected by Bresenham’s line algorithm will be burned in. (See
+                         rasterio.features.rasterize).
+
         """
         b = deepcopy(self)
         b.config[
             'rasterizer_options'] = RasterizedSourceConfig.RasterizerOptions(
-                background_class_id)
+                background_class_id, all_touched)
         return b

--- a/rastervision/protos/raster_source.proto
+++ b/rastervision/protos/raster_source.proto
@@ -34,6 +34,9 @@ message RasterSourceConfig {
             // VectorSource.
             // Number of pixels to add to each side of line when rasterized.
             optional int32 line_buffer = 3 [default=15];
+
+            // Whether to rasterize all touched pixels
+            optional bool all_touched = 4 [default=false];
         }
         required VectorSourceConfig vector_source = 1;
         required RasterizerOptions rasterizer_options = 2;
@@ -66,6 +69,6 @@ message RasterSourceConfig {
         GeoJSONFile geojson_file = 6;
         google.protobuf.Struct custom_config = 7;
         RasterizedSource rasterized_source = 8;
-        RasterioSource rasterio_source = 9;        
+        RasterioSource rasterio_source = 9;
     }
 }

--- a/rastervision/protos/raster_source_pb2.py
+++ b/rastervision/protos/raster_source_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='rastervision/protos/raster_source.proto',
   package='rv.protos',
   syntax='proto2',
-  serialized_pb=_b('\n\'rastervision/protos/raster_source.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\x1a,rastervision/protos/raster_transformer.proto\x1a\'rastervision/protos/vector_source.proto\"\x8e\t\n\x12RasterSourceConfig\x12\x13\n\x0bsource_type\x18\x01 \x02(\t\x12\x38\n\x0ctransformers\x18\x02 \x03(\x0b\x32\".rv.protos.RasterTransformerConfig\x12\x15\n\rchannel_order\x18\x03 \x03(\x05\x12\x43\n\rgeotiff_files\x18\x04 \x01(\x0b\x32*.rv.protos.RasterSourceConfig.GeoTiffFilesH\x00\x12=\n\nimage_file\x18\x05 \x01(\x0b\x32\'.rv.protos.RasterSourceConfig.ImageFileH\x00\x12\x41\n\x0cgeojson_file\x18\x06 \x01(\x0b\x32).rv.protos.RasterSourceConfig.GeoJSONFileH\x00\x12\x30\n\rcustom_config\x18\x07 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12K\n\x11rasterized_source\x18\x08 \x01(\x0b\x32..rv.protos.RasterSourceConfig.RasterizedSourceH\x00\x12G\n\x0frasterio_source\x18\t \x01(\x0b\x32,.rv.protos.RasterSourceConfig.RasterioSourceH\x00\x1aL\n\x0cGeoTiffFiles\x12\x0c\n\x04uris\x18\x01 \x03(\t\x12\x16\n\x0ex_shift_meters\x18\x02 \x01(\x02\x12\x16\n\x0ey_shift_meters\x18\x03 \x01(\x02\x1a\x18\n\tImageFile\x12\x0b\n\x03uri\x18\x01 \x02(\t\x1aN\n\x0eRasterioSource\x12\x0c\n\x04uris\x18\x01 \x03(\t\x12\x16\n\x0ex_shift_meters\x18\x02 \x01(\x02\x12\x16\n\x0ey_shift_meters\x18\x03 \x01(\x02\x1a\xf1\x01\n\x10RasterizedSource\x12\x34\n\rvector_source\x18\x01 \x02(\x0b\x32\x1d.rv.protos.VectorSourceConfig\x12\\\n\x12rasterizer_options\x18\x02 \x02(\x0b\x32@.rv.protos.RasterSourceConfig.RasterizedSource.RasterizerOptions\x1aI\n\x11RasterizerOptions\x12\x1b\n\x13\x62\x61\x63kground_class_id\x18\x02 \x02(\x05\x12\x17\n\x0bline_buffer\x18\x03 \x01(\x05:\x02\x31\x35\x1a\xbe\x01\n\x0bGeoJSONFile\x12\x0b\n\x03uri\x18\x01 \x02(\t\x12W\n\x12rasterizer_options\x18\x02 \x02(\x0b\x32;.rv.protos.RasterSourceConfig.GeoJSONFile.RasterizerOptions\x1aI\n\x11RasterizerOptions\x12\x1b\n\x13\x62\x61\x63kground_class_id\x18\x02 \x02(\x05\x12\x17\n\x0bline_buffer\x18\x03 \x01(\x05:\x02\x31\x35\x42\x16\n\x14raster_source_config')
+  serialized_pb=_b('\n\'rastervision/protos/raster_source.proto\x12\trv.protos\x1a\x1cgoogle/protobuf/struct.proto\x1a,rastervision/protos/raster_transformer.proto\x1a\'rastervision/protos/vector_source.proto\"\xaa\t\n\x12RasterSourceConfig\x12\x13\n\x0bsource_type\x18\x01 \x02(\t\x12\x38\n\x0ctransformers\x18\x02 \x03(\x0b\x32\".rv.protos.RasterTransformerConfig\x12\x15\n\rchannel_order\x18\x03 \x03(\x05\x12\x43\n\rgeotiff_files\x18\x04 \x01(\x0b\x32*.rv.protos.RasterSourceConfig.GeoTiffFilesH\x00\x12=\n\nimage_file\x18\x05 \x01(\x0b\x32\'.rv.protos.RasterSourceConfig.ImageFileH\x00\x12\x41\n\x0cgeojson_file\x18\x06 \x01(\x0b\x32).rv.protos.RasterSourceConfig.GeoJSONFileH\x00\x12\x30\n\rcustom_config\x18\x07 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12K\n\x11rasterized_source\x18\x08 \x01(\x0b\x32..rv.protos.RasterSourceConfig.RasterizedSourceH\x00\x12G\n\x0frasterio_source\x18\t \x01(\x0b\x32,.rv.protos.RasterSourceConfig.RasterioSourceH\x00\x1aL\n\x0cGeoTiffFiles\x12\x0c\n\x04uris\x18\x01 \x03(\t\x12\x16\n\x0ex_shift_meters\x18\x02 \x01(\x02\x12\x16\n\x0ey_shift_meters\x18\x03 \x01(\x02\x1a\x18\n\tImageFile\x12\x0b\n\x03uri\x18\x01 \x02(\t\x1aN\n\x0eRasterioSource\x12\x0c\n\x04uris\x18\x01 \x03(\t\x12\x16\n\x0ex_shift_meters\x18\x02 \x01(\x02\x12\x16\n\x0ey_shift_meters\x18\x03 \x01(\x02\x1a\x8d\x02\n\x10RasterizedSource\x12\x34\n\rvector_source\x18\x01 \x02(\x0b\x32\x1d.rv.protos.VectorSourceConfig\x12\\\n\x12rasterizer_options\x18\x02 \x02(\x0b\x32@.rv.protos.RasterSourceConfig.RasterizedSource.RasterizerOptions\x1a\x65\n\x11RasterizerOptions\x12\x1b\n\x13\x62\x61\x63kground_class_id\x18\x02 \x02(\x05\x12\x17\n\x0bline_buffer\x18\x03 \x01(\x05:\x02\x31\x35\x12\x1a\n\x0b\x61ll_touched\x18\x04 \x01(\x08:\x05\x66\x61lse\x1a\xbe\x01\n\x0bGeoJSONFile\x12\x0b\n\x03uri\x18\x01 \x02(\t\x12W\n\x12rasterizer_options\x18\x02 \x02(\x0b\x32;.rv.protos.RasterSourceConfig.GeoJSONFile.RasterizerOptions\x1aI\n\x11RasterizerOptions\x12\x1b\n\x13\x62\x61\x63kground_class_id\x18\x02 \x02(\x05\x12\x17\n\x0bline_buffer\x18\x03 \x01(\x05:\x02\x31\x35\x42\x16\n\x14raster_source_config')
   ,
   dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,rastervision_dot_protos_dot_raster__transformer__pb2.DESCRIPTOR,rastervision_dot_protos_dot_vector__source__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -169,6 +169,13 @@ _RASTERSOURCECONFIG_RASTERIZEDSOURCE_RASTERIZEROPTIONS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='all_touched', full_name='rv.protos.RasterSourceConfig.RasterizedSource.RasterizerOptions.all_touched', index=2,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=True, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -182,7 +189,7 @@ _RASTERSOURCECONFIG_RASTERIZEDSOURCE_RASTERIZEROPTIONS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1048,
-  serialized_end=1121,
+  serialized_end=1149,
 )
 
 _RASTERSOURCECONFIG_RASTERIZEDSOURCE = _descriptor.Descriptor(
@@ -219,7 +226,7 @@ _RASTERSOURCECONFIG_RASTERIZEDSOURCE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=880,
-  serialized_end=1121,
+  serialized_end=1149,
 )
 
 _RASTERSOURCECONFIG_GEOJSONFILE_RASTERIZEROPTIONS = _descriptor.Descriptor(
@@ -292,8 +299,8 @@ _RASTERSOURCECONFIG_GEOJSONFILE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1124,
-  serialized_end=1314,
+  serialized_start=1152,
+  serialized_end=1342,
 )
 
 _RASTERSOURCECONFIG = _descriptor.Descriptor(
@@ -382,7 +389,7 @@ _RASTERSOURCECONFIG = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=172,
-  serialized_end=1338,
+  serialized_end=1366,
 )
 
 _RASTERSOURCECONFIG_GEOTIFFFILES.containing_type = _RASTERSOURCECONFIG

--- a/tests/data/raster_source/test_rasterized_source.py
+++ b/tests/data/raster_source/test_rasterized_source.py
@@ -105,8 +105,8 @@ class TestRasterizedSource(unittest.TestCase):
                 'geometry': {
                     'type':
                     'Polygon',
-                    'coordinates': [[[0., 0.], [0., 0.4], [0.4, 0.4], [0.4, 0.],
-                                     [0., 0.]]]
+                    'coordinates': [[[0., 0.], [0., 0.4], [0.4, 0.4],
+                                     [0.4, 0.], [0., 0.]]]
                 },
                 'properties': {
                     'class_id': self.class_id,


### PR DESCRIPTION
## Overview

This PR adds the `all_touched` option to the rasterized RasterSource. This passes through to the rasterio rasterize method, which uses the `all_touched` option to determine whether a geometry needs to encompass the center of the pixel in order to be burned into the resulting raster, or if it just needs to touch the pixel.

This option is useful when rasterizing geometries on a low-resolution grid, e.g. for the presence of buildings under a Sentinel-2 pixel, we want that pixel to be marked as building no matter how small or where the building is in the pixel boundary.
