### PR TITLE
Provide GDAL VSI filesystem plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,10 @@ RUN apt-get update && apt-get install -y software-properties-common python-softw
 RUN add-apt-repository ppa:ubuntugis/ppa && \
     apt-get update && \
     apt-get install -y wget=1.* git=1:2.* python-protobuf=2.* python3-tk=3.* \
-                       gdal-bin=2.2.* \
                        jq=1.5* \
                        build-essential libsqlite3-dev=3.11.* zlib1g-dev=1:1.2.* \
                        libopencv-dev=2.4.* python-opencv=2.4.* unzip curl && \
     apt-get autoremove && apt-get autoclean && apt-get clean
-
-# Setup GDAL_DATA directory, rasterio needs it.
-ENV GDAL_DATA=/usr/share/gdal/2.2/
 
 # See https://github.com/mapbox/rasterio/issues/1289
 ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
@@ -32,7 +28,10 @@ RUN wget -q -O ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.7
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh
 ENV PATH /opt/conda/bin:$PATH
-RUN conda install -y python=3.6
+RUN conda install -y python=3.6 && conda install -c conda-forge -y gdal=3.0.4
+
+# Setup GDAL_DATA directory, rasterio needs it.
+ENV GDAL_DATA=/opt/conda/share/gdal/
 
 WORKDIR /opt/src/
 ENV PYTHONPATH=/opt/src:$PYTHONPATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,10 @@ RUN wget -q -O ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.7
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh
 ENV PATH /opt/conda/bin:$PATH
-RUN conda install -y python=3.6 && conda install -c conda-forge -y gdal=3.0.4
+ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
+RUN conda install -y python=3.6
+RUN python -m pip install --upgrade pip
+RUN conda install -y -c conda-forge gdal=3.0.4
 
 # Setup GDAL_DATA directory, rasterio needs it.
 ENV GDAL_DATA=/opt/conda/lib/python3.6/site-packages/rasterio/gdal_data/
@@ -42,7 +45,9 @@ RUN cd /tmp && \
     unzip 1.32.5.zip && \
     cd tippecanoe-1.32.5 && \
     make && \
-    make install
+    make install && \
+    cd /tmp && \
+    rm -rf tippecanoe-1.32.5
 
 # Install requirements-dev.txt
 COPY ./requirements-dev.txt /opt/src/requirements-dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV PATH /opt/conda/bin:$PATH
 RUN conda install -y python=3.6 && conda install -c conda-forge -y gdal=3.0.4
 
 # Setup GDAL_DATA directory, rasterio needs it.
-ENV GDAL_DATA=/opt/conda/share/gdal/
+ENV GDAL_DATA=/opt/conda/lib/python3.6/site-packages/rasterio/gdal_data/
 
 WORKDIR /opt/src/
 ENV PYTHONPATH=/opt/src:$PYTHONPATH
@@ -72,3 +72,4 @@ RUN pip install -r optional-requirements.txt
 # Needed for click to work
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
+ENV PROJ_LIB /opt/conda/share/proj/

--- a/rastervision2/gdal_vsi/__init__.py
+++ b/rastervision2/gdal_vsi/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
 import rastervision2.pipeline
-from rastervision2.gdal_vsi.s3_file_system import VsiFileSystem
+from rastervision2.gdal_vsi.vsi_file_system import VsiFileSystem
 
 
 def register_plugin(registry):

--- a/rastervision2/gdal_vsi/__init__.py
+++ b/rastervision2/gdal_vsi/__init__.py
@@ -1,0 +1,8 @@
+# flake8: noqa
+
+import rastervision2.pipeline
+from rastervision2.gdal_vsi.s3_file_system import VsiFileSystem
+
+
+def register_plugin(registry):
+    registry.add_file_system(VsiFileSystem)

--- a/rastervision2/gdal_vsi/vsi_file_system.py
+++ b/rastervision2/gdal_vsi/vsi_file_system.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 import os
 from pathlib import Path
-import time
 from typing import (List, Optional)
 from urllib.parse import urlparse
 
@@ -16,6 +15,14 @@ class VsiFileSystem(FileSystem):
 
     @staticmethod
     def uri_to_vsi_path(uri: str) -> str:
+        """A function to convert Rasterio-like URIs to VSI path strings
+
+        Args:
+            uri: URI of the file, possibly nested within archives as follows
+                 <archive_scheme>+<archive_URI>!path/to/contained/file.ext
+                 Acceptable URI schemes are file, s3, gs, http, https, and ftp
+                 Allowable archive schema are tar, zip, and gzip
+        """
         parsed = urlparse(uri)
         scheme = parsed.scheme.split('+')[0]
 
@@ -45,30 +52,22 @@ class VsiFileSystem(FileSystem):
                         scheme))
 
     @staticmethod
-    def matches_uri(uri: str, mode: str) -> bool:
+    def matches_uri(vsipath: str, mode: str) -> bool:
         """Returns True if this FS can be used for the given URI/mode pair.
 
         Args:
             uri: URI of file
             mode: mode to open file in, 'r' or 'w'
         """
-        parsed = parse_path(uri)
-        if isinstance(parsed, UnparsedPath):
-            return False
+        if mode == 'r' and vsipath.startswith('/vsi'):
+            return True
+        elif mode == 'w' and vsipath.startswith('/vsi') and '/vsicurl/' not in vsipath:
+            return True
         else:
-            try:
-                vsi_path = VsiFileSystem.uri_to_vsi_path(uri)
-            except:
-                return False
-            if mode == 'r':
-                return True
-            elif mode == 'w':
-                return '/vsicurl/' not in vsi_path
-            else:
-                raise ValueError('Unrecognized mode string: {}'.format(mode))
+            return False
 
     @staticmethod
-    def file_exists(uri: str, include_dir: bool = True) -> bool:
+    def file_exists(vsipath: str, include_dir: bool = True) -> bool:
         """Check if a file exists.
 
         Args:
@@ -77,46 +76,35 @@ class VsiFileSystem(FileSystem):
             supports directory reads. Otherwise only return true if a single
             file exists at the URI.
         """
-        vsi_path = VsiFileSystem.uri_to_vsi_path(uri)
-        file_stats = gdal.VSIStatL(vsi_path)
+        file_stats = gdal.VSIStatL(vsipath)
         if include_dir:
             return True if file_stats else False
         else:
             return True if file_stats and not file_stats.IsDirectory() else False
 
     @staticmethod
-    def read_bytes_vsi(vsipath: str) -> bytes:
+    def read_bytes(vsipath: str) -> bytes:
         try:
             handle = gdal.VSIFOpenL(vsipath, 'rb')
             stats = gdal.VSIStatL(vsipath)
+            if not stats or stats.IsDirectory():
+                raise FileNotFoundError('{} does not exist'.format(vsipath))
             return gdal.VSIFReadL(1, stats.size, handle)
         finally:
             gdal.VSIFCloseL(handle)
 
     @staticmethod
-    def read_bytes(uri: str) -> bytes:
-        """Read contents of URI to bytes."""
-        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
-        return VsiFileSystem.read_bytes_vsi(vsipath)
-
-    @staticmethod
     def read_str(uri: str) -> str:
         """Read contents of URI to a string."""
-        VsiFileSystem.read_bytes(uri).decode("UTF-8")
+        return VsiFileSystem.read_bytes(uri).decode("UTF-8")
 
     @staticmethod
-    def write_bytes_vsi(vsipath: str, data: bytes):
+    def write_bytes(vsipath: str, data: bytes):
         try:
             handle = gdal.VSIFOpenL(vsipath, 'wb')
             gdal.VSIFWriteL(data, 1, len(data), handle)
         finally:
             gdal.VSIFCloseL(handle)
-
-    @staticmethod
-    def write_bytes(uri: str, data: bytes):
-        """Write bytes in data to URI."""
-        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
-        VsiFileSystem.write_bytes_vsi(vsipath, data)
 
     @staticmethod
     def write_str(uri: str, data: str):
@@ -143,22 +131,21 @@ class VsiFileSystem(FileSystem):
                 if item.is_dir():
                     work(item, item_vsi_dest)
                 else:
-                    VsiFileSystem.copy_to_vsi(str(item), item_vsi_dest)
+                    VsiFileSystem.copy_to(str(item), item_vsi_dest)
 
-        vsipath = VsiFileSystem.uri_to_vi_path(dst_dir_uri)
-        stats = gdal.VSIStatL(vsipath)
+        stats = gdal.VSIStatL(dst_dir_uri)
         if stats:
             assert delete, "Cannot overwrite existing files if delete=False"
             if stats.IsDirectory():
-                gdal.RmdirRecursive(vsipath)
+                gdal.RmdirRecursive(dst_dir_uri)
             else:
-                gdal.Unlink(vsipath)
+                gdal.Unlink(dst_dir_uri)
 
         src = Path(src_dir)
         assert src.exists() and src.is_dir(), \
             "Local source ({}) must be a directory".format(src_dir)
 
-        work(src, vsipath)
+        work(src, dst_dir_uri)
 
     @staticmethod
     def sync_from_dir(src_dir_uri: str, dst_dir: str, delete: bool = False):
@@ -185,13 +172,12 @@ class VsiFileSystem(FileSystem):
                 else:
                     assert not target.exists() or delete, \
                         "Target location must not exist if delete=False"
-                    VsiFileSystem.copy_from_vsi(item_vsi_src, str(target))
+                    VsiFileSystem.copy_from(item_vsi_src, str(target))
 
-        vsipath = VsiFileSystem.uri_to_vi_path(src_dir_uri)
-        stats = gdal.VSIStatL(vsipath)
+        stats = gdal.VSIStatL(src_dir_uri)
         assert stats and stats.IsDirectory(), "Source must be a directory"
 
-        work(vsipath, Path(dst_dir))
+        work(src_dir_uri, Path(dst_dir))
 
     @staticmethod
     def copy_to(src_path: str, dst_uri: str):
@@ -208,12 +194,6 @@ class VsiFileSystem(FileSystem):
         VsiFileSystem.write_bytes(dst_uri, buf)
 
     @staticmethod
-    def copy_to_vsi(src_path: str, dst_vsi: str):
-        with open(src_path, 'rb') as f:
-            buf = f.read()
-        VsiFileSystem.write_bytes_vsi(dst_vsi, buf)
-
-    @staticmethod
     def copy_from(src_uri: str, dst_path: str):
         """Copy a source file to a local destination.
 
@@ -228,13 +208,7 @@ class VsiFileSystem(FileSystem):
             f.write(buf)
 
     @staticmethod
-    def copy_from_vsi(src_vsi: str, dst_path: str):
-        buf = VsiFileSystem.read_bytes_vsi(src_vsi)
-        with open(dst_path, 'wb') as f:
-            f.write(buf)
-
-    @staticmethod
-    def local_path(uri: str, download_dir: str) -> str:
+    def local_path(vsipath: str, download_dir: str) -> str:
         """Return the path where a local copy should be stored.
 
         Args:
@@ -242,12 +216,11 @@ class VsiFileSystem(FileSystem):
             download_dir: path of the local directory in which files should
                 be copied
         """
-        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
         filename = Path(vsipath).name
         return os.path.join(download_dir, filename)
 
     @staticmethod
-    def last_modified(uri: str) -> Optional[datetime]:
+    def last_modified(vsipath: str) -> Optional[datetime]:
         """Get the last modified date of a file.
 
         Args:
@@ -257,12 +230,11 @@ class VsiFileSystem(FileSystem):
             the last modified date in UTC of a file or None if this FileSystem
             does not support this operation.
         """
-        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
         stats = gdal.VSIStatL(vsipath)
-        return time.gmtime(stats.mtime) if stats else None
+        return datetime.fromtimestamp(stats.mtime) if stats else None
 
     @staticmethod
-    def list_paths(uri: str, ext: Optional[str] = None) -> List[str]:
+    def list_paths(vsipath: str, ext: Optional[str] = None) -> List[str]:
         """List paths rooted at URI.
 
         Optionally only includes paths with a certain file extension.
@@ -271,7 +243,6 @@ class VsiFileSystem(FileSystem):
             uri: the URI of a directory
             ext: the optional file extension to filter by
         """
-        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
         items = gdal.ReadDir(vsipath)
         ext = ext if ext else ''
         return [os.path.join(vsipath, item)  # This may not work for windows paths

--- a/rastervision2/gdal_vsi/vsi_file_system.py
+++ b/rastervision2/gdal_vsi/vsi_file_system.py
@@ -112,6 +112,11 @@ class VsiFileSystem(FileSystem):
         VsiFileSystem.write_bytes(uri, data.encode())
 
     @staticmethod
+    def write_str(uri: str, data: str):
+        """Write string in data to URI."""
+        VsiFileSystem.write_bytes(uri, data.encode())
+
+    @staticmethod
     def sync_to_dir(src_dir: str, dst_dir_uri: str, delete: bool = False):
         """Syncs a local source directory to a destination directory.
 

--- a/rastervision2/gdal_vsi/vsi_file_system.py
+++ b/rastervision2/gdal_vsi/vsi_file_system.py
@@ -83,11 +83,12 @@ class VsiFileSystem(FileSystem):
 
     @staticmethod
     def read_bytes(vsipath: str) -> bytes:
+        stats = gdal.VSIStatL(vsipath)
+        if not stats or stats.IsDirectory():
+            raise FileNotFoundError('{} does not exist'.format(vsipath))
+
         try:
             handle = gdal.VSIFOpenL(vsipath, 'rb')
-            stats = gdal.VSIStatL(vsipath)
-            if not stats or stats.IsDirectory():
-                raise FileNotFoundError('{} does not exist'.format(vsipath))
             return gdal.VSIFReadL(1, stats.size, handle)
         finally:
             gdal.VSIFCloseL(handle)

--- a/rastervision2/gdal_vsi/vsi_file_system.py
+++ b/rastervision2/gdal_vsi/vsi_file_system.py
@@ -112,11 +112,6 @@ class VsiFileSystem(FileSystem):
         VsiFileSystem.write_bytes(uri, data.encode())
 
     @staticmethod
-    def write_str(uri: str, data: str):
-        """Write string in data to URI."""
-        VsiFileSystem.write_bytes(uri, data.encode())
-
-    @staticmethod
     def sync_to_dir(src_dir: str, dst_dir_uri: str, delete: bool = False):
         """Syncs a local source directory to a destination directory.
 

--- a/rastervision2/gdal_vsi/vsi_file_system.py
+++ b/rastervision2/gdal_vsi/vsi_file_system.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse
 from rastervision2.pipeline.file_system import FileSystem
 
 from osgeo import gdal
-from rasterio.path import (UnparsedPath, parse_path)
 
 
 class VsiFileSystem(FileSystem):

--- a/rastervision2/gdal_vsi/vsi_file_system.py
+++ b/rastervision2/gdal_vsi/vsi_file_system.py
@@ -1,0 +1,272 @@
+import os
+import stat
+import time
+from pathlib import Path
+
+from rastervision2.pipeline.file_system import (FileSystem, NotReadableError, NotWritableError)
+
+from osgeo import gdal
+from rasterio.path import (Path, UnparsedPath, parse_path)
+
+class VsiFileSystem(FileSystem):
+    """A FileSystem to access files over any protocol supported by GDAL's VSI"""
+
+    @staticmethod
+    def uri_to_vsi_path(uri: str) -> str:
+        parsed = urlparse(uri)
+        scheme = parsed.scheme
+
+        archive_content = uri.rfind('!')
+        if archive_content == -1:
+            # regular URI
+            if scheme=='http' or scheme=='https' or scheme=='ftp':
+                return '/vsicurl/{}'.format(uri)
+            elif scheme=='s3' or scheme=='gs':
+                return '/vsi{}/{}{}'.format(scheme, parsed.netloc, parsed.path)
+            else:
+                # assume file schema
+                return os.path.abspath(os.path.join(parsed.netloc, parsed.path))
+        else:
+            archive_target = uri.find(':')
+            assert archive_target != -1
+
+            if scheme in ['zip','tar','gzip']:
+                return '/vsi{}/{}/{}'.format(scheme, VsiFileSystem.uri_to_vsi_path(uri[archive_target+1:archive_content]), uri[archive_content+1:])
+            else:
+                raise ValueError('Attempted access into archive with unsupported scheme "{}"'.format(scheme))
+
+
+    @staticmethod
+    def matches_uri(uri: str, mode: str) -> bool:
+        """Returns True if this FS can be used for the given URI/mode pair.
+
+        Args:
+            uri: URI of file
+            mode: mode to open file in, 'r' or 'w'
+        """
+        parsed = parse_path(uri)
+        if isinstance(parsed, UnparsedPath):
+            return False
+        else:
+            vsi_path = VsiFileSystem.uri_to_vsi_path(uri)
+            file_stats = gdal.VSIStatL(vsi_path)
+            if mode == 'r':
+                if file_stats:
+                    return not file_stats.IsDirectory()
+                else:
+                    return False
+            elif mode == 'w':
+                return True # this may fail for vsicurl?
+            else:
+                raise ValueError('Unrecognized mode string: {}'.format(mode))
+
+
+    @staticmethod
+    @abstractmethod
+    def file_exists(uri: str, include_dir: bool = True) -> bool:
+        """Check if a file exists.
+
+        Args:
+          uri: The URI to check
+          include_dir: Include directories in check, if this file_system
+            supports directory reads. Otherwise only return true if a single
+            file exists at the URI.
+        """
+        vsi_path = VsiFileSystem.uri_to_vsi_path(uri)
+        file_stats = gdal.VSIStatL(vsi_path)
+        if include_dir:
+            True if file_stats else False
+        else:
+            return file_stats and not file_stats.IsDirectory()
+
+    @staticmethod
+    def read_str(uri: str) -> str:
+        """Read contents of URI to a string."""
+        read_bytes(uri).decode("UTF-8")
+
+    @staticmethod
+    def read_bytes_vsi(vsipath: str) -> bytes:
+        try:
+            handle = gdal.VSIFOpenL(vsipath, 'rb')
+            stats = gdal.VSIStatL(vsipath)
+            return gdal.VSIFReadL(1, stats.size, handle)
+        finally:
+            gdal.VSIFCloseL(handle)
+
+    @staticmethod
+    def read_bytes(uri: str) -> bytes:
+        """Read contents of URI to bytes."""
+        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
+        return VsiFileSystem.read_bytes_vsi(vsipath)
+
+    @staticmethod
+    def write_str(uri: str, data: str):
+        """Write string in data to URI."""
+        write_bytes(uri, data.encode())
+
+    @staticmethod
+    def write_bytes_vsi(vsipath: str, data: bytes):
+        try:
+            handle = gdal.VSIFOpenL(vsipath, 'wb')
+            gdal.VSIFWriteL(data, 1, len(data), handle)
+        finally:
+            gdal.VSIFCloseL(handle)
+
+    @staticmethod
+    def write_bytes(uri: str, data: bytes):
+        """Write bytes in data to URI."""
+        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
+        VsiFileSystem.write_bytes_vsi(vsipath, data)
+
+    @staticmethod
+    def sync_to_dir(src_dir: str, dst_dir_uri: str, delete: bool = False):
+        """Syncs a local source directory to a destination directory.
+
+        If the FileSystem is remote, this involves uploading.
+
+        Args:
+            src_dir: local source directory to sync from
+            dst_dir_uri: A destination directory that can be synced to by this
+                FileSystem
+            delete: True if the destination should be deleted first.
+        """
+        def work(src, vsi_dest):
+            gdal.Mkdir(vsi_dest, 0o777)
+
+            for item in src.iterdir():
+                item_vsi_dest = os.path.join(vsi_dest, item.name)
+                if item.is_dir():
+                    work(item, item_vsi_dest)
+                else:
+                    VsiFileSystem.copy_to_vsi(str(item), item_vsi_dest)
+
+        vsipath = VsiFileSystem.uri_to_vi_path(dst_dir_uri)
+        stats = gdal.VSIStatL(vsipath)
+        if stats:
+            assert delete, "Cannot overwrite existing files if delete=False"
+            if stats.IsDirectory():
+                gdal.RmdirRecursive(vsipath)
+            else:
+                gdal.Unlink(vsipath)
+
+        src = Path(src_dir)
+        assert src.exists() and src.is_dir(), "Local source ({}) must be a directory".format(src_dir)
+
+        work(src, vsipath)
+
+    @staticmethod
+    def sync_from_dir(src_dir_uri: str, dst_dir: str, delete: bool = False):
+        """Syncs a source directory to a local destination directory.
+
+        If the FileSystem is remote, this involves downloading.
+
+        Args:
+            src_dir_uri: source directory that can be synced from by this FileSystem
+            dst_dir: A local destination directory
+            delete: True if the destination should be deleted first.
+        """
+        def work(vsi_src, dest):
+            if dest.exists():
+                assert dest.is_dir(), "Local target ({}) must be a directory".format(dest)
+            else:
+                dest.mkdir()
+
+            for item in gdal.ReadDir(vsi_src):
+                item_vsi_src = os.path.join(vsi_src, item)
+                target = dest.joinpath(item)
+                if gdal.VSIStatL(item_vsi_src).IsDirectory():
+                    work(item_vsi_src, target)
+                else:
+                    assert not target.exists() or delete, "Target location may not exist if delete=False"
+                    VsiFileSystem.copy_from_vsi(item_vsi_src, str(target))
+
+        vsipath = VsiFileSystem.uri_to_vi_path(src_dir_uri)
+        stats = gdal.VSIStatL(vsipath)
+        assert stats and stats.IsDirectory(), "Source must be a directory"
+
+        work(vsipath, Path(dst_dir))
+
+    @staticmethod
+    def copy_to(src_path: str, dst_uri: str):
+        """Copy a local source file to a destination.
+
+        If the FileSystem is remote, this involves uploading.
+
+        Args:
+            src_path: local path to source file
+            dst_uri: uri of destination that can be copied to by this FileSystem
+        """
+        with open(src_path, 'rb') as f:
+            buf = f.read()
+        write_bytes(dst_uri, buf)
+
+    @staticmethod
+    def copy_to_vsi(src_path: str, dst_vsi: str):
+        with open(src_path, 'rb') as f:
+            buf = f.read()
+        write_bytes_vsi(dst_vsi, buf)
+
+    @staticmethod
+    def copy_from(src_uri: str, dst_path: str):
+        """Copy a source file to a local destination.
+
+        If the FileSystem is remote, this involves downloading.
+
+        Args:
+            src_uri: uri of source that can be copied from by this FileSystem
+            dst_path: local path to destination file
+        """
+        buf = read_bytes(src_uri)
+        with open(dst_path, 'wb') as f:
+            f.write(buf)
+
+    @staticmethod
+    def copy_from_vsi(src_vsi: str, dst_path: str):
+        buf = read_bytes_vsi(src_vsi)
+        with open(dst_path, 'wb') as f:
+            f.write(buf)
+
+    @staticmethod
+    def local_path(uri: str, download_dir: str) -> str:
+        """Return the path where a local copy should be stored.
+
+        Args:
+            uri: the URI of the file to be copied
+            download_dir: path of the local directory in which files should
+                be copied
+        """
+        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
+        filename = Path(vsipath).name
+        return os.path.join(download_dir, filename)
+
+    @staticmethod
+    def last_modified(uri: str) -> Optional[datetime]:
+        """Get the last modified date of a file.
+
+        Args:
+            uri: the URI of the file
+
+        Returns:
+            the last modified date in UTC of a file or None if this FileSystem
+            does not support this operation.
+        """
+        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
+        stats = gdal.VSIStatL(vsipath)
+        return time.gmtime(stats.mtime) if stats else None
+
+    @staticmethod
+    def list_paths(uri: str, ext: Optional[str] = None) -> List[str]:
+        """List paths rooted at URI.
+
+        Optionally only includes paths with a certain file extension.
+
+        Args:
+            uri: the URI of a directory
+            ext: the optional file extension to filter by
+        """
+        vsipath = VsiFileSystem.uri_to_vsi_path(uri)
+        items = gdal.ReadDir(vsipath)
+        ext = ext if ext else ''
+        return [os.path.join(vsipath, item) # This may not work for windows paths
+                for item
+                in filter(lambda x: x.endswith(ext), items)]


### PR DESCRIPTION
## Overview

Files may be sourced from a wide array of endpoints, and piecemeal implementation of those different target schemas would take time.  GDAL provides a virtual file system interface that provides support for many basic schemes (s3, Google cloud storage, http, ftp, and file), with the ability to read (and sometimes write) files from inside archives stored on those remote targets.

Supported schema are s3, http, https, ftp, gs, and file, which may be combined with the archive schema (tar, zip, gzip).  For example,
```
 zip:tar:s3://jpolchlopek/test.tar/!test/test.zip!test.tif
```
reads a TIF from inside a ZIP, which is stored in a TAR on S3.  These URIs may be formed as
```
<archive_scheme>:<archive_URI>!path/to/contained/file.ext
```
(Note: we may need to use a `+` in place of the `:` for Rasterio compatibility, though the colon notation seems to be in line with [JAR access](https://docs.oracle.com/javase/6/docs/api/java/net/JarURLConnection.html).)

### Checklist

- [ ] Updated `docs/changelog.rst`
- [ ] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This PR requires at least version 2.3 of GDAL.  Current docker images supply 2.2.2.  I have developed against GDAL 3.0.4.

Also, attempted to run `scripts/format_code`, and the set of files affected was very large, so for the sake of PR hygiene, I reverted.

## Testing Instructions (TBD)

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #905 
