### PR TITLE
Fix for examples breaking when augment = False

### DIFF
--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -161,6 +161,9 @@ def get_config(runner,
             mean=(-mu / std).tolist(),
             std=(1 / std).tolist(),
             max_pixel_value=1.)
+        aug_transform = A.to_dict(aug_transform)
+        base_transform = A.to_dict(base_transform)
+        plot_transform = A.to_dict(plot_transform)
     else:
         aug_transform = None
         base_transform = None
@@ -172,9 +175,9 @@ def get_config(runner,
         log_tensorboard=log_tensorboard,
         run_tensorboard=run_tensorboard,
         test_mode=test,
-        base_transform=A.to_dict(base_transform),
-        aug_transform=A.to_dict(aug_transform),
-        plot_options=PlotOptions(transform=A.to_dict(plot_transform)))
+        base_transform=base_transform,
+        aug_transform=aug_transform,
+        plot_options=PlotOptions(transform=plot_transform))
 
     config = ChipClassificationConfig(
         root_uri=root_uri,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
@@ -163,6 +163,9 @@ def get_config(runner,
             mean=(-mu / std).tolist(),
             std=(1 / std).tolist(),
             max_pixel_value=1.)
+        aug_transform = A.to_dict(aug_transform)
+        base_transform = A.to_dict(base_transform)
+        plot_transform = A.to_dict(plot_transform)
     else:
         aug_transform = None
         base_transform = None
@@ -180,9 +183,9 @@ def get_config(runner,
         log_tensorboard=True,
         run_tensorboard=False,
         test_mode=test,
-        base_transform=A.to_dict(base_transform),
-        aug_transform=A.to_dict(aug_transform),
-        plot_options=PlotOptions(transform=A.to_dict(plot_transform)))
+        base_transform=base_transform,
+        aug_transform=aug_transform,
+        plot_options=PlotOptions(transform=plot_transform))
 
     if multiband:
         channel_display_groups = {'RGB': (0, 1, 2), 'IR': (3, )}


### PR DESCRIPTION
## Overview

Fix for the code in `spacenet_rio.py` and `isprs_potsdam.py` incorrectly passing `None` to `A.to_dict()` when `augment = False`.
