### PR TITLE
Add ignore_last_class in Segmentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Features
 * Upgrade to pyproj 2.6 `#1000 <https://github.com/azavea/raster-vision/pull/1000>`_
 * Add support for arbitrary albumentations transforms `#1001 <https://github.com/azavea/raster-vision/pull/1001>`_
 * Minor tweaks to regression learner `#1013 <https://github.com/azavea/raster-vision/pull/1013>`_
+* Add ignore_last_class in Segmentation `#1017 <https://github.com/azavea/raster-vision/pull/1017>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,7 +17,7 @@ Features
 * Add support for arbitrary albumentations transforms `#1001 <https://github.com/azavea/raster-vision/pull/1001>`_
 * Minor tweaks to regression learner `#1013 <https://github.com/azavea/raster-vision/pull/1013>`_
 * Add ability to specify number of PyTorch reader processes `#1008 <https://github.com/azavea/raster-vision/pull/1008>`_
-* Add ignore_last_class in Segmentation `#1017 <https://github.com/azavea/raster-vision/pull/1017>`_
+* Add ignore_last_class capability to segmentation `#1017 <https://github.com/azavea/raster-vision/pull/1017>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -48,6 +48,9 @@ class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
 
     @validator('solver')
     def validate_solver_config(cls, v):
+        if v.ignore_last_class:
+            raise ConfigError(
+                'ignore_last_class is not supported for Object Detection.')
         if v.class_loss_weights is not None:
             raise ConfigError(
                 'class_loss_weights is currently not supported for '

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -41,6 +41,12 @@ class ClassificationLearnerConfig(LearnerConfig):
     def validate_config(self):
         super().validate_config()
         self.validate_class_loss_weights()
+        self.validate_ignore_last_class()
+
+    def validate_ignore_last_class(self):
+        if self.solver.ignore_last_class:
+            raise ConfigError(
+                'ignore_last_class is not supported for Chip Classification.')
 
     def validate_class_loss_weights(self):
         if self.solver.class_loss_weights is None:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -195,6 +195,9 @@ class SolverConfig(Config):
         [], description=('List of epoch indices at which to divide LR by 10.'))
     class_loss_weights: Optional[Union[list, tuple]] = Field(
         None, description=('Class weights for weighted loss.'))
+    ignore_last_class: bool = Field(
+        False,
+        description=('Whether to ignore the last class during training.'))
     external_loss_def: Optional[ExternalModuleConfig] = Field(
         None,
         description='If specified, the loss will be built from the definition '
@@ -206,6 +209,11 @@ class SolverConfig(Config):
     def validate_config(self):
         has_weights = self.class_loss_weights is not None
         has_external_loss_def = self.external_loss_def is not None
+
+        if self.ignore_last_class and has_external_loss_def:
+            raise ConfigError(
+                'ignore_last_class is not supported with external_loss_def.')
+
         if has_weights and has_external_loss_def:
             raise ConfigError(
                 'class_loss_weights is not supported with external_loss_def.')


### PR DESCRIPTION
## Overview

Adds the ability to ignore the last class (presumably the added `null` class) in training of segmentation models.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes https://github.com/azavea/raster-vision/issues/1014