### PR TITLE
Add Zero-Configuration Profile

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Features
 - Added the possibility for chip classification to use data augmentors from the albumentations libary to enhance the training data. `#859 <https://github.com/azavea/raster-vision/pull/859>`__
 - Updated the Quickstart doc with pytorch docker image and model `#863 <https://github.com/azavea/raster-vision/pull/863>`__
 - Added the possibility to deal with class imbalances through oversampling. `#868 <https://github.com/azavea/raster-vision/pull/868>`
+- Added trivial local profile `#903 <https://github.com/azavea/raster-vision/pull/903>`
 
 Raster Vision 0.11.0
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -152,6 +152,8 @@ profile: if you had two profiles (the ``default`` and one named ``myprofile``), 
 
 Use the ``rastervision --profile`` option in the :ref:`cli` to set the profile.
 
+(Please note that the profile name ``local`` is reserved.)
+
 Configuration File Sections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Overview

Allow local use of raster vision without AWS setup.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

- Move or disable existing profile information
- Run the tiny SpaceNet example using the profile `local`.  It should succeed locally even though there is no setup.
