### PR TITLE
Set drop_last = True in train dataloader

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -486,6 +486,7 @@ class Learner(ABC):
             train_ds,
             shuffle=True,
             batch_size=batch_sz,
+            drop_last=True,
             num_workers=num_workers,
             pin_memory=True,
             collate_fn=collate_fn)


### PR DESCRIPTION
## Overview

If the length of the dataset is not divisible by the batch size, the last batch will always be smaller than the batch size. If the last batch happens to be of length one, it will cause the batchnorm layers in the model to throw an error (this is only a problem when the layers are in training mode, so only `train_dl` has been modified).

Setting `drop_last = True` makes the data loader drop the last batch. [Docs](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader).

Note: Since the data is shuffled every epoch, we do not need to worry about the model not seeing certain data points at all.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
