### PR TITLE
Add ability to Use Fewer Channels w/ Pretrained Model

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Features
 * Add filtering capability to segmentation sliding window chip generation `#1018 <https://github.com/azavea/raster-vision/pull/1018>`_
 * Add raster transformer to remove NaNs from float rasters, add raster transformers to cast to arbitrary numpy types `#1016 <https://github.com/azavea/raster-vision/pull/1016>`_
 * Add plot options for regression `#1023 <https://github.com/azavea/raster-vision/pull/1023>`_
+* Add ability to use fewer channels w/ pretrained models `#1026 <https://github.com/azavea/raster-vision/pull/1026>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -146,6 +146,8 @@ class SemanticSegmentationLearner(Learner):
         elif input_channels < old_conv.in_channels:
             model.backbone.conv1 = nn.Conv2d(
                 in_channels=input_channels, **old_conv_args)
+            model.backbone.conv1.weight.data[:, :input_channels] = \
+                old_conv.weight.data[:, :input_channels]
         else:
             raise ConfigError(f'Something went wrong')
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -143,10 +143,11 @@ class SemanticSegmentationLearner(Learner):
                 Parallel(old_conv, new_conv),
                 # sum the parallel outputs
                 AddTensors())
+        elif input_channels < old_conv.in_channels:
+            model.backbone.conv1 = nn.Conv2d(
+                in_channels=input_channels, **old_conv_args)
         else:
-            raise ConfigError(
-                (f'Fewer input channels ({input_channels}) than what'
-                 f'the pretrained model expects ({old_conv.in_channels})'))
+            raise ConfigError(f'Something went wrong')
 
         return model
 


### PR DESCRIPTION
## Overview

This allows use of mostly-pretrained networks when the number of input channels is fewer than that of the pretrained network.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
