### PR TITLE
Fix Mapbox style-based vector rasterization

### DIFF
--- a/rastervision2/core/data/vector_source/class_inference.py
+++ b/rastervision2/core/data/vector_source/class_inference.py
@@ -17,7 +17,7 @@ class ClassInference():
 
         if self.class_id_to_filter is not None:
             self.class_id_to_filter = {}
-            for class_id, filter_exp in self.class_id_to_filter.items():
+            for class_id, filter_exp in class_id_to_filter.items():
                 self.class_id_to_filter[class_id] = create_filter(filter_exp)
 
     def infer_class_id(self, feature):

--- a/rastervision2/core/data/vector_source/vector_source_config.py
+++ b/rastervision2/core/data/vector_source/vector_source_config.py
@@ -4,6 +4,7 @@ from rastervision2.pipeline.config import Config, register_config, Field
 
 ClassFilter = Sequence[Union[str, 'ClassFilter']]
 
+
 @register_config('vector_source')
 class VectorSourceConfig(Config):
     default_class_id: Optional[int] = Field(

--- a/rastervision2/core/data/vector_source/vector_source_config.py
+++ b/rastervision2/core/data/vector_source/vector_source_config.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, Sequence
 
 from rastervision2.pipeline.config import Config, register_config, Field
 
@@ -11,7 +11,7 @@ class VectorSourceConfig(Config):
         ('The default class_id to use if class cannot be inferred using other '
          'mechanisms. If a feature defaults to a class_id of None, then that feature '
          'will be deleted.'))
-    class_id_to_filter: Optional[Dict[int, Optional[Dict]]] = Field(
+    class_id_to_filter: Optional[Dict[int, Optional[Sequence[str]]]] = Field(
         None,
         description=(
             'Map from class_id to JSON filter used to infer missing class_ids. The '

--- a/rastervision2/core/data/vector_source/vector_source_config.py
+++ b/rastervision2/core/data/vector_source/vector_source_config.py
@@ -1,8 +1,8 @@
-from typing import Dict, Optional, Sequence, TypeVar, Union
+from typing import Dict, Optional, Sequence, Union
 
 from rastervision2.pipeline.config import Config, register_config, Field
 
-T = TypeVar('T')
+ClassFilter = Sequence[Union[str, 'ClassFilter']]
 
 @register_config('vector_source')
 class VectorSourceConfig(Config):
@@ -12,7 +12,7 @@ class VectorSourceConfig(Config):
         ('The default class_id to use if class cannot be inferred using other '
          'mechanisms. If a feature defaults to a class_id of None, then that feature '
          'will be deleted.'))
-    class_id_to_filter: Optional[Dict[int, Optional[Sequence[T]]]] = Field(
+    class_id_to_filter: Optional[Dict[int, Optional[ClassFilter]]] = Field(
         None,
         description=(
             'Map from class_id to JSON filter used to infer missing class_ids. The '

--- a/rastervision2/core/data/vector_source/vector_source_config.py
+++ b/rastervision2/core/data/vector_source/vector_source_config.py
@@ -11,7 +11,7 @@ class VectorSourceConfig(Config):
         ('The default class_id to use if class cannot be inferred using other '
          'mechanisms. If a feature defaults to a class_id of None, then that feature '
          'will be deleted.'))
-    class_id_to_filter: Optional[Dict[int, Optional[Sequence[str]]]] = Field(
+    class_id_to_filter: Optional[Dict[int, Optional[Sequence]]] = Field(
         None,
         description=(
             'Map from class_id to JSON filter used to infer missing class_ids. The '

--- a/rastervision2/core/data/vector_source/vector_source_config.py
+++ b/rastervision2/core/data/vector_source/vector_source_config.py
@@ -1,7 +1,8 @@
-from typing import Dict, Optional, Union, Sequence
+from typing import Dict, Optional, Sequence, TypeVar, Union
 
 from rastervision2.pipeline.config import Config, register_config, Field
 
+T = TypeVar('T')
 
 @register_config('vector_source')
 class VectorSourceConfig(Config):
@@ -11,7 +12,7 @@ class VectorSourceConfig(Config):
         ('The default class_id to use if class cannot be inferred using other '
          'mechanisms. If a feature defaults to a class_id of None, then that feature '
          'will be deleted.'))
-    class_id_to_filter: Optional[Dict[int, Optional[Sequence]]] = Field(
+    class_id_to_filter: Optional[Dict[int, Optional[Sequence[T]]]] = Field(
         None,
         description=(
             'Map from class_id to JSON filter used to infer missing class_ids. The '


### PR DESCRIPTION
## Overview

When a `class_id` is not provided in the `properties` field of a GeoJSON, we may need to specify a test to determine what class is applicable.  This is done using a dictionary of the following form:
```python
filter_dict = {
    0: ['==', 'wacky_field', 'background'],
    1: ['!=', 'wacky_field', 'background']
}
```

This was not functioning previously; this PR aims to fix that.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
