### PR TITLE
Update all relevant saved URIs in config before instantiating Pipeline

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,13 @@ Features
 * Add multi raster source `#978 <https://github.com/azavea/raster-vision/pull/978>`_
 * Add support for fetching and saving external model definitions `#985 <https://github.com/azavea/raster-vision/pull/985>`_
 
+Bug Fixes
+~~~~~~~~~~~~
+
+* Update all relevant saved URIs in config before instantiating Pipeline `#993 <https://github.com/azavea/raster-vision/pull/993>`_
+* Pass verbose flag to batch jobs `#988 <https://github.com/azavea/raster-vision/pull/988>`_
+* Fix: Ensure Integer class_id `#990 <https://github.com/azavea/raster-vision/pull/990>`_
+
 Raster Vision 0.12
 -------------------
 

--- a/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer_config.py
@@ -18,7 +18,7 @@ class StatsTransformerConfig(RasterTransformerConfig):
          'inside an RVPipeline, then this field will be auto-generated.'))
 
     def update(self, pipeline=None, scene=None):
-        if pipeline is not None:
+        if pipeline is not None and self.stats_uri is None:
             self.stats_uri = join(pipeline.analyze_uri, 'stats.json')
 
     def build(self):

--- a/rastervision_core/rastervision/core/data/scene_config.py
+++ b/rastervision_core/rastervision/core/data/scene_config.py
@@ -60,7 +60,8 @@ class SceneConfig(Config):
         super().update()
 
         self.raster_source.update(pipeline=pipeline, scene=self)
-        self.label_source.update(pipeline=pipeline, scene=self)
+        if self.label_source is not None:
+            self.label_source.update(pipeline=pipeline, scene=self)
         if self.label_store is None and pipeline is not None:
             self.label_store = pipeline.get_default_label_store(scene=self)
         if self.label_store is not None:


### PR DESCRIPTION
This PR is to fix the ability to use the Potsdam model bundle which broke after the changes in https://github.com/azavea/raster-vision/pull/972. That PR made it so that instantiating the `SemanticSegmentationPipeline` instantiates the first scene. This created a problem because (before this PR) the Predictor instantiated the `Pipeline` before updating the raster source and transformer URIs. So this postpones instantiating the pipeline until after all URIs are updated.

Closes #986 
