### PR TITLE
Give Cache A Chance

### DIFF
--- a/rastervision_gdal_vsi/rastervision/gdal_vsi/vsi_file_system.py
+++ b/rastervision_gdal_vsi/rastervision/gdal_vsi/vsi_file_system.py
@@ -103,14 +103,12 @@ class VsiFileSystem(FileSystem):
         try:
             with VsiFileSystem.read_handle_cache_lock:
                 if vsipath in VsiFileSystem.read_handle_cache:
-                    print(f'YES {os.getpid()} {vsipath}')
                     handle = VsiFileSystem.read_handle_cache.get(vsipath)
                     del VsiFileSystem.read_handle_cache[vsipath]
                     VsiFileSystem.read_handle_cache[vsipath] = handle
                 else:
                     (_, old_handle
                      ) = VsiFileSystem.read_handle_cache.popitem(last=False)
-                    print(f'NO {os.getpid()} {vsipath}')
                     handle = VsiFileSystem.read_handle_cache[
                         vsipath] = gdal.VSIFOpenL(vsipath, 'rb')
                 result = gdal.VSIFReadL(1, stats.size, handle)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -1,7 +1,7 @@
 import warnings
 warnings.filterwarnings('ignore')  # noqa
 
-from typing import Union, IO, Callable, List, Iterable, Optional, Tuple
+from typing import Union, Callable, List, Iterable, Optional, Tuple
 from os.path import join, isdir
 from pathlib import Path
 
@@ -80,7 +80,7 @@ class SemanticSegmentationDataset(Dataset):
             y = out['mask']
 
         if np.issubdtype(x.dtype, np.unsignedinteger):
-            max_val = np.iinfo(dtype).max
+            max_val = np.iinfo(x.dtype).max
             x = x.astype(np.float32) / max_val
 
         x = torch.from_numpy(x).permute(2, 0, 1).float()


### PR DESCRIPTION
## Overview

Hold VSI handles open (rather than closing them immediately) in the GDAL VSI file system to allow GDAL's caching behavior to operate.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

The particular use-case that motivated this PR was one in which a small number of very large vector label files were shared by a larger number of scenes.  In that instance, the re-downloaded of the vector labels was quite noticeable.

To test, use the GDAL VSI file system to repeatedly read assets of some kind.  If the environment variables `VSI_CACHE` and `VSI_CACHE_SIZE` are appropriately set, one should be able to detect a difference.