### PR TITLE
Handle different versions of pyproj

### DIFF
--- a/rastervision/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision/data/crs_transformer/rasterio_crs_transformer.py
@@ -16,14 +16,10 @@ class RasterioCRSTransformer(CRSTransformer):
             image_dataset: Rasterio DatasetReader
             map_crs: CRS code
         """
-        if pyproj.__version__ > '2.0.0':
-            self.map_proj = pyproj.Proj(init=map_crs)
-            self.image_proj = pyproj.Proj(image_crs.wkt)
-            super().__init__(image_crs.wkt, map_crs, transform)
-        else:
-            self.map_proj = pyproj.Proj(init=map_crs)
-            self.image_proj = pyproj.Proj(image_crs)
-            super().__init__(image_crs, map_crs, transform)
+        self.map_proj = pyproj.Proj(init=map_crs)
+        self.image_proj = pyproj.Proj(image_crs.wkt)
+
+        super().__init__(image_crs.wkt, map_crs, transform)
 
     def map_to_pixel(self, map_point):
         """Transform point from map to pixel-based coordinates.

--- a/rastervision/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision/data/crs_transformer/rasterio_crs_transformer.py
@@ -16,10 +16,14 @@ class RasterioCRSTransformer(CRSTransformer):
             image_dataset: Rasterio DatasetReader
             map_crs: CRS code
         """
-        self.map_proj = pyproj.Proj(init=map_crs)
-        self.image_proj = pyproj.Proj(image_crs)
-
-        super().__init__(image_crs, map_crs, transform)
+        if pyproj.__version__ > '2.0.0':
+            self.map_proj = pyproj.Proj(init=map_crs)
+            self.image_proj = pyproj.Proj(image_crs.wkt)
+            super().__init__(image_crs.wkt, map_crs, transform)
+        else:
+            self.map_proj = pyproj.Proj(init=map_crs)
+            self.image_proj = pyproj.Proj(image_crs)
+            super().__init__(image_crs, map_crs, transform)
 
     def map_to_pixel(self, map_point):
         """Transform point from map to pixel-based coordinates.

--- a/rastervision/data/raster_source/rasterio_source.py
+++ b/rastervision/data/raster_source/rasterio_source.py
@@ -167,7 +167,7 @@ class RasterioSource(ActivateMixin, RasterSource):
             self.image_dataset)
         self.crs = self.image_dataset.crs
         if self.crs:
-            self.proj = pyproj.Proj(self.crs)
+            self.proj = self.crs_transformer.image_proj
         else:
             self.proj = None
         self.crs = str(self.crs)

--- a/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
@@ -16,10 +16,15 @@ class RasterioCRSTransformer(CRSTransformer):
             image_dataset: Rasterio DatasetReader
             map_crs: CRS code
         """
-        self.map_proj = pyproj.Proj(init=map_crs)
-        self.image_proj = pyproj.Proj(image_crs)
+        if pyproj.__version__ > '2.0.0':
+            self.map_proj = pyproj.Proj(init=map_crs)
+            self.image_proj = pyproj.Proj(image_crs.wkt)
+            super().__init__(image_crs.wkt, map_crs, transform)
+        else:
+            self.map_proj = pyproj.Proj(init=map_crs)
+            self.image_proj = pyproj.Proj(image_crs)
+            super().__init__(image_crs, map_crs, transform)
 
-        super().__init__(image_crs, map_crs, transform)
 
     def map_to_pixel(self, map_point):
         """Transform point from map to pixel-based coordinates.

--- a/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
@@ -16,14 +16,10 @@ class RasterioCRSTransformer(CRSTransformer):
             image_dataset: Rasterio DatasetReader
             map_crs: CRS code
         """
-        if pyproj.__version__ > '2.0.0':
-            self.map_proj = pyproj.Proj(init=map_crs)
-            self.image_proj = pyproj.Proj(image_crs.wkt)
-            super().__init__(image_crs.wkt, map_crs, transform)
-        else:
-            self.map_proj = pyproj.Proj(init=map_crs)
-            self.image_proj = pyproj.Proj(image_crs)
-            super().__init__(image_crs, map_crs, transform)
+        self.map_proj = pyproj.Proj(init=map_crs)
+        self.image_proj = pyproj.Proj(image_crs.wkt)
+
+        super().__init__(image_crs.wkt, map_crs, transform)
 
 
     def map_to_pixel(self, map_point):

--- a/rastervision2/core/data/raster_source/rasterio_source.py
+++ b/rastervision2/core/data/raster_source/rasterio_source.py
@@ -167,7 +167,7 @@ class RasterioSource(ActivateMixin, RasterSource):
             self.image_dataset)
         self.crs = self.image_dataset.crs
         if self.crs:
-            self.proj = pyproj.Proj(self.crs)
+            self.proj = self.crs_transformer.image_proj
         else:
             self.proj = None
         self.crs = str(self.crs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ everett==0.9
 pluginbase==0.7
 lxml==4.2.*
 shapely==1.6.*
-pyproj==1.9.6
+pyproj==2.6.1.post1
 imageio==2.3.*
 scikit-learn==0.19.*
 six==1.11.*


### PR DESCRIPTION
## Overview

When using pipelines in derived environments that have later versions of pyproj installed, a problem arises with RasterioCRSTransformer failing to correctly use the CRS from a Rasterio data source.  This PR introduces a version check and provides correct logic for either case.

Supersedes #923 

### Checklist

- [ ] Updated `docs/changelog.rst`
- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Notes

The requirement for versions of pyproj above 2.2.0 is imposed by s2cloudless, used by cloud-buster, so this seems like a necessary feature to handle.

## Testing

In a container, install s2cloudless, and run `python -m unittest discover tests` and `tests_v2`.  Both test commands work before and after the s2cloudless install.