### PR TITLE
Bump pyproj version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ everett==0.9
 pluginbase==0.7
 lxml==4.2.*
 shapely==1.6.*
-pyproj==1.9.5.*
+pyproj==1.9.6
 imageio==2.3.*
 scikit-learn==0.19.*
 six==1.11.*


### PR DESCRIPTION
## Overview

Clean installs under python3.7 were repeatedly running into

```
PyThreadState {aka struct _ts}’ has no member named ‘exc_traceback’; did you mean ‘curexc_traceback’
```

when trying to build pyproj. I forced the dependency in the setting where I'm installing to
1.9.6, and, while `pip` was mad that I'd forced the dependency too high, nothing appeared
to break.

Since both of these dependencies are now pretty old and don't appear to have any forthcoming
`.*` releases, I also removed that and hard pinned to 1.9.6.

### Checklist

- ~Updated `docs/changelog.rst`~
- ~Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes (didn't actually but should be fine)
- ~Documentation updated if needed~
- ~PR has a name that won't get you publicly shamed for vagueness~

## Testing Instructions

I am hopeful that whatever uses pyproj is well exercised in existing tests so that further testing is unnecessary if CI passes