### PR TITLE
Pass verbose flag to batch jobs

### DIFF
--- a/rastervision_aws_batch/rastervision/aws_batch/aws_batch_runner.py
+++ b/rastervision_aws_batch/rastervision/aws_batch/aws_batch_runner.py
@@ -155,10 +155,13 @@ class AWSBatchRunner(Runner):
             job_name = f'{pipeline_run_name}-{command}-{uuid.uuid4()}'
 
             if not external:
-                cmd = [
-                    'python', '-m', 'rastervision.pipeline.cli run_command',
-                    cfg_json_uri, command, '--runner', AWS_BATCH
-                ]
+                cmd = ['python', '-m', 'rastervision.pipeline.cli']
+                if rv_config.get_verbosity() > 1:
+                    cmd.append('-' + 'v' * (rv_config.get_verbosity() - 1))
+                cmd.extend([
+                    'run_command', cfg_json_uri, command, '--runner', AWS_BATCH
+                ])
+
                 if command in pipeline.split_commands and num_splits > 1:
                     num_array_jobs = num_splits
                     cmd += ['--num-splits', str(num_splits)]


### PR DESCRIPTION
The -v flag works with the inprocess runner, but doesn't seem to get forwarded to remote jobs when using the batch runner. This PR fixes that. Note that the default log level (without using `-v`) is `info`.

Closes #987 
