### PR TITLE
Set seed before getting random subset of training inds

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -299,6 +299,7 @@ class Learner(ABC):
                 group_train_sz = self.cfg.data.group_train_sz
                 if group_train_sz is not None:
                     train_inds = list(range(len(train_ds)))
+                    random.seed(1234)
                     random.shuffle(train_inds)
                     train_inds = train_inds[0:group_train_sz]
                     train_ds = Subset(train_ds, train_inds)
@@ -341,6 +342,7 @@ class Learner(ABC):
 
         if cfg.data.train_sz is not None:
             train_inds = list(range(len(train_ds)))
+            random.seed(1234)
             random.shuffle(train_inds)
             train_inds = train_inds[0:cfg.data.train_sz]
             train_ds = Subset(train_ds, train_inds)


### PR DESCRIPTION
This is so that repeated runs that use the `group_train_sz` or `train_sz` option will use the same random subset of training images, reducing a source of variance.
