### PR TITLE
Add ReclassTransformer for Label Rasters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Features
 * Add filtering capability to segmentation sliding window chip generation `#1018 <https://github.com/azavea/raster-vision/pull/1018>`_
 * Add raster transformer to remove NaNs from float rasters, add raster transformers to cast to arbitrary numpy types `#1016 <https://github.com/azavea/raster-vision/pull/1016>`_
 * Add plot options for regression `#1023 <https://github.com/azavea/raster-vision/pull/1023>`_
+* Add reclassification transformer for segmentation label rasters `#1024 <https://github.com/azavea/raster-vision/pull/1024>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -95,7 +95,7 @@ class SemanticSegmentationLabelSource(ActivateMixin, LabelSource):
         """
         labels = SemanticSegmentationLabels()
         window = window or self.raster_source.get_extent()
-        raw_labels = self.raster_source.get_raw_chip(window)
+        raw_labels = self.raster_source.get_chip(window)
         label_arr = (np.squeeze(raw_labels) if self.class_transformer is None
                      else self.class_transformer.rgb_to_class(raw_labels))
 

--- a/rastervision_core/rastervision/core/data/raster_transformer/__init__.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/__init__.py
@@ -8,3 +8,5 @@ from rastervision.core.data.raster_transformer.nan_transformer import *
 from rastervision.core.data.raster_transformer.nan_transformer_config import *
 from rastervision.core.data.raster_transformer.cast_transformer import *
 from rastervision.core.data.raster_transformer.cast_transformer_config import *
+from rastervision.core.data.raster_transformer.reclass_transformer import *
+from rastervision.core.data.raster_transformer.reclass_transformer_config import *

--- a/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer.py
@@ -1,0 +1,41 @@
+from typing import Dict
+from rastervision.core.data.raster_transformer.raster_transformer \
+    import RasterTransformer
+
+import numpy as np  # noqa
+
+
+class ReclassTransformer(RasterTransformer):
+    """Reclassifies label raster
+    """
+
+    def __init__(self, mapping: Dict[int, int]):
+        """Construct a new ReclassTransformer.
+
+        Args:
+            mapping: (dict) Remapping dictionary
+        """
+        self.mapping = mapping
+
+    def transform(self, chip, channel_order=None):
+        """Transform a chip.
+
+        Reclassify a label raster using the given mapping.
+
+        Args:
+            chip: ndarray of shape [height, width, channels] This is assumed to already
+                have the channel_order applied to it if channel_order is set. In other
+                words, channels should be equal to len(channel_order).
+
+        Returns:
+            [height, width, channels] numpy array
+
+        """
+        masks = []
+        for (value_from, value_to) in self.mapping.items():
+            mask = (chip == value_from)
+            masks.append((mask, value_to))
+        for (mask, value_to) in masks:
+            chip[mask] = value_to
+
+        return chip

--- a/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer_config.py
@@ -1,0 +1,20 @@
+from typing import Dict
+
+from rastervision.pipeline.config import register_config, Field
+from rastervision.core.data.raster_transformer.raster_transformer_config import (  # noqa
+    RasterTransformerConfig)
+from rastervision.core.data.raster_transformer.reclass_transformer import (  # noqa
+    ReclassTransformer)
+
+
+@register_config('reclass_transformer')
+class ReclassTransformerConfig(RasterTransformerConfig):
+    mapping: Dict[int, int] = Field(
+        ..., description=('The reclassification mapping.'))
+
+    def update(self, pipeline=None, scene=None):
+        if pipeline is not None and self.mapping is None:
+            self.mapping = pipeline.mapping
+
+    def build(self):
+        return ReclassTransformer(mapping=self.mapping)


### PR DESCRIPTION
## Overview

The main use-case for this is reclassification of segmentation raster labels.  Also includes a change to how labels are retrieved: `get_raw_chip` has been changed to `get_chip`.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
