### PR TITLE
Allow filtering out chips based on proportion of NODATA pixels

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Features
 * Add filtering capability to segmentation sliding window chip generation `#1018 <https://github.com/azavea/raster-vision/pull/1018>`_
 * Add raster transformer to remove NaNs from float rasters, add raster transformers to cast to arbitrary numpy types `#1016 <https://github.com/azavea/raster-vision/pull/1016>`_
 * Add plot options for regression `#1023 <https://github.com/azavea/raster-vision/pull/1023>`_
+* Allow filtering out chips based on proportion of NODATA pixels `#1025 <https://github.com/azavea/raster-vision/pull/1025>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_core/rastervision/core/rv_pipeline/chip_classification.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/chip_classification.py
@@ -15,7 +15,7 @@ def get_train_windows(scene, chip_size, chip_nodata_threshold=1.):
         windows = Box.filter_by_aoi(windows, scene.aoi_polygons)
     for window in windows:
         chip = scene.raster_source.get_chip(window)
-        if (chip == 0).mean() < chip_nodata_threshold:
+        if (chip.sum(dim=-1) == 0).mean() < chip_nodata_threshold:
             train_windows.append(window)
     return train_windows
 

--- a/rastervision_core/rastervision/core/rv_pipeline/chip_classification.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/chip_classification.py
@@ -1,14 +1,12 @@
 import logging
 
-import numpy as np
-
 from rastervision.core.rv_pipeline.rv_pipeline import RVPipeline
 from rastervision.core.box import Box
 
 log = logging.getLogger(__name__)
 
 
-def get_train_windows(scene, chip_size):
+def get_train_windows(scene, chip_size, chip_nodata_threshold=1.):
     train_windows = []
     extent = scene.raster_source.get_extent()
     stride = chip_size
@@ -17,14 +15,17 @@ def get_train_windows(scene, chip_size):
         windows = Box.filter_by_aoi(windows, scene.aoi_polygons)
     for window in windows:
         chip = scene.raster_source.get_chip(window)
-        if np.sum(chip.ravel()) > 0:
+        if (chip == 0).mean() < chip_nodata_threshold:
             train_windows.append(window)
     return train_windows
 
 
 class ChipClassification(RVPipeline):
     def get_train_windows(self, scene):
-        return get_train_windows(scene, self.config.train_chip_sz)
+        return get_train_windows(
+            scene,
+            self.config.train_chip_sz,
+            chip_nodata_threshold=self.config.chip_nodata_threshold)
 
     def get_train_labels(self, window, scene):
         return scene.ground_truth_label_source.get_labels(window=window)

--- a/rastervision_core/rastervision/core/rv_pipeline/chip_classification.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/chip_classification.py
@@ -15,7 +15,7 @@ def get_train_windows(scene, chip_size, chip_nodata_threshold=1.):
         windows = Box.filter_by_aoi(windows, scene.aoi_polygons)
     for window in windows:
         chip = scene.raster_source.get_chip(window)
-        if (chip.sum(dim=-1) == 0).mean() < chip_nodata_threshold:
+        if (chip.sum(axis=-1) == 0).mean() < chip_nodata_threshold:
             train_windows.append(window)
     return train_windows
 

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
@@ -80,9 +80,9 @@ def make_neg_windows(raster_source,
         labels = ObjectDetectionLabels.get_overlapping(
             label_store.get_labels(), window, ioa_thresh=0.2)
 
-        # If no labels and enough data pixels, append the chip
-        enough_data_pixels = (chip == 0).mean() < chip_nodata_threshold
-        if len(labels) == 0 and enough_data_pixels:
+        # If no labels and not too many nodata pixels, append the chip
+        nodata_prop = (chip.sum(dim=-1) == 0).mean()
+        if len(labels) == 0 and nodata_prop < chip_nodata_threshold:
             neg_windows.append(window)
 
         if len(neg_windows) == nb_windows:

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
@@ -1,7 +1,5 @@
 import logging
 
-import numpy as np
-
 from rastervision.core.rv_pipeline.rv_pipeline import RVPipeline
 from rastervision.core.rv_pipeline.object_detection_config import (
     ObjectDetectionWindowMethod)
@@ -64,8 +62,13 @@ def make_pos_windows(image_extent, label_store, chip_size, window_method,
             'Window method: {} is cannot be handled.'.format(window_method))
 
 
-def make_neg_windows(raster_source, label_store, chip_size, nb_windows,
-                     max_attempts, filter_windows):
+def make_neg_windows(raster_source,
+                     label_store,
+                     chip_size,
+                     nb_windows,
+                     max_attempts,
+                     filter_windows,
+                     chip_nodata_threshold=1.):
     extent = raster_source.get_extent()
     neg_windows = []
     for _ in range(max_attempts):
@@ -77,8 +80,9 @@ def make_neg_windows(raster_source, label_store, chip_size, nb_windows,
         labels = ObjectDetectionLabels.get_overlapping(
             label_store.get_labels(), window, ioa_thresh=0.2)
 
-        # If no labels and not blank, append the chip
-        if len(labels) == 0 and np.sum(chip.ravel()) > 0:
+        # If no labels and enough data pixels, append the chip
+        enough_data_pixels = (chip == 0).mean() < chip_nodata_threshold
+        if len(labels) == 0 and enough_data_pixels:
             neg_windows.append(window)
 
         if len(neg_windows) == nb_windows:
@@ -87,7 +91,7 @@ def make_neg_windows(raster_source, label_store, chip_size, nb_windows,
     return list(neg_windows)
 
 
-def get_train_windows(scene, chip_opts, chip_size):
+def get_train_windows(scene, chip_opts, chip_size, chip_nodata_threshold=1.):
     raster_source = scene.raster_source
     label_store = scene.ground_truth_label_source
 
@@ -119,17 +123,25 @@ def get_train_windows(scene, chip_opts, chip_size):
     else:
         nb_neg_windows = 100  # just make some
     max_attempts = 100 * nb_neg_windows
-    neg_windows = make_neg_windows(raster_source, label_store, chip_size,
-                                   nb_neg_windows, max_attempts,
-                                   filter_windows)
+    neg_windows = make_neg_windows(
+        raster_source,
+        label_store,
+        chip_size,
+        nb_neg_windows,
+        max_attempts,
+        filter_windows,
+        chip_nodata_threshold=chip_nodata_threshold)
 
     return pos_windows + neg_windows
 
 
 class ObjectDetection(RVPipeline):
     def get_train_windows(self, scene):
-        return get_train_windows(scene, self.config.chip_options,
-                                 self.config.train_chip_sz)
+        return get_train_windows(
+            scene,
+            self.config.chip_options,
+            self.config.train_chip_sz,
+            chip_nodata_threshold=self.config.chip_nodata_threshold)
 
     def get_train_labels(self, window, scene):
         window_labels = scene.ground_truth_label_source.get_labels(

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
@@ -81,7 +81,7 @@ def make_neg_windows(raster_source,
             label_store.get_labels(), window, ioa_thresh=0.2)
 
         # If no labels and not too many nodata pixels, append the chip
-        nodata_prop = (chip.sum(dim=-1) == 0).mean()
+        nodata_prop = (chip.sum(axis=-1) == 0).mean()
         if len(labels) == 0 and nodata_prop < chip_nodata_threshold:
             neg_windows.append(window)
 

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
@@ -46,7 +46,9 @@ class RVPipelineConfig(PipelineConfig):
     chip_nodata_threshold: Proportion = Field(
         1,
         description='Discard chips where the proportion of NODATA values is '
-        'greater than or equal to this value.')
+        'greater than or equal to this value. Might result in false positives '
+        'if there are many legitimate black pixels in the chip. Use with '
+        'caution.')
 
     analyze_uri: Optional[str] = Field(
         None,

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
@@ -1,5 +1,6 @@
 from os.path import join
 from typing import List, TYPE_CHECKING, Optional
+from pydantic import confloat
 
 from rastervision.pipeline.pipeline_config import PipelineConfig
 from rastervision.core.data import (DatasetConfig, StatsTransformerConfig,
@@ -12,6 +13,8 @@ from rastervision.pipeline.config import register_config, Field
 
 if TYPE_CHECKING:
     from rastervision.core.backend.backend import Backend  # noqa
+
+Proportion = confloat(ge=0, le=1)
 
 
 @register_config('rv_pipeline')
@@ -40,6 +43,10 @@ class RVPipelineConfig(PipelineConfig):
         300, description='Size of predictions chips in pixels.')
     predict_batch_sz: int = Field(
         8, description='Batch size to use during prediction.')
+    chip_nodata_threshold: Proportion = Field(
+        1,
+        description='Discard chips where the proportion of NODATA values is '
+        'greater than or equal to this value.')
 
     analyze_uri: Optional[str] = Field(
         None,

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -35,12 +35,12 @@ def get_train_windows(scene,
 
             filt_windows = []
             for w in windows:
-                chip = raster_source.get_chip(window)
+                chip = raster_source.get_chip(w)
                 nodata_prop = (chip.sum(axis=-1) == 0).mean()
                 nodata_below_thresh = nodata_prop < chip_nodata_threshold
 
-                labels = label_source.get_labels(w).get_label_arr(w)
-                null_labels = labels == class_config.get_null_class_id()
+                label_arr = label_source.get_labels(w).get_label_arr(w)
+                null_labels = label_arr == class_config.get_null_class_id()
 
                 if not np.all(null_labels) and nodata_below_thresh:
                     filt_windows.append(w)

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -90,8 +90,8 @@ def get_train_windows(scene,
 def fill_no_data(img, label_arr, null_class_id):
     # If chip has null labels, fill in those pixels with nodata.
     mask = label_arr == null_class_id
-    if np.count_nonzero(mask) > 0:
-        img[mask] = 0
+    if np.any(mask):
+        img[mask, :] = 0
     return img
 
 

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -35,9 +35,14 @@ def get_train_windows(scene,
 
             filt_windows = []
             for w in windows:
-                label_arr = label_source.get_labels(w).get_label_arr(w)
-                null_mask = label_arr == class_config.get_null_class_id()
-                if null_mask.mean() < chip_nodata_threshold:
+                chip = raster_source.get_chip(window)
+                nodata_prop = (chip.sum(axis=-1) == 0).mean()
+                nodata_below_thresh = nodata_prop < chip_nodata_threshold
+
+                labels = label_source.get_labels(w).get_label_arr(w)
+                null_labels = labels == class_config.get_null_class_id()
+
+                if not np.all(null_labels) and nodata_below_thresh:
                     filt_windows.append(w)
             windows = filt_windows
         return windows


### PR DESCRIPTION
## Overview

- Add `chip_nodata_threshold` field to `RVPipelineConfig`. 
- Filter out chips where the proportion of NODATA values in the chip is greater than or equal to this value.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

- Unrelated change: simplified code for `fill_no_data()` in `core/rv_pipeline/semantic_segmentation.py`.

Closes #999 
