### PR TITLE
Make num_workers Specifiable

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Features
 * Upgrade to pyproj 2.6 `#1000 <https://github.com/azavea/raster-vision/pull/1000>`_
 * Add support for arbitrary albumentations transforms `#1001 <https://github.com/azavea/raster-vision/pull/1001>`_
 * Minor tweaks to regression learner `#1013 <https://github.com/azavea/raster-vision/pull/1013>`_
+* Add ability to specify number of PyTorch reader processes `#1008 <https://github.com/azavea/raster-vision/pull/1008>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
@@ -23,6 +23,7 @@ class PyTorchChipClassificationConfig(PyTorchLearnerBackendConfig):
         data.base_transform = self.base_transform
         data.aug_transform = self.aug_transform
         data.plot_options = self.plot_options
+        data.num_workers = self.num_workers
 
         learner = ClassificationLearnerConfig(
             data=data,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -43,6 +43,8 @@ class PyTorchLearnerBackendConfig(BackendConfig):
          'pytorch_learner.learner_config.LearnerConfig.test_mode.'))
     plot_options: Optional[PlotOptions] = Field(
         PlotOptions(), description='Options to control plotting.')
+    num_workers: int = Field(
+        4, description='The number of workers to use in PyTorch to read data.')
 
     # validators
     _base_tf = validator(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -23,6 +23,7 @@ class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
         data.base_transform = self.base_transform
         data.aug_transform = self.aug_transform
         data.plot_options = self.plot_options
+        data.num_workers = self.num_workers
 
         learner = ObjectDetectionLearnerConfig(
             data=data,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -21,6 +21,7 @@ class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
             img_channels=pipeline.dataset.img_channels,
             img_format=pipeline.img_format,
             label_format=pipeline.label_format,
+            num_workers=self.num_workers,
             augmentors=self.augmentors,
             base_transform=self.base_transform,
             aug_transform=self.aug_transform,


### PR DESCRIPTION
## Overview

The requirement for shared memory comes from the fact that worker/reader processes used for chip reading use shared memory to send chips back to the main process.  Setting this to a number lower than the default 4 reduces pressure, and setting it to 0 removes the need for shared memory entirely.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
