### PR TITLE
Changed return value for the mock augmentor

### DIFF
--- a/tests/mock/augmentor.py
+++ b/tests/mock/augmentor.py
@@ -62,7 +62,7 @@ class MockAugmentorConfigBuilder(SupressDeepCopyMixin, AugmentorConfigBuilder):
         super().__init__(MockAugmentorConfig, {})
         self.mock = Mock()
 
-        self.mock.from_proto = None
+        self.mock.from_proto.return_value = None
 
     def from_proto(self, msg):
         result = self.mock.from_proto(msg)


### PR DESCRIPTION
## Overview

I think the mock augmentor used during the unittest had a slight typo in it. Not sure though. I think this will also fix the test of the[ pull request ](https://github.com/azavea/raster-vision/pull/825)I sent a couple of weeks earlier, if it is still relevant.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I think that because of the issue the above PR addresses, this part of the mock augmentor `from_proto()` method was never called.

## Testing Instructions

* needs a check for logic, is what I think correct?
