### PR TITLE
Improve Batch job names by adding a custom run name and the command name

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -59,10 +59,11 @@ Run is the main interface into running pipelines.
     this is omitted, all commands will be run.
 
     Options:
-    -a, --arg KEY VALUE   Arguments to pass to get_config function
-    -s, --splits INTEGER  Number of processes to run in parallel for splittable
-                          commands
-    --help                Show this message and exit.
+    -a, --arg            KEY VALUE   Arguments to pass to get_config function
+    -s, --splits         INTEGER     Number of processes to run in parallel for splittable
+                                     commands
+    --pipeline-run-name  TEXT        The name for this run of the pipeline.
+    --help                           Show this message and exit.
 
 Some specific parameters to call out:
 

--- a/rastervision_aws_batch/rastervision/aws_batch/aws_batch_runner.py
+++ b/rastervision_aws_batch/rastervision/aws_batch/aws_batch_runner.py
@@ -106,7 +106,12 @@ class AWSBatchRunner(Runner):
     ```
     """
 
-    def run(self, cfg_json_uri, pipeline, commands, num_splits=1, pipeline_run_name: str = 'raster-vision'):
+    def run(self,
+            cfg_json_uri,
+            pipeline,
+            commands,
+            num_splits=1,
+            pipeline_run_name: str = 'raster-vision'):
         parent_job_ids = []
 
         # pipeline-specific job queue

--- a/rastervision_aws_batch/rastervision/aws_batch/aws_batch_runner.py
+++ b/rastervision_aws_batch/rastervision/aws_batch/aws_batch_runner.py
@@ -158,13 +158,13 @@ class AWSBatchRunner(Runner):
                     num_array_jobs = num_splits
                     cmd += ['--num-splits', str(num_splits)]
                 job_id = submit_job(
-                            cmd=' '.join(cmd),
-                            job_name=job_name,
-                            parent_job_ids=parent_job_ids,
-                            num_array_jobs=num_array_jobs,
-                            use_gpu=use_gpu,
-                            job_queue=job_queue,
-                            job_def=job_def)
+                    cmd=' '.join(cmd),
+                    job_name=job_name,
+                    parent_job_ids=parent_job_ids,
+                    num_array_jobs=num_array_jobs,
+                    use_gpu=use_gpu,
+                    job_queue=job_queue,
+                    job_def=job_def)
                 parent_job_ids = [job_id]
             else:
                 if command in pipeline.split_commands and num_splits > 1:
@@ -172,13 +172,13 @@ class AWSBatchRunner(Runner):
                         cmd = fn(-num_splits)
                         num_array_jobs = num_splits
                         job_id = submit_job(
-                                    cmd=' '.join(cmd),
-                                    job_name=job_name,
-                                    parent_job_ids=parent_job_ids,
-                                    num_array_jobs=num_array_jobs,
-                                    use_gpu=use_gpu,
-                                    job_queue=job_queue,
-                                    job_def=job_def)
+                            cmd=' '.join(cmd),
+                            job_name=job_name,
+                            parent_job_ids=parent_job_ids,
+                            num_array_jobs=num_array_jobs,
+                            use_gpu=use_gpu,
+                            job_queue=job_queue,
+                            job_def=job_def)
                         parent_job_ids = [job_id]
                     elif len(params) == 1 and not array_job_capable:
                         num_array_jobs = None

--- a/rastervision_aws_batch/rastervision/aws_batch/aws_batch_runner.py
+++ b/rastervision_aws_batch/rastervision/aws_batch/aws_batch_runner.py
@@ -13,6 +13,7 @@ AWS_BATCH = 'batch'
 
 
 def submit_job(cmd: List[str],
+               job_name: str,
                debug: bool = False,
                profile: str = False,
                attempts: int = 5,
@@ -54,7 +55,6 @@ def submit_job(cmd: List[str],
 
     import boto3
     client = boto3.client('batch')
-    job_name = 'raster-vision-{}'.format(uuid.uuid4())
 
     cmd_list = cmd.split(' ')
     if debug:
@@ -106,7 +106,7 @@ class AWSBatchRunner(Runner):
     ```
     """
 
-    def run(self, cfg_json_uri, pipeline, commands, num_splits=1):
+    def run(self, cfg_json_uri, pipeline, commands, num_splits=1, pipeline_run_name: str = 'raster-vision'):
         parent_job_ids = []
 
         # pipeline-specific job queue
@@ -147,6 +147,8 @@ class AWSBatchRunner(Runner):
             num_array_jobs = None
             use_gpu = command in pipeline.gpu_commands
 
+            job_name = f'{pipeline_run_name}-{command}-{uuid.uuid4()}'
+
             if not external:
                 cmd = [
                     'python', '-m', 'rastervision.pipeline.cli run_command',
@@ -156,12 +158,13 @@ class AWSBatchRunner(Runner):
                     num_array_jobs = num_splits
                     cmd += ['--num-splits', str(num_splits)]
                 job_id = submit_job(
-                    ' '.join(cmd),
-                    parent_job_ids=parent_job_ids,
-                    num_array_jobs=num_array_jobs,
-                    use_gpu=use_gpu,
-                    job_queue=job_queue,
-                    job_def=job_def)
+                            cmd=' '.join(cmd),
+                            job_name=job_name,
+                            parent_job_ids=parent_job_ids,
+                            num_array_jobs=num_array_jobs,
+                            use_gpu=use_gpu,
+                            job_queue=job_queue,
+                            job_def=job_def)
                 parent_job_ids = [job_id]
             else:
                 if command in pipeline.split_commands and num_splits > 1:
@@ -169,19 +172,21 @@ class AWSBatchRunner(Runner):
                         cmd = fn(-num_splits)
                         num_array_jobs = num_splits
                         job_id = submit_job(
-                            ' '.join(cmd),
-                            parent_job_ids=parent_job_ids,
-                            num_array_jobs=num_array_jobs,
-                            use_gpu=use_gpu,
-                            job_queue=job_queue,
-                            job_def=job_def)
+                                    cmd=' '.join(cmd),
+                                    job_name=job_name,
+                                    parent_job_ids=parent_job_ids,
+                                    num_array_jobs=num_array_jobs,
+                                    use_gpu=use_gpu,
+                                    job_queue=job_queue,
+                                    job_def=job_def)
                         parent_job_ids = [job_id]
                     elif len(params) == 1 and not array_job_capable:
                         num_array_jobs = None
                         new_parent_job_ids = []
                         for cmd in fn(num_splits):
                             job_id = submit_job(
-                                ' '.join(cmd),
+                                cmd=' '.join(cmd),
+                                job_name=job_name,
                                 parent_job_ids=parent_job_ids,
                                 num_array_jobs=num_array_jobs,
                                 use_gpu=use_gpu,
@@ -193,7 +198,8 @@ class AWSBatchRunner(Runner):
                         cmd = fn()
                         num_array_jobs = None
                         job_id = submit_job(
-                            ' '.join(cmd),
+                            cmd=' '.join(cmd),
+                            job_name=job_name,
                             parent_job_ids=parent_job_ids,
                             num_array_jobs=num_array_jobs,
                             use_gpu=use_gpu,
@@ -207,7 +213,8 @@ class AWSBatchRunner(Runner):
                         cmd = fn(1)[0]
                     num_array_jobs = 1
                     job_id = submit_job(
-                        ' '.join(cmd),
+                        cmd=' '.join(cmd),
+                        job_name=job_name,
                         parent_job_ids=parent_job_ids,
                         num_array_jobs=num_array_jobs,
                         use_gpu=use_gpu,

--- a/rastervision_pipeline/rastervision/pipeline/cli.py
+++ b/rastervision_pipeline/rastervision/pipeline/cli.py
@@ -104,7 +104,7 @@ def main(ctx: click.Context, profile: Optional[str], verbose: int,
     rv_config.set_everett_config(profile=profile)
 
 
-def _run_pipeline(cfg, runner, tmp_dir, splits=1, commands=None):
+def _run_pipeline(cfg, runner, tmp_dir, splits=1, commands=None, pipeline_run_name: str = 'raster-vision'):
     cfg.update()
     cfg.recursive_validate_config()
     # This is to run the validation again to check any fields that may have changed
@@ -116,7 +116,8 @@ def _run_pipeline(cfg, runner, tmp_dir, splits=1, commands=None):
     if not commands:
         commands = pipeline.commands
 
-    runner.run(cfg_json_uri, pipeline, commands, num_splits=splits)
+    runner.run(cfg_json_uri, pipeline, commands, num_splits=splits,
+               pipeline_run_name=pipeline_run_name)
 
 
 @main.command('run', short_help='Run sequence of commands within pipeline(s).')
@@ -135,8 +136,12 @@ def _run_pipeline(cfg, runner, tmp_dir, splits=1, commands=None):
     '-s',
     default=1,
     help='Number of splits to run in parallel for splittable commands')
+@click.option(
+    '--pipeline-run-name',
+    default='raster-vision',
+    help='The name for this run of the pipeline.')
 def run(runner: str, cfg_module: str, commands: List[str],
-        arg: List[Tuple[str, str]], splits: int):
+        arg: List[Tuple[str, str]], splits: int, pipeline_run_name: str):
     """Run COMMANDS within pipelines in CFG_MODULE using RUNNER.
 
     RUNNER: name of the Runner to use
@@ -157,7 +162,7 @@ def run(runner: str, cfg_module: str, commands: List[str],
     runner = registry.get_runner(runner)()
 
     for cfg in cfgs:
-        _run_pipeline(cfg, runner, tmp_dir, splits, commands)
+        _run_pipeline(cfg, runner, tmp_dir, splits, commands, pipeline_run_name)
 
 
 def _run_command(cfg_json_uri: str,

--- a/rastervision_pipeline/rastervision/pipeline/cli.py
+++ b/rastervision_pipeline/rastervision/pipeline/cli.py
@@ -104,7 +104,12 @@ def main(ctx: click.Context, profile: Optional[str], verbose: int,
     rv_config.set_everett_config(profile=profile)
 
 
-def _run_pipeline(cfg, runner, tmp_dir, splits=1, commands=None, pipeline_run_name: str = 'raster-vision'):
+def _run_pipeline(cfg,
+                  runner,
+                  tmp_dir,
+                  splits=1,
+                  commands=None,
+                  pipeline_run_name: str = 'raster-vision'):
     cfg.update()
     cfg.recursive_validate_config()
     # This is to run the validation again to check any fields that may have changed
@@ -116,8 +121,12 @@ def _run_pipeline(cfg, runner, tmp_dir, splits=1, commands=None, pipeline_run_na
     if not commands:
         commands = pipeline.commands
 
-    runner.run(cfg_json_uri, pipeline, commands, num_splits=splits,
-               pipeline_run_name=pipeline_run_name)
+    runner.run(
+        cfg_json_uri,
+        pipeline,
+        commands,
+        num_splits=splits,
+        pipeline_run_name=pipeline_run_name)
 
 
 @main.command('run', short_help='Run sequence of commands within pipeline(s).')
@@ -162,7 +171,8 @@ def run(runner: str, cfg_module: str, commands: List[str],
     runner = registry.get_runner(runner)()
 
     for cfg in cfgs:
-        _run_pipeline(cfg, runner, tmp_dir, splits, commands, pipeline_run_name)
+        _run_pipeline(cfg, runner, tmp_dir, splits, commands,
+                      pipeline_run_name)
 
 
 def _run_command(cfg_json_uri: str,

--- a/rastervision_pipeline/rastervision/pipeline/runner/inprocess_runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/inprocess_runner.py
@@ -13,7 +13,12 @@ class InProcessRunner(Runner):
     Useful for testing and debugging.
     """
 
-    def run(self, cfg_json_uri, pipeline, commands, num_splits=1):
+    def run(self,
+            cfg_json_uri,
+            pipeline,
+            commands,
+            num_splits=1,
+            pipeline_run_name: str = 'raster-vision'):
         for command in commands:
 
             # detect external command

--- a/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
@@ -16,7 +16,12 @@ class LocalRunner(Runner):
     This is implemented by generating a Makefile and then running it using make.
     """
 
-    def run(self, cfg_json_uri, pipeline, commands, num_splits=1, pipeline_run_name: str = 'raster-vision'):
+    def run(self,
+            cfg_json_uri,
+            pipeline,
+            commands,
+            num_splits=1,
+            pipeline_run_name: str = 'raster-vision'):
         num_commands = 0
         for command in commands:
             if command in pipeline.split_commands and num_splits > 1:

--- a/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
@@ -16,7 +16,7 @@ class LocalRunner(Runner):
     This is implemented by generating a Makefile and then running it using make.
     """
 
-    def run(self, cfg_json_uri, pipeline, commands, num_splits=1):
+    def run(self, cfg_json_uri, pipeline, commands, num_splits=1, pipeline_run_name: str = 'raster-vision'):
         num_commands = 0
         for command in commands:
             if command in pipeline.split_commands and num_splits > 1:

--- a/rastervision_pipeline/rastervision/pipeline/runner/runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/runner.py
@@ -16,7 +16,8 @@ class Runner():
             cfg_json_uri: str,
             pipeline: Pipeline,
             commands: List[str],
-            num_splits: int = 1):
+            num_splits: int = 1,
+            pipeline_run_name: str = 'raster-vision'):
         """Run commands in a Pipeline using a serialized PipelineConfig.
 
         Args:


### PR DESCRIPTION
## Overview

Implements the changes suggested in #967.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes


## Testing Instructions

* How to test this PR
-- Just run a `rastervision run batch` command with the option `--pipeline-run-name <name>`. The job(s) should show up on Batch with a name like `<name>-<command>-<uuid>`.

Closes #967 
