### PR TITLE
Default to same train and predict chip size

### DIFF
--- a/Dockerfile-pytorch
+++ b/Dockerfile-pytorch
@@ -6,16 +6,10 @@ RUN pip install cython==0.28.*
 RUN pip install pycocotools==2.0.*
 
 COPY scripts/rastervision /usr/local/bin/
+COPY scripts/rastervision2 /usr/local/bin/
 COPY rastervision /opt/src/rastervision
 COPY rastervision2 /opt/src/rastervision2
 COPY scripts /opt/src/scripts/
-
-# Added so that entrypoints from setup.py will be installed, which is needed for
-# rastervision2 to work correctly as a CLI script.
-COPY . /opt/src/repo/
-RUN pip install /opt/src/repo/
-RUN rm -r /opt/src/repo/
-
 RUN /opt/src/scripts/compile
 
 CMD ["bash"]

--- a/rastervision2/core/rv_pipeline/chip_classification_config.py
+++ b/rastervision2/core/rv_pipeline/chip_classification_config.py
@@ -1,4 +1,4 @@
-from rastervision2.pipeline.config import register_config
+from rastervision2.pipeline.config import register_config, ConfigError
 from rastervision2.core.rv_pipeline import RVPipelineConfig
 from rastervision2.core.data.label_store import (
     ChipClassificationGeoJSONStoreConfig)
@@ -10,6 +10,12 @@ class ChipClassificationConfig(RVPipelineConfig):
     def build(self, tmp_dir):
         from rastervision2.core.rv_pipeline.chip_classification import ChipClassification
         return ChipClassification(self, tmp_dir)
+
+    def validate_config(self):
+        if self.train_chip_sz != self.predict_chip_sz:
+            raise ConfigError(
+                'train_chip_sz must be equal to predict_chip_sz for chip '
+                'classification.')
 
     def get_default_label_store(self, scene):
         return ChipClassificationGeoJSONStoreConfig()

--- a/rastervision2/core/rv_pipeline/rv_pipeline_config.py
+++ b/rastervision2/core/rv_pipeline/rv_pipeline_config.py
@@ -32,7 +32,7 @@ class RVPipelineConfig(PipelineConfig):
     train_chip_sz: int = Field(
         200, description='Size of training chips in pixels.')
     predict_chip_sz: int = Field(
-        800, description='Size of predictions chips in pixels.')
+        200, description='Size of predictions chips in pixels.')
     predict_batch_sz: int = Field(
         8, description='Batch size to use during prediction.')
 

--- a/rastervision2/examples/chip_classification.py
+++ b/rastervision2/examples/chip_classification.py
@@ -18,12 +18,11 @@ def get_config(runner, test=False, output_dir='output'):
     if runner in ['inprocess']:
         raw_uri = '/opt/data/raw-data/spacenet-dataset'
         processed_uri = '/opt/data/examples/spacenet/rio/processed-data'
-        root_uri = '/opt/data/examples/test-output/rio-chip-classification'
+        root_uri = '/opt/data/examples/spacenet-rio-cc'
     else:
         raw_uri = 's3://spacenet-dataset/'
         processed_uri = 's3://raster-vision-lf-dev/examples/spacenet/rio/processed-data'
-        root_uri = ('s3://raster-vision-lf-dev/examples/test-output/'
-                    'rio-chip-classification')
+        root_uri = 's3://raster-vision-lf-dev/examples/spacenet-rio-cc'
     root_uri = join(root_uri, output_dir)
 
     debug = False
@@ -89,7 +88,7 @@ def get_config(runner, test=False, output_dir='output'):
 
     model = ClassificationModelConfig(backbone='resnet50')
     solver = SolverConfig(
-        lr=2e-4, num_epochs=3, test_num_epochs=3, batch_sz=8, one_cycle=True)
+        lr=1e-4, num_epochs=20, test_num_epochs=3, batch_sz=32, one_cycle=True)
     backend = PyTorchChipClassificationConfig(
         model=model,
         solver=solver,

--- a/rastervision2/examples/object_detection.py
+++ b/rastervision2/examples/object_detection.py
@@ -16,11 +16,11 @@ def get_config(runner, test=False, output_dir='output'):
     if runner in ['inprocess']:
         raw_uri = '/opt/data/raw-data/isprs-potsdam'
         processed_uri = '/opt/data/examples/cowc-potsdam/processed-data'
-        root_uri = '/opt/data/examples/cowc-potsdam/local-output'
+        root_uri = '/opt/data/examples/cowc-potsdam-od'
     else:
         raw_uri = 's3://raster-vision-raw-data/isprs-potsdam'
         processed_uri = 's3://raster-vision-lf-dev/examples/cowc-potsdam/processed-data'
-        root_uri = 's3://raster-vision-lf-dev/examples/cowc-potsdam/remote-output'
+        root_uri = 's3://raster-vision-lf-dev/examples/cowc-potsdam-od'
     root_uri = join(root_uri, output_dir)
 
     train_ids = [

--- a/rastervision2/examples/semantic_segmentation.py
+++ b/rastervision2/examples/semantic_segmentation.py
@@ -16,11 +16,11 @@ def get_config(runner, test=False, output_dir='output'):
     if runner in ['inprocess']:
         raw_uri = '/opt/data/raw-data/isprs-potsdam/'
         processed_uri = '/opt/data/examples/potsdam/processed-data'
-        root_uri = '/opt/data/examples/potsdam/local-output/'
+        root_uri = '/opt/data/examples/potsdam-semseg/'
     else:
         raw_uri = 's3://raster-vision-raw-data/isprs-potsdam'
         processed_uri = 's3://raster-vision-lf-dev/examples/potsdam/processed-data'
-        root_uri = 's3://raster-vision-lf-dev/examples/potsdam/remote-output'
+        root_uri = 's3://raster-vision-lf-dev/examples/potsdam-semseg'
     root_uri = join(root_uri, output_dir)
 
     train_ids = [

--- a/scripts/rastervision2
+++ b/scripts/rastervision2
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Run the rastervision cli
+python -m rastervision2.pipeline.cli $@


### PR DESCRIPTION
Previously we were using a different training and predict chip size for the chip classification example which doesn't make sense when `infer_cells=True` because then the ground truth and predictions becomes incomparable. So this disallows that possibility and fixes the config.