### PR TITLE
[Draft] Add torch.hub support

### DIFF
--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -76,14 +76,14 @@ def get_config(runner, raw_uri, processed_uri, root_uri, test=False):
         train_scenes=train_scenes,
         validation_scenes=val_scenes)
 
-    model = ClassificationModelConfig(torch_hub=TorchHubConfig(
-        load_args = {
-            'github': 'lukemelas/EfficientNet-PyTorch',
-            'model': 'efficientnet_b0',
-            'num_classes': len(class_config.names),
-            'pretrained': 'imagenet'
-        }
-    ))
+    model = ClassificationModelConfig(
+        torch_hub=TorchHubConfig(
+            load_args={
+                'github': 'lukemelas/EfficientNet-PyTorch',
+                'model': 'efficientnet_b0',
+                'num_classes': len(class_config.names),
+                'pretrained': 'imagenet'
+            }))
     solver = SolverConfig(
         lr=1e-4, num_epochs=20, test_num_epochs=3, batch_sz=32, one_cycle=True)
     backend = PyTorchChipClassificationConfig(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -76,7 +76,14 @@ def get_config(runner, raw_uri, processed_uri, root_uri, test=False):
         train_scenes=train_scenes,
         validation_scenes=val_scenes)
 
-    model = ClassificationModelConfig(backbone=Backbone.resnet50)
+    model = ClassificationModelConfig(torch_hub=TorchHubConfig(
+        load_args = {
+            'github': 'lukemelas/EfficientNet-PyTorch',
+            'model': 'efficientnet_b0',
+            'num_classes': len(class_config.names),
+            'pretrained': 'imagenet'
+        }
+    ))
     solver = SolverConfig(
         lr=1e-4, num_epochs=20, test_num_epochs=3, batch_sz=32, one_cycle=True)
     backend = PyTorchChipClassificationConfig(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner.py
@@ -21,6 +21,9 @@ log = logging.getLogger(__name__)
 
 class ClassificationLearner(Learner):
     def build_model(self):
+        if self.cfg.model.torch_hub is not None:
+            model = self.load_torch_hub_model()
+            return model
         pretrained = self.cfg.model.pretrained
         model = getattr(
             models, self.cfg.model.get_backbone_str())(pretrained=pretrained)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -206,7 +206,7 @@ class Learner(ABC):
         state_dict_args = self.cfg.model.torch_hub.state_dict_args
         if state_dict_args is not None:
             state_dict = torch.hub.load_state_dict_from_url(**state_dict_args)
-
+            model.load_state_dict(state_dict)
         return model
 
     def unzip_data(self, uri: Union[str, List[str]]) -> List[str]:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -25,6 +25,7 @@ import torch
 from torch import Tensor
 import torch.nn as nn
 import torch.optim as optim
+import torch.hub
 from torch.optim.lr_scheduler import CyclicLR, MultiStepLR, _LRScheduler
 from torch.utils.tensorboard import SummaryWriter
 from torch.utils.data import DataLoader, Subset, Dataset, ConcatDataset
@@ -195,6 +196,18 @@ class Learner(ABC):
     def build_model(self) -> nn.Module:
         """Build a PyTorch model."""
         pass
+
+    def load_torch_hub_model(self) -> nn.Module:
+        """Load a model using torch.hub."""
+        # load model
+        load_args = self.cfg.model.torch_hub.load_args
+        model = torch.hub.load(**load_args)
+        # load weights
+        state_dict_args = self.cfg.model.torch_hub.state_dict_args
+        if state_dict_args is not None:
+            state_dict = torch.hub.load_state_dict_from_url(**state_dict_args)
+
+        return model
 
     def unzip_data(self, uri: Union[str, List[str]]) -> List[str]:
         """Unzip dataset zip files.

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -141,8 +141,7 @@ class ModelConfig(Config):
         description=('URI of PyTorch model weights used to initialize model. '
                      'If set, this supercedes the pretrained option.'))
     torch_hub: Optional[TorchHubConfig] = Field(
-        None,
-        description='Config for loading models via torch.hub.')
+        None, description='Config for loading models via torch.hub.')
 
     def update(self, learner: Optional['LearnerConfig'] = None):
         pass


### PR DESCRIPTION
## Overview

Superseded by #985. 

A simple implementation and example of `torch.hub` support (#975). This works perfectly fine with the current model bundling scheme, as long as the machine running RV is able to access GitHub.

See `spacenet_rio.py`, which has been modified to use EfficientNet-B0 instead of its default ResNet, for example usage.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [ ] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* Run the `spacenet_rio.py` example.
