### PR TITLE
Make SemanticSegmentationLearner.post_forward() more flexible

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -236,7 +236,9 @@ class SemanticSegmentationLearner(Learner):
         return metrics
 
     def post_forward(self, x):
-        return x['out']
+        if isinstance(x, dict):
+            return x['out']
+        return x
 
     def prob_to_pred(self, x):
         return x.argmax(1)


### PR DESCRIPTION
## Overview

The `SemanticSegmentationLearner.post_forward()` method currently assumes that its input will be a `dict`, which works when using TorchVision's DeepLab implementation, but not necessarily other external models. This PR slightly weakens that assumption so that models that output tensors directly can now work with `SemanticSegmentationLearner`.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
