### PR TITLE
Adds mirror augmentor using numpy matrices

### DIFF
--- a/rastervision/augmentor/__init__.py
+++ b/rastervision/augmentor/__init__.py
@@ -4,3 +4,5 @@ from rastervision.augmentor.augmentor import *
 from rastervision.augmentor.augmentor_config import *
 from rastervision.augmentor.nodata_augmentor import *
 from rastervision.augmentor.nodata_augmentor_config import *
+from rastervision.augmentor.mirror_augmentor import *
+from rastervision.augmentor.mirror_augmentor_config import *

--- a/rastervision/augmentor/api.py
+++ b/rastervision/augmentor/api.py
@@ -5,5 +5,6 @@
 AUGMENTOR = 'AUGMENTOR'
 
 NODATA_AUGMENTOR = 'NODATA_AUGMENTOR'
+MIRROR_AUGMENTOR = 'MIRROR_AUGMENTOR'
 
 from rastervision.augmentor.augmentor_config import AugmentorConfig

--- a/rastervision/augmentor/mirror_augmentor.py
+++ b/rastervision/augmentor/mirror_augmentor.py
@@ -17,13 +17,10 @@ class MirrorAugmentor(Augmentor):
 	Args:
 		prob: (float) probability that the data is mirrord
 
-		axes: (int) Either 4 or 8. When 4 is used, the images are mirrored along their horizontal
-		and vertical axes. If 8 is used, also the diagonal axes (transpose and transverse) are used.
 	"""
 
-	def __init__(self, aug_prob, axes):
+	def __init__(self, aug_prob):
 		self.aug_prob = aug_prob
-		self.axes = axes
 
 	def process(self, training_data, tmp_dir):
 		augmented_data = TrainingData() # Initiatlize empty training data object
@@ -41,21 +38,12 @@ class MirrorAugmentor(Augmentor):
 		def mirror_diagonal2(chip):
 			return np.transpose(np.copy(mirror_horizontally(chip)), axes = [1,0,2])
 
-		# If loop on top level to avoid a per-chip if statement
-		if self.axes == 4:
-			for chip, window, labels in training_data:
-				if random.uniform(0,1) < self.aug_prob:
-					chip = np.copy(chip)
-					augmented_data.append(mirror_horizontally(chip), window, labels)
-					augmented_data.append(mirror_vertically(chip), window, labels)
-
-		elif self.axes == 8:
-			for chip, window, labels in training_data:
-				if random.uniform(0,1) < self.aug_prob:
-					chip = np.copy(chip)
-					augmented_data.append(mirror_horizontally(chip), window, labels)
-					augmented_data.append(mirror_vertically(chip), window, labels)
-					augmented_data.append(mirror_diagonal1(chip), window, labels)
-					augmented_data.append(mirror_diagonal2(chip), window, labels)
+		for chip, window, labels in training_data:
+			if random.uniform(0,1) < self.aug_prob:
+				chip = np.copy(chip)
+				augmented_data.append(mirror_horizontally(chip), window, labels)
+				augmented_data.append(mirror_vertically(chip), window, labels)
+				augmented_data.append(mirror_diagonal1(chip), window, labels)
+				augmented_data.append(mirror_diagonal2(chip), window, labels)
 
 		return augmented_data

--- a/rastervision/augmentor/mirror_augmentor.py
+++ b/rastervision/augmentor/mirror_augmentor.py
@@ -1,14 +1,21 @@
 import random
 import numpy as np
 from rastervision.core import TrainingData
+from rastervision.augmentor import Augmentor
+from rastervision.core import TrainingData
+
 
 class MirrorAugmentor(Augmentor):
 	"""Randomly add a mirrored copy of the chips to the data.
 
-	In case where there is not much training data, this might increase the amount of training data
+	In case where there is not much training data, this might
+	increase the amount of training data. It is meant to be used with
+	the chip-classification task, as the labels are not mirrored. This would
+	result in wrongly placed labels for any other task than chip-classification.
+
 
 	Args:
-		prob: probability that the data is mirrord
+		prob: (float) probability that the data is mirrord
 
 		axes: (int) Either 4 or 8. When 4 is used, the images are mirrored along their horizontal
 		and vertical axes. If 8 is used, also the diagonal axes (transpose and transverse) are used.

--- a/rastervision/augmentor/mirror_augmentor.py
+++ b/rastervision/augmentor/mirror_augmentor.py
@@ -3,6 +3,7 @@ import numpy as np
 from rastervision.core import TrainingData
 from rastervision.augmentor import Augmentor
 from rastervision.core import TrainingData
+import scipy.misc # For testing, saves the images
 
 
 class MirrorAugmentor(Augmentor):
@@ -38,7 +39,9 @@ class MirrorAugmentor(Augmentor):
 		def mirror_diagonal2(chip):
 			return np.transpose(np.copy(mirror_horizontally(chip)), axes = [1,0,2])
 
+		topcounter = 0
 		for chip, window, labels in training_data:
+			topcounter += 1 
 			if random.uniform(0,1) < self.aug_prob:
 				
 				original = np.copy(chip)
@@ -68,8 +71,10 @@ class MirrorAugmentor(Augmentor):
 					original_vertical_diag1,
 					horizontal_vertical_diag2
 					]
-
+				bottomcounter = 0
 				for copy in copies:
+					bottomcounter += 1
 					augmented_data.append(copy,window,labels)
+					scipy.misc.imsave('/opt/data/mirrored/' + str(stopcounter) + '_' + bottomcounter + '.png', copy)
 
 		return augmented_data

--- a/rastervision/augmentor/mirror_augmentor.py
+++ b/rastervision/augmentor/mirror_augmentor.py
@@ -7,16 +7,22 @@ import scipy.misc # For testing, saves the images
 
 
 class MirrorAugmentor(Augmentor):
-	"""Randomly add a mirrored copy of the chips to the data.
+	"""Add mirrored copies of the chips to the data.
 
-	In case where there is not much training data, this might
-	increase the amount of training data. It is meant to be used with
+	In case where there is not much training data, this can be used to
+	increase the amount of training data. Data is mirrored along 4 axes.
+	First a horizontal and vertical mirrored copy is made. Now there are
+	4 images, including the original. Each of these four images is then
+	mirrored along its two diagonal axes. So a total of 4 + 8 = 12 copies
+	are returned. This also means an increase in required storage space by
+	a factor 12.
+
+	It is meant to be used with
 	the chip-classification task, as the labels are not mirrored. This would
 	result in wrongly placed labels for any other task than chip-classification.
 
-
 	Args:
-		prob: (float) probability that the data is mirrord
+		aug_prob: (float between 0.0 and 1.0) probability that the data is mirrored.
 
 	"""
 
@@ -27,27 +33,36 @@ class MirrorAugmentor(Augmentor):
 		augmented_data = TrainingData() # Initiatlize empty training data object
 
 		# Define functions that do the mirroring
-		def mirror_horizontally(chip):
+		# Later these might include mirroring the labels as well
+		def mirror_horizontally(chip,label=None):
+			# Mirror label horizontally
 			return np.flip(np.copy(chip), axis = 1)
 
-		def mirror_vertically(chip):
+		def mirror_vertically(chip,label=None):
+			# Mirror label vertically
 			return np.flip(np.copy(chip), axis = 0)
 
-		def mirror_diagonal1(chip):
+		def mirror_diagonal1(chip,label=None):
+			# Mirror label diagonal 1
+			# The mirror axis is from top left to bottom right
 			return np.transpose(np.copy(chip), axes = [1,0,2])
 
-		def mirror_diagonal2(chip):
+		def mirror_diagonal2(chip,label=None):
+			# Mirror label diagonal 2
+			# The mirror axis is from bottom left to top right
 			return np.transpose(np.copy(mirror_horizontally(chip)), axes = [1,0,2])
 
 		for chip, window, labels in training_data:
 			if random.uniform(0,1) < self.aug_prob:
 				
+				# Mirror along horizontal and vertical axes
 				original = np.copy(chip)
 				horizontal = mirror_horizontally(original)
-
 				original_vertical = mirror_vertically(original)
 				horizontal_vertical = mirror_vertically(horizontal)
 
+				# For each of the above copies, make a mirror along
+				# both diagonal axes.
 				original_diag1 = mirror_diagonal1(original)
 				original_diag2 = mirror_diagonal2(original)
 
@@ -55,7 +70,10 @@ class MirrorAugmentor(Augmentor):
 				horizontal_diag2 = mirror_diagonal2(horizontal)
 
 				original_vertical_diag1 = mirror_diagonal1(original_vertical)
-				horizontal_vertical_diag2 = mirror_diagonal2(original_vertical)
+				original_vertical_diag2 = mirror_diagonal2(original_vertical)
+
+				horizontal_vertical_diag1 = mirror_diagonal1(horizontal_vertical)
+				horizontal_vertical_diag2 = mirror_diagonal2(horizontal_vertical)
 
 				copies = [
 					original,
@@ -67,10 +85,14 @@ class MirrorAugmentor(Augmentor):
 					horizontal_diag1,
 					horizontal_diag2,
 					original_vertical_diag1,
+					original_vertical_diag2,
+					horizontal_vertical_diag1,
 					horizontal_vertical_diag2
 					]
 
 				for copy in copies:
+					# For each copy set the same window and labels as for the original
+					# Note: the labels are not mirrored (yet)
 					augmented_data.append(copy,window,labels)
 
 		return augmented_data

--- a/rastervision/augmentor/mirror_augmentor.py
+++ b/rastervision/augmentor/mirror_augmentor.py
@@ -40,13 +40,36 @@ class MirrorAugmentor(Augmentor):
 
 		for chip, window, labels in training_data:
 			if random.uniform(0,1) < self.aug_prob:
-				chip = np.copy(chip)
-				augmented_data.append(mirror_horizontally(chip), window, labels)
 				
-				augmented_data.append(mirror_vertically(chip), window, labels)
-				augmented_data.append(mirror_horizontally(mirror_horizontally(chip)), window, labels)
-				
-				augmented_data.append(mirror_diagonal1(chip), window, labels)
-				augmented_data.append(mirror_diagonal2(chip), window, labels)
+				original = np.copy(chip)
+				horizontal = mirror_horizontally(original)
+
+				original_vertical = mirror_vertically(original)
+				horizontal_vertical = mirror_vertically(horizontal)
+
+				original_diag1 = mirror_diagonal1(original)
+				original_diag2 = mirror_diagonal2(original)
+
+				horizontal_diag1 = mirror_diagonal1(horizontal)
+				horizontal_diag2 = mirror_diagonal2(horizontal)
+
+				original_vertical_diag1 = mirror_diagonal1(original_vertical)
+				horizontal_vertical_diag2 = mirror_diagonal2(original_vertical)
+
+				copies = [
+					original,
+					horizontal,
+					original_vertical,
+					horizontal_vertical,
+					original_diag1,
+					original_diag2,
+					horizontal_diag1,
+					horizontal_diag2,
+					original_vertical_diag1,
+					horizontal_vertical_diag2
+					]
+
+				for copy in copies:
+					augmented_data.append(copy,window,labels)
 
 		return augmented_data

--- a/rastervision/augmentor/mirror_augmentor.py
+++ b/rastervision/augmentor/mirror_augmentor.py
@@ -42,7 +42,10 @@ class MirrorAugmentor(Augmentor):
 			if random.uniform(0,1) < self.aug_prob:
 				chip = np.copy(chip)
 				augmented_data.append(mirror_horizontally(chip), window, labels)
+				
 				augmented_data.append(mirror_vertically(chip), window, labels)
+				augmented_data.append(mirror_horizontally(mirror_horizontally(chip)), window, labels)
+				
 				augmented_data.append(mirror_diagonal1(chip), window, labels)
 				augmented_data.append(mirror_diagonal2(chip), window, labels)
 

--- a/rastervision/augmentor/mirror_augmentor.py
+++ b/rastervision/augmentor/mirror_augmentor.py
@@ -28,10 +28,10 @@ class MirrorAugmentor(Augmentor):
 
 		# Define functions that do the mirroring
 		def mirror_horizontally(chip):
-			return np.flip(np.copy(chip), axes = 1)
+			return np.flip(np.copy(chip), axis = 1)
 
 		def mirror_vertically(chip):
-			return np.copy(chip, axes = 0)
+			return np.flip(np.copy(chip), axis = 0)
 
 		def mirror_diagonal1(chip):
 			return np.transpose(np.copy(chip), axes = [1,0,2])
@@ -39,9 +39,7 @@ class MirrorAugmentor(Augmentor):
 		def mirror_diagonal2(chip):
 			return np.transpose(np.copy(mirror_horizontally(chip)), axes = [1,0,2])
 
-		topcounter = 0
 		for chip, window, labels in training_data:
-			topcounter += 1 
 			if random.uniform(0,1) < self.aug_prob:
 				
 				original = np.copy(chip)
@@ -71,10 +69,8 @@ class MirrorAugmentor(Augmentor):
 					original_vertical_diag1,
 					horizontal_vertical_diag2
 					]
-				bottomcounter = 0
+
 				for copy in copies:
-					bottomcounter += 1
 					augmented_data.append(copy,window,labels)
-					scipy.misc.imsave('/opt/data/mirrored/' + str(stopcounter) + '_' + bottomcounter + '.png', copy)
 
 		return augmented_data

--- a/rastervision/augmentor/mirror_augmentor.py
+++ b/rastervision/augmentor/mirror_augmentor.py
@@ -1,0 +1,54 @@
+import random
+import numpy as np
+from rastervision.core import TrainingData
+
+class MirrorAugmentor(Augmentor):
+	"""Randomly add a mirrored copy of the chips to the data.
+
+	In case where there is not much training data, this might increase the amount of training data
+
+	Args:
+		prob: probability that the data is mirrord
+
+		axes: (int) Either 4 or 8. When 4 is used, the images are mirrored along their horizontal
+		and vertical axes. If 8 is used, also the diagonal axes (transpose and transverse) are used.
+	"""
+
+	def __init__(self, aug_prob, axes):
+		self.aug_prob = aug_prob
+		self.axes = axes
+
+	def process(self, training_data, tmp_dir):
+		augmented_data = TrainingData() # Initiatlize empty training data object
+
+		# Define functions that do the mirroring
+		def mirror_horizontally(chip):
+			return np.flip(np.copy(chip), axes = 1)
+
+		def mirror_vertically(chip):
+			return np.copy(chip, axes = 0)
+
+		def mirror_diagonal1(chip):
+			return np.transpose(np.copy(chip), axes = [1,0,2])
+
+		def mirror_diagonal2(chip):
+			return np.transpose(np.copy(mirror_horizontally(chip)), axes = [1,0,2])
+
+		# If loop on top level to avoid a per-chip if statement
+		if self.axes == 4:
+			for chip, window, labels in training_data:
+				if random.uniform(0,1) < self.aug_prob:
+					chip = np.copy(chip)
+					augmented_data.append(mirror_horizontally(chip), window, labels)
+					augmented_data.append(mirror_vertically(chip), window, labels)
+
+		elif self.axes == 8:
+			for chip, window, labels in training_data:
+				if random.uniform(0,1) < self.aug_prob:
+					chip = np.copy(chip)
+					augmented_data.append(mirror_horizontally(chip), window, labels)
+					augmented_data.append(mirror_vertically(chip), window, labels)
+					augmented_data.append(mirror_diagonal1(chip), window, labels)
+					augmented_data.append(mirror_diagonal2(chip), window, labels)
+
+		return augmented_data

--- a/rastervision/augmentor/mirror_augmentor_config.py
+++ b/rastervision/augmentor/mirror_augmentor_config.py
@@ -8,7 +8,7 @@ from rastervision.protos.augmentor_pb2 import AugmentorConfig as AugmentorConfig
 
 
 class MirrorAugmentorConfig(AugmentorConfig):
-	def __init__(self, aug_prob=1.0, axes=4):
+	def __init__(self, aug_prob=1.0):
 		super().__init__(rv.MIRROR_AUGMENTOR)
 		self.aug_prob = aug_prob
 		self.axes = axes
@@ -18,7 +18,6 @@ class MirrorAugmentorConfig(AugmentorConfig):
 			augmentor_type = 
 				self.augmentor_type,
 				aug_prob = self.aug_prob,
-				axes = self.axes
 		)
 		return msg
 
@@ -36,14 +35,12 @@ class MirrorAugmentorConfigBuilder(AugmentorConfigBuilder):
 		config = {}
 		if prev:
 			config = {
-				'aug_prob': prev.aug_prob,
-				'axes': prev.axes
+				'aug_prob': prev.aug_prob
 			}
 		super().__init__(MirrorAugmentorConfig, config)
 
 	def from_proto(self, msg):
 		a = self.with_probability(msg.aug_prob)
-		a = self.with_axes(msg.axes)
 		return a
 
 	def with_probability(self, aug_prob):

--- a/rastervision/augmentor/mirror_augmentor_config.py
+++ b/rastervision/augmentor/mirror_augmentor_config.py
@@ -22,8 +22,7 @@ class MirrorAugmentorConfig(AugmentorConfig):
 
 	def create_augmentor(self):
 		return MirrorAugmentor(
-			self.aug_prob,
-			self.axes
+			self.aug_prob
 		)
 
 	def report_io(self, command_type, io_def):
@@ -51,17 +50,4 @@ class MirrorAugmentorConfigBuilder(AugmentorConfigBuilder):
 		'''
 		b = deepcopy(self)
 		b.config['aug_prob'] = aug_prob
-		return b
-
-	def with_axes(self, axes):
-		'''Sets the axis along which the mirrorring that is done.
-
-		Default is 4, meaning that mirroring is done
-		along the x and y axis, which is a horizontal and vertical mirror.
-		If set to 8 also both the diagonal axis are used. Beware that this
-		also increases the amount of data by a factor 8, so ensure
-		you have enough storage available.
-		'''
-		b = deepcopy(self)
-		b.config['axes'] = axes
 		return b

--- a/rastervision/augmentor/mirror_augmentor_config.py
+++ b/rastervision/augmentor/mirror_augmentor_config.py
@@ -1,6 +1,11 @@
 from copy import deepcopy
 
 import rastervision as rv
+from rastervision.augmentor.mirror_augmentor import MirrorAugmentor
+from rastervision.augmentor.augmentor_config \
+	import (AugmentorConfig, AugmentorConfigBuilder)
+from rastervision.protos.augmentor_pb2 import AugmentorConfig as AugmentorConfigMsg
+
 
 class MirrorAugmentorConfig(AugmentorConfig):
 	def __init__(self, aug_prob=1.0, axes=4):
@@ -46,7 +51,7 @@ class MirrorAugmentorConfigBuilder(AugmentorConfigBuilder):
 
 		Determines how probable it is that this augmentation will happen to all chips.
 		Since this augmentation is usually applied when ther is little training data 
-		available, the default is 1.
+		available, the default is 1.0.
 		'''
 		b = deepcopy(self)
 		b.config['aug_prob'] = aug_prob
@@ -64,43 +69,3 @@ class MirrorAugmentorConfigBuilder(AugmentorConfigBuilder):
 		b = deepcopy(self)
 		b.config['axes'] = axes
 		return b
-
-
-class NodataAugmentorConfig(AugmentorConfig):
-    def __init__(self, aug_prob=0.5):
-        super().__init__(rv.NODATA_AUGMENTOR)
-        self.aug_prob = aug_prob
-
-    def to_proto(self):
-        msg = AugmentorConfigMsg(
-            augmentor_type=self.augmentor_type, aug_prob=self.aug_prob)
-        return msg
-
-    def create_augmentor(self):
-        return NodataAugmentor(self.aug_prob)
-
-    def report_io(self, command_type, io_def):
-        pass
-
-class NodataAugmentorConfigBuilder(AugmentorConfigBuilder):
-    def __init__(self, prev=None):
-        config = {}
-        if prev:
-            config = {'aug_prob': prev.aug_prob}
-        super().__init__(NodataAugmentorConfig, config)
-
-    def from_proto(self, msg):
-        return self.with_probablity(msg.aug_prob)
-
-    def with_probability(self, aug_prob):
-        """Sets the probability for this augmentation.
-
-        Determines how probable this augmentation will happen
-        to negative chips.
-
-        Args:
-           aug_prob: Float value between 0.0 and 1.0
-        """
-        b = deepcopy(self)
-        b.config['aug_prob'] = aug_prob
-        return b

--- a/rastervision/augmentor/mirror_augmentor_config.py
+++ b/rastervision/augmentor/mirror_augmentor_config.py
@@ -11,7 +11,6 @@ class MirrorAugmentorConfig(AugmentorConfig):
 	def __init__(self, aug_prob=1.0):
 		super().__init__(rv.MIRROR_AUGMENTOR)
 		self.aug_prob = aug_prob
-		self.axes = axes
 
 	def to_proto(self):
 		msg = AugmentorConfigMsg(

--- a/rastervision/augmentor/mirror_augmentor_config.py
+++ b/rastervision/augmentor/mirror_augmentor_config.py
@@ -22,7 +22,7 @@ class MirrorAugmentorConfig(AugmentorConfig):
 		)
 		return msg
 
-	def creat_augmentor(self):
+	def create_augmentor(self):
 		return MirrorAugmentor(
 			self.aug_prob,
 			self.axes

--- a/rastervision/augmentor/mirror_augmentor_config.py
+++ b/rastervision/augmentor/mirror_augmentor_config.py
@@ -11,7 +11,7 @@ class MirrorAugmentorConfig(AugmentorConfig):
 	def __init__(self, aug_prob=1.0):
 		super().__init__(rv.MIRROR_AUGMENTOR)
 		self.aug_prob = aug_prob
-
+	
 	def to_proto(self):
 		msg = AugmentorConfigMsg(
 			augmentor_type = 

--- a/rastervision/augmentor/mirror_augmentor_config.py
+++ b/rastervision/augmentor/mirror_augmentor_config.py
@@ -1,0 +1,106 @@
+from copy import deepcopy
+
+import rastervision as rv
+
+class MirrorAugmentorConfig(AugmentorConfig):
+	def __init__(self, aug_prob=1.0, axes=4):
+		super().__init__(rv.MIRROR_AUGMENTOR)
+		self.aug_prob = aug_prob
+		self.axes = axes
+
+	def to_proto(self):
+		msg = AugmentorConfigMsg(
+			augmentor_type = 
+				self.augmentor_type,
+				aug_prob = self.aug_prob,
+				axes = self.axes
+		)
+		return msg
+
+	def creat_augmentor(self):
+		return MirrorAugmentor(
+			self.aug_prob,
+			self.axes
+		)
+
+	def report_io(self, command_type, io_def):
+		pass
+
+class MirrorAugmentorConfigBuilder(AugmentorConfigBuilder):
+	def __init__(self, prev=None):
+		config = {}
+		if prev:
+			config = {
+				'aug_prob': prev.aug_prob,
+				'axes': prev.axes
+			}
+		super().__init__(MirrorAugmentorConfig, config)
+
+	def from_proto(self, msg):
+		a = self.with_probability(msg.aug_prob)
+		a = self.with_axes(msg.axes)
+		return a
+
+	def with_probability(self, aug_prob):
+		'''Sets the probability for this augmentation.
+
+		Determines how probable it is that this augmentation will happen to all chips.
+		Since this augmentation is usually applied when ther is little training data 
+		available, the default is 1.
+		'''
+		b = deepcopy(self)
+		b.config['aug_prob'] = aug_prob
+		return b
+
+	def with_axes(self, axes):
+		'''Sets the axis along which the mirrorring that is done.
+
+		Default is 4, meaning that mirroring is done
+		along the x and y axis, which is a horizontal and vertical mirror.
+		If set to 8 also both the diagonal axis are used. Beware that this
+		also increases the amount of data by a factor 8, so ensure
+		you have enough storage available.
+		'''
+		b = deepcopy(self)
+		b.config['axes'] = axes
+		return b
+
+
+class NodataAugmentorConfig(AugmentorConfig):
+    def __init__(self, aug_prob=0.5):
+        super().__init__(rv.NODATA_AUGMENTOR)
+        self.aug_prob = aug_prob
+
+    def to_proto(self):
+        msg = AugmentorConfigMsg(
+            augmentor_type=self.augmentor_type, aug_prob=self.aug_prob)
+        return msg
+
+    def create_augmentor(self):
+        return NodataAugmentor(self.aug_prob)
+
+    def report_io(self, command_type, io_def):
+        pass
+
+class NodataAugmentorConfigBuilder(AugmentorConfigBuilder):
+    def __init__(self, prev=None):
+        config = {}
+        if prev:
+            config = {'aug_prob': prev.aug_prob}
+        super().__init__(NodataAugmentorConfig, config)
+
+    def from_proto(self, msg):
+        return self.with_probablity(msg.aug_prob)
+
+    def with_probability(self, aug_prob):
+        """Sets the probability for this augmentation.
+
+        Determines how probable this augmentation will happen
+        to negative chips.
+
+        Args:
+           aug_prob: Float value between 0.0 and 1.0
+        """
+        b = deepcopy(self)
+        b.config['aug_prob'] = aug_prob
+        return b

--- a/rastervision/command/chip_command.py
+++ b/rastervision/command/chip_command.py
@@ -24,6 +24,8 @@ class ChipCommand(Command):
         val_scenes = list(
             map(lambda s: s.create_scene(cc.task, tmp_dir), cc.val_scenes))
 
+        print("chip_command.py line 27", cc.augmentors)
         augmentors = list(map(lambda a: a.create_augmentor(), cc.augmentors))
+        print("chip_command.py line 29", augmentors)
 
         task.make_chips(train_scenes, val_scenes, augmentors, tmp_dir)

--- a/rastervision/command/chip_command.py
+++ b/rastervision/command/chip_command.py
@@ -24,8 +24,6 @@ class ChipCommand(Command):
         val_scenes = list(
             map(lambda s: s.create_scene(cc.task, tmp_dir), cc.val_scenes))
 
-        print("chip_command.py line 27", cc.augmentors)
         augmentors = list(map(lambda a: a.create_augmentor(), cc.augmentors))
-        print("chip_command.py line 29", augmentors)
 
         task.make_chips(train_scenes, val_scenes, augmentors, tmp_dir)

--- a/rastervision/command/chip_command_config.py
+++ b/rastervision/command/chip_command_config.py
@@ -42,13 +42,15 @@ class ChipCommandConfig(CommandConfig):
         backend = self.backend.to_proto()
         train_scenes = list(map(lambda s: s.to_proto(), self.train_scenes))
         val_scenes = list(map(lambda s: s.to_proto(), self.val_scenes))
+        augmentors = list(map(lambda a: a.to_proto(), self.augmentors))
         msg.MergeFrom(
             CommandConfigMsg(
                 chip_config=CommandConfigMsg.ChipConfig(
                     task=task,
                     backend=backend,
                     train_scenes=train_scenes,
-                    val_scenes=val_scenes)))
+                    val_scenes=val_scenes,
+                    augmentors=augmentors)))
 
         return msg
 

--- a/rastervision/registry.py
+++ b/rastervision/registry.py
@@ -107,7 +107,7 @@ class Registry:
             (rv.AUGMENTOR, rv.NODATA_AUGMENTOR):
             rv.augmentor.NodataAugmentorConfigBuilder,
             (rv.AUGMENTOR, rv.MIRROR_AUGMENTOR):
-            rv.augmentor. rv.MirrorAugmentorConfigBuilder,
+            rv.augmentor.MirrorAugmentorConfigBuilder,
 
             # Evaluators
             (rv.EVALUATOR, rv.CHIP_CLASSIFICATION_EVALUATOR):

--- a/rastervision/registry.py
+++ b/rastervision/registry.py
@@ -106,6 +106,8 @@ class Registry:
             # Augmentors
             (rv.AUGMENTOR, rv.NODATA_AUGMENTOR):
             rv.augmentor.NodataAugmentorConfigBuilder,
+            (rv.AUGMENTOR, rv.MIRROR_AUGMENTOR):
+            rv.augmentor. rv.MirrorAugmentorConfigBuilder,
 
             # Evaluators
             (rv.EVALUATOR, rv.CHIP_CLASSIFICATION_EVALUATOR):


### PR DESCRIPTION
## Overview

This adds a "mirror" augmentor that augments training data by adding a total of 11 copies (12 including the original) of the training data by mirroring along the x, y, and two diagonal axes. It is meant to be used for chip-classification, as the labels are not mirrored. I assume this would give invalid results for non-chip classification tasks. I have placed comments where the labels should be processed, but have not yet implemented the code. Not planning to do so on the short run. I have tested it with the chip classification on my own data; it works. It also means that the training data is increased by 12-fold.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Testing can by done by creating a chip classification taks with the augmentor set on the dataset.

Closes #XXX
