### PR TITLE
add jupyter to docker environment

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -83,7 +83,7 @@ do
         ;;
         --jupyter)
         JUPYTER="-v ${RASTER_VISION_NOTEBOOK_DIR}:/opt/notebooks -p 8888:8888"
-        CMD=(/run_jupyter.sh --ip 0.0.0.0 --port 8888 --no-browser --allow-root --notebook-dir=/opt/notebooks)
+        CMD=(jupyter notebook --ip 0.0.0.0 --port 8888 --no-browser --allow-root --notebook-dir=/opt/notebooks)
         shift
         ;;
         --docs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ unify==0.4
 sphinx==1.8.*
 sphinx-autobuild==0.7.*
 ptvsd==4.2.*
+jupyter==1.0.*


### PR DESCRIPTION
## Overview

Installs Jupyter in docker image and updates the docker run script to no longer rely on a jupyter notebook script that doesn't exist

### Checklist

- [ ] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Rebuild docker image: `docker/build`
* Run jupyter notebook in docker container `docker/run --jupyter`

Closes #827 
