### PR TITLE
Add multi raster source

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Added support for multiband images `#972 <https://github.com/azavea/raster-vision/pull/972>`_
+* Added a multi raster source `#978 <https://github.com/azavea/raster-vision/pull/982>`_
 
 
 Raster Vision 0.12

--- a/rastervision_core/rastervision/core/data/raster_source/__init__.py
+++ b/rastervision_core/rastervision/core/data/raster_source/__init__.py
@@ -6,3 +6,5 @@ from rastervision.core.data.raster_source.rasterio_source import *
 from rastervision.core.data.raster_source.rasterio_source_config import *
 from rastervision.core.data.raster_source.rasterized_source import *
 from rastervision.core.data.raster_source.rasterized_source_config import *
+from rastervision.core.data.raster_source.multi_raster_source import *
+from rastervision.core.data.raster_source.multi_raster_source_config import *

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -1,0 +1,78 @@
+import logging
+import math
+import os
+import pyproj
+import subprocess
+from decimal import Decimal
+import tempfile
+
+import numpy as np
+import rasterio
+from rasterio.enums import (ColorInterp, MaskFlags)
+
+from rastervision.pipeline.file_system import download_if_needed
+from rastervision.core.box import Box
+from rastervision.core.data.raster_source import RasterSource
+from rastervision.core.data import (ActivateMixin, ActivationError)
+
+
+class MultiRasterSource(ActivateMixin, RasterSource):
+
+	def __init__(self, raster_sources, raster_transformers=[]):
+		self.raster_sources = raster_sources
+        self.raster_transformers = raster_transformers
+
+    def _activate(self):
+        for rs in self.raster_sources:
+			rs._activate()
+
+    def _deactivate(self):
+        for rs in self.raster_sources:
+			rs._deactivate()
+
+    def get_extent(self):
+        raise NotImplementedError()
+
+    def get_dtype(self):
+        raise NotImplementedError()
+
+    def get_crs_transformer(self):
+        raise NotImplementedError()
+
+    def _get_chip(self, window):
+        """Return the raw chip located in the window.
+
+        Args:
+            window: Box
+
+        Returns:
+            [height, width, channels] numpy array
+        """
+        chip_slices = [rs._get_chip(window) for rs in self.raster_sources]
+		chip = np.concatenate(chip_slices, axis=-1)
+		return chip
+
+    def get_raw_chip(self, window):
+        """Return raw chip without using channel_order or applying transforms.
+
+        Args:
+            window: (Box) the window for which to get the chip
+
+        Returns:
+            np.ndarray with shape [height, width, channels]
+        """
+        return self._get_chip(window)
+
+    def get_image_array(self):
+        """Return entire transformed image array.
+
+        Not safe to call on very large RasterSources.
+        """
+        raise NotImplementedError()
+
+    def get_raw_image_array(self):
+        """Return entire raw image without using channel_order or applying transforms.
+
+        Not safe to call on very large RasterSources.
+        """
+        raise NotImplementedError()

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -14,30 +14,58 @@ from rastervision.pipeline.file_system import download_if_needed
 from rastervision.core.box import Box
 from rastervision.core.data.raster_source import RasterSource
 from rastervision.core.data import (ActivateMixin, ActivationError)
+from rastervision.core.data.crs_transformer import CRSTransformer
+from rastervision.core.data.utils import all_equal
+
+
+class MultiRasterSourceError(Exception):
+    pass
 
 
 class MultiRasterSource(ActivateMixin, RasterSource):
+    def __init__(self,
+                 raster_sources,
+                 raw_channel_order,
+                 raster_transformers=[]):
+        super().__init__([], len(raw_channel_order), raster_transformers)
+        self.raster_sources = raster_sources
+        self.raw_channel_order = raw_channel_order
+        self.num_channels = len(self.raw_channel_order)
+        self.crs_transformer = CRSTransformer()
+        self.validate_raster_sources()
 
-	def __init__(self, raster_sources, raster_transformers=[]):
-		self.raster_sources = raster_sources
-        self.raster_transformers = raster_transformers
+    def validate_raster_sources(self):
+        dtypes = [rs.get_dtype() for rs in self.raster_sources]
+        if not all_equal(dtypes):
+            raise MultiRasterSourceError(
+                'dtypes of all sub raster sources must be same')
+
+        num_channels = sum(rs.num_channels for rs in self.raster_sources)
+        if num_channels != self.num_channels:
+            raise MultiRasterSourceError(
+                'num_channels and channel mappings for sub raster sources do '
+                'not match')
 
     def _activate(self):
         for rs in self.raster_sources:
-			rs._activate()
+            rs._activate()
 
     def _deactivate(self):
         for rs in self.raster_sources:
-			rs._deactivate()
+            rs._deactivate()
 
     def get_extent(self):
-        raise NotImplementedError()
+        rs = self.raster_sources[0]
+        extent = rs.get_extent()
+        return extent
 
     def get_dtype(self):
-        raise NotImplementedError()
+        rs = self.raster_sources[0]
+        dtype = rs.get_dtype()
+        return dtype
 
     def get_crs_transformer(self):
-        raise NotImplementedError()
+        return self.crs_transformer
 
     def _get_chip(self, window):
         """Return the raw chip located in the window.
@@ -49,8 +77,9 @@ class MultiRasterSource(ActivateMixin, RasterSource):
             [height, width, channels] numpy array
         """
         chip_slices = [rs._get_chip(window) for rs in self.raster_sources]
-		chip = np.concatenate(chip_slices, axis=-1)
-		return chip
+        chip = np.concatenate(chip_slices, axis=-1)
+        chip = chip[..., self.raw_channel_order]
+        return chip
 
     def get_raw_chip(self, window):
         """Return raw chip without using channel_order or applying transforms.
@@ -63,16 +92,18 @@ class MultiRasterSource(ActivateMixin, RasterSource):
         """
         return self._get_chip(window)
 
-    def get_image_array(self):
-        """Return entire transformed image array.
-
-        Not safe to call on very large RasterSources.
-        """
-        raise NotImplementedError()
-
     def get_raw_image_array(self):
         """Return entire raw image without using channel_order or applying transforms.
 
         Not safe to call on very large RasterSources.
         """
-        raise NotImplementedError()
+        window = self.get_extent()
+        return self.get_raw_chip(window)
+
+    def get_image_array(self):
+        """Return entire transformed image array.
+
+        Not safe to call on very large RasterSources.
+        """
+        window = self.get_extent()
+        return self.get_chip(window)

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -6,8 +6,7 @@ import numpy as np
 from rastervision.core.box import Box
 from rastervision.core.data import ActivateMixin
 from rastervision.core.data.raster_source import RasterSource
-from rastervision.core.data.crs_transformer import (CRSTransformer,
-                                                    IdentityCRSTransformer)
+from rastervision.core.data.crs_transformer import CRSTransformer
 from rastervision.core.data.utils import all_equal
 
 
@@ -30,11 +29,11 @@ class MultiRasterSource(ActivateMixin, RasterSource):
 
         Args:
             raster_sources (Sequence[RasterSource]): Sequence of RasterSources.
-            raw_channel_order (Sequence[conint(ge=0)]): Channel ordering that 
+            raw_channel_order (Sequence[conint(ge=0)]): Channel ordering that
                 will always be applied before channel_order.
-            channel_order (Sequence[conint(ge=0)], optional): Channel ordering  
+            channel_order (Sequence[conint(ge=0)], optional): Channel ordering
                 that will be used by .get_chip(). Defaults to None.
-            raster_transformers (Sequence, optional): Sequence of transformers. 
+            raster_transformers (Sequence, optional): Sequence of transformers.
                 Defaults to [].
         """
         num_channels = len(raw_channel_order)
@@ -103,7 +102,7 @@ class MultiRasterSource(ActivateMixin, RasterSource):
         return chip
 
     def get_chip(self, window: Box) -> np.ndarray:
-        """Return the transformed chip in the window. 
+        """Return the transformed chip in the window.
 
         Get raw chips from sub raster sources, concatenate them,
         apply raw_channel_order, followed by channel_order, followed

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -4,7 +4,7 @@ from pydantic import conint
 import numpy as np
 
 from rastervision.core.box import Box
-from rastervision.core.data import (ActivateMixin, ActivationError)
+from rastervision.core.data import ActivateMixin
 from rastervision.core.data.raster_source import RasterSource
 from rastervision.core.data.crs_transformer import (CRSTransformer,
                                                     IdentityCRSTransformer)

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -19,10 +19,12 @@ class MultiRasterSource(ActivateMixin, RasterSource):
     """A RasterSource that combines multiple RasterSources by concatenting
     their output along the channel dimension (assumed to be the last dimension).
     """
+
     def __init__(self,
                  raster_sources: Sequence[RasterSource],
                  raw_channel_order: Sequence[conint(ge=0)],
                  channel_order: Optional[Sequence[conint(ge=0)]] = None,
+                 crs_source: conint(ge=0) = 0,
                  raster_transformers: Sequence = []):
         """Constructor.
 
@@ -43,10 +45,9 @@ class MultiRasterSource(ActivateMixin, RasterSource):
 
         self.raster_sources = raster_sources
         self.raw_channel_order = list(raw_channel_order)
+        self.crs_source = crs_source
 
         self.validate_raster_sources()
-
-        self.crs_transformer = IdentityCRSTransformer()
 
     def validate_raster_sources(self) -> None:
         dtypes = [rs.get_dtype() for rs in self.raster_sources]
@@ -81,7 +82,8 @@ class MultiRasterSource(ActivateMixin, RasterSource):
         return dtype
 
     def get_crs_transformer(self) -> CRSTransformer:
-        return self.crs_transformer
+        rs = self.raster_sources[self.crs_source]
+        return rs.get_crs_transformer()
 
     def _get_chip(self, window: Box) -> np.ndarray:
         """Return the raw chip located in the window.

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -27,7 +27,11 @@ class MultiRasterSource(ActivateMixin, RasterSource):
                  raster_sources,
                  raw_channel_order,
                  raster_transformers=[]):
-        super().__init__([], len(raw_channel_order), raster_transformers)
+
+        num_channels = len(raw_channel_order)
+        channel_order = list(range(num_channels))
+        super().__init__(channel_order, num_channels, raster_transformers)
+
         self.raster_sources = raster_sources
         self.raw_channel_order = raw_channel_order
         self.num_channels = len(self.raw_channel_order)

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -39,18 +39,20 @@ class MultiRasterSource(ActivateMixin, RasterSource):
         dtypes = [rs.get_dtype() for rs in self.raster_sources]
         if not all_equal(dtypes):
             raise MultiRasterSourceError(
-                'dtypes of all sub raster sources must be equal')
+                'dtypes of all sub raster sources must be equal. '
+                f'Got: {dtypes}')
 
         extents = [rs.get_extent() for rs in self.raster_sources]
         if not all_equal(extents):
             raise MultiRasterSourceError(
-                'extents of all sub raster sources must be equal')
+                'extents of all sub raster sources must be equal. '
+                f'Got: {extents}')
 
-        num_channels = sum(rs.num_channels for rs in self.raster_sources)
-        if num_channels != self.num_channels:
+        sub_num_channels = sum(rs.num_channels for rs in self.raster_sources)
+        if sub_num_channels != self.num_channels:
             raise MultiRasterSourceError(
-                'num_channels and channel mappings for sub raster sources do '
-                'not match')
+                f'num_channels ({self.num_channels}) != sum of num_channels '
+                f'of sub raster sources ({sub_num_channels})')
 
     def _subcomponents_to_activate(self) -> None:
         return self.raster_sources

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -1,26 +1,63 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
-from rastervision.pipeline.config import Config, register_config, Field
+import numpy as np
+
+from rastervision.pipeline.config import (Config, register_config, Field,
+                                          ConfigError)
 from rastervision.core.data.raster_transformer import RasterTransformerConfig
-from rastervision.core.data.raster_source import RasterSourceConfig, MultiRasterSource
+from rastervision.core.data.raster_source import RasterSourceConfig, RasterioSourceConfig, MultiRasterSource
 
 
-@register_config('raster_source')
+@register_config('multi_raster_source')
 class MultiRasterSourceConfig(RasterSourceConfig):
-	# TODO add descriptions
-	raster_source_configs: List[Tuple[RasterSourceConfig, tuple]] = Field([], description='')
-	raw_channel_order: Optional[List[int]] = Field(None, description='')
+    raster_sources: List[Tuple[RasterSourceConfig, Union[tuple, List[
+        int]]]] = Field(
+            ...,
+            description='List of (RasterSourceConfig, indices) pair, where '
+            'are the positions to which each channel of the raster source will '
+            'be sent.')
 
-	def update(self):
-		self.raw_channel_order = sum(list(cfg[1]) for cfg in self.raster_source_configs], [])
+    def get_raw_channel_order(self):
+        channel_mappings = sum((list(inds) for _, inds in self.raster_sources),
+                               [])
+        self.validate_channel_mappings(channel_mappings)
+        raw_channel_order = np.argsort(channel_mappings)
+
+        return raw_channel_order
+
+    def validate_channel_mappings(self, channel_mappings):
+        # ensure we have a source channel for each channel idx
+        if set(channel_mappings) != set(range(len(channel_mappings))):
+            raise ConfigError(f'Missing mappings for some channels.')
+
+    def validate_config(self):
+        super().validate_config()
+
+        if len(self.raster_sources) == 0:
+            raise ConfigError(f'No raster sources provided.')
+
+        for i, (_, inds) in enumerate(self.raster_sources):
+            if len(inds) == 0:
+                raise ConfigError(
+                    f'Got no indices for raster source at index {i}.')
+            if isinstance(inds, tuple):
+                if any(not isinstance(ind, int) for ind in inds):
+                    raise ConfigError(f'Indices must be ints. Got: {ind}.')
+            if any(ind < 0 for ind in inds):
+                raise ConfigError(f'Indices must be >= 0. Got: {ind}.')
 
     def build(self, tmp_dir, use_transformers=True):
         raster_transformers = ([rt.build() for rt in self.transformers]
                                if use_transformers else [])
 
-		raster_sources = [cfg.build(tmp_dir, use_transformers) for cfg in self.raster_source_configs]
-		multi_raster_source = MultiRasterSource(raster_sources, raster_transformers)
-		return multi_raster_source
+        raster_sources = [
+            cfg.build(tmp_dir, use_transformers) for cfg, _ in self.raster_sources
+        ]
+        multi_raster_source = MultiRasterSource(
+            raster_sources=raster_sources,
+            raw_channel_order=self.get_raw_channel_order(),
+            raster_transformers=raster_transformers)
+        return multi_raster_source
 
     def update(self, pipeline=None, scene=None):
         for t in self.transformers:

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -15,7 +15,7 @@ class SubRasterSourceConfig(Config):
     raster_source: RasterSourceConfig = Field(
         ...,
         description=
-        'A RasterSourceConfig that will provide some of the channels.')
+        'A RasterSourceConfig that will provide a subset of the channels.')
     target_channels: Sequence[conint(ge=0)] = Field(
         ...,
         description='Channel indices to send each of the channels in this '
@@ -35,7 +35,7 @@ class SubRasterSourceConfig(Config):
 @register_config('multi_raster_source')
 class MultiRasterSourceConfig(RasterSourceConfig):
     raster_sources: Sequence[SubRasterSourceConfig] = Field(
-        ..., description='List of SubRasterSourceConfig to combine.')
+        ..., description='List of SubRasterSourceConfigs to combine.')
 
     def get_raw_channel_order(self):
         # concatenate all target_channels

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -33,6 +33,10 @@ class SubRasterSourceConfig(Config):
 class MultiRasterSourceConfig(RasterSourceConfig):
     raster_sources: Sequence[SubRasterSourceConfig] = Field(
         ..., description='List of SubRasterSourceConfigs to combine.')
+    crs_source: conint(ge=0) = Field(
+        0,
+        description=
+        'Use the crs_transformer of the raster source at this index.')
 
     def get_raw_channel_order(self):
         # concatenate all target_channels
@@ -83,6 +87,7 @@ class MultiRasterSourceConfig(RasterSourceConfig):
             raster_sources=built_raster_sources,
             raw_channel_order=self.get_raw_channel_order(),
             channel_order=self.channel_order,
+            crs_source=self.crs_source,
             raster_transformers=raster_transformers)
         return multi_raster_source
 

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -62,7 +62,7 @@ class MultiRasterSourceConfig(RasterSourceConfig):
 
         # check compatibility with channel_order, if given
         if self.channel_order:
-            if len(self.channel_order != len(raw_channel_order)):
+            if len(self.channel_order) != len(raw_channel_order):
                 raise ConfigError(
                     f'Channel mappings ({raw_channel_order}) and '
                     f'channel_order ({channel_order}) are incompatible.')

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -1,0 +1,27 @@
+from typing import List, Optional, Tuple
+
+from rastervision.pipeline.config import Config, register_config, Field
+from rastervision.core.data.raster_transformer import RasterTransformerConfig
+from rastervision.core.data.raster_source import RasterSourceConfig, MultiRasterSource
+
+
+@register_config('raster_source')
+class MultiRasterSourceConfig(RasterSourceConfig):
+	# TODO add descriptions
+	raster_source_configs: List[Tuple[RasterSourceConfig, tuple]] = Field([], description='')
+	raw_channel_order: Optional[List[int]] = Field(None, description='')
+
+	def update(self):
+		self.raw_channel_order = sum(list(cfg[1]) for cfg in self.raster_source_configs], [])
+
+    def build(self, tmp_dir, use_transformers=True):
+        raster_transformers = ([rt.build() for rt in self.transformers]
+                               if use_transformers else [])
+
+		raster_sources = [cfg.build(tmp_dir, use_transformers) for cfg in self.raster_source_configs]
+		multi_raster_source = MultiRasterSource(raster_sources, raster_transformers)
+		return multi_raster_source
+
+    def update(self, pipeline=None, scene=None):
+        for t in self.transformers:
+            t.update(pipeline, scene)

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -1,11 +1,8 @@
 from typing import Sequence
 from pydantic import conint
 
-import numpy as np
-
 from rastervision.pipeline.config import (Config, register_config, Field,
                                           ConfigError, validator)
-from rastervision.core.data.raster_transformer import RasterTransformerConfig
 from rastervision.core.data.raster_source import (RasterSourceConfig,
                                                   MultiRasterSource)
 
@@ -65,7 +62,7 @@ class MultiRasterSourceConfig(RasterSourceConfig):
             if len(self.channel_order) != len(raw_channel_order):
                 raise ConfigError(
                     f'Channel mappings ({raw_channel_order}) and '
-                    f'channel_order ({channel_order}) are incompatible.')
+                    f'channel_order ({self.channel_order}) are incompatible.')
 
     @validator('raster_sources')
     def validate_raster_sources(cls, v):

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -78,7 +78,7 @@ def get_config(runner,
                processed_uri: str,
                root_uri: str,
                test: bool = False) -> SemanticSegmentationConfig:
-    '''Generate the pipeline config for this task. This function will be called
+    """Generate the pipeline config for this task. This function will be called
     by RV, with arguments from the command line, when this example is run.
 
     Args:
@@ -91,7 +91,7 @@ def get_config(runner,
 
     Returns:
         SemanticSegmentationConfig: A pipeline config.
-    '''
+    """
     if not test:
         train_ids, val_ids = TRAIN_IDS, VAL_IDS
     else:
@@ -156,7 +156,7 @@ def get_config(runner,
 # Utils
 ####################
 class UriPath(object):
-    ''' Workaround for pathlib.Path converting "s3://abc to s3:/abc" '''
+    """ Workaround for pathlib.Path converting "s3://abc to s3:/abc" """
 
     def __init__(self, s):
         from pathlib import Path
@@ -214,7 +214,7 @@ def make_scene(raw_uri: UriPath,
 def make_multi_raster_source(
         rgbir_raster_uri: Union[UriPath, str],
         elevation_raster_uri: Union[UriPath, str]) -> MultiRasterSourceConfig:
-    ''' Create multi raster source by combining rgbir and elevation sources. '''
+    """ Create multi raster source by combining rgbir and elevation sources. """
     rgbir_raster_uri = str(rgbir_raster_uri)
     elevation_raster_uri = str(elevation_raster_uri)
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -214,20 +214,22 @@ def make_scene(raw_uri: UriPath,
 def make_multi_raster_source(
         rgbir_raster_uri: Union[UriPath, str],
         elevation_raster_uri: Union[UriPath, str]) -> MultiRasterSourceConfig:
+    ''' Create multi raster source by combining rgbir and elevation sources. '''
     rgbir_raster_uri = str(rgbir_raster_uri)
     elevation_raster_uri = str(elevation_raster_uri)
 
-    # create multi raster source by combining rgbir and elevation sources
-    rgbir_source = SubRasterSourceConfig(
-        raster_source=RasterioSourceConfig(
-            uris=[rgbir_raster_uri], channel_order=[0, 1, 2, 3]),
-        target_channels=[0, 1, 2, 3])
-    elevation_source = SubRasterSourceConfig(
-        raster_source=RasterioSourceConfig(
-            uris=[elevation_raster_uri], channel_order=[0]),
-        target_channels=[4])
-    raster_source = MultiRasterSourceConfig(
-        raster_sources=[rgbir_source, elevation_source])
+    rgbir_source = RasterioSourceConfig(
+        uris=[rgbir_raster_uri], channel_order=[0, 1, 2, 3])
+
+    elevation_source = RasterioSourceConfig(
+        uris=[elevation_raster_uri], channel_order=[0])
+
+    raster_source = MultiRasterSourceConfig(raster_sources=[
+        SubRasterSourceConfig(
+            raster_source=rgbir_source, target_channels=[0, 1, 2, 3]),
+        SubRasterSourceConfig(
+            raster_source=elevation_source, target_channels=[4])
+    ])
 
     return raster_source
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -11,7 +11,7 @@ from rastervision.core.rv_pipeline import (
 from rastervision.core.data import (
     ClassConfig, RasterioSourceConfig, MultiRasterSourceConfig,
     SubRasterSourceConfig, SemanticSegmentationLabelSourceConfig,
-    SemanticSegmentationLabelStoreConfig)
+    SemanticSegmentationLabelStoreConfig, PolygonVectorOutputConfig)
 
 from rastervision.pytorch_backend import (PyTorchSemanticSegmentationConfig,
                                           SemanticSegmentationModelConfig)
@@ -254,7 +254,7 @@ def make_crop(processed_uri: UriPath,
     return crop_uri, label_crop_uri
 
 
-def make_label_source(class_config, label_uri: Union[UriPath, str]
+def make_label_source(class_config: ClassConfig, label_uri: Union[UriPath, str]
                       ) -> Tuple[SemanticSegmentationLabelSourceConfig,
                                  SemanticSegmentationLabelStoreConfig]:
     label_uri = str(label_uri)
@@ -267,6 +267,7 @@ def make_label_source(class_config, label_uri: Union[UriPath, str]
     # URI will be injected by scene config.
     # Using rgb=True because we want prediction TIFFs to be in
     # RGB format.
-    label_store = SemanticSegmentationLabelStoreConfig(rgb=True)
+    label_store = SemanticSegmentationLabelStoreConfig(
+        rgb=True, vector_output=[PolygonVectorOutputConfig(class_id=0)])
 
     return label_source, label_store

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -73,7 +73,10 @@ TEST_CROP_DIR = 'crops'
 ################
 # Config
 ################
-def get_config(runner, raw_uri, processed_uri, root_uri,
+def get_config(runner,
+               raw_uri: str,
+               processed_uri: str,
+               root_uri: str,
                test: bool = False) -> SemanticSegmentationConfig:
     '''Generate the pipeline config for this task. This function will be called
     by RV, with arguments from the command line, when this example is run.

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -174,7 +174,7 @@ class UriPath(object):
         import re
         s = str(self._path)
         # s3:/abc --> s3://abc
-        s = re.sub(r'^([^/]+):/([^/]?)', r'\1://\2', s)
+        s = re.sub(r'^([^/]+):(?:/([^/]|$))', r'\1://\2', s)
         return s
 
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -1,0 +1,212 @@
+# flake8: noqa
+
+import os
+from os.path import join
+from pathlib import Path
+from functools import partial
+
+from rastervision.core.rv_pipeline import *
+from rastervision.core.backend import *
+from rastervision.core.data import *
+from rastervision.core.analyzer import *
+from rastervision.pytorch_backend import *
+from rastervision.pytorch_learner import *
+from rastervision.pytorch_backend.examples.utils import get_scene_info, save_image_crop
+
+# -----------------
+# Input files
+# -----------------
+RGBIR_DIR = '4_Ortho_RGBIR'
+ELEVATION_DIR = 'elevation'
+LABEL_DIR = '5_Labels_for_participants'
+CROP_DIR = 'crops'
+
+RGBIR_FNAME = lambda scene_id: f'top_potsdam_{scene_id}_RGBIR.tif'
+ELEVATION_FNAME = lambda scene_id: f'{scene_id}.jpg'
+LABEL_FNAME = lambda scene_id: f'top_potsdam_{scene_id}_label.tif'
+
+TRAIN_IDS = [
+    '2-10', '2-11', '3-10', '3-11', '4-10', '4-11', '4-12', '5-10', '5-11',
+    '5-12', '6-10', '6-11', '6-7', '6-9', '7-10', '7-11', '7-12', '7-7', '7-8',
+    '7-9'
+]
+VAL_IDS = ['2-12', '3-12', '6-12']
+
+# -----------------
+# Data prep
+# -----------------
+CLASS_NAMES = [
+    'Car', 'Building', 'Low Vegetation', 'Tree', 'Impervious', 'Clutter'
+]
+CLASS_COLORS = [
+    '#ffff00', '#0000ff', '#00ffff', '#00ff00', '#ffffff', '#ff0000'
+]
+
+CHIP_SIZE = 300
+
+# -----------------
+# Training
+# -----------------
+LR = 1e-4
+NUM_EPOCHS = 10
+BATCH_SIZE = 8
+ONE_CYCLE = True
+LOG_TENSORBOARD = True
+RUN_TENSORBOARD = False
+CHANNEL_DISPLAY_GROUPS = {'RGB': (0, 1, 2), 'IR': (3, ), 'Elevation': (4, )}
+
+# -----------------
+# Test mode settings
+# -----------------
+TEST_MODE_TRAIN_IDS = TRAIN_IDS[:2]
+TEST_MODE_VAL_IDS = VAL_IDS[:2]
+TEST_MODE_NUM_EPOCHS = 2
+TEST_MODE_BATCH_SIZE = 2
+TEST_CROP_SIZE = 600
+
+
+####################
+# Utils
+####################
+def make_crop(processed_uri, raster_uri, label_uri):
+    crop_uri = processed_uri / CROP_DIR / raster_uri.name
+    label_crop_uri = processed_uri / CROP_DIR / label_uri.name
+
+    save_image_crop(
+        str(raster_uri),
+        str(crop_uri),
+        label_uri=str(label_uri),
+        label_crop_uri=str(label_crop_uri),
+        size=TEST_CROP_SIZE,
+        vector_labels=False)
+
+    return crop_uri, label_crop_uri
+
+
+def make_label_source(class_config, label_uri):
+    label_uri = str(label_uri)
+    # Using with_rgb_class_map because label TIFFs have classes encoded as
+    # RGB colors.
+    label_source = SemanticSegmentationLabelSourceConfig(
+        rgb_class_config=class_config,
+        raster_source=RasterioSourceConfig(uris=[label_uri]))
+
+    # URI will be injected by scene config.
+    # Using rgb=True because we want prediction TIFFs to be in
+    # RGB format.
+    label_store = SemanticSegmentationLabelStoreConfig(
+        rgb=True, vector_output=[PolygonVectorOutputConfig(class_id=0)])
+
+    return label_source, label_store
+
+
+def make_multi_raster_source(rgbir_raster_uri, elevation_raster_uri):
+    rgbir_raster_uri = str(rgbir_raster_uri)
+    elevation_raster_uri = str(elevation_raster_uri)
+
+    # create multi raster source by combining rgbir and elevation sources
+    rgbir_source = RasterioSourceConfig(uris=[rgbir_raster_uri])
+    elevation_source = RasterioSourceConfig(uris=[elevation_raster_uri])
+
+    raster_source = MultiRasterSourceConfig(
+        raster_sources=[
+            (rgbir_source, (0, 1, 2, 3)),
+            (elevation_source, (4, ))])
+
+    return raster_source
+
+
+def make_scene(raw_uri, processed_uri, class_config, test, scene_id):
+    scene_id = scene_id.replace('-', '_')
+    rgbir_raster_uri = raw_uri / RGBIR_DIR / RGBIR_FNAME(scene_id)
+    elevation_raster_uri = raw_uri / ELEVATION_DIR / ELEVATION_FNAME(scene_id)
+    label_uri = raw_uri / LABEL_DIR / LABEL_FNAME(scene_id)
+
+    if test:
+        rgbir_raster_uri, _ = make_crop(processed_uri, rgbir_raster_uri,
+                                        label_uri)
+
+        elevation_raster_uri, label_uri = make_crop(
+            processed_uri, elevation_raster_uri, label_uri)
+
+    raster_source = make_multi_raster_source(rgbir_raster_uri,
+                                             elevation_raster_uri)
+
+    label_source, label_store = make_label_source(class_config, label_uri)
+
+    scene = SceneConfig(
+        id=scene_id,
+        raster_source=raster_source,
+        label_source=label_source,
+        label_store=label_store)
+
+    return scene
+
+
+################
+# Config
+################
+def get_config(runner, raw_uri, processed_uri, root_uri, test=False):
+
+    if test:
+        train_ids = TEST_MODE_TRAIN_IDS
+        val_ids = TEST_MODE_VAL_IDS
+    else:
+        train_ids = TRAIN_IDS
+        val_ids = VAL_IDS
+
+    raw_uri = Path(raw_uri)
+    processed_uri = Path(processed_uri)
+
+    # ----------------------------
+    # Configure chip generation
+    # ----------------------------
+    chip_sz = CHIP_SIZE
+    chip_options = SemanticSegmentationChipOptions(
+        window_method=SemanticSegmentationWindowMethod.sliding, stride=chip_sz)
+
+    # -------------------------------
+    # Configure dataset generation
+    # -------------------------------
+    class_config = ClassConfig(names=CLASS_NAMES, colors=CLASS_COLORS)
+
+    _make_scene = partial(make_scene, raw_uri, processed_uri, class_config,
+                          test)
+    dataset_config = DatasetConfig(
+        class_config=class_config,
+        train_scenes=[_make_scene(id) for id in train_ids],
+        validation_scenes=[_make_scene(id) for id in val_ids])
+
+    # --------------------------------------------
+    # Configure PyTorch backend and training
+    # --------------------------------------------
+
+    model_config = SemanticSegmentationModelConfig(backbone=Backbone.resnet50)
+
+    solver_config = SolverConfig(
+        lr=LR,
+        num_epochs=NUM_EPOCHS,
+        batch_sz=BATCH_SIZE,
+        test_num_epochs=TEST_MODE_NUM_EPOCHS,
+        test_batch_sz=TEST_MODE_BATCH_SIZE,
+        one_cycle=ONE_CYCLE)
+
+    backend_config = PyTorchSemanticSegmentationConfig(
+        model=model_config,
+        solver=solver_config,
+        log_tensorboard=LOG_TENSORBOARD,
+        run_tensorboard=RUN_TENSORBOARD,
+        test_mode=test)
+
+    # -----------------------------------------------
+    # Pass configurations to the pipeline config
+    # -----------------------------------------------
+    return SemanticSegmentationConfig(
+        root_uri=root_uri,
+        train_chip_sz=chip_sz,
+        predict_chip_sz=chip_sz,
+        chip_options=chip_options,
+        dataset=dataset_config,
+        backend=backend_config,
+        channel_display_groups=CHANNEL_DISPLAY_GROUPS,
+    )


### PR DESCRIPTION
## Overview

- Add a multi raster source that combines image channels from multiple sub raster sources. 
```python3
class MultiRasterSourceConfig(RasterSourceConfig):
    raster_sources: Sequence[SubRasterSourceConfig] = Field(
        ..., description='List of SubRasterSourceConfigs to combine.')
    crs_source: conint(ge=0) = Field(
        0,
        description=
        'Use the crs_transformer of the raster source at this index.')

class SubRasterSourceConfig(Config):
    raster_source: RasterSourceConfig = Field(
        ...,
        description=
        'A RasterSourceConfig that will provide a subset of the channels.')
    target_channels: Sequence[conint(ge=0)] = Field(
        ...,
        description='Channel indices to send each of the channels in this '
        'raster source to.')
```
- Example usage:
```python3
rgbir_source = RasterioSourceConfig(
    uris=[rgbir_raster_uri], channel_order=[0, 1, 2, 3])

elevation_source = RasterioSourceConfig(
    uris=[elevation_raster_uri], channel_order=[0])

raster_source = MultiRasterSourceConfig(
    raster_sources=[
        SubRasterSourceConfig(raster_source=rgbir_source,
                              target_channels=[0, 1, 2, 3]),
        SubRasterSourceConfig(raster_source=elevation_source,
                              target_channels=[4])
    ])
```
- Add new example, `isprs_potsdam_multi_source.py`, that uses this functionality to train a SS model on RGBIR + Elevation on the Potsdam data.
    - Output of an example run of this can be found at: `s3://raster-vision-ahassan/potsdam/rgbire`
- ~Does not support combining `crs_transformers` of sub raster sources. Returns an `IdentityCrsTransformer` when `.get_crs_transformer()` is called.~ The sub raster source whose `crs_transformer` will be used globally can be specified by setting the `crs_source` option in `MultiRasterSourceConfig`. It defaults to `0`.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

- How to test this PR
    - Using image, `279682201306.dkr.ecr.us-east-1.amazonaws.com/raster-vision-ahassan:latest`,
    - run 
    ```bash
	rastervision run batch \
	/opt/src/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py \
	-a raw_uri s3://raster-vision-ahassan/potsdam/data/raw \
	-a processed_uri s3://... \
	-a root_uri s3://... \
	--pipeline-run-name rgbire
    ```

Closes #973 
