### PR TITLE
Convert CRS to a type interpretable by pyproj

### DIFF
--- a/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
@@ -57,7 +57,7 @@ class RasterioCRSTransformer(CRSTransformer):
             return IdentityCRSTransformer()
         transform = dataset.transform
         image_crs = dataset.crs
-        return cls(transform, image_crs, map_crs)
+        return cls(transform, image_crs.wkt, map_crs)
 
     def get_affine_transform(self):
         return self.transform

--- a/rastervision2/core/data/raster_source/rasterio_source.py
+++ b/rastervision2/core/data/raster_source/rasterio_source.py
@@ -167,7 +167,7 @@ class RasterioSource(ActivateMixin, RasterSource):
             self.image_dataset)
         self.crs = self.image_dataset.crs
         if self.crs:
-            self.proj = pyproj.Proj(self.crs)
+            self.proj = pyproj.Proj(self.crs.wkt)
         else:
             self.proj = None
         self.crs = str(self.crs)


### PR DESCRIPTION
## Overview

Rasterio datasets produce their CRS responses in `rasterio.crs.CRS`.  These cannot be passed directly to the `pyproj.Proj` constructor.  Converting to WKT prior to use was sufficient to fix the bug.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This may be an artifact of versions, as I am using a development container that relies on GDAL 3 and may have a more recent Rasterio version installed, causing problems.

