### PR TITLE
Allow ignore_last_class w/ External Loss Functions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Features
 * Remove 4GB file size limit from VSI file system, allow streaming reads `#1020 <https://github.com/azavea/raster-vision/pull/1020>`_
 * Add reclassification transformer for segmentation label rasters `#1024 <https://github.com/azavea/raster-vision/pull/1024>`_
 * Allow filtering out chips based on proportion of NODATA pixels `#1025 <https://github.com/azavea/raster-vision/pull/1025>`_
+* Allow ignore_last_class to take either a boolean or the literal 'force'; in the latter case validation of that argument is skipped so that it can be used with external loss functions `#1027 <https://github.com/azavea/raster-vision/pull/1027>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -2,6 +2,7 @@ from os.path import join
 from enum import Enum
 
 from typing import (List, Optional, Union, TYPE_CHECKING)
+from typing_extensions import Literal
 from pydantic import PositiveFloat, PositiveInt, constr
 
 from rastervision.pipeline.config import (Config, register_config, ConfigError,
@@ -195,7 +196,7 @@ class SolverConfig(Config):
         [], description=('List of epoch indices at which to divide LR by 10.'))
     class_loss_weights: Optional[Union[list, tuple]] = Field(
         None, description=('Class weights for weighted loss.'))
-    ignore_last_class: bool = Field(
+    ignore_last_class: Union[bool, Literal['force']] = Field(
         False,
         description=('Whether to ignore the last class during training.'))
     external_loss_def: Optional[ExternalModuleConfig] = Field(
@@ -210,7 +211,7 @@ class SolverConfig(Config):
         has_weights = self.class_loss_weights is not None
         has_external_loss_def = self.external_loss_def is not None
 
-        if self.ignore_last_class and has_external_loss_def:
+        if self.ignore_last_class is True and has_external_loss_def:
             raise ConfigError(
                 'ignore_last_class is not supported with external_loss_def.')
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -213,7 +213,10 @@ class SolverConfig(Config):
 
         if self.ignore_last_class is True and has_external_loss_def:
             raise ConfigError(
-                'ignore_last_class is not supported with external_loss_def.')
+                'ignore_last_class=True is not supported with external_loss_def.  '
+                'Please carefully considering using ignore_last_class=\'force\' '
+                'and setting the external loss function to ignore the last index.'
+            )
 
         if has_weights and has_external_loss_def:
             raise ConfigError(


### PR DESCRIPTION
## Overview

Allow the last class to be ignored when an external loss function is used.  This is done by passing `'force'` to `ignore_last_class` rather than `True` or `False`.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
