### PR TITLE
Make img_sz specifiable

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Features
 * Add support for external loss definitions `#992 <https://github.com/azavea/raster-vision/pull/992>`_
 * Upgrade to pyproj 2.6 `#1000 <https://github.com/azavea/raster-vision/pull/1000>`_
 * Add support for arbitrary albumentations transforms `#1001 <https://github.com/azavea/raster-vision/pull/1001>`_
+* Make img_sz specifiable `#1012 <https://github.com/azavea/raster-vision/pull/1012>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
@@ -14,11 +14,14 @@ class PyTorchChipClassificationConfig(PyTorchLearnerBackendConfig):
     model: ClassificationModelConfig
 
     def get_learner_config(self, pipeline):
+        if self.img_sz is None:
+            self.img_sz = pipeline.train_chip_sz
+
         data = ClassificationDataConfig()
         data.uri = pipeline.chip_uri
         data.class_names = pipeline.dataset.class_config.names
         data.class_colors = pipeline.dataset.class_config.colors
-        data.img_sz = pipeline.train_chip_sz
+        data.img_sz = self.img_sz
         data.augmentors = self.augmentors
         data.base_transform = self.base_transform
         data.aug_transform = self.aug_transform

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+from pydantic import PositiveInt
 
 from rastervision.pipeline.config import (register_config, Field, validator)
 from rastervision.core.backend import BackendConfig
@@ -43,6 +44,11 @@ class PyTorchLearnerBackendConfig(BackendConfig):
          'pytorch_learner.learner_config.LearnerConfig.test_mode.'))
     plot_options: Optional[PlotOptions] = Field(
         PlotOptions(), description='Options to control plotting.')
+    img_sz: Optional[PositiveInt] = Field(
+        None,
+        description='Length of a side of each image in pixels. This is the '
+        'size to transform it to during training, not the size in the raw '
+        'dataset. Defaults to train_chip_sz in the pipeline config.')
 
     # validators
     _base_tf = validator(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -14,11 +14,14 @@ class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
     model: ObjectDetectionModelConfig
 
     def get_learner_config(self, pipeline):
+        if self.img_sz is None:
+            self.img_sz = pipeline.train_chip_sz
+
         data = ObjectDetectionDataConfig()
         data.uri = pipeline.chip_uri
         data.class_names = pipeline.dataset.class_config.names
         data.class_colors = pipeline.dataset.class_config.colors
-        data.img_sz = pipeline.train_chip_sz
+        data.img_sz = self.img_sz
         data.augmentors = self.augmentors
         data.base_transform = self.base_transform
         data.aug_transform = self.aug_transform

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -13,11 +13,14 @@ class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
     model: SemanticSegmentationModelConfig
 
     def get_learner_config(self, pipeline):
+        if self.img_sz is None:
+            self.img_sz = pipeline.train_chip_sz
+
         data = SemanticSegmentationDataConfig(
             uri=pipeline.chip_uri,
             class_names=pipeline.dataset.class_config.names,
             class_colors=pipeline.dataset.class_config.colors,
-            img_sz=pipeline.train_chip_sz,
+            img_sz=self.img_sz,
             img_channels=pipeline.dataset.img_channels,
             img_format=pipeline.img_format,
             label_format=pipeline.label_format,


### PR DESCRIPTION
## Overview

Allows the user to specify `img_sz` in the backend config. This is the size that the image are resized to before being passed to the model during training;. If not provided, `train_chip_sz` from the pipeline config is used (meaning no resizing).

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* How to test this PR
  - Try passing in some `img_sz` that is different from the chip size and check if the model inputs are resized to this size.

Closes #998 
