### PR TITLE
Fix API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'pallets_sphinx_themes',
-    'sphinxcontrib.programoutput'
+    'sphinxcontrib.programoutput',
+    'sphinxcontrib.napoleon',
 ]
 
 # https://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx~=1.8.0
 Pallets-Sphinx-Themes~=1.1.0
 sphinxcontrib-programoutput==0.11
+sphinxcontrib-napoleon==0.7

--- a/extras_requirements.json
+++ b/extras_requirements.json
@@ -8,8 +8,8 @@
         "tensorflow-gpu==1.10.1"
     ],
     "pytorch": [
-        "torch==1.2.*",
-        "torchvision==0.4.*",
+        "torch==1.2.0",
+        "torchvision==0.4.0",
         "tensorboard==1.14.*",
         "numpy<1.17"
     ],

--- a/rastervision/backend/pytorch_chip_classification_config.py
+++ b/rastervision/backend/pytorch_chip_classification_config.py
@@ -73,9 +73,8 @@ class PyTorchChipClassificationConfigBuilder(SimpleBackendConfigBuilder):
                 details.
             num_epochs: (int) number of epochs (sweeps through training set) to
                 train model for
-            model_arch: (str) classification model backbone to use for UNet
-                architecture. Any option in torchvision.models is valid, for
-                example, resnet18.
+            model_arch: (str) Any classification model option in
+                torchvision.models is valid, for example, resnet18.
             sync_interval: (int) sync training directory to cloud every
                 sync_interval epochs.
             debug: (bool) if True, save debug chips (ie. visualizations of


### PR DESCRIPTION
This PR adds `sphinxcontrib-napolean` to correctly render Google-style API docs (which we are using), and fixes a typo.

Closes #843 