### PR TITLE
Support chips from a list of zip files in Learner

### DIFF
--- a/rastervision2/pytorch_learner/learner.py
+++ b/rastervision2/pytorch_learner/learner.py
@@ -202,14 +202,20 @@ class Learner(ABC):
             paths to directories that each contain contents of one zip file
         """
         cfg = self.cfg
-        if cfg.data.uri.startswith('s3://') or cfg.data.uri.startswith('/'):
-            data_uri = cfg.data.uri
-        else:
-            data_uri = join(cfg.base_uri, cfg.data.uri)
-
         data_dirs = []
-        zip_uris = [data_uri] if data_uri.endswith('.zip') else list_paths(
-            data_uri, 'zip')
+
+        if isinstance(cfg.data.uri, list):
+            zip_uris = cfg.data.uri
+        else:
+            if cfg.data.uri.startswith('s3://') or cfg.data.uri.startswith(
+                    '/'):
+                data_uri = cfg.data.uri
+            else:
+                data_uri = join(cfg.base_uri, cfg.data.uri)
+            zip_uris = ([data_uri]
+                        if data_uri.endswith('.zip') else list_paths(
+                            data_uri, 'zip'))
+
         for zip_ind, zip_uri in enumerate(zip_uris):
             zip_path = get_local_path(zip_uri, self.data_cache_dir)
             if not isfile(zip_path):

--- a/rastervision2/pytorch_learner/learner_config.py
+++ b/rastervision2/pytorch_learner/learner_config.py
@@ -130,12 +130,11 @@ class SolverConfig(Config):
 @register_config('data')
 class DataConfig(Config):
     """Config related to dataset for training and testing."""
-    # TODO shouldn't this be required?
-    uri: Optional[str] = Field(
+    uri: Union[None, str, List[str]] = Field(
         None,
         description=
-        ('URI of the dataset. This can be a zip file, or a directory which contains '
-         'a set of zip files.'))
+        ('URI of the dataset. This can be a zip file, a list of zip files, or a '
+         'directory which contains a set of zip files.'))
     data_format: Optional[str] = Field(
         None, description='Name of dataset format.')
     class_names: List[str] = Field([], description='Names of classes.')


### PR DESCRIPTION
This PR makes it so it's possible to specify a list of zip files (as opposed to a single zip file or a directory containing zip files) containing chips to a `Learner`.