### PR TITLE
Support groups of chips and limits on training size

### DIFF
--- a/rastervision2/pytorch_learner/classification_learner.py
+++ b/rastervision2/pytorch_learner/classification_learner.py
@@ -29,12 +29,12 @@ class ClassificationLearner(Learner):
         model.fc = nn.Linear(in_features, num_labels)
         return model
 
-    def get_datasets(self):
+    def _get_datasets(self, uri):
         cfg = self.cfg
         class_names = cfg.data.class_names
 
         if cfg.data.data_format == ClassificationDataFormat.image_folder:
-            data_dirs = self.unzip_data()
+            data_dirs = self.unzip_data(uri)
 
         transform, aug_transform = self.get_data_transforms()
 

--- a/rastervision2/pytorch_learner/learner_config.py
+++ b/rastervision2/pytorch_learner/learner_config.py
@@ -135,6 +135,18 @@ class DataConfig(Config):
         description=
         ('URI of the dataset. This can be a zip file, a list of zip files, or a '
          'directory which contains a set of zip files.'))
+    train_sz: Optional[int] = Field(
+        None, description=(
+            'If set, the number of training images to use. If fewer images exist, '
+            'then an exception will be raised.'))
+    group_uris: Union[None, List[Union[str, List[str]]]] = Field(None, description=(
+        'This can be set instead of uri in order to specify groups of chips. Each '
+        'element in the list is expected to be an object of the same form accepted by '
+        'the uri field. The purpose of separating chips into groups is to be able to '
+        'use the group_train_sz field.'))
+    group_train_sz: Optional[int] = Field(None, description=(
+        'If group_uris is set, this can be used to specify the number of chips to use '
+        'per group.'))
     data_format: Optional[str] = Field(
         None, description='Name of dataset format.')
     class_names: List[str] = Field([], description='Names of classes.')

--- a/rastervision2/pytorch_learner/object_detection_learner.py
+++ b/rastervision2/pytorch_learner/object_detection_learner.py
@@ -40,11 +40,11 @@ class ObjectDetectionLearner(Learner):
     def get_collate_fn(self):
         return collate_fn
 
-    def get_datasets(self):
+    def _get_datasets(self, uri):
         cfg = self.cfg
 
         if cfg.data.data_format == ObjectDetectionDataFormat.default:
-            data_dirs = self.unzip_data()
+            data_dirs = self.unzip_data(uri)
 
         transform, aug_transform = self.get_data_transforms()
 

--- a/rastervision2/pytorch_learner/regression_learner.py
+++ b/rastervision2/pytorch_learner/regression_learner.py
@@ -83,9 +83,9 @@ class RegressionLearner(Learner):
             pos_out_inds=pos_out_inds)
         return model
 
-    def get_datasets(self):
+    def _get_datasets(self, uri):
         cfg = self.cfg
-        data_dirs = self.unzip_data()
+        data_dirs = self.unzip_data(uri)
         transform, aug_transform = self.get_data_transforms()
 
         train_ds, valid_ds, test_ds = [], [], []

--- a/rastervision2/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision2/pytorch_learner/semantic_segmentation_learner.py
@@ -60,10 +60,10 @@ class SemanticSegmentationLearner(Learner):
             pretrained_backbone=pretrained)
         return model
 
-    def get_datasets(self):
+    def _get_datasets(self, uri):
         cfg = self.cfg
 
-        data_dirs = self.unzip_data()
+        data_dirs = self.unzip_data(uri)
         transform, aug_transform = self.get_data_transforms()
 
         train_ds, valid_ds, test_ds = [], [], []


### PR DESCRIPTION
This PR adds support for separating chip URIs into groups and to set the number of training chips to use for each group. This is useful for training on different cities and ensuring that an equal number of chips is used for each city.