### PR TITLE
Add support for weighted loss for classification and semantic segmentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Added support for multiband images `#972 <https://github.com/azavea/raster-vision/pull/972>`_
+* Add support for weighted loss for classification and semantic segmentation `#977 <https://github.com/azavea/raster-vision/pull/977>`_
 
 
 Raster Vision 0.12

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
@@ -92,7 +92,10 @@ def save_image_crop(image_uri,
             if label_uri and vector_labels:
                 crs_transformer = RasterioCRSTransformer.from_dataset(
                     im_dataset)
-                geojson_vs_config = GeoJSONVectorSourceConfig(uri=label_uri)
+                geojson_vs_config = GeoJSONVectorSourceConfig(
+                    uri=label_uri,
+                    default_class_id=0,
+                    ignore_crs_field=True)
                 vs = geojson_vs_config.build(class_config, crs_transformer)
                 geojson = vs.get_geojson()
                 geoms = []

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
@@ -93,9 +93,7 @@ def save_image_crop(image_uri,
                 crs_transformer = RasterioCRSTransformer.from_dataset(
                     im_dataset)
                 geojson_vs_config = GeoJSONVectorSourceConfig(
-                    uri=label_uri,
-                    default_class_id=0,
-                    ignore_crs_field=True)
+                    uri=label_uri, default_class_id=0, ignore_crs_field=True)
                 vs = geojson_vs_config.build(class_config, crs_transformer)
                 geojson = vs.get_geojson()
                 geoms = []

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
@@ -30,6 +30,7 @@ class PyTorchChipClassificationConfig(PyTorchLearnerBackendConfig):
             log_tensorboard=self.log_tensorboard,
             run_tensorboard=self.run_tensorboard)
         learner.update()
+        learner.validate_config()
         return learner
 
     def build(self, pipeline, tmp_dir):

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -1,7 +1,10 @@
 from typing import List
 
-from rastervision.pipeline.config import register_config, Field
+from rastervision.pipeline.config import (register_config, Field, validator,
+                                          ConfigError)
 from rastervision.core.backend import BackendConfig
+from rastervision.pytorch_backend import (PyTorchSemanticSegmentationConfig,
+                                          PyTorchChipClassificationConfig)
 from rastervision.pytorch_learner.learner_config import (
     SolverConfig, ModelConfig, default_augmentors, augmentors as
     augmentor_list)
@@ -36,3 +39,12 @@ class PyTorchLearnerBackendConfig(BackendConfig):
 
     def build(self, pipeline, tmp_dir):
         raise NotImplementedError()
+
+    @validator('solver')
+    def validate_solver_config(cls, v):
+        if v.class_loss_weights is not None:
+            if cls not in (PyTorchSemanticSegmentationConfig,
+                           PyTorchChipClassificationConfig):
+                raise ConfigError(
+                    'class_loss_weights is currently only supported for '
+                    'Semantic Segmentation and Chip Classification.')

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -41,8 +41,9 @@ class PyTorchLearnerBackendConfig(BackendConfig):
     @validator('solver')
     def validate_solver_config(cls, v):
         if v.class_loss_weights is not None:
-            from rastervision.pytorch_backend import (PyTorchSemanticSegmentationConfig,
-                                                      PyTorchChipClassificationConfig)
+            from rastervision.pytorch_backend import (
+                PyTorchSemanticSegmentationConfig,
+                PyTorchChipClassificationConfig)
             if cls not in (PyTorchSemanticSegmentationConfig,
                            PyTorchChipClassificationConfig):
                 raise ConfigError(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -3,8 +3,6 @@ from typing import List
 from rastervision.pipeline.config import (register_config, Field, validator,
                                           ConfigError)
 from rastervision.core.backend import BackendConfig
-from rastervision.pytorch_backend import (PyTorchSemanticSegmentationConfig,
-                                          PyTorchChipClassificationConfig)
 from rastervision.pytorch_learner.learner_config import (
     SolverConfig, ModelConfig, default_augmentors, augmentors as
     augmentor_list)
@@ -43,8 +41,11 @@ class PyTorchLearnerBackendConfig(BackendConfig):
     @validator('solver')
     def validate_solver_config(cls, v):
         if v.class_loss_weights is not None:
+            from rastervision.pytorch_backend import (PyTorchSemanticSegmentationConfig,
+                                                      PyTorchChipClassificationConfig)
             if cls not in (PyTorchSemanticSegmentationConfig,
                            PyTorchChipClassificationConfig):
                 raise ConfigError(
                     'class_loss_weights is currently only supported for '
                     'Semantic Segmentation and Chip Classification.')
+        return v

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -33,6 +33,7 @@ class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
             log_tensorboard=self.log_tensorboard,
             run_tensorboard=self.run_tensorboard)
         learner.update()
+        learner.validate_config()
         return learner
 
     def build(self, pipeline, tmp_dir):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner.py
@@ -7,7 +7,6 @@ from typing import Optional
 import torch
 from torchvision import models
 import torch.nn as nn
-import torch.nn.functional as F
 from torch.utils.data import ConcatDataset
 
 from rastervision.pytorch_learner.learner import Learner

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner.py
@@ -37,7 +37,7 @@ class ClassificationLearner(Learner):
 
         loss_weights = self.cfg.solver.class_loss_weights
         if loss_weights is not None:
-            loss_weights = torch.Tensor(loss_weights, device=self.device)
+            loss_weights = torch.tensor(loss_weights, device=self.device)
             self.loss_fn = nn.CrossEntropyLoss(weight=loss_weights)
         else:
             self.loss_fn = nn.CrossEntropyLoss()

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from rastervision.pipeline.config import register_config
+from rastervision.pipeline.config import register_config, ConfigError
 from rastervision.pytorch_learner.learner_config import (
     LearnerConfig, DataConfig, ModelConfig)
 
@@ -28,3 +28,18 @@ class ClassificationLearnerConfig(LearnerConfig):
         from rastervision.pytorch_learner.classification_learner import (
             ClassificationLearner)
         return ClassificationLearner(self, tmp_dir, model_path=model_path)
+
+    def validate_config(self):
+        super().validate_config()
+        self.validate_class_loss_weights()
+
+    def validate_class_loss_weights(self):
+        if self.solver.class_loss_weights is None:
+            return
+
+        num_weights = len(self.solver.class_loss_weights)
+        num_classes = len(self.data.class_names)
+        if num_weights != num_classes:
+            raise ConfigError(
+                f'class_loss_weights ({num_weights}) must be same length as '
+                f'the number of classes ({num_classes})')

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -1,8 +1,11 @@
-from typing import List, Optional, Union, TYPE_CHECKING
 from os.path import join
 from enum import Enum
 
+from typing import List, Optional, Union, TYPE_CHECKING
 from pydantic import PositiveFloat, PositiveInt
+
+import numpy as np
+import torch
 
 from rastervision.pipeline.config import (Config, register_config, ConfigError,
                                           Field)
@@ -150,6 +153,8 @@ class SolverConfig(Config):
          'epochs with start and end LR being lr/10 and the peak being lr.'))
     multi_stage: List = Field(
         [], description=('List of epoch indices at which to divide LR by 10.'))
+    class_loss_weights: Optional[Union[list, tuple]] = Field(
+        None, description=('Class weights for weighted loss.'))
 
     def update(self, learner: Optional['LearnerConfig'] = None):
         pass

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -4,9 +4,6 @@ from enum import Enum
 from typing import List, Optional, Union, TYPE_CHECKING
 from pydantic import PositiveFloat, PositiveInt
 
-import numpy as np
-import torch
-
 from rastervision.pipeline.config import (Config, register_config, ConfigError,
                                           Field)
 from rastervision.pytorch_learner.utils import color_to_triple

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -16,7 +16,6 @@ from PIL import Image
 
 import torch
 from torch import nn
-import torch.nn.functional as F
 from torch.utils.data import Dataset, ConcatDataset
 from torchvision import models
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -114,7 +114,7 @@ class SemanticSegmentationLearner(Learner):
 
         loss_weights = self.cfg.solver.class_loss_weights
         if loss_weights is not None:
-            loss_weights = torch.Tensor(loss_weights, device=self.device)
+            loss_weights = torch.tensor(loss_weights, device=self.device)
             self.loss_fn = nn.CrossEntropyLoss(weight=loss_weights)
         else:
             self.loss_fn = nn.CrossEntropyLoss()


### PR DESCRIPTION
## Overview

- Adds support for using a class weighted loss for classification and semantic segmentation (#867) 
    - custom weights can be provided as the optional parameter, `class_loss_weights`, to `SolverConfig`
        - must be provided as `list` or `tuple` since pydantic does not support serialization of numpy arrays and torch Tensors (if weights are generated as numpy arrays and torch Tensors, they can be conveniently converted to `list` using `.tolist()`)
    - if provided, the weights are converted to a `torch.Tensor` and passed as the `weight` parameter to `nn.CrossEntropyLoss`
    - validation for `class_loss_weights` involves checking if its length is equal to `len(DataConfig.class_names)`

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

- Also fixes a bug in a call to `GeoJSONVectorSourceConfig` in the chip classification example
- Not added to object detection, because the classification loss is calculated [deep within the FasterRCNN model](https://github.com/pytorch/vision/blob/master/torchvision/models/detection/roi_heads.py#L35) and it does not expose an API to provide weights for it.

## Testing Instructions

* How to test this PR
    - e.g. pass `class_loss_weights=torch.ones(len(class_config.names) + 1).tolist()` to SolverConfig in `isprs_potsdam.py`
    - e.g. pass `class_loss_weights=torch.ones(len(class_config.names)).tolist()` to SolverConfig in `isprs_potsdam.py`
    - on passing all zeros, the loss should be zero

Closes #867 