### PR TITLE
External Commands in `inprocess` Runner

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Features
 - Updated the Quickstart doc with pytorch docker image and model `#863 <https://github.com/azavea/raster-vision/pull/863>`__
 - Added the possibility to deal with class imbalances through oversampling. `#868 <https://github.com/azavea/raster-vision/pull/868>`
 - Added trivial local profile `#903 <https://github.com/azavea/raster-vision/pull/903>`
+- Added ability to run external commands in `inprocess` runner `#912 <https://github.com/azavea/raster-vision/pull/912>`
 
 Raster Vision 0.11.0
 ~~~~~~~~~~~~~~~~~~~~~

--- a/rastervision2/pipeline/runner/inprocess_runner.py
+++ b/rastervision2/pipeline/runner/inprocess_runner.py
@@ -1,3 +1,6 @@
+import subprocess
+from inspect import signature
+
 from rastervision2.pipeline.cli import _run_command
 from rastervision2.pipeline.runner.runner import Runner
 
@@ -12,8 +15,22 @@ class InProcessRunner(Runner):
 
     def run(self, cfg_json_uri, pipeline, commands, num_splits=1):
         for command in commands:
-            if command in pipeline.split_commands and num_splits > 1:
-                for split_ind in range(num_splits):
-                    _run_command(cfg_json_uri, command, split_ind, num_splits)
+
+            # detect external command
+            if hasattr(pipeline, command):
+                fn = getattr(pipeline, command)
+                params = signature(fn).parameters
+                external = hasattr(fn, 'external') and len(params) == 0
             else:
-                _run_command(cfg_json_uri, command, 0, 1)
+                external = False
+
+            if not external:
+                if command in pipeline.split_commands and num_splits > 1:
+                    for split_ind in range(num_splits):
+                        _run_command(cfg_json_uri, command, split_ind,
+                                     num_splits)
+                else:
+                    _run_command(cfg_json_uri, command, 0, 1)
+            else:
+                cmd = fn()
+                subprocess.run(cmd, check=True)


### PR DESCRIPTION
## Overview

Add ability to run external commands in the `inprocess` runner. An external command is a non-raster-vision command.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

my_config.py:
```python
from typing import List, Optional

from rastervision2.pipeline.pipeline import Pipeline
from rastervision2.pipeline.pipeline_config import PipelineConfig
from rastervision2.pipeline.config import Config, register_config
from rastervision2.pipeline.file_system import str_to_file, file_to_str
from rastervision2.pipeline.utils import split_into_groups


@register_config('sample_pipeline')
class SamplePipelineConfig(PipelineConfig):
    # Config classes are configuration schemas. Each field is an attributes
    # with a type and optional default value.
    names: List[str] = ['alice', 'bob']
    message_uris: Optional[List[str]] = None

    def build(self, tmp_dir):
        # The build method is used to instantiate the corresponding object
        # using this configuration.
        return SamplePipeline(self, tmp_dir)

    def update(self):
        # The update method is used to set default values as a function of
        # other values.
        if self.message_uris is None:
            self.message_uris = [
                self.root_uri + '{}.txt'.format(name)
                for name in self.names
            ]


class SamplePipeline(Pipeline):
    # The order in which commands run. Each command correspond to a method.
    commands: List[str] = ['say_hello', 'to_my_little_friend']

    # Split commands can be split up and run in parallel.
    split_commands = ['save_messages']

    # GPU commands are run using GPUs if available. There are no commands worth running
    # on a GPU in this pipeline.
    gpu_commands = []

    def save_messages(self, split_ind=0, num_splits=1):
        # Save a file for each name with a message.

        # The num_splits is the number of parallel jobs to use and
        # split_ind tracks the index of the parallel job. In this case
        # we are splitting on the names/message_uris.
        split_groups = split_into_groups(
            list(zip(self.config.names, self.config.message_uris)), num_splits)
        split_group = split_groups[split_ind]

        for name, message_uri in split_group:
            message = 'hello {}!'.format(name)
            # str_to_file and most functions in the file_system package can
            # read and write transparently to different file systems based on
            # the URI pattern.
            str_to_file(message, message_uri)
            print('Saved message to {}'.format(message_uri))

    def print_messages(self):
        # Read all the message files and print them.
        for message_uri in self.config.message_uris:
            message = file_to_str(message_uri)
            print(message)

    def say_hello(self):
        return ['ps', 'uxa']

    setattr(say_hello, 'external', True)
    setattr(say_hello, 'job_queue', 'MyJobQueue')
    setattr(say_hello, 'job_def', 'MyJobDef:33')

    def to_my_little_friend(self):
        return ['cat', '/proc/cpuinfo']

    setattr(to_my_little_friend, 'external', True)
    setattr(to_my_little_friend, 'job_queue', MyJobQueue')
    setattr(to_my_little_friend, 'job_def', 'MyJobDef:33')


def get_config(runner, root_uri):
    # The get_config function returns an instantiated PipelineConfig and
    # plays a similar role as a typical "config file" used in other systems.
    # It's different in that it can have loops, conditionals, local variables,
    # etc. The runner argument is the name of the runner used to run the
    # pipeline (eg. local or aws_batch). Any other arguments are passed from
    # the CLI using the -a option.
    names = ['alice', 'bob', 'susan']

    # Note that root_uri is a field that is inherited from PipelineConfig,
    # the parent class of SamplePipelineConfig, and specifies the root URI
    # where any output files are saved.
    return SamplePipelineConfig(root_uri=root_uri, names=names)
```

1. `docker run -it --rm -v $HOME/.aws:/root/.aws:ro -v $(pwd):/opt/src -v /tmp/rv:/tmp/rv quay.io/azavea/raster-vision:pytorch-latest bash`
2. `rastervision2 --profile local run inprocess /tmp/rv/rastervision2/pipeline/my_config.py -a root_uri /tmp/xxx/`

Depends on https://github.com/azavea/raster-vision/pull/906
