### PR TITLE
Revert pyproj upgrade

### DIFF
--- a/rastervision/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision/data/crs_transformer/rasterio_crs_transformer.py
@@ -16,10 +16,14 @@ class RasterioCRSTransformer(CRSTransformer):
             image_dataset: Rasterio DatasetReader
             map_crs: CRS code
         """
-        self.map_proj = pyproj.Proj(init=map_crs)
-        self.image_proj = pyproj.Proj(image_crs.wkt)
-
-        super().__init__(image_crs.wkt, map_crs, transform)
+        if pyproj.__version__ > '2.0.0':
+            self.map_proj = pyproj.Proj(init=map_crs)
+            self.image_proj = pyproj.Proj(image_crs.wkt)
+            super().__init__(image_crs.wkt, map_crs, transform)
+        else:
+            self.map_proj = pyproj.Proj(init=map_crs)
+            self.image_proj = pyproj.Proj(image_crs)
+            super().__init__(image_crs, map_crs, transform)
 
     def map_to_pixel(self, map_point):
         """Transform point from map to pixel-based coordinates.

--- a/rastervision/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision/data/crs_transformer/rasterio_crs_transformer.py
@@ -16,14 +16,10 @@ class RasterioCRSTransformer(CRSTransformer):
             image_dataset: Rasterio DatasetReader
             map_crs: CRS code
         """
-        if pyproj.__version__ > '2.0.0':
-            self.map_proj = pyproj.Proj(init=map_crs)
-            self.image_proj = pyproj.Proj(image_crs.wkt)
-            super().__init__(image_crs.wkt, map_crs, transform)
-        else:
-            self.map_proj = pyproj.Proj(init=map_crs)
-            self.image_proj = pyproj.Proj(image_crs)
-            super().__init__(image_crs, map_crs, transform)
+        self.map_proj = pyproj.Proj(init=map_crs)
+        self.image_proj = pyproj.Proj(image_crs)
+
+        super().__init__(image_crs, map_crs, transform)
 
     def map_to_pixel(self, map_point):
         """Transform point from map to pixel-based coordinates.

--- a/rastervision/data/raster_source/rasterio_source.py
+++ b/rastervision/data/raster_source/rasterio_source.py
@@ -167,7 +167,7 @@ class RasterioSource(ActivateMixin, RasterSource):
             self.image_dataset)
         self.crs = self.image_dataset.crs
         if self.crs:
-            self.proj = self.crs_transformer.image_proj
+            self.proj = pyproj.Proj(self.crs)
         else:
             self.proj = None
         self.crs = str(self.crs)

--- a/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
@@ -16,15 +16,10 @@ class RasterioCRSTransformer(CRSTransformer):
             image_dataset: Rasterio DatasetReader
             map_crs: CRS code
         """
-        if pyproj.__version__ > '2.0.0':
-            self.map_proj = pyproj.Proj(init=map_crs)
-            self.image_proj = pyproj.Proj(image_crs.wkt)
-            super().__init__(image_crs.wkt, map_crs, transform)
-        else:
-            self.map_proj = pyproj.Proj(init=map_crs)
-            self.image_proj = pyproj.Proj(image_crs)
-            super().__init__(image_crs, map_crs, transform)
+        self.map_proj = pyproj.Proj(init=map_crs)
+        self.image_proj = pyproj.Proj(image_crs)
 
+        super().__init__(image_crs, map_crs, transform)
 
     def map_to_pixel(self, map_point):
         """Transform point from map to pixel-based coordinates.

--- a/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision2/core/data/crs_transformer/rasterio_crs_transformer.py
@@ -16,10 +16,14 @@ class RasterioCRSTransformer(CRSTransformer):
             image_dataset: Rasterio DatasetReader
             map_crs: CRS code
         """
-        self.map_proj = pyproj.Proj(init=map_crs)
-        self.image_proj = pyproj.Proj(image_crs.wkt)
-
-        super().__init__(image_crs.wkt, map_crs, transform)
+        if pyproj.__version__ > '2.0.0':
+            self.map_proj = pyproj.Proj(init=map_crs)
+            self.image_proj = pyproj.Proj(image_crs.wkt)
+            super().__init__(image_crs.wkt, map_crs, transform)
+        else:
+            self.map_proj = pyproj.Proj(init=map_crs)
+            self.image_proj = pyproj.Proj(image_crs)
+            super().__init__(image_crs, map_crs, transform)
 
 
     def map_to_pixel(self, map_point):

--- a/rastervision2/core/data/raster_source/rasterio_source.py
+++ b/rastervision2/core/data/raster_source/rasterio_source.py
@@ -167,7 +167,7 @@ class RasterioSource(ActivateMixin, RasterSource):
             self.image_dataset)
         self.crs = self.image_dataset.crs
         if self.crs:
-            self.proj = self.crs_transformer.image_proj
+            self.proj = pyproj.Proj(self.crs)
         else:
             self.proj = None
         self.crs = str(self.crs)

--- a/rastervision2/examples/pipeline.py
+++ b/rastervision2/examples/pipeline.py
@@ -1,6 +1,5 @@
-from rastervision2.aws_batch.aws_batch_runner import AWS_BATCH
 from rastervision2.pipeline.pipeline_config import PipelineConfig
-
+from rastervision2.aws_batch.aws_batch_runner import AWS_BATCH
 
 def get_config(runner):
     root_uri = ('s3://raster-vision-lf-dev/examples/test-output/pipeline'

--- a/rastervision2/examples/test.py
+++ b/rastervision2/examples/test.py
@@ -101,7 +101,7 @@ def run_experiment(exp_cfg, output_dir, test=True, remote=False, commands=None):
     rv_profile = exp_cfg.get('rv_profile')
     if rv_profile is not None:
         cmd += ['-p', rv_profile]
-    cmd += ['run', 'aws_batch' if remote else 'inprocess', exp_cfg['module']]
+    cmd += ['run', 'batch' if remote else 'inprocess', exp_cfg['module']]
     if commands is not None:
         cmd += commands
     cmd += ['-a', 'raw_uri', uris['raw_uri']]

--- a/rastervision2/pipeline/rv_config.py
+++ b/rastervision2/pipeline/rv_config.py
@@ -9,7 +9,6 @@ from everett import NO_VALUE
 from everett.manager import (ConfigManager, ConfigDictEnv, ConfigIniEnv,
                              ConfigOSEnv)
 
-from rastervision2.aws_batch.aws_batch_runner import AWS_BATCH
 from rastervision2.pipeline.verbosity import Verbosity
 
 log = logging.getLogger(__name__)
@@ -18,7 +17,7 @@ log = logging.getLogger(__name__)
 class LocalEnv(object):
     def get(self, key, namespace=None):
         if isinstance(namespace, list):
-            if AWS_BATCH in namespace or 'aws_s3' in namespace:
+            if 'batch' in namespace or 'aws_s3' in namespace:
                 return ''
         else:
             return NO_VALUE

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ everett==0.9
 pluginbase==0.7
 lxml==4.2.*
 shapely==1.6.*
-pyproj==2.6.1.post1
+pyproj==1.9.6
 imageio==2.3.*
 scikit-learn==0.19.*
 six==1.11.*


### PR DESCRIPTION
This PR reverts #940 which upgraded pyproj and also fixes some problems from #926. Unfortunately, the upgrade broke the ability to generate chips, but this wasn't caught by the integration or unit tests. Also, the upgrade caused pyproj to start spraying a huge number of FutureWarnings which I was unable to suppress. We will have to revisit this after the release.