### PR TITLE
Allow Internal Commands in External Pipelines

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Features
 - Added ability to run external commands in `inprocess` runner `#912 <https://github.com/azavea/raster-vision/pull/912>`
 - Added ability to run external commands in `aws_batch` runner `#911 <https://github.com/azavea/raster-vision/pull/911>`
 - Added ability to run external commands in `local` runner `#913 <https://github.com/azavea/raster-vision/pull/913>`
+- Added ability to use internal commands in derivative custom pipelines `#914 <https://github.com/azavea/raster-vision/pull/914>`
 
 Raster Vision 0.11.0
 ~~~~~~~~~~~~~~~~~~~~~

--- a/rastervision2/aws_batch/aws_batch_runner.py
+++ b/rastervision2/aws_batch/aws_batch_runner.py
@@ -109,15 +109,15 @@ class AWSBatchRunner(Runner):
 
         # pipeline-specific job queue
         if hasattr(pipeline, 'job_queue'):
-            job_queue = pipeline.job_queue
+            pipeline_job_queue = pipeline.job_queue
         else:
-            job_queue = None
+            pipeline_job_queue = None
 
         # pipeline-specific job definition
         if hasattr(pipeline, 'job_def'):
-            job_def = pipeline.job_def
+            pipeline_job_def = pipeline.job_def
         else:
-            job_def = None
+            pipeline_job_def = None
 
         for command in commands:
 
@@ -130,6 +130,8 @@ class AWSBatchRunner(Runner):
                 external = False
 
             # command-specific job queue, job definition
+            job_def = pipeline_job_def
+            job_queue = pipeline_job_queue
             if hasattr(pipeline, command):
                 fn = getattr(pipeline, command)
                 if hasattr(fn, 'job_def'):
@@ -164,6 +166,9 @@ class AWSBatchRunner(Runner):
                 job_queue=job_queue,
                 job_def=job_def)
             parent_job_ids = [job_id]
+
+            job_queue = None
+            job_def = None
 
     def get_split_ind(self):
         return int(os.environ.get('AWS_BATCH_JOB_ARRAY_INDEX', 0))

--- a/rastervision2/pipeline/config.py
+++ b/rastervision2/pipeline/config.py
@@ -131,19 +131,46 @@ def build_config(x: Union[dict, List[Union[dict, Config]], Config]
             new_x[k] = build_config(v)
         type_hint = new_x.get('type_hint')
         if type_hint is not None:
+            # The following try/except logic has the following
+            # motivation.  If one has an custom raster-vision pipeline
+            # but wants to be able to run internal raster-vision
+            # commands in processes or containers that do not have
+            # that pipeline loaded in (e.g. in a "stock" raster-vision
+            # container on AWS) then this code enables that.
+            #
+            # When a pipeline config is being loaded here, the first
+            # attempt is to load it using the normal `type_hint` field
+            # found within it.  If that succeeds, then everything
+            # proceeds.
+            #
+            # If the the attempt fails but the pipeline config
+            # contains a `fallback_type_hint`, then that is used,
+            # instead.
+            #
+            # What that allows one to do is create a custom pipeline,
+            # derived from a stock pipeline, and tell raster-vision to
+            # treat it as a stock pipeline -- for purposes of the
+            # present function -- if the custom pipeline has not been
+            # registered.
+            #
+            # Please see https://github.com/azavea/raster-vision/pull/914
             try:
                 # Try to use the given type hint
                 config_cls = registry.get_config(type_hint)
-            except:
-                # If that fails, downgrade to fallback type
-                type_hint = new_x.get('fallback_type_hint')
-                config_cls = registry.get_config(type_hint)
-                new_x['type_hint'] = type_hint
-                permitted_keys = config_cls().__dict__.keys()
-                current_keys = set(new_x.keys())
-                for k in current_keys:
-                    if k not in permitted_keys:
-                        del new_x[k]
+            except Exception as e:
+                # ... if that fails, try to downgrade to fallback type
+                try:
+                    type_hint = new_x.get('fallback_type_hint')
+                    config_cls = registry.get_config(type_hint)
+                    new_x['type_hint'] = type_hint
+                    permitted_keys = config_cls().__dict__.keys()
+                    current_keys = set(new_x.keys())
+                    for k in current_keys:
+                        if k not in permitted_keys:
+                            del new_x[k]
+                # ... if that fails, throw the original exception
+                except Exception:
+                    raise e
             new_x = config_cls(**new_x)
         return new_x
     elif isinstance(x, list):


### PR DESCRIPTION
## Overview

These changes allow one to call in-tree, internal raster-vision commands from out-of-tree pipelines.  This allows one to effectively mix raster-vision functionality with external functionality.

- in-tree = code that is found within the raster-vision source tree and/or contained within some relevant docker container.
- out-of-tree = code that found outside of the raster-vision source tree, such as in `/tmp`.
- internal command = commands built into raster-vision, such as `test_cpu`

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

`my_config.py`:
```python
from typing import List, Optional

from rastervision2.pipeline.pipeline import Pipeline
from rastervision2.pipeline.pipeline_config import PipelineConfig
from rastervision2.pipeline.config import Config, register_config
from rastervision2.pipeline.file_system import str_to_file, file_to_str
from rastervision2.pipeline.utils import split_into_groups


@register_config('sample_pipeline')
class SamplePipelineConfig(PipelineConfig):
    # Config classes are configuration schemas. Each field is an attributes
    # with a type and optional default value.
    names: List[str] = ['alice', 'bob']
    message_uris: Optional[List[str]] = None
    fallback_type_hint: Optional[str] = 'pipeline'

    def build(self, tmp_dir):
        # The build method is used to instantiate the corresponding object
        # using this configuration.
        return SamplePipeline(self, tmp_dir)

    def update(self):
        # The update method is used to set default values as a function of
        # other values.
        if self.message_uris is None:
            self.message_uris = [
                self.root_uri + '{}.txt'.format(name)
                for name in self.names
            ]


class SamplePipeline(Pipeline):
    # The order in which commands run. Each command correspond to a method.
    commands: List[str] = ['test_cpu', 'say_hello', 'test_cpu', 'to_my_little_friend', 'test_cpu']

    # Split commands can be split up and run in parallel.
    split_commands = ['save_messages']

    # GPU commands are run using GPUs if available. There are no commands worth running
    # on a GPU in this pipeline.
    gpu_commands = []

    def save_messages(self, split_ind=0, num_splits=1):
        # Save a file for each name with a message.

        # The num_splits is the number of parallel jobs to use and
        # split_ind tracks the index of the parallel job. In this case
        # we are splitting on the names/message_uris.
        split_groups = split_into_groups(
            list(zip(self.config.names, self.config.message_uris)), num_splits)
        split_group = split_groups[split_ind]

        for name, message_uri in split_group:
            message = 'hello {}!'.format(name)
            # str_to_file and most functions in the file_system package can
            # read and write transparently to different file systems based on
            # the URI pattern.
            str_to_file(message, message_uri)
            print('Saved message to {}'.format(message_uri))

    def print_messages(self):
        # Read all the message files and print them.
        for message_uri in self.config.message_uris:
            message = file_to_str(message_uri)
            print(message)

    def say_hello(self):
        return ['ps', 'uxa']

    setattr(say_hello, 'external', True)
    setattr(say_hello, 'job_queue', 'MyJobQueue')
    setattr(say_hello, 'job_def', 'MyJobDef:33')

    def to_my_little_friend(self):
        return ['cat', '/proc/cpuinfo']

    setattr(to_my_little_friend, 'external', True)
    setattr(to_my_little_friend, 'job_queue', 'MyJobQueue')
    setattr(to_my_little_friend, 'job_def', 'MyJobDef:33')


def get_config(runner, root_uri):
    # The get_config function returns an instantiated PipelineConfig and
    # plays a similar role as a typical "config file" used in other systems.
    # It's different in that it can have loops, conditionals, local variables,
    # etc. The runner argument is the name of the runner used to run the
    # pipeline (eg. local or aws_batch). Any other arguments are passed from
    # the CLI using the -a option.
    names = ['alice', 'bob', 'susan']

    # Note that root_uri is a field that is inherited from PipelineConfig,
    # the parent class of SamplePipelineConfig, and specifies the root URI
    # where any output files are saved.
    return SamplePipelineConfig(root_uri=root_uri, names=names)
```
1. `docker run -it --rm -v $HOME/.aws:/root/.aws:ro -v $(pwd):/opt/src -v /tmp/rv:/tmp/rv quay.io/azavea/raster-vision:pytorch-latest bash`
2. `rastervision2 --profile local run local /tmp/rv/rastervision2/pipeline/my_config.py -a root_uri /tmp/XXX/` (if rebased on top of https://github.com/azavea/raster-vision/pull/913 )
3. `rastervision2 run aws_batch /tmp/rv/rastervision2/pipeline/my_config.py -a root_uri s3://my-bucket/my-prefix/` (using a job definition from your profile that points to an image that has these changes)

Closes https://github.com/azavea/raster-vision/issues/909