### PR TITLE
Add support for external loss function definition

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Features
 * Add support for weighted loss for classification and semantic segmentation `#977 <https://github.com/azavea/raster-vision/pull/977>`_
 * Add multi raster source `#978 <https://github.com/azavea/raster-vision/pull/978>`_
 * Add support for fetching and saving external model definitions `#985 <https://github.com/azavea/raster-vision/pull/985>`_
+* Add support for external loss definitions `#992 <https://github.com/azavea/raster-vision/pull/992>`_
 
 Raster Vision 0.12
 -------------------

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -111,7 +111,7 @@ def get_config(runner,
         external_loss_def = None
 
     solver = SolverConfig(
-        lr=1e-2,
+        lr=1e-4,
         num_epochs=20,
         test_num_epochs=4,
         batch_sz=32,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -19,7 +19,8 @@ def get_config(runner,
                processed_uri,
                root_uri,
                test=False,
-               external_model=False):
+               external_model=False,
+               external_loss=False):
     debug = False
     train_scene_info = get_scene_info(join(processed_uri, 'train-scenes.csv'))
     val_scene_info = get_scene_info(join(processed_uri, 'val-scenes.csv'))
@@ -96,8 +97,27 @@ def get_config(runner,
     else:
         model = ClassificationModelConfig(backbone=Backbone.resnet50)
 
+    if external_loss:
+        external_loss_def = ExternalModuleConfig(
+            github_repo='AdeelH/pytorch-multi-class-focal-loss',
+            name='focal_loss',
+            entrypoint='focal_loss',
+            force_reload=False,
+            entrypoint_kwargs={
+                'alpha': [.75, .25],
+                'gamma': 2
+            })
+    else:
+        external_loss_def = None
+
     solver = SolverConfig(
-        lr=1e-4, num_epochs=20, test_num_epochs=3, batch_sz=32, one_cycle=True)
+        lr=1e-2,
+        num_epochs=20,
+        test_num_epochs=4,
+        batch_sz=32,
+        one_cycle=True,
+        external_loss_def=external_loss_def)
+
     backend = PyTorchChipClassificationConfig(
         model=model,
         solver=solver,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -1,7 +1,6 @@
 from typing import List
 
-from rastervision.pipeline.config import (register_config, Field, validator,
-                                          ConfigError)
+from rastervision.pipeline.config import register_config, Field
 from rastervision.core.backend import BackendConfig
 from rastervision.pytorch_learner.learner_config import (
     SolverConfig, ModelConfig, default_augmentors, augmentors as
@@ -37,16 +36,3 @@ class PyTorchLearnerBackendConfig(BackendConfig):
 
     def build(self, pipeline, tmp_dir):
         raise NotImplementedError()
-
-    @validator('solver')
-    def validate_solver_config(cls, v):
-        if v.class_loss_weights is not None:
-            from rastervision.pytorch_backend import (
-                PyTorchSemanticSegmentationConfig,
-                PyTorchChipClassificationConfig)
-            if cls not in (PyTorchSemanticSegmentationConfig,
-                           PyTorchChipClassificationConfig):
-                raise ConfigError(
-                    'class_loss_weights is currently only supported for '
-                    'Semantic Segmentation and Chip Classification.')
-        return v

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -42,3 +42,15 @@ class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
             raise ConfigError('external_def is currently not supported for '
                               'Object Detection.')
         return v
+
+    @validator('solver')
+    def validate_solver_config(cls, v):
+        if v.class_loss_weights is not None:
+            raise ConfigError(
+                'class_loss_weights is currently not supported for '
+                'Object Detection.')
+        if v.external_loss_def is not None:
+            raise ConfigError(
+                'external_loss_def is currently not supported for '
+                'Object Detection.')
+        return v

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -24,14 +24,19 @@ class ClassificationLearnerConfig(LearnerConfig):
     data: ClassificationDataConfig
     model: ClassificationModelConfig
 
-    def build(self, tmp_dir, model_path=None, model_def_path=None):
+    def build(self,
+              tmp_dir,
+              model_path=None,
+              model_def_path=None,
+              loss_def_path=None):
         from rastervision.pytorch_learner.classification_learner import (
             ClassificationLearner)
         return ClassificationLearner(
             self,
             tmp_dir=tmp_dir,
             model_path=model_path,
-            model_def_path=model_def_path)
+            model_def_path=model_def_path,
+            loss_def_path=loss_def_path)
 
     def validate_config(self):
         super().validate_config()

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -206,7 +206,7 @@ class Learner(ABC):
             if self.cfg.run_tensorboard:
                 self.tb_process.terminate()
 
-    def setup_model(self, model_def_path: str = None) -> None:
+    def setup_model(self, model_def_path: Optional[str] = None) -> None:
         """Setup self.model.
 
         Args:
@@ -568,7 +568,7 @@ class Learner(ABC):
         return metric_names
 
     @abstractmethod
-    def train_step(self, batch: any, batch_ind: int) -> MetricDict:
+    def train_step(self, batch: Any, batch_ind: int) -> MetricDict:
         """Compute loss for a single training batch.
 
         Args:
@@ -581,7 +581,7 @@ class Learner(ABC):
         pass
 
     @abstractmethod
-    def validate_step(self, batch: any, batch_ind: int) -> MetricDict:
+    def validate_step(self, batch: Any, batch_ind: int) -> MetricDict:
         """Compute metrics on validation batch.
 
         Args:
@@ -621,7 +621,7 @@ class Learner(ABC):
                                       ]).sum().item() / num_samples
         return metrics
 
-    def post_forward(self, x: any) -> any:
+    def post_forward(self, x: Any) -> Any:
         """Post process output of call to model().
 
         Useful for when predictions are inside a structure returned by model().
@@ -663,7 +663,7 @@ class Learner(ABC):
     def predict(self,
                 x: Tensor,
                 normalize: bool = False,
-                raw_out: bool = False) -> any:
+                raw_out: bool = False) -> Any:
         """Make prediction for an image or batch of images.
 
         Args:
@@ -686,7 +686,7 @@ class Learner(ABC):
         out = self.to_device(out, 'cpu')
         return out
 
-    def output_to_numpy(self, out: any) -> any:
+    def output_to_numpy(self, out: Any) -> Any:
         """Convert output of model to numpy format.
 
         Args:
@@ -696,7 +696,7 @@ class Learner(ABC):
         """
         return out.numpy()
 
-    def numpy_predict(self, x: np.ndarray, raw_out: bool = False) -> any:
+    def numpy_predict(self, x: np.ndarray, raw_out: bool = False) -> Any:
         """Make a prediction using an image or batch of images in numpy format.
 
         Args:
@@ -928,7 +928,7 @@ class Learner(ABC):
             self.model.load_state_dict(
                 torch.load(self.last_model_path, map_location=self.device))
 
-    def to_device(self, x: any, device: str) -> any:
+    def to_device(self, x: Any, device: str) -> Any:
         """Load Tensors onto a device.
 
         Args:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -242,7 +242,9 @@ class Learner(ABC):
                 extCfg=extCfg, hubconf_dir=hubconf_dir)
         else:
             self.loss = self.build_loss()
-        self.loss.to(self.device)
+
+        if self.loss is not None and isinstance(self.loss, nn.Module):
+            self.loss.to(self.device)
 
     def build_loss(self) -> nn.Module:
         """Build a loss Callable."""

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -102,6 +102,7 @@ NonEmptyStr = constr(strip_whitespace=True, min_length=1)
 
 @register_config('external-module')
 class ExternalModuleConfig(Config):
+    """Config describing an object to be loaded via Torch Hub."""
     uri: Optional[NonEmptyStr] = Field(
         None,
         description=('Local uri of a zip file, or local uri of a directory,'
@@ -118,11 +119,14 @@ class ExternalModuleConfig(Config):
         description=('Name of a callable present in hubconf.py. '
                      'See docs for torch.hub for details.'))
     entrypoint_args: list = Field(
-        [], description='Args to pass to the entrypoint.')
+        [],
+        description='Args to pass to the entrypoint. Must be serializable.')
     entrypoint_kwargs: dict = Field(
-        {}, description='Keyword args to pass to the entrypoint.')
+        {},
+        description=
+        'Keyword args to pass to the entrypoint. Must be serializable.')
     force_reload: bool = Field(
-        False, description='Force reload of the module definition.')
+        False, description='Force reload of module definition.')
 
     def validate_config(self):
         has_uri = self.uri is not None

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -190,9 +190,20 @@ class SolverConfig(Config):
         [], description=('List of epoch indices at which to divide LR by 10.'))
     class_loss_weights: Optional[Union[list, tuple]] = Field(
         None, description=('Class weights for weighted loss.'))
+    external_loss_def: Optional[ExternalModuleConfig] = Field(
+        None,
+        description='If specified, the loss will be built from the definition '
+        'from this external source, using Torch Hub.')
 
     def update(self, learner: Optional['LearnerConfig'] = None):
         pass
+
+    def validate_config(self):
+        has_weights = self.class_loss_weights is not None
+        has_external_loss_def = self.external_loss_def is not None
+        if has_weights and has_external_loss_def:
+            raise ConfigError(
+                'class_loss_weights is not supported with external_loss_def.')
 
 
 @register_config('data')

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -39,11 +39,16 @@ class ObjectDetectionLearnerConfig(LearnerConfig):
     data: ObjectDetectionDataConfig
     model: ObjectDetectionModelConfig
 
-    def build(self, tmp_dir, model_path=None, model_def_path=None):
+    def build(self,
+              tmp_dir,
+              model_path=None,
+              model_def_path=None,
+              loss_def_path=None):
         from rastervision.pytorch_learner.object_detection_learner import (
             ObjectDetectionLearner)
         return ObjectDetectionLearner(
             self,
-            tmp_dir,
+            tmp_dir=tmp_dir,
             model_path=model_path,
-            model_def_path=model_def_path)
+            model_def_path=model_def_path,
+            loss_def_path=loss_def_path)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -21,7 +21,6 @@ from torchvision import models
 
 from rastervision.pipeline.config import ConfigError
 from rastervision.pytorch_learner.learner import Learner
-from rastervision.pytorch_learner.learner_config import LearnerConfig
 from rastervision.pytorch_learner.utils import (
     compute_conf_mat_metrics, compute_conf_mat, color_to_triple, SplitTensor,
     Parallel, AddTensors)
@@ -98,30 +97,6 @@ class SemanticSegmentationDataset(Dataset):
 
 
 class SemanticSegmentationLearner(Learner):
-    def __init__(self,
-                 cfg: LearnerConfig,
-                 tmp_dir: str,
-                 model_path: Optional[str] = None,
-                 model_def_path: Optional[str] = None):
-        """Constructor.
-
-        Args:
-            cfg: configuration
-            tmp_dir: root of temp dirs
-            model_path: a local path to model weights. If provided, the model is loaded
-                and it is assumed that this Learner will be used for prediction only.
-            model_def_path: a local path to a directory with a hubconf.py. If
-                provided, the model definition is imported from here.
-        """
-        super().__init__(cfg, tmp_dir, model_path)
-
-        loss_weights = self.cfg.solver.class_loss_weights
-        if loss_weights is not None:
-            loss_weights = torch.tensor(loss_weights, device=self.device)
-            self.loss_fn = nn.CrossEntropyLoss(weight=loss_weights)
-        else:
-            self.loss_fn = nn.CrossEntropyLoss()
-
     def build_model(self) -> nn.Module:
         # TODO support FCN option
         pretrained = self.cfg.model.pretrained
@@ -175,6 +150,15 @@ class SemanticSegmentationLearner(Learner):
                  f'the pretrained model expects ({old_conv.in_channels})'))
 
         return model
+
+    def build_loss(self):
+        loss_weights = self.cfg.solver.class_loss_weights
+        if loss_weights is not None:
+            loss_weights = torch.tensor(loss_weights, device=self.device)
+            loss = nn.CrossEntropyLoss(weight=loss_weights)
+        else:
+            loss = nn.CrossEntropyLoss()
+        return loss
 
     def _get_datasets(self, uri: Union[str, List[str]]):
         cfg = self.cfg

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -203,12 +203,12 @@ class SemanticSegmentationLearner(Learner):
     def train_step(self, batch, batch_ind):
         x, y = batch
         out = self.post_forward(self.model(x))
-        return {'train_loss': self.loss_fn(out, y)}
+        return {'train_loss': self.loss(out, y)}
 
     def validate_step(self, batch, batch_ind):
         x, y = batch
         out = self.post_forward(self.model(x))
-        val_loss = self.loss_fn(out, y)
+        val_loss = self.loss(out, y)
 
         num_labels = len(self.cfg.data.class_names)
         y = y.view(-1)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
@@ -71,14 +71,19 @@ class SemanticSegmentationLearnerConfig(LearnerConfig):
     data: SemanticSegmentationDataConfig
     model: SemanticSegmentationModelConfig
 
-    def build(self, tmp_dir, model_path=None, model_def_path=None):
+    def build(self,
+              tmp_dir,
+              model_path=None,
+              model_def_path=None,
+              loss_def_path=None):
         from rastervision.pytorch_learner.semantic_segmentation_learner import (
             SemanticSegmentationLearner)
         return SemanticSegmentationLearner(
             self,
-            tmp_dir,
+            tmp_dir=tmp_dir,
             model_path=model_path,
-            model_def_path=model_def_path)
+            model_def_path=model_def_path,
+            loss_def_path=loss_def_path)
 
     def validate_config(self):
         super().validate_config()


### PR DESCRIPTION
## Overview

Adds support for loading the loss function via torch.hub. Currently not supported for object detection.

- An external loss definition can be specified by supplying an `ExternalModuleConfig` to `SolverConfig.external_loss_def`.
- Example usage:
	- classification (`spacenet_rio.py`)
	```python3
    if external_loss:
        external_loss_def = ExternalModuleConfig(
            github_repo='AdeelH/pytorch-multi-class-focal-loss',
            name='focal_loss',
            entrypoint='focal_loss',
            force_reload=False,
            entrypoint_kwargs={
                'alpha': [.75, .25],
                'gamma': 2
            })
    else:
        external_loss_def = None

    solver = SolverConfig(
        lr=1e-2,
        num_epochs=20,
        test_num_epochs=4,
        batch_sz=32,
        one_cycle=True,
        external_loss_def=external_loss_def)
	}))
	```
- Example usage included in `spacenet_rio.py`, and can be enabled through the `external_loss` argument.
- When loading from a bundle, the definition is recovered and its path provided to `learner.__init__()` via a new `loss_def_path` param.
- Everything else works the same way as in #985.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* How to test this PR
    - Use example above. Try with different options.

Closes #983
