### PR TITLE
Allow continuing training from a model bundle

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Features
 * Add ignore_last_class capability to segmentation `#1017 <https://github.com/azavea/raster-vision/pull/1017>`_
 * Add filtering capability to segmentation sliding window chip generation `#1018 <https://github.com/azavea/raster-vision/pull/1018>`_
 * Add raster transformer to remove NaNs from float rasters, add raster transformers to cast to arbitrary numpy types `#1016 <https://github.com/azavea/raster-vision/pull/1016>`_
+* Allow continuing training from a model bundle `#1022 <https://github.com/azavea/raster-vision/pull/1022>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
@@ -111,7 +111,7 @@ class RVPipeline(Pipeline):
     def train(self):
         """Train a model and save it."""
         backend = self.config.backend.build(self.config, self.tmp_dir)
-        backend.train()
+        backend.train(source_bundle_uri=self.config.source_bundle_uri)
 
     def post_process_sample(self, sample: DataSample) -> DataSample:
         """Post-process sample in pipeline-specific way.

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
@@ -63,6 +63,10 @@ class RVPipelineConfig(PipelineConfig):
         None,
         description='URI for output of bundle. If None, will be auto-generated.'
     )
+    source_bundle_uri: Optional[str] = Field(
+        None,
+        description='If provided, the model will be loaded from this bundle '
+        'for the train stage. Useful for fine-tuning.')
 
     def update(self):
         super().update()

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
@@ -64,13 +64,27 @@ class PyTorchLearnerBackend(Backend):
         self.tmp_dir = tmp_dir
         self.learner = None
 
-    def train(self):
-        learner = self.learner_cfg.build(self.tmp_dir)
+    def train(self, source_bundle_uri=None):
+        if source_bundle_uri is not None:
+            learner = self._build_learner_from_bundle(
+                bundle_uri=source_bundle_uri,
+                cfg=self.learner_cfg,
+                training=True)
+        else:
+            learner = self.learner_cfg.build(self.tmp_dir, training=True)
         learner.main()
 
     def load_model(self):
-        self.learner = Learner.from_model_bundle(
-            self.learner_cfg.get_model_bundle_uri(), self.tmp_dir)
+        self.learner = self._build_learner_from_bundle(training=False)
+
+    def _build_learner_from_bundle(self,
+                                   bundle_uri=None,
+                                   cfg=None,
+                                   training=False):
+        if bundle_uri is None:
+            bundle_uri = self.learner_cfg.get_model_bundle_uri()
+        return Learner.from_model_bundle(
+            bundle_uri, self.tmp_dir, cfg=cfg, training=training)
 
     def get_sample_writer(self):
         raise NotImplementedError()

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -28,7 +28,8 @@ class ClassificationLearnerConfig(LearnerConfig):
               tmp_dir,
               model_path=None,
               model_def_path=None,
-              loss_def_path=None):
+              loss_def_path=None,
+              training=True):
         from rastervision.pytorch_learner.classification_learner import (
             ClassificationLearner)
         return ClassificationLearner(
@@ -36,7 +37,8 @@ class ClassificationLearnerConfig(LearnerConfig):
             tmp_dir=tmp_dir,
             model_path=model_path,
             model_def_path=model_def_path,
-            loss_def_path=loss_def_path)
+            loss_def_path=loss_def_path,
+            training=training)
 
     def validate_config(self):
         super().validate_config()

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -69,18 +69,25 @@ class Learner(ABC):
                  tmp_dir: str,
                  model_path: Optional[str] = None,
                  model_def_path: Optional[str] = None,
-                 loss_def_path: Optional[str] = None):
+                 loss_def_path: Optional[str] = None,
+                 training: bool = True):
         """Constructor.
 
         Args:
-            cfg: configuration
-            tmp_dir: root of temp dirs
-            model_path: a local path to model weights. If provided, the model is loaded
-                and it is assumed that this Learner will be used for prediction only.
-            model_def_path: a local path to a directory with a hubconf.py. If
-                provided, the model definition is imported from here.
-            loss_def_path: a local path to a directory with a hubconf.py. If
-                provided, the loss function definition is imported from here.
+            cfg (LearnerConfig): Configuration.
+            tmp_dir (str): Root of temp dirs.
+            model_path (str, optional): A local path to model weights.
+                Defaults to None.
+            model_def_path (str, optional): A local path to a directory with a
+                hubconf.py. If provided, the model definition is imported from
+                here. Defaults to None.
+            loss_def_path (str, optional): A local path to a directory with a
+                hubconf.py. If provided, the loss function definition is
+                imported from here. Defaults to None.
+            training (bool, optional): Whether the model is to be used for
+                training or prediction. If False, the model is put in eval mode
+                and the loss function, optimizer, etc. are not initialized.
+                Defaults to True.
         """
         self.cfg = cfg
         self.tmp_dir = tmp_dir
@@ -107,44 +114,16 @@ class Learner(ABC):
 
         if model_path is not None:
             if isfile(model_path):
+                log.info(f'Loading model weights from: {model_path}')
                 self.model.load_state_dict(
                     torch.load(model_path, map_location=self.device))
             else:
                 raise Exception(
                     'Model could not be found at {}'.format(model_path))
-            self.model.eval()
+        if training:
+            self.setup_training(loss_def_path=loss_def_path)
         else:
-            log.info(self.cfg)
-
-            # ds = dataset, dl = dataloader
-            self.train_ds = None
-            self.train_dl = None
-            self.valid_ds = None
-            self.valid_dl = None
-            self.test_ds = None
-            self.test_dl = None
-
-            self.config_path = join(self.output_dir, 'learner-config.json')
-            str_to_file(self.cfg.json(), self.config_path)
-
-            self.log_path = join(self.output_dir, 'log.csv')
-            self.train_state_path = join(self.output_dir, 'train-state.json')
-            model_bundle_fname = basename(cfg.get_model_bundle_uri())
-            self.model_bundle_path = join(self.output_dir, model_bundle_fname)
-            self.metric_names = self.build_metric_names()
-
-            self.last_model_path = join(self.output_dir, 'last-model.pth')
-            self.load_checkpoint()
-
-            self.setup_loss(loss_def_path=loss_def_path)
-            self.opt = self.build_optimizer()
-            self.setup_data()
-            self.start_epoch = self.get_start_epoch()
-            self.steps_per_epoch = len(
-                self.train_ds) // self.cfg.solver.batch_sz
-            self.step_scheduler = self.build_step_scheduler()
-            self.epoch_scheduler = self.build_epoch_scheduler()
-            self.setup_tensorboard()
+            self.model.eval()
 
     def main(self):
         """Main training sequence.
@@ -170,6 +149,38 @@ class Learner(ABC):
         self.eval_model('test')
         self.sync_to_cloud()
         self.stop_tensorboard()
+
+    def setup_training(self, loss_def_path=None):
+        log.info(self.cfg)
+
+        # ds = dataset, dl = dataloader
+        self.train_ds = None
+        self.train_dl = None
+        self.valid_ds = None
+        self.valid_dl = None
+        self.test_ds = None
+        self.test_dl = None
+
+        self.config_path = join(self.output_dir, 'learner-config.json')
+        str_to_file(self.cfg.json(), self.config_path)
+
+        self.log_path = join(self.output_dir, 'log.csv')
+        self.train_state_path = join(self.output_dir, 'train-state.json')
+        model_bundle_fname = basename(self.cfg.get_model_bundle_uri())
+        self.model_bundle_path = join(self.output_dir, model_bundle_fname)
+        self.metric_names = self.build_metric_names()
+
+        self.last_model_path = join(self.output_dir, 'last-model.pth')
+        self.load_checkpoint()
+
+        self.setup_loss(loss_def_path=loss_def_path)
+        self.opt = self.build_optimizer()
+        self.setup_data()
+        self.start_epoch = self.get_start_epoch()
+        self.steps_per_epoch = len(self.train_ds) // self.cfg.solver.batch_sz
+        self.step_scheduler = self.build_step_scheduler()
+        self.epoch_scheduler = self.build_epoch_scheduler()
+        self.setup_tensorboard()
 
     def sync_to_cloud(self):
         """Sync any output to the cloud at output_uri."""
@@ -243,6 +254,7 @@ class Learner(ABC):
         if self.loss is not None and isinstance(self.loss, nn.Module):
             self.loss.to(self.device)
 
+    @abstractmethod
     def build_loss(self) -> nn.Module:
         """Build a loss Callable."""
         pass
@@ -848,42 +860,49 @@ class Learner(ABC):
                                  join(self.output_dir, 'dataloaders/test.png'))
 
     @staticmethod
-    def from_model_bundle(model_bundle_uri: str, tmp_dir: str):
+    def from_model_bundle(model_bundle_uri: str,
+                          tmp_dir: str,
+                          cfg: Optional[LearnerConfig] = None,
+                          training: bool = False):
         """Create a Learner from a model bundle."""
         model_bundle_path = download_if_needed(model_bundle_uri, tmp_dir)
         model_bundle_dir = join(tmp_dir, 'model-bundle')
         unzip(model_bundle_path, model_bundle_dir)
 
-        config_path = join(model_bundle_dir, 'pipeline-config.json')
         model_path = join(model_bundle_dir, 'model.pth')
 
-        config_dict = file_to_json(config_path)
-        config_dict = upgrade_config(config_dict)
+        if cfg is None:
+            config_path = join(model_bundle_dir, 'pipeline-config.json')
 
-        cfg = build_config(config_dict)
+            config_dict = file_to_json(config_path)
+            config_dict = upgrade_config(config_dict)
+
+            cfg = build_config(config_dict)
+            cfg = cfg.learner
 
         hub_dir = join(model_bundle_dir, MODULES_DIRNAME)
         model_def_path = None
         loss_def_path = None
 
         # retrieve existing model definition, if available
-        ext_cfg = cfg.learner.model.external_def
+        ext_cfg = cfg.model.external_def
         if ext_cfg is not None:
             model_def_path = get_hubconf_dir_from_cfg(ext_cfg, parent=hub_dir)
             log.info(
                 f'Using model definition found in bundle: {model_def_path}')
 
         # retrieve existing loss function definition, if available
-        ext_cfg = cfg.learner.solver.external_loss_def
-        if ext_cfg is not None:
+        ext_cfg = cfg.solver.external_loss_def
+        if ext_cfg is not None and training:
             loss_def_path = get_hubconf_dir_from_cfg(ext_cfg, parent=hub_dir)
             log.info(f'Using loss definition found in bundle: {loss_def_path}')
 
-        return cfg.learner.build(
+        return cfg.build(
             tmp_dir=tmp_dir,
             model_path=model_path,
             model_def_path=model_def_path,
-            loss_def_path=loss_def_path)
+            loss_def_path=loss_def_path,
+            training=training)
 
     def save_model_bundle(self):
         """Save a model bundle.
@@ -896,7 +915,7 @@ class Learner(ABC):
 
         log.info('Creating bundle.')
         model_bundle_dir = join(self.tmp_dir, 'model-bundle')
-        make_dir(model_bundle_dir)
+        make_dir(model_bundle_dir, force_empty=True)
 
         shutil.copyfile(self.last_model_path,
                         join(model_bundle_dir, 'model.pth'))

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -254,7 +254,6 @@ class Learner(ABC):
         if self.loss is not None and isinstance(self.loss, nn.Module):
             self.loss.to(self.device)
 
-    @abstractmethod
     def build_loss(self) -> nn.Module:
         """Build a loss Callable."""
         pass

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -381,15 +381,25 @@ class LearnerConfig(Config):
     def build(self,
               tmp_dir: str,
               model_path: Optional[str] = None,
-              model_def_path: Optional[str] = None) -> 'Learner':
+              model_def_path: Optional[str] = None,
+              loss_def_path: Optional[str] = None,
+              training=True) -> 'Learner':
         """Returns a Learner instantiated using this Config.
 
         Args:
-            tmp_dir: root of temp dirs
-            model_path: local path to model weights. If this is passed, the Learner
-                is assumed to be used to make predictions and not train a model.
-            model_def_path: a local path to a directory with a hubconf.py. If
-                provided, the model definition is imported from here.
+            tmp_dir (str): Root of temp dirs.
+            model_path (str, optional): A local path to model weights.
+                Defaults to None.
+            model_def_path (str, optional): A local path to a directory with a
+                hubconf.py. If provided, the model definition is imported from
+                here. Defaults to None.
+            loss_def_path (str, optional): A local path to a directory with a
+                hubconf.py. If provided, the loss function definition is
+                imported from here. Defaults to None.
+            training (bool, optional): Whether the model is to be used for
+                training or prediction. If False, the model is put in eval mode
+                and the loss function, optimizer, etc. are not initialized.
+                Defaults to True.
         """
         raise NotImplementedError()
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -43,7 +43,8 @@ class ObjectDetectionLearnerConfig(LearnerConfig):
               tmp_dir,
               model_path=None,
               model_def_path=None,
-              loss_def_path=None):
+              loss_def_path=None,
+              training=True):
         from rastervision.pytorch_learner.object_detection_learner import (
             ObjectDetectionLearner)
         return ObjectDetectionLearner(
@@ -51,4 +52,5 @@ class ObjectDetectionLearnerConfig(LearnerConfig):
             tmp_dir=tmp_dir,
             model_path=model_path,
             model_def_path=model_def_path,
-            loss_def_path=loss_def_path)
+            loss_def_path=loss_def_path,
+            training=training)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
@@ -75,7 +75,8 @@ class SemanticSegmentationLearnerConfig(LearnerConfig):
               tmp_dir,
               model_path=None,
               model_def_path=None,
-              loss_def_path=None):
+              loss_def_path=None,
+              training=True):
         from rastervision.pytorch_learner.semantic_segmentation_learner import (
             SemanticSegmentationLearner)
         return SemanticSegmentationLearner(
@@ -83,7 +84,8 @@ class SemanticSegmentationLearnerConfig(LearnerConfig):
             tmp_dir=tmp_dir,
             model_path=model_path,
             model_def_path=model_def_path,
-            loss_def_path=loss_def_path)
+            loss_def_path=loss_def_path,
+            training=training)
 
     def validate_config(self):
         super().validate_config()


### PR DESCRIPTION
## Overview

Adds ability to continue training from a model bundle.

- Adds new `source_bundle_uri` field to `RVPipelineConfig`.
- During the `train` stage, the learner is built from the bundle at `source_bundle_uri`, if provided.
  - This means model weights and model, loss definitions from the bundle are used.
  - The new learner config instead of the one in the bundle is used, so that `output_uri` etc. reflect the current run.

Usage
```python3
SemanticSegmentationConfig(
    root_uri=root_uri,
    source_bundle_uri='s3://raster-vision-ahassan/potsdam/rgb/output/train/model-bundle.zip',
    dataset=dataset,
    backend=backend,
    train_chip_sz=chip_sz,
    predict_chip_sz=chip_sz,
    chip_options=chip_options
)
```

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes #1002 
