### PR TITLE
Add support for vector output to predict command

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Added support for multiband images `#972 <https://github.com/azavea/raster-vision/pull/972>`_
-
+* Add support for vector output to predict command `#980 <https://github.com/azavea/raster-vision/pull/980>`_
 
 Raster Vision 0.12
 -------------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -108,15 +108,17 @@ Use ``predict`` to make predictions on new imagery given a :ref:`model bundle <m
 
     > rastervision predict --help
 
-    Usage: rastervision predict [OPTIONS] MODEL_BUNDLE IMAGE_URI OUTPUT_URI
+    Usage: rastervision predict [OPTIONS] MODEL_BUNDLE IMAGE_URI LABEL_URI
 
     Make predictions on the images at IMAGE_URI using MODEL_BUNDLE and store
-    the prediction output at OUTPUT_URI.
+    the prediction output at LABEL_URI.
 
     Options:
-    -a, --update-stats    Run an analysis on this individual image, as opposed
-                            to using any analysis like statistics that exist in
-                            the prediction package
-    --channel-order TEXT  List of indices comprising channel_order. Example: 2 1
-                            0
-    --help                Show this message and exit.
+    --vector-label-uri TEXT  URI to save vectorized labels for semantic
+                            segmentation model bundles that support it
+    -a, --update-stats       Run an analysis on this individual image, as
+                            opposed to using any analysis like statistics that
+                            exist in the prediction package
+    --channel-order TEXT     List of indices comprising channel_order. Example:
+                            2 1 0
+    --help                   Show this message and exit.

--- a/rastervision_core/rastervision/core/cli.py
+++ b/rastervision_core/rastervision/core/cli.py
@@ -39,7 +39,13 @@ class OptionEatAll(click.Option):
     'predict', short_help='Use a model bundle to predict on new images.')
 @click.argument('model_bundle')
 @click.argument('image_uri')
-@click.argument('output_uri')
+@click.argument('label_uri')
+@click.option(
+    '--vector-label-uri',
+    type=str,
+    help=
+    ('URI to save vectorized labels for semantic segmentation model bundles that support '
+     'it'))
 @click.option(
     '--update-stats',
     '-a',
@@ -51,9 +57,10 @@ class OptionEatAll(click.Option):
     '--channel-order',
     cls=OptionEatAll,
     help='List of indices comprising channel_order. Example: 2 1 0')
-def predict(model_bundle, image_uri, output_uri, update_stats, channel_order):
+def predict(model_bundle, image_uri, label_uri, vector_label_uri, update_stats,
+            channel_order):
     """Make predictions on the images at IMAGE_URI
-    using MODEL_BUNDLE and store the prediction output at OUTPUT_URI.
+    using MODEL_BUNDLE and store the prediction output at LABEL_URI.
     """
     if channel_order is not None:
         channel_order = [
@@ -63,4 +70,5 @@ def predict(model_bundle, image_uri, output_uri, update_stats, channel_order):
     with rv_config.get_tmp_dir() as tmp_dir:
         predictor = Predictor(model_bundle, tmp_dir, update_stats,
                               channel_order)
-        predictor.predict([image_uri], output_uri)
+        predictor.predict(
+            [image_uri], label_uri, vector_label_uri=vector_label_uri)


### PR DESCRIPTION
This PR fixes a bug #976 and also adds support for saving vector output for semantic segmentation model bundles that support it.

```
export BASE="https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples"

# does not try to write vector output
rastervision predict $BASE/model-zoo-0.12/spacenet-vegas-buildings-ss/model-bundle.zip \
    $BASE/model-zoo-0.12/spacenet-vegas-buildings-ss/1929.tif \
    /opt/data/test-predict/prediction.tif

# saves vector output to designated directory
rastervision predict $BASE/model-zoo-0.12/spacenet-vegas-buildings-ss/model-bundle.zip \
    $BASE/model-zoo-0.12/spacenet-vegas-buildings-ss/1929.tif \
    /opt/data/test-predict/prediction.tif \
    --vector-label-uri /opt/data/test-predict/vector/
```