### PR TITLE
Bugfix serialization of the chip command

### DIFF
--- a/rastervision/command/chip_command_config.py
+++ b/rastervision/command/chip_command_config.py
@@ -42,13 +42,15 @@ class ChipCommandConfig(CommandConfig):
         backend = self.backend.to_proto()
         train_scenes = list(map(lambda s: s.to_proto(), self.train_scenes))
         val_scenes = list(map(lambda s: s.to_proto(), self.val_scenes))
+        augmentors = list(map(lambda a: a.to_proto(), self.augmentors))
         msg.MergeFrom(
             CommandConfigMsg(
                 chip_config=CommandConfigMsg.ChipConfig(
                     task=task,
                     backend=backend,
                     train_scenes=train_scenes,
-                    val_scenes=val_scenes)))
+                    val_scenes=val_scenes,
+                    augmentors=augmentors)))
 
         return msg
 


### PR DESCRIPTION
Bugfix serialization of augmentors in the chip command

## Overview

Fixes bug where any data augmentors are not serialized when the chip classification command is used.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
