### PR TITLE
Add Focal Loss for chip classification and semantic segmentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,8 @@ Features
 * Added support for multiband images `#972 <https://github.com/azavea/raster-vision/pull/972>`_
 * Add support for vector output to predict command `#980 <https://github.com/azavea/raster-vision/pull/980>`_
 * Add support for weighted loss for classification and semantic segmentation `#977 <https://github.com/azavea/raster-vision/pull/977>`_
-* Add multi raster source `#978 <https://github.com/azavea/raster-vision/pull/982>`_
+* Add multi raster source `#978 <https://github.com/azavea/raster-vision/pull/978>`_
+* Add Focal Loss for chip classification and semantic segmentation `#982 <https://github.com/azavea/raster-vision/pull/982>`_
 
 Raster Vision 0.12
 -------------------

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -40,13 +40,20 @@ class PyTorchLearnerBackendConfig(BackendConfig):
 
     @validator('solver')
     def validate_solver_config(cls, v):
+        from rastervision.pytorch_backend import (
+            PyTorchSemanticSegmentationConfig, PyTorchChipClassificationConfig)
+
         if v.class_loss_weights is not None:
-            from rastervision.pytorch_backend import (
-                PyTorchSemanticSegmentationConfig,
-                PyTorchChipClassificationConfig)
             if cls not in (PyTorchSemanticSegmentationConfig,
                            PyTorchChipClassificationConfig):
                 raise ConfigError(
                     'class_loss_weights is currently only supported for '
+                    'Semantic Segmentation and Chip Classification.')
+
+        if v.focal_loss_gamma is not None:
+            if cls not in (PyTorchSemanticSegmentationConfig,
+                           PyTorchChipClassificationConfig):
+                raise ConfigError(
+                    'focal_loss_gamma is currently only supported for '
                     'Semantic Segmentation and Chip Classification.')
         return v

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -151,7 +151,13 @@ class SolverConfig(Config):
     multi_stage: List = Field(
         [], description=('List of epoch indices at which to divide LR by 10.'))
     class_loss_weights: Optional[Union[list, tuple]] = Field(
-        None, description=('Class weights for weighted loss.'))
+        None,
+        description=('Class weights for weighted loss. '
+                     'If Focal Loss is used, this is used as alpha.'))
+    focal_loss_gamma: float = Field(
+        None,
+        description=(
+            'If provided, Focal Loss will be used with this as gamma.'))
 
     def update(self, learner: Optional['LearnerConfig'] = None):
         pass

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -154,7 +154,7 @@ class SolverConfig(Config):
         None,
         description=('Class weights for weighted loss. '
                      'If Focal Loss is used, this is used as alpha.'))
-    focal_loss_gamma: float = Field(
+    focal_loss_gamma: Optional[float] = Field(
         None,
         description=(
             'If provided, Focal Loss will be used with this as gamma.'))

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils.py
@@ -193,7 +193,7 @@ class FocalLoss(nn.Module):
 
         if self.reduction == 'mean':
             loss = loss.mean()
-        if self.reduction == 'sum':
+        elif self.reduction == 'sum':
             loss = loss.sum()
 
         return loss


### PR DESCRIPTION
## Overview

Add Focal Loss, as described in the RetinaNet paper, https://arxiv.org/abs/1708.02002. It is essentially an enhancement to cross-entropy loss and is useful for classification tasks when there is a large class imbalance. It has the effect of underweighting easy examples.

- Adds `class FocalLoss(nn.Module)`, which behaves very much like `nn.CrossEntropyLoss()` i.e.
    - supports the `reduction` and `ignore_index` params, and
    - is able to work with 2D inputs of shape `(N, C)` as well as K-dimensional inputs of shape `(N, C, d1, d2, ..., dK)`.
- Example usage
    ```python3
    focal_loss = FocalLoss(alpha, gamma)
	...
	inp, targets = batch
    out = model(inp)
	loss = focal_loss(out, targets)
    ```
- Adds a `focal_loss_gamma` option to `SolveConfig`, which is used as the `γ` for focal loss. The existing `class_loss_weights` option is used as the `α`, if provided.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

- How to test this PR
    - Pass e.g. `focal_loss_gamma=2`, with or without specifying `class_loss_weights`, to `SolverConfig` in `spacenet_rio.py` or `isprs_potsdam.py`.

Closes #979 

cc @jamesmcclain 
