### PR TITLE
Remove 4GB Limit from VSI File System

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Features
 * Add filtering capability to segmentation sliding window chip generation `#1018 <https://github.com/azavea/raster-vision/pull/1018>`_
 * Add raster transformer to remove NaNs from float rasters, add raster transformers to cast to arbitrary numpy types `#1016 <https://github.com/azavea/raster-vision/pull/1016>`_
 * Add plot options for regression `#1023 <https://github.com/azavea/raster-vision/pull/1023>`_
+* Remove 4GB file size limit from VSI file system, allow streaming reads `#1020 <https://github.com/azavea/raster-vision/pull/1020>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
@@ -12,6 +12,10 @@ class RasterioSourceConfig(RasterSourceConfig):
         ('List of image URIs that comprise imagery for a scene. The format of each file '
          'can be any that can be read by Rasterio/GDAL. If > 1 URI is provided, a VRT '
          'will be created to mosaic together the individual images.'))
+    allow_streaming: bool = Field(
+        False,
+        description=(
+            'Allow streaming of assets rather than always downloading.'))
     x_shift: float = Field(
         0.0,
         descriptions=
@@ -31,6 +35,7 @@ class RasterioSourceConfig(RasterSourceConfig):
             self.uris,
             raster_transformers,
             tmp_dir,
+            allow_streaming=self.allow_streaming,
             channel_order=self.channel_order,
             x_shift=self.x_shift,
             y_shift=self.y_shift)

--- a/rastervision_gdal_vsi/rastervision/gdal_vsi/vsi_file_system.py
+++ b/rastervision_gdal_vsi/rastervision/gdal_vsi/vsi_file_system.py
@@ -91,8 +91,14 @@ class VsiFileSystem(FileSystem):
             raise FileNotFoundError('{} does not exist'.format(vsipath))
 
         try:
+            retval = bytes()
             handle = gdal.VSIFOpenL(vsipath, 'rb')
-            return gdal.VSIFReadL(1, stats.size, handle)
+            bytes_left = stats.size
+            while bytes_left > 0:
+                bytes_to_read = min(bytes_left, 1 << 30)
+                retval += gdal.VSIFReadL(1, bytes_to_read, handle)
+                bytes_left -= bytes_to_read
+            return retval
         finally:
             gdal.VSIFCloseL(handle)
 


### PR DESCRIPTION
## Overview

Remove the 4GB file size limit from the VSI file system.  Also allow rasterio to stream assets.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
