### PR TITLE
Fix polygon prediction upload bug

### DIFF
--- a/rastervision/data/label_store/semantic_segmentation_raster_store.py
+++ b/rastervision/data/label_store/semantic_segmentation_raster_store.py
@@ -3,7 +3,7 @@ import rasterio
 
 import rastervision as rv
 from rastervision.utils.files import (get_local_path, make_dir, upload_or_copy,
-                                      file_exists)
+                                      file_exists, str_to_file)
 from rastervision.data.label import SemanticSegmentationLabels
 from rastervision.data.label_store import LabelStore
 from rastervision.data.label_source import SegmentationClassTransformer
@@ -154,7 +154,6 @@ class SemanticSegmentationRasterStore(LabelStore):
                 mode = vo['mode']
                 class_id = vo['class_id']
                 class_mask = np.array(mask == class_id, dtype=np.uint8)
-                local_geojson_path = get_local_path(uri, self.tmp_dir)
 
                 def transform(x, y):
                     return self.crs_transformer.pixel_to_map((x, y))
@@ -176,10 +175,7 @@ class SemanticSegmentationRasterStore(LabelStore):
                     geojson = vectorification.geojson_from_mask(
                         mask=class_mask, transform=transform, mode=mode)
 
-                if local_geojson_path:
-                    with open(local_geojson_path, 'w') as file_out:
-                        file_out.write(geojson)
-                        upload_or_copy(local_geojson_path, uri)
+                str_to_file(geojson, uri)
 
     def empty_labels(self):
         """Returns an empty SemanticSegmentationLabels object."""

--- a/rastervision2/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision2/core/data/label_store/semantic_segmentation_label_store.py
@@ -161,7 +161,6 @@ class SemanticSegmentationLabelStore(LabelStore):
                         mask=class_mask, transform=transform, mode=mode)
                 str_to_file(geojson, uri)
 
-
     def empty_labels(self):
         """Returns an empty SemanticSegmentationLabels object."""
         return SemanticSegmentationLabels()

--- a/rastervision2/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision2/core/data/label_store/semantic_segmentation_label_store.py
@@ -1,8 +1,8 @@
 import numpy as np
 import rasterio
 
-from rastervision2.pipeline.file_system import (get_local_path, make_dir,
-                                                upload_or_copy, file_exists)
+from rastervision2.pipeline.file_system import (
+    get_local_path, make_dir, upload_or_copy, file_exists, str_to_file)
 from rastervision2.core.data.label import SemanticSegmentationLabels
 from rastervision2.core.data.label_store import LabelStore
 from rastervision2.core.data.label_source import SegmentationClassTransformer
@@ -140,7 +140,6 @@ class SemanticSegmentationLabelStore(LabelStore):
                 mode = vo.get_mode()
                 class_id = vo.class_id
                 class_mask = np.array(mask == class_id, dtype=np.uint8)
-                local_geojson_path = get_local_path(uri, self.tmp_dir)
 
                 def transform(x, y):
                     return self.crs_transformer.pixel_to_map((x, y))
@@ -160,11 +159,8 @@ class SemanticSegmentationLabelStore(LabelStore):
                 elif uri and mode == 'polygons':
                     geojson = vectorification.geojson_from_mask(
                         mask=class_mask, transform=transform, mode=mode)
+                str_to_file(geojson, uri)
 
-                if local_geojson_path:
-                    with open(local_geojson_path, 'w') as file_out:
-                        file_out.write(geojson)
-                        upload_or_copy(local_geojson_path, uri)
 
     def empty_labels(self):
         """Returns an empty SemanticSegmentationLabels object."""

--- a/rastervision2/core/data/label_store/semantic_segmentation_label_store_config.py
+++ b/rastervision2/core/data/label_store/semantic_segmentation_label_store_config.py
@@ -100,7 +100,7 @@ class SemanticSegmentationLabelStoreConfig(LabelStoreConfig):
             crs_transformer,
             tmp_dir,
             vector_output=self.vector_output,
-            class_config=class_config)
+            class_config=class_config if self.rgb else None)
 
     def update(self, pipeline=None, scene=None):
         if pipeline is not None and scene is not None:

--- a/rastervision2/core/evaluation/semantic_segmentation_evaluator.py
+++ b/rastervision2/core/evaluation/semantic_segmentation_evaluator.py
@@ -74,7 +74,7 @@ class SemanticSegmentationEvaluator(ClassificationEvaluator):
                     mode = vo.get_mode()
                     class_id = vo.class_id
                     pred_geojson_source = GeoJSONVectorSourceConfig(
-                        uri=pred_geojson_uri, default_class_id=None).build(
+                        uri=pred_geojson_uri, default_class_id=class_id).build(
                             self.class_config,
                             scene.raster_source.get_crs_transformer())
                     pred_geojson = pred_geojson_source.get_geojson()


### PR DESCRIPTION
This PR makes it so polygon predictions are uploaded correctly to S3 and also makes it so the `rgb` option is respected.

Closes #835 