### PR TITLE
Make Everett Namespaces Lower Case

### DIFF
--- a/rastervision2/aws_batch/aws_batch_runner.py
+++ b/rastervision2/aws_batch/aws_batch_runner.py
@@ -37,7 +37,7 @@ def submit_job(cmd: List[str],
         job_queue: if set, use this job queue
         job_def: if set, use this job definition
     """
-    batch_config = rv_config.get_namespace_config('AWS_BATCH')
+    batch_config = rv_config.get_namespace_config(AWS_BATCH)
 
     if job_queue is None:
         if use_gpu:

--- a/rastervision2/aws_s3/s3_file_system.py
+++ b/rastervision2/aws_s3/s3_file_system.py
@@ -83,7 +83,7 @@ class S3FileSystem(FileSystem):
     def get_request_payer():
         # Import here to avoid circular reference.
         from rastervision2.pipeline import rv_config
-        s3_config = rv_config.get_namespace_config('AWS_S3')
+        s3_config = rv_config.get_namespace_config(AWS_S3)
 
         # 'None' needs the quotes because boto3 cannot handle None.
         return ('requester' if s3_config(


### PR DESCRIPTION
## Overview

It seems as though the namespace names given to Everett should be lower case.  I noticed this issue because I was setting `requester_pays` and the value seemed not to be making it [here](https://github.com/azavea/raster-vision/blob/master/rastervision2/aws_s3/s3_file_system.py#L88).

If that is not the case, please feel free to close this PR.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

