### PR TITLE
Correctly get_local_path for some zxy tile URIS 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Bug Fixes
 - Ensure randint args are ints `#849 <https://github.com/azavea/raster-vision/pull/849>`__
 - The augmentors were not serialized properly for the chip command  `#857 <https://github.com/azavea/raster-vision/pull/857>`__
 - Fix problems with pretrained flag `#860 <https://github.com/azavea/raster-vision/pull/860>`__
+- Correctly get_local_path for some zxy tile URIS `#865 <https://github.com/azavea/raster-vision/pull/865>`__
 
 Raster Vision 0.10
 ------------------

--- a/rastervision/filesystem/http_filesystem.py
+++ b/rastervision/filesystem/http_filesystem.py
@@ -73,6 +73,13 @@ class HttpFileSystem(FileSystem):
         parsed_uri = urlparse(uri)
         path = os.path.join(download_dir, 'http', parsed_uri.netloc,
                             parsed_uri.path[1:])
+        # This function is expected to return something that is file path-like
+        # (as opposed to directory-like),
+        # so if the path ends with / we strip it off. This was motivated by
+        # a URI that was a zxy tile schema that doesn't end in .png which is
+        # parsed by urlparse into a path that ends in a /.
+        if path.endswith('/'):
+            path = path[:-1]
         return path
 
     @staticmethod

--- a/rastervision/filesystem/local_filesystem.py
+++ b/rastervision/filesystem/local_filesystem.py
@@ -14,7 +14,7 @@ def make_dir(path, check_empty=False, force_empty=False, use_dirname=False):
         check_empty: if True, check that directory is empty
         force_empty: if True, delete files if necessary to make directory
             empty
-        use_dirname: if path is a file, use the the parent directory as path
+        use_dirname: if True, use the the parent directory as path
 
     Raises:
         ValueError if check_empty is True and directory is not empty

--- a/rastervision/utils/files.py
+++ b/rastervision/utils/files.py
@@ -139,7 +139,7 @@ def download_if_needed(uri, download_dir, fs=None):
     make_dir(path, use_dirname=True)
 
     if path != uri:
-        log.info('Downloading {} to {}'.format(uri, path))
+        log.debug('Downloading {} to {}'.format(uri, path))
 
     fs.copy_from(uri, path)
 

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -129,6 +129,11 @@ class TestGetLocalPath(unittest.TestCase):
         path = get_local_path(uri, download_dir)
         self.assertEqual(path, '/download_dir/http/bucket/my/file.txt')
 
+        # simulate a zxy tile URI
+        uri = 'http://bucket/10/25/53?auth=426753'
+        path = get_local_path(uri, download_dir)
+        self.assertEqual(path, '/download_dir/http/bucket/10/25/53')
+
 
 class TestFileToStr(unittest.TestCase):
     """Test file_to_str and str_to_file."""


### PR DESCRIPTION
This PR fixes a bug in `get_local_path` so that we can use URIs for ZXY tiles that do not end in `.png`. 

