### PR TITLE
Add NaN Transformer and Cast Transformer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Features
 * Make img_sz specifiable `#1012 <https://github.com/azavea/raster-vision/pull/1012>`_
 * Add ignore_last_class capability to segmentation `#1017 <https://github.com/azavea/raster-vision/pull/1017>`_
 * Add filtering capability to segmentation sliding window chip generation `#1018 <https://github.com/azavea/raster-vision/pull/1018>`_
+* Add raster transformer to remove NaNs from float rasters, add raster transformers to cast to arbitrary numpy types `#1016 <https://github.com/azavea/raster-vision/pull/1016>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -82,7 +82,6 @@ Future Work
 The next big features we plan on developing are:
 
 * the ability to read and write data in `STAC <https://stacspec.org/>`_ format using the `label extension <https://github.com/radiantearth/stac-spec/tree/master/extensions/label>`_. This will facilitate integration with other tools such as `GroundWork <https://groundwork.azavea.com/>`_.
-* the ability to `train models on multi-band imagery <https://www.azavea.com/blog/2019/08/30/transfer-learning-from-rgb-to-multi-band-imagery/>`_, rather than having to pick a subset of three bands.
 
 Raster Vision 0.11
 -------------------

--- a/rastervision_core/rastervision/core/data/raster_transformer/__init__.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/__init__.py
@@ -4,3 +4,5 @@ from rastervision.core.data.raster_transformer.raster_transformer import *
 from rastervision.core.data.raster_transformer.raster_transformer_config import *
 from rastervision.core.data.raster_transformer.stats_transformer import *
 from rastervision.core.data.raster_transformer.stats_transformer_config import *
+from rastervision.core.data.raster_transformer.nan_transformer import *
+from rastervision.core.data.raster_transformer.nan_transformer_config import *

--- a/rastervision_core/rastervision/core/data/raster_transformer/__init__.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/__init__.py
@@ -6,3 +6,5 @@ from rastervision.core.data.raster_transformer.stats_transformer import *
 from rastervision.core.data.raster_transformer.stats_transformer_config import *
 from rastervision.core.data.raster_transformer.nan_transformer import *
 from rastervision.core.data.raster_transformer.nan_transformer_config import *
+from rastervision.core.data.raster_transformer.cast_transformer import *
+from rastervision.core.data.raster_transformer.cast_transformer_config import *

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
@@ -1,0 +1,39 @@
+import re
+
+from rastervision.core.data.raster_transformer.raster_transformer \
+    import RasterTransformer
+
+import numpy as np  # noqa
+
+
+class CastTransformer(RasterTransformer):
+    """Removes Cast values from float raster
+    """
+
+    def __init__(self, to_dtype: str = 'np.uint8'):
+        """Construct a new CastTransformer.
+
+        Args:
+            to_dtype: (str) Chips are casted to this dtype
+        """
+        mo = re.search(r'np\.(u|)(int|float)[0-9]+', to_dtype)
+        if mo:
+            self.to_dtype = eval(mo.group(0))
+        else:
+            raise ValueError(f'Unsupported to_dtype {to_dtype}')
+
+    def transform(self, chip, channel_order=None):
+        """Transform a chip.
+
+        Cast chip to the specified dtype.
+
+        Args:
+            chip: ndarray of shape [height, width, channels] This is assumed to already
+                have the channel_order applied to it if channel_order is set. In other
+                words, channels should be equal to len(channel_order).
+
+        Returns:
+            [height, width, channels] numpy array
+
+        """
+        return chip.astype(self.to_dtype)

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer_config.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from rastervision.pipeline.config import register_config, Field
+from rastervision.core.data.raster_transformer.raster_transformer_config import (  # noqa
+    RasterTransformerConfig)
+from rastervision.core.data.raster_transformer.cast_transformer import (  # noqa
+    CastTransformer)
+
+
+@register_config('cast_transformer')
+class CastTransformerConfig(RasterTransformerConfig):
+    to_dtype: Optional[str] = Field(
+        'np.uint8', description=('dtype to cast raster to.'))
+
+    def update(self, pipeline=None, scene=None):
+        if pipeline is not None and self.to_dtype is None:
+            self.to_dtype = pipeline.to_dtype
+
+    def build(self):
+        return CastTransformer(to_dtype=self.to_dtype)

--- a/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from rastervision.core.data.raster_transformer.raster_transformer \
+    import RasterTransformer
+
+
+class NanTransformer(RasterTransformer):
+    """Removes NaN values from float raster
+    """
+
+    def __init__(self, to_value: float = 0.0):
+        """Construct a new NanTransformer.
+
+        Args:
+            to_value: (float) NaN values are replaced
+                with this
+        """
+        self.to_value = to_value
+
+    def transform(self, chip, channel_order=None):
+        """Transform a chip.
+
+        Removes NaN values.
+
+        Args:
+            chip: ndarray of shape [height, width, channels] This is assumed to already
+                have the channel_order applied to it if channel_order is set. In other
+                words, channels should be equal to len(channel_order).
+
+        Returns:
+            [height, width, channels] numpy array
+
+        """
+        chip[np.isnan(chip)] = self.to_value
+        return chip

--- a/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer_config.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from rastervision.pipeline.config import register_config, Field
+from rastervision.core.data.raster_transformer.raster_transformer_config import (  # noqa
+    RasterTransformerConfig)
+from rastervision.core.data.raster_transformer.nan_transformer import (  # noqa
+    NanTransformer)
+
+
+@register_config('nan_transformer')
+class NanTransformerConfig(RasterTransformerConfig):
+    to_value: Optional[float] = Field(
+        0.0, description=('Turn all NaN values into this value.'))
+
+    def update(self, pipeline=None, scene=None):
+        if pipeline is not None and self.to_value is None:
+            self.to_value = pipeline.to_value
+
+    def build(self):
+        return NanTransformer(to_value=self.to_value)


### PR DESCRIPTION
## Overview

The NaN transformer turns NaN values in float rasters into the specified value.  The cast transformer casts rasters to the specified numpy dtype.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
