### PR TITLE
Viable Module Name for Custom Pipeline

### DIFF
--- a/rastervision2/pipeline/cli.py
+++ b/rastervision2/pipeline/cli.py
@@ -55,7 +55,7 @@ def get_configs(cfg_module_path: str, runner: str, args: Dict[str, any]
     """
     if cfg_module_path.endswith('.py'):
         # From https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path  # noqa
-        spec = importlib.util.spec_from_file_location('module.name',
+        spec = importlib.util.spec_from_file_location('rastervision2.pipeline',
                                                       cfg_module_path)
         cfg_module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(cfg_module)


### PR DESCRIPTION
## Overview

The name `module.name` seems unlikely to work in most circumstances.  ~It seems that the file must be in a location that matches the module name, and it seems unlikely that the files will be in a directory named `.../module/name`.~

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

1. Create a directory with the name `/tmp/xxx/rastervision2/pipeline/`.
2. Put the following file into that directory under the name `my_config.py`
```python
from typing import List, Optional

from rastervision2.pipeline.pipeline import Pipeline
from rastervision2.pipeline.pipeline_config import PipelineConfig
from rastervision2.pipeline.config import Config, register_config
from rastervision2.core.utils.misc import split_into_groups
from rastervision2.pipeline.file_system import str_to_file, file_to_str


@register_config('sample_pipeline')
class SamplePipelineConfig(PipelineConfig):
    # Config classes are configuration schemas. Each field is an attributes
    # with a type and optional default value.
    names: List[str] = ['alice', 'bob']
    message_uris: Optional[List[str]] = None

    def build(self, tmp_dir):
        # The build method is used to instantiate the corresponding object
        # using this configuration.
        return SamplePipeline(self, tmp_dir)

    def update(self):
        # The update method is used to set default values as a function of
        # other values.
        if self.message_uris is None:
            self.message_uris = [
                self.root_uri + '{}.txt'.format(name)
                for name in self.names
            ]


class SamplePipeline(Pipeline):
    # The order in which commands run. Each command correspond to a method.
    commands: List[str] = ['save_messages', 'print_messages']

    # Split commands can be split up and run in parallel.
    split_commands = ['save_messages']

    # GPU commands are run using GPUs if available. There are no commands worth running
    # on a GPU in this pipeline.
    gpu_commands = []

    def save_messages(self, split_ind=0, num_splits=1):
        # Save a file for each name with a message.

        # The num_splits is the number of parallel jobs to use and
        # split_ind tracks the index of the parallel job. In this case
        # we are splitting on the names/message_uris.
        split_groups = split_into_groups(
            list(zip(self.config.names, self.config.message_uris)), num_splits)
        split_group = split_groups[split_ind]

        for name, message_uri in split_group:
            message = 'hello {}!'.format(name)
            # str_to_file and most functions in the file_system package can
            # read and write transparently to different file systems based on
            # the URI pattern.
            str_to_file(message, message_uri)
            print('Saved message to {}'.format(message_uri))

    def print_messages(self):
        # Read all the message files and print them.
        for message_uri in self.config.message_uris:
            message = file_to_str(message_uri)
            print(message)


def get_config(runner, root_uri):
    # The get_config function returns an instantiated PipelineConfig and
    # plays a similar role as a typical "config file" used in other systems.
    # It's different in that it can have loops, conditionals, local variables,
    # etc. The runner argument is the name of the runner used to run the
    # pipeline (eg. local or aws_batch). Any other arguments are passed from
    # the CLI using the -a option.
    names = ['alice', 'bob', 'susan']

    # Note that root_uri is a field that is inherited from PipelineConfig,
    # the parent class of SamplePipelineConfig, and specifies the root URI
    # where any output files are saved.
    return SamplePipelineConfig(root_uri=root_uri, names=names)
```
3. Run the custom pipeline `cd /tmp/xxx ; rastervision2 run inprocess rastervision2/pipeline/my_config.py -a root_uri /tmp/xxx/`
