### PR TITLE
Add ability to crop raster source extent

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Features
 * Remove 4GB file size limit from VSI file system, allow streaming reads `#1020 <https://github.com/azavea/raster-vision/pull/1020>`_
 * Add reclassification transformer for segmentation label rasters `#1024 <https://github.com/azavea/raster-vision/pull/1024>`_
 * Allow filtering out chips based on proportion of NODATA pixels `#1025 <https://github.com/azavea/raster-vision/pull/1025>`_
+* Add ability to crop raster source extent `#1030 <https://github.com/azavea/raster-vision/pull/1030>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -83,7 +83,7 @@ class Box():
         for boxind, box in enumerate(boxes):
             npboxes[boxind, :] = box.npbox_format()
         return npboxes
-    
+
     def __iter__(self):
         return iter(self.tuple_format())
 

--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -83,12 +83,18 @@ class Box():
         for boxind, box in enumerate(boxes):
             npboxes[boxind, :] = box.npbox_format()
         return npboxes
+    
+    def __iter__(self):
+        return iter(self.tuple_format())
+
+    def __getitem__(self, i):
+        return self.tuple_format()[i]
 
     def __str__(self):  # pragma: no cover
         return str(self.npbox_format())
 
     def __repr__(self):  # pragma: no cover
-        return str(self)
+        return f'{type(self).__name__}{self.tuple_format()}'
 
     def geojson_coordinates(self):
         """Return Box as GeoJSON coordinates."""

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from rastervision.core.box import Box
 from rastervision.core.data import ActivateMixin
-from rastervision.core.data.raster_source import RasterSource
+from rastervision.core.data.raster_source import (RasterSource, CropOffsets)
 from rastervision.core.data.crs_transformer import CRSTransformer
 from rastervision.core.data.utils import all_equal
 
@@ -28,7 +28,7 @@ class MultiRasterSource(ActivateMixin, RasterSource):
             channel_order: Optional[Sequence[conint(ge=0)]] = None,
             crs_source: conint(ge=0) = 0,
             raster_transformers: Sequence = [],
-            extent_crop: Optional[Tuple[float, float, float, float]] = None):
+            extent_crop: Optional[CropOffsets] = None):
         """Constructor.
 
         Args:
@@ -49,7 +49,7 @@ class MultiRasterSource(ActivateMixin, RasterSource):
                 that will be used by .get_chip(). Defaults to None.
             raster_transformers (Sequence, optional): Sequence of transformers.
                 Defaults to [].
-            extent_crop (Tuple[float, float, float, float], optional): Relative
+            extent_crop (CropOffsets, optional): Relative
                 offsets (top, left, bottom, right) for cropping the extent.
                 Useful for using splitting a scene into different datasets.
                 Defaults to None i.e. no cropping.

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -84,7 +84,8 @@ class MultiRasterSource(ActivateMixin, RasterSource):
                 f'Got: {extents} '
                 '(carefully consider using allow_different_extents)')
 
-        sub_num_channels = sum(len(rs.channel_order) for rs in self.raster_sources)
+        sub_num_channels = sum(
+            len(rs.channel_order) for rs in self.raster_sources)
         if sub_num_channels != self.num_channels:
             raise MultiRasterSourceError(
                 f'num_channels ({self.num_channels}) != sum of num_channels '

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -99,9 +99,9 @@ class MultiRasterSource(ActivateMixin, RasterSource):
         extent = rs.get_extent()
         if self.extent_crop is not None:
             h, w = extent.get_height(), extent.get_width()
-            top, left, bottom, right = self.extent_crop
-            ymin, xmin = int(h * top), int(w * left)
-            ymax, xmax = h - int(h * bottom), w - int(w * right)
+            skip_top, skip_left, skip_bottom, skip_right = self.extent_crop
+            ymin, xmin = int(h * skip_top), int(w * skip_left)
+            ymax, xmax = h - int(h * skip_bottom), w - int(w * skip_right)
             return Box(ymin, xmin, ymax, xmax)
         return extent
 

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 from pydantic import conint
 
 import numpy as np
@@ -19,14 +19,16 @@ class MultiRasterSource(ActivateMixin, RasterSource):
     their output along the channel dimension (assumed to be the last dimension).
     """
 
-    def __init__(self,
-                 raster_sources: Sequence[RasterSource],
-                 raw_channel_order: Sequence[conint(ge=0)],
-                 allow_different_extents: bool = False,
-                 force_same_dtype: bool = False,
-                 channel_order: Optional[Sequence[conint(ge=0)]] = None,
-                 crs_source: conint(ge=0) = 0,
-                 raster_transformers: Sequence = []):
+    def __init__(
+            self,
+            raster_sources: Sequence[RasterSource],
+            raw_channel_order: Sequence[conint(ge=0)],
+            allow_different_extents: bool = False,
+            force_same_dtype: bool = False,
+            channel_order: Optional[Sequence[conint(ge=0)]] = None,
+            crs_source: conint(ge=0) = 0,
+            raster_transformers: Sequence = [],
+            extent_crop: Optional[Tuple[float, float, float, float]] = None):
         """Constructor.
 
         Args:
@@ -47,6 +49,10 @@ class MultiRasterSource(ActivateMixin, RasterSource):
                 that will be used by .get_chip(). Defaults to None.
             raster_transformers (Sequence, optional): Sequence of transformers.
                 Defaults to [].
+            extent_crop (Tuple[float, float, float, float], optional): Relative
+                offsets (top, left, bottom, right) for cropping the extent.
+                Useful for using splitting a scene into different datasets.
+                Defaults to None i.e. no cropping.
         """
         num_channels = len(raw_channel_order)
         if not channel_order:
@@ -59,6 +65,7 @@ class MultiRasterSource(ActivateMixin, RasterSource):
         self.raster_sources = raster_sources
         self.raw_channel_order = list(raw_channel_order)
         self.crs_source = crs_source
+        self.extent_crop = extent_crop
 
         self.validate_raster_sources()
 
@@ -77,7 +84,7 @@ class MultiRasterSource(ActivateMixin, RasterSource):
                 f'Got: {extents} '
                 '(carefully consider using allow_different_extents)')
 
-        sub_num_channels = sum(rs.num_channels for rs in self.raster_sources)
+        sub_num_channels = sum(len(rs.channel_order) for rs in self.raster_sources)
         if sub_num_channels != self.num_channels:
             raise MultiRasterSourceError(
                 f'num_channels ({self.num_channels}) != sum of num_channels '
@@ -89,6 +96,12 @@ class MultiRasterSource(ActivateMixin, RasterSource):
     def get_extent(self) -> Box:
         rs = self.raster_sources[0]
         extent = rs.get_extent()
+        if self.extent_crop is not None:
+            h, w = extent.get_height(), extent.get_width()
+            top, left, bottom, right = self.extent_crop
+            ymin, xmin = int(h * top), int(w * left)
+            ymax, xmax = h - int(h * bottom), w - int(w * right)
+            return Box(ymin, xmin, ymax, xmax)
         return extent
 
     def get_dtype(self) -> np.dtype:

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Tuple
+from typing import Optional, Sequence
 from pydantic import conint
 
 import numpy as np
@@ -19,16 +19,15 @@ class MultiRasterSource(ActivateMixin, RasterSource):
     their output along the channel dimension (assumed to be the last dimension).
     """
 
-    def __init__(
-            self,
-            raster_sources: Sequence[RasterSource],
-            raw_channel_order: Sequence[conint(ge=0)],
-            allow_different_extents: bool = False,
-            force_same_dtype: bool = False,
-            channel_order: Optional[Sequence[conint(ge=0)]] = None,
-            crs_source: conint(ge=0) = 0,
-            raster_transformers: Sequence = [],
-            extent_crop: Optional[CropOffsets] = None):
+    def __init__(self,
+                 raster_sources: Sequence[RasterSource],
+                 raw_channel_order: Sequence[conint(ge=0)],
+                 allow_different_extents: bool = False,
+                 force_same_dtype: bool = False,
+                 channel_order: Optional[Sequence[conint(ge=0)]] = None,
+                 crs_source: conint(ge=0) = 0,
+                 raster_transformers: Sequence = [],
+                 extent_crop: Optional[CropOffsets] = None):
         """Constructor.
 
         Args:

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -96,7 +96,8 @@ class MultiRasterSourceConfig(RasterSourceConfig):
             allow_different_extents=self.allow_different_extents,
             channel_order=self.channel_order,
             crs_source=self.crs_source,
-            raster_transformers=raster_transformers)
+            raster_transformers=raster_transformers,
+            extent_crop=self.extent_crop)
         return multi_raster_source
 
     def update(self, pipeline=None, scene=None):

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, NamedTuple
+from typing import List, Optional
+from pydantic.dataclasses import dataclass
 
 from rastervision.pipeline.config import (Config, register_config, Field,
                                           validator, ConfigError)
@@ -6,7 +7,8 @@ from rastervision.core.data.raster_transformer import RasterTransformerConfig
 from rastervision.core.utils.misc import Proportion
 
 
-class CropOffsets(NamedTuple):
+@dataclass
+class CropOffsets:
     """Tuple of relative offsets.
 
     Args:
@@ -20,6 +22,10 @@ class CropOffsets(NamedTuple):
     skip_left: Proportion = 0.
     skip_bottom: Proportion = 0.
     skip_right: Proportion = 0.
+
+    def __iter__(self):
+        return iter((self.skip_top, self.skip_left, self.skip_bottom,
+                     self.skip_right))
 
 
 @register_config('raster_source')

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -14,9 +14,9 @@ class RasterSourceConfig(Config):
     extent_crop: Optional[Tuple[float, float, float, float]] = Field(
         None,
         description='Relative offsets (top, left, bottom, right) for cropping '
-        'the extent of the raster source. Useful for using splitting a scene '
-        'into different datasets. E.g. (0, 0, .8, 0) for the training set and '
-        '(.8, 0, 0, 0) for the validation set will do a 80-20 split by '
+        'the extent of the raster source. Useful for splitting a scene into '
+        'different dataset splits. E.g. (0, 0, 0.8, 0) for the training set '
+        'and (0.8, 0, 0, 0) for the validation set will do a 80-20 split by '
         'height. Defaults to None i.e. no cropping.')
 
     def build(self, tmp_dir, use_transformers=True):

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from rastervision.pipeline.config import Config, register_config, Field
 from rastervision.core.data.raster_transformer import RasterTransformerConfig
@@ -11,6 +11,13 @@ class RasterSourceConfig(Config):
         description=
         'The sequence of channel indices to use when reading imagery.')
     transformers: List[RasterTransformerConfig] = []
+    extent_crop: Optional[Tuple[float, float, float, float]] = Field(
+        None,
+        description='Relative offsets (top, left, bottom, right) for cropping '
+        'the extent of the raster source. Useful for using splitting a scene '
+        'into different datasets. E.g. (0, 0, .8, 0) for the training set and '
+        '(.8, 0, 0, 0) for the validation set will do a 80-20 split by '
+        'height. Defaults to None i.e. no cropping.')
 
     def build(self, tmp_dir, use_transformers=True):
         raise NotImplementedError()

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -15,7 +15,7 @@ class RasterSourceConfig(Config):
         None,
         description='Relative offsets (top, left, bottom, right) for cropping '
         'the extent of the raster source. Useful for splitting a scene into '
-        'different dataset splits. E.g. (0, 0, 0.8, 0) for the training set '
+        'different dataset splits. E.g. (0, 0, 0.2, 0) for the training set '
         'and (0.8, 0, 0, 0) for the validation set will do a 80-20 split by '
         'height. Defaults to None i.e. no cropping.')
 

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -7,6 +7,15 @@ from rastervision.core.utils.misc import Proportion
 
 
 class CropOffsets(NamedTuple):
+    """Tuple of relative offsets.
+
+    Args:
+        skip_top (Proportion): Proportion of height to exclude from the top.
+        skip_left (Proportion): Proportion of width to exclude from the left.
+        skip_bottom (Proportion): Proportion of height to exclude from the
+            bottom.
+        skip_right (Proportion): Proportion of width to exclude from the right.
+    """
     skip_top: Proportion = 0.
     skip_left: Proportion = 0.
     skip_bottom: Proportion = 0.
@@ -41,6 +50,8 @@ class RasterSourceConfig(Config):
 
     @validator('extent_crop')
     def validate_extent_crop(cls, v):
+        if v is None:
+            return v
         skip_top, skip_left, skip_bottom, skip_right = v
         if skip_top + skip_bottom >= 1:
             raise ConfigError(

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -14,7 +14,7 @@ from rasterio.enums import (ColorInterp, MaskFlags)
 from rastervision.pipeline.file_system import download_if_needed
 from rastervision.core.box import Box
 from rastervision.core.data.crs_transformer import RasterioCRSTransformer
-from rastervision.core.data.raster_source import RasterSource
+from rastervision.core.data.raster_source import (RasterSource, CropOffsets)
 from rastervision.core.data import (ActivateMixin, ActivationError)
 
 log = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class RasterioSource(ActivateMixin, RasterSource):
             channel_order=None,
             x_shift=0.0,
             y_shift=0.0,
-            extent_crop: Optional[Tuple[float, float, float, float]] = None):
+            extent_crop: Optional[CropOffsets] = None):
         """Constructor.
 
         This RasterSource can read any file that can be opened by Rasterio/GDAL
@@ -95,7 +95,7 @@ class RasterioSource(ActivateMixin, RasterSource):
 
         Args:
             channel_order: list of indices of channels to extract from raw imagery
-            extent_crop (Tuple[float, float, float, float], optional): Relative
+            extent_crop (CropOffsets, optional): Relative
                 offsets (top, left, bottom, right) for cropping the extent.
                 Useful for using splitting a scene into different datasets.
                 Defaults to None i.e. no cropping.

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -5,6 +5,7 @@ from pyproj import Transformer
 import subprocess
 from decimal import Decimal
 import tempfile
+from typing import Optional, Tuple
 
 import numpy as np
 import rasterio
@@ -73,14 +74,16 @@ def load_window(image_dataset, window=None, is_masked=False):
 
 
 class RasterioSource(ActivateMixin, RasterSource):
-    def __init__(self,
-                 uris,
-                 raster_transformers,
-                 tmp_dir,
-                 allow_streaming=False,
-                 channel_order=None,
-                 x_shift=0.0,
-                 y_shift=0.0):
+    def __init__(
+            self,
+            uris,
+            raster_transformers,
+            tmp_dir,
+            allow_streaming=False,
+            channel_order=None,
+            x_shift=0.0,
+            y_shift=0.0,
+            extent_crop: Optional[Tuple[float, float, float, float]] = None):
         """Constructor.
 
         This RasterSource can read any file that can be opened by Rasterio/GDAL
@@ -92,6 +95,10 @@ class RasterioSource(ActivateMixin, RasterSource):
 
         Args:
             channel_order: list of indices of channels to extract from raw imagery
+            extent_crop (Tuple[float, float, float, float], optional): Relative
+                offsets (top, left, bottom, right) for cropping the extent.
+                Useful for using splitting a scene into different datasets.
+                Defaults to None i.e. no cropping.
         """
         self.uris = uris
         self.tmp_dir = tmp_dir
@@ -101,6 +108,7 @@ class RasterioSource(ActivateMixin, RasterSource):
         self.y_shift = y_shift
         self.do_shift = self.x_shift != 0.0 or self.y_shift != 0.0
         self.allow_streaming = allow_streaming
+        self.extent_crop = extent_crop
 
         num_channels = None
 
@@ -156,7 +164,13 @@ class RasterioSource(ActivateMixin, RasterSource):
         return self.crs_transformer
 
     def get_extent(self):
-        return Box(0, 0, self.height, self.width)
+        h, w = self.height, self.width
+        if self.extent_crop is not None:
+            top, left, bottom, right = self.extent_crop
+            ymin, xmin = int(h * top), int(w * left)
+            ymax, xmax = h - int(h * bottom), w - int(w * right)
+            return Box(ymin, xmin, ymax, xmax)
+        return Box(0, 0, h, w)
 
     def get_dtype(self):
         """Return the numpy.dtype of this scene"""

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -5,7 +5,7 @@ from pyproj import Transformer
 import subprocess
 from decimal import Decimal
 import tempfile
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import rasterio
@@ -74,16 +74,15 @@ def load_window(image_dataset, window=None, is_masked=False):
 
 
 class RasterioSource(ActivateMixin, RasterSource):
-    def __init__(
-            self,
-            uris,
-            raster_transformers,
-            tmp_dir,
-            allow_streaming=False,
-            channel_order=None,
-            x_shift=0.0,
-            y_shift=0.0,
-            extent_crop: Optional[CropOffsets] = None):
+    def __init__(self,
+                 uris,
+                 raster_transformers,
+                 tmp_dir,
+                 allow_streaming=False,
+                 channel_order=None,
+                 x_shift=0.0,
+                 y_shift=0.0,
+                 extent_crop: Optional[CropOffsets] = None):
         """Constructor.
 
         This RasterSource can read any file that can be opened by Rasterio/GDAL

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -166,9 +166,9 @@ class RasterioSource(ActivateMixin, RasterSource):
     def get_extent(self):
         h, w = self.height, self.width
         if self.extent_crop is not None:
-            top, left, bottom, right = self.extent_crop
-            ymin, xmin = int(h * top), int(w * left)
-            ymax, xmax = h - int(h * bottom), w - int(w * right)
+            skip_top, skip_left, skip_bottom, skip_right = self.extent_crop
+            ymin, xmin = int(h * skip_top), int(w * skip_left)
+            ymax, xmax = h - int(h * skip_bottom), w - int(w * skip_right)
             return Box(ymin, xmin, ymax, xmax)
         return Box(0, 0, h, w)
 

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
@@ -38,4 +38,5 @@ class RasterioSourceConfig(RasterSourceConfig):
             allow_streaming=self.allow_streaming,
             channel_order=self.channel_order,
             x_shift=self.x_shift,
-            y_shift=self.y_shift)
+            y_shift=self.y_shift,
+            extent_crop=self.extent_crop)

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
@@ -1,10 +1,10 @@
 from os.path import join
 from typing import List, TYPE_CHECKING, Optional
-from pydantic import confloat
 
 from rastervision.pipeline.pipeline_config import PipelineConfig
 from rastervision.core.data import (DatasetConfig, StatsTransformerConfig,
                                     LabelStoreConfig, SceneConfig)
+from rastervision.core.utils.misc import Proportion
 from rastervision.core.analyzer import StatsAnalyzerConfig
 from rastervision.core.backend import BackendConfig
 from rastervision.core.evaluation import EvaluatorConfig
@@ -13,8 +13,6 @@ from rastervision.pipeline.config import register_config, Field
 
 if TYPE_CHECKING:
     from rastervision.core.backend.backend import Backend  # noqa
-
-Proportion = confloat(ge=0, le=1)
 
 
 @register_config('rv_pipeline')

--- a/rastervision_core/rastervision/core/utils/misc.py
+++ b/rastervision_core/rastervision/core/utils/misc.py
@@ -1,9 +1,12 @@
 import io
+from pydantic import confloat
 
 from PIL import Image
 import numpy as np
 import imageio
 import logging
+
+Proportion = confloat(ge=0, le=1)
 
 log = logging.getLogger(__name__)
 

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -50,8 +50,9 @@ class TestRasterioSource(unittest.TestCase):
         f = 1 / 4
         cfg_crop = make_cfg('small-rgb-tile.tif', extent_crop=(f, f, f, f))
         rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)
-        extent_crop = rs_crop.get_extent()
 
+        # test extent box
+        extent_crop = rs_crop.get_extent()
         self.assertEqual(extent_crop.ymin, 64)
         self.assertEqual(extent_crop.xmin, 64)
         self.assertEqual(extent_crop.ymax, 192)

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -87,6 +87,12 @@ class TestRasterioSource(unittest.TestCase):
             ValidationError,
             lambda: make_cfg('small-rgb-tile.tif', extent_crop=extent_crop))
 
+        # test extent_crop=None
+        try:
+            _ = make_cfg('small-rgb-tile.tif', extent_crop=None)
+        except Exception:
+            self.fail('extent_crop=None caused an error.')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -1,7 +1,9 @@
 import unittest
+from pydantic import ValidationError
 
-from rastervision.core.data import (
-    RasterioSourceConfig, MultiRasterSourceConfig, SubRasterSourceConfig)
+from rastervision.core.data import (RasterioSourceConfig,
+                                    MultiRasterSourceConfig,
+                                    SubRasterSourceConfig, CropOffsets)
 from rastervision.pipeline import rv_config
 
 from tests import data_file_path
@@ -55,11 +57,35 @@ class TestRasterioSource(unittest.TestCase):
         self.assertEqual(extent_crop.ymax, 192)
         self.assertEqual(extent_crop.xmax, 192)
 
+        # test windows
         windows = extent_crop.get_windows(64, 64)
         self.assertEqual(windows[0].ymin, 64)
         self.assertEqual(windows[0].xmin, 64)
         self.assertEqual(windows[-1].ymax, 192)
         self.assertEqual(windows[-1].xmax, 192)
+
+        # test CropOffsets class
+        cfg_crop = make_cfg(
+            'small-rgb-tile.tif',
+            extent_crop=CropOffsets(skip_top=.5, skip_right=.5))
+        rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)
+        extent_crop = rs_crop.get_extent()
+
+        self.assertEqual(extent_crop.ymin, 128)
+        self.assertEqual(extent_crop.xmin, 0)
+        self.assertEqual(extent_crop.ymax, 256)
+        self.assertEqual(extent_crop.xmax, 128)
+
+        # test validation
+        extent_crop = CropOffsets(skip_top=.5, skip_bottom=.5)
+        self.assertRaises(
+            ValidationError,
+            lambda: make_cfg('small-rgb-tile.tif', extent_crop=extent_crop))
+
+        extent_crop = CropOffsets(skip_left=.5, skip_right=.5)
+        self.assertRaises(
+            ValidationError,
+            lambda: make_cfg('small-rgb-tile.tif', extent_crop=extent_crop))
 
 
 if __name__ == '__main__':

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -1,14 +1,7 @@
 import unittest
-from os.path import join
 
-import numpy as np
-import rasterio
-from rasterio.enums import ColorInterp
-
-from rastervision.core import (RasterStats)
-from rastervision.core.utils.misc import save_img
-from rastervision.core.data import (ChannelOrderError, RasterioSourceConfig,
-                                    StatsTransformerConfig, MultiRasterSourceConfig, SubRasterSourceConfig)
+from rastervision.core.data import (
+    RasterioSourceConfig, MultiRasterSourceConfig, SubRasterSourceConfig)
 from rastervision.pipeline import rv_config
 
 from tests import data_file_path
@@ -20,12 +13,15 @@ def make_cfg(img_path='small-rgb-tile.tif', **kwargs):
     g_source = RasterioSourceConfig(uris=[img_path], channel_order=[1])
     b_source = RasterioSourceConfig(uris=[img_path], channel_order=[2])
 
-    cfg = MultiRasterSourceConfig(raster_sources=[
-        SubRasterSourceConfig(raster_source=r_source, target_channels=[0]),
-        SubRasterSourceConfig(raster_source=g_source, target_channels=[1]),
-        SubRasterSourceConfig(raster_source=b_source, target_channels=[2])
-    ], **kwargs)
+    cfg = MultiRasterSourceConfig(
+        raster_sources=[
+            SubRasterSourceConfig(raster_source=r_source, target_channels=[0]),
+            SubRasterSourceConfig(raster_source=g_source, target_channels=[1]),
+            SubRasterSourceConfig(raster_source=b_source, target_channels=[2])
+        ],
+        **kwargs)
     return cfg
+
 
 class TestRasterioSource(unittest.TestCase):
     def setUp(self):
@@ -49,11 +45,6 @@ class TestRasterioSource(unittest.TestCase):
         self.assertEqual(xmax, 256)
 
     def test_extent_crop(self):
-        cfg_no_crop = make_cfg('small-rgb-tile.tif')
-        rs_no_crop = cfg_no_crop.build(tmp_dir=self.tmp_dir)
-        extent_no_crop = rs_no_crop.get_extent()
-        h, w = extent_no_crop.get_height(), extent_no_crop.get_width()
-
         f = 1 / 4
         cfg_crop = make_cfg('small-rgb-tile.tif', extent_crop=(f, f, f, f))
         rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -1,0 +1,75 @@
+import unittest
+from os.path import join
+
+import numpy as np
+import rasterio
+from rasterio.enums import ColorInterp
+
+from rastervision.core import (RasterStats)
+from rastervision.core.utils.misc import save_img
+from rastervision.core.data import (ChannelOrderError, RasterioSourceConfig,
+                                    StatsTransformerConfig, MultiRasterSourceConfig, SubRasterSourceConfig)
+from rastervision.pipeline import rv_config
+
+from tests import data_file_path
+
+
+def make_cfg(img_path='small-rgb-tile.tif', **kwargs):
+    img_path = data_file_path(img_path)
+    r_source = RasterioSourceConfig(uris=[img_path], channel_order=[0])
+    g_source = RasterioSourceConfig(uris=[img_path], channel_order=[1])
+    b_source = RasterioSourceConfig(uris=[img_path], channel_order=[2])
+
+    cfg = MultiRasterSourceConfig(raster_sources=[
+        SubRasterSourceConfig(raster_source=r_source, target_channels=[0]),
+        SubRasterSourceConfig(raster_source=g_source, target_channels=[1]),
+        SubRasterSourceConfig(raster_source=b_source, target_channels=[2])
+    ], **kwargs)
+    return cfg
+
+class TestRasterioSource(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir_obj = rv_config.get_tmp_dir()
+        self.tmp_dir = self.tmp_dir_obj.name
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
+
+    def test_extent(self):
+        cfg = make_cfg('small-rgb-tile.tif')
+        rs = cfg.build(tmp_dir=self.tmp_dir)
+        extent = rs.get_extent()
+        h, w = extent.get_height(), extent.get_width()
+        ymin, xmin, ymax, xmax = extent
+        self.assertEqual(h, 256)
+        self.assertEqual(w, 256)
+        self.assertEqual(ymin, 0)
+        self.assertEqual(xmin, 0)
+        self.assertEqual(ymax, 256)
+        self.assertEqual(xmax, 256)
+
+    def test_extent_crop(self):
+        cfg_no_crop = make_cfg('small-rgb-tile.tif')
+        rs_no_crop = cfg_no_crop.build(tmp_dir=self.tmp_dir)
+        extent_no_crop = rs_no_crop.get_extent()
+        h, w = extent_no_crop.get_height(), extent_no_crop.get_width()
+
+        f = 1 / 4
+        cfg_crop = make_cfg('small-rgb-tile.tif', extent_crop=(f, f, f, f))
+        rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)
+        extent_crop = rs_crop.get_extent()
+
+        self.assertEqual(extent_crop.ymin, 64)
+        self.assertEqual(extent_crop.xmin, 64)
+        self.assertEqual(extent_crop.ymax, 192)
+        self.assertEqual(extent_crop.xmax, 192)
+
+        windows = extent_crop.get_windows(64, 64)
+        self.assertEqual(windows[0].ymin, 64)
+        self.assertEqual(windows[0].xmin, 64)
+        self.assertEqual(windows[-1].ymax, 192)
+        self.assertEqual(windows[-1].xmax, 192)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -90,7 +90,7 @@ class TestRasterioSource(unittest.TestCase):
 
         # test extent_crop=None
         try:
-            _ = make_cfg('small-rgb-tile.tif', extent_crop=None)
+            _ = make_cfg('small-rgb-tile.tif', extent_crop=None)  # noqa
         except Exception:
             self.fail('extent_crop=None caused an error.')
 

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -274,8 +274,9 @@ class TestRasterioSource(unittest.TestCase):
         cfg_crop = RasterioSourceConfig(
             uris=[img_path], extent_crop=(f, f, f, f))
         rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)
-        extent_crop = rs_crop.get_extent()
 
+        # test extent box
+        extent_crop = rs_crop.get_extent()
         self.assertEqual(extent_crop.ymin, 64)
         self.assertEqual(extent_crop.xmin, 64)
         self.assertEqual(extent_crop.ymax, 192)

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -1,5 +1,6 @@
 import unittest
 from os.path import join
+from pydantic import ValidationError
 
 import numpy as np
 import rasterio
@@ -8,7 +9,7 @@ from rasterio.enums import ColorInterp
 from rastervision.core import (RasterStats)
 from rastervision.core.utils.misc import save_img
 from rastervision.core.data import (ChannelOrderError, RasterioSourceConfig,
-                                    StatsTransformerConfig)
+                                    StatsTransformerConfig, CropOffsets)
 from rastervision.pipeline import rv_config
 
 from tests import data_file_path
@@ -269,6 +270,7 @@ class TestRasterioSource(unittest.TestCase):
     def test_extent_crop(self):
         f = 1 / 4
         img_path = data_file_path('small-rgb-tile.tif')
+
         cfg_crop = RasterioSourceConfig(
             uris=[img_path], extent_crop=(f, f, f, f))
         rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)
@@ -279,11 +281,37 @@ class TestRasterioSource(unittest.TestCase):
         self.assertEqual(extent_crop.ymax, 192)
         self.assertEqual(extent_crop.xmax, 192)
 
+        # test windows
         windows = extent_crop.get_windows(64, 64)
         self.assertEqual(windows[0].ymin, 64)
         self.assertEqual(windows[0].xmin, 64)
         self.assertEqual(windows[-1].ymax, 192)
         self.assertEqual(windows[-1].xmax, 192)
+
+        # test CropOffsets class
+        cfg_crop = RasterioSourceConfig(
+            uris=[img_path],
+            extent_crop=CropOffsets(skip_top=.5, skip_right=.5))
+        rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)
+        extent_crop = rs_crop.get_extent()
+
+        self.assertEqual(extent_crop.ymin, 128)
+        self.assertEqual(extent_crop.xmin, 0)
+        self.assertEqual(extent_crop.ymax, 256)
+        self.assertEqual(extent_crop.xmax, 128)
+
+        # test validation
+        extent_crop = CropOffsets(skip_top=.5, skip_bottom=.5)
+        self.assertRaises(
+            ValidationError,
+            lambda: RasterioSourceConfig(uris=[img_path],
+                                         extent_crop=extent_crop))
+
+        extent_crop = CropOffsets(skip_left=.5, skip_right=.5)
+        self.assertRaises(
+            ValidationError,
+            lambda: RasterioSourceConfig(uris=[img_path],
+                                         extent_crop=extent_crop))
 
 
 if __name__ == '__main__':

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -316,7 +316,7 @@ class TestRasterioSource(unittest.TestCase):
 
         # test extent_crop=None
         try:
-            _ = RasterioSourceConfig(uris=[img_path], extent_crop=None)
+            _ = RasterioSourceConfig(uris=[img_path], extent_crop=None)  # noqa
         except Exception:
             self.fail('extent_crop=None caused an error.')
 

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -313,6 +313,12 @@ class TestRasterioSource(unittest.TestCase):
             lambda: RasterioSourceConfig(uris=[img_path],
                                          extent_crop=extent_crop))
 
+        # test extent_crop=None
+        try:
+            _ = RasterioSourceConfig(uris=[img_path], extent_crop=None)
+        except Exception:
+            self.fail('extent_crop=None caused an error.')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -252,6 +252,44 @@ class TestRasterioSource(unittest.TestCase):
                 'Creating RasterioSource with CRS with no EPSG attribute '
                 'raised an exception when it should not have.')
 
+    def test_extent(self):
+        img_path = data_file_path('small-rgb-tile.tif')
+        cfg = RasterioSourceConfig(uris=[img_path])
+        rs = cfg.build(tmp_dir=self.tmp_dir)
+        extent = rs.get_extent()
+        h, w = extent.get_height(), extent.get_width()
+        ymin, xmin, ymax, xmax = extent
+        self.assertEqual(h, 256)
+        self.assertEqual(w, 256)
+        self.assertEqual(ymin, 0)
+        self.assertEqual(xmin, 0)
+        self.assertEqual(ymax, 256)
+        self.assertEqual(xmax, 256)
+
+    def test_extent_crop(self):
+        img_path = data_file_path('small-rgb-tile.tif')
+        cfg_no_crop = RasterioSourceConfig(uris=[img_path])
+        rs_no_crop = cfg_no_crop.build(tmp_dir=self.tmp_dir)
+        extent_no_crop = rs_no_crop.get_extent()
+        h, w = extent_no_crop.get_height(), extent_no_crop.get_width()
+
+        f = 1 / 4
+        cfg_crop = RasterioSourceConfig(
+            uris=[img_path], extent_crop=(f, f, f, f))
+        rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)
+        extent_crop = rs_crop.get_extent()
+
+        self.assertEqual(extent_crop.ymin, 64)
+        self.assertEqual(extent_crop.xmin, 64)
+        self.assertEqual(extent_crop.ymax, 192)
+        self.assertEqual(extent_crop.xmax, 192)
+
+        windows = extent_crop.get_windows(64, 64)
+        self.assertEqual(windows[0].ymin, 64)
+        self.assertEqual(windows[0].xmin, 64)
+        self.assertEqual(windows[-1].ymax, 192)
+        self.assertEqual(windows[-1].xmax, 192)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -267,13 +267,8 @@ class TestRasterioSource(unittest.TestCase):
         self.assertEqual(xmax, 256)
 
     def test_extent_crop(self):
-        img_path = data_file_path('small-rgb-tile.tif')
-        cfg_no_crop = RasterioSourceConfig(uris=[img_path])
-        rs_no_crop = cfg_no_crop.build(tmp_dir=self.tmp_dir)
-        extent_no_crop = rs_no_crop.get_extent()
-        h, w = extent_no_crop.get_height(), extent_no_crop.get_width()
-
         f = 1 / 4
+        img_path = data_file_path('small-rgb-tile.tif')
         cfg_crop = RasterioSourceConfig(
             uris=[img_path], extent_crop=(f, f, f, f))
         rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)

--- a/tests/core/test_box.py
+++ b/tests/core/test_box.py
@@ -195,6 +195,23 @@ class TestBox(unittest.TestCase):
             [window.tuple_format() for window in expected_windows])
         self.assertSetEqual(windows, expected_windows)
 
+    def test_unpacking(self):
+        box = Box(1, 2, 3, 4)
+        ymin, xmin, ymax, xmax = box
+        self.assertEqual((ymin, xmin, ymax, xmax), box.tuple_format())
+
+    def test_subscripting(self):
+        box = Box(1, 2, 3, 4)
+        self.assertEqual(box[0], 1)
+        self.assertEqual(box[1], 2)
+        self.assertEqual(box[2], 3)
+        self.assertEqual(box[3], 4)
+        self.assertRaises(IndexError, lambda: box[4])
+
+    def test_repr(self):
+        box = Box(1, 2, 3, 4)
+        self.assertEqual(box.__repr__(), 'Box(1, 2, 3, 4)')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

Allows different portions of the same scene image to be used in different dataset splits.
- Adds an `extent_crop` field to `RasterSourceConfig` that is passed on to the RasterSources. 
https://github.com/azavea/raster-vision/blob/1d278f855deea3a5879912d8ff82be109f5d3200/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py#L23-L33
- Updates `RaterioSource` and `MultiRasterSource` to make use of `extent_crop`.
- Some minor improvements to `Box()`.
- Adds unit tests.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* How to test this PR
    - See new unit tests
