### PR TITLE
Fixess and improvements for nodata filtering

### DIFF
--- a/rastervision_core/rastervision/core/rv_pipeline/__init__.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/__init__.py
@@ -11,3 +11,4 @@ from rastervision.core.rv_pipeline.semantic_segmentation import *
 from rastervision.core.rv_pipeline.semantic_segmentation_config import *
 from rastervision.core.rv_pipeline.object_detection import *
 from rastervision.core.rv_pipeline.object_detection_config import *
+from rastervision.core.rv_pipeline.utils import *

--- a/rastervision_core/rastervision/core/rv_pipeline/chip_classification.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/chip_classification.py
@@ -1,6 +1,7 @@
 import logging
 
 from rastervision.core.rv_pipeline.rv_pipeline import RVPipeline
+from rastervision.core.rv_pipeline.utils import nodata_below_threshold
 from rastervision.core.box import Box
 
 log = logging.getLogger(__name__)
@@ -15,7 +16,7 @@ def get_train_windows(scene, chip_size, chip_nodata_threshold=1.):
         windows = Box.filter_by_aoi(windows, scene.aoi_polygons)
     for window in windows:
         chip = scene.raster_source.get_chip(window)
-        if (chip.sum(axis=-1) == 0).mean() < chip_nodata_threshold:
+        if nodata_below_threshold(chip, chip_nodata_threshold, nodata_val=0):
             train_windows.append(window)
     return train_windows
 

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
@@ -1,6 +1,7 @@
 import logging
 
 from rastervision.core.rv_pipeline.rv_pipeline import RVPipeline
+from rastervision.core.rv_pipeline.utils import nodata_below_threshold
 from rastervision.core.rv_pipeline.object_detection_config import (
     ObjectDetectionWindowMethod)
 from rastervision.core.box import Box
@@ -81,8 +82,9 @@ def make_neg_windows(raster_source,
             label_store.get_labels(), window, ioa_thresh=0.2)
 
         # If no labels and not too many nodata pixels, append the chip
-        nodata_prop = (chip.sum(axis=-1) == 0).mean()
-        if len(labels) == 0 and nodata_prop < chip_nodata_threshold:
+        nodata_below_thresh = nodata_below_threshold(
+            chip, chip_nodata_threshold, nodata_val=0)
+        if len(labels) == 0 and nodata_below_thresh:
             neg_windows.append(window)
 
         if len(neg_windows) == nb_windows:

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -33,18 +33,18 @@ def get_train_windows(scene,
         if scene.aoi_polygons:
             windows = Box.filter_by_aoi(windows, scene.aoi_polygons)
 
-            filt_windows = []
-            for w in windows:
-                chip = raster_source.get_chip(w)
-                nodata_prop = (chip.sum(axis=-1) == 0).mean()
-                nodata_below_thresh = nodata_prop < chip_nodata_threshold
+        filt_windows = []
+        for w in windows:
+            chip = raster_source.get_chip(w)
+            nodata_prop = (chip.sum(axis=-1) == 0).mean()
+            nodata_below_thresh = nodata_prop < chip_nodata_threshold
 
-                label_arr = label_source.get_labels(w).get_label_arr(w)
-                null_labels = label_arr == class_config.get_null_class_id()
+            label_arr = label_source.get_labels(w).get_label_arr(w)
+            null_labels = label_arr == class_config.get_null_class_id()
 
-                if not np.all(null_labels) and nodata_below_thresh:
-                    filt_windows.append(w)
-            windows = filt_windows
+            if not np.all(null_labels) and nodata_below_thresh:
+                filt_windows.append(w)
+        windows = filt_windows
         return windows
 
     def should_use_window(window):

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -4,6 +4,8 @@ from typing import List
 import numpy as np
 
 from rastervision.core.rv_pipeline.rv_pipeline import RVPipeline
+from rastervision.core.rv_pipeline.utils import (fill_no_data,
+                                                 nodata_below_threshold)
 from rastervision.core.box import Box
 from rastervision.core.rv_pipeline.semantic_segmentation_config import (
     SemanticSegmentationWindowMethod)
@@ -36,8 +38,8 @@ def get_train_windows(scene,
         filt_windows = []
         for w in windows:
             chip = raster_source.get_chip(w)
-            nodata_prop = (chip.sum(axis=-1) == 0).mean()
-            nodata_below_thresh = nodata_prop < chip_nodata_threshold
+            nodata_below_thresh = nodata_below_threshold(
+                chip, chip_nodata_threshold, nodata_val=0)
 
             label_arr = label_source.get_labels(w).get_label_arr(w)
             null_labels = label_arr == class_config.get_null_class_id()
@@ -85,14 +87,6 @@ def get_train_windows(scene,
                 windows.append(window)
 
     return windows
-
-
-def fill_no_data(img, label_arr, null_class_id):
-    # If chip has null labels, fill in those pixels with nodata.
-    mask = label_arr == null_class_id
-    if np.any(mask):
-        img[mask, :] = 0
-    return img
 
 
 class SemanticSegmentation(RVPipeline):

--- a/rastervision_core/rastervision/core/rv_pipeline/utils.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/utils.py
@@ -1,0 +1,21 @@
+# from typing import
+import numpy as np
+
+
+def nodata_below_threshold(chip: np.ndarray,
+                           threshold: float,
+                           nodata_val: int = 0) -> bool:
+    """ Check if proportion of nodata pixels is below the threshold. """
+    if len(chip.shape) == 3:
+        chip = chip.sum(axis=-1)
+    nodata_prop = (chip == 0).mean()
+    return nodata_prop < threshold
+
+
+def fill_no_data(img: np.ndarray, label_arr: np.ndarray,
+                 null_class_id: int) -> None:
+    """ If chip has null labels, fill in those pixels with nodata. """
+    mask = label_arr == null_class_id
+    if np.any(mask):
+        img[mask, :] = 0
+    return img

--- a/tests/core/rv_pipeline/test_utils.py
+++ b/tests/core/rv_pipeline/test_utils.py
@@ -1,0 +1,53 @@
+import unittest
+
+import numpy as np
+
+from rastervision.core.rv_pipeline.utils import (fill_no_data,
+                                                 nodata_below_threshold)
+
+
+class TestUtils(unittest.TestCase):
+    def test_fill_no_data(self):
+        chip = np.ones((256, 256, 3), dtype=np.uint8)
+        label = np.zeros((256, 256), dtype=np.uint8)
+        label[:, 128:] = 2
+
+        chip_filled = fill_no_data(chip, label, null_class_id=2)
+        self.assertEqual(chip_filled[:, 128:].sum(), 0)
+        self.assertEqual(chip_filled[:, :128].sum(), chip[:, :128].sum())
+
+    def test_nodata_below_threshold(self):
+        chip = np.ones((256, 256, 3), dtype=np.uint8)
+        # different proportions of nodata
+        mask_0 = np.ones_like(chip)
+        mask_50 = np.ones_like(chip)
+        mask_50[:128] = 0
+        mask_100 = np.zeros_like(chip)
+
+        # 0% nodata
+        test_chip = chip & mask_0
+        self.assertFalse(nodata_below_threshold(test_chip, threshold=0.00))
+        self.assertTrue(nodata_below_threshold(test_chip, threshold=0.25))
+        self.assertTrue(nodata_below_threshold(test_chip, threshold=0.50))
+        self.assertTrue(nodata_below_threshold(test_chip, threshold=0.75))
+        self.assertTrue(nodata_below_threshold(test_chip, threshold=1.00))
+
+        # 50% nodata
+        test_chip = chip & mask_50
+        self.assertFalse(nodata_below_threshold(test_chip, threshold=0.00))
+        self.assertFalse(nodata_below_threshold(test_chip, threshold=0.25))
+        self.assertFalse(nodata_below_threshold(test_chip, threshold=0.50))
+        self.assertTrue(nodata_below_threshold(test_chip, threshold=0.75))
+        self.assertTrue(nodata_below_threshold(test_chip, threshold=1.00))
+
+        # 100% nodata
+        test_chip = chip & mask_100
+        self.assertFalse(nodata_below_threshold(test_chip, threshold=0.00))
+        self.assertFalse(nodata_below_threshold(test_chip, threshold=0.25))
+        self.assertFalse(nodata_below_threshold(test_chip, threshold=0.50))
+        self.assertFalse(nodata_below_threshold(test_chip, threshold=0.75))
+        self.assertFalse(nodata_below_threshold(test_chip, threshold=1.00))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

### FIxes
- Changes the indentation level of the filtering logic (lines 36-47 below) by moving it outside the `if scene.aoi_polygon` block, so that it always executes.
**Before**
https://github.com/azavea/raster-vision/blob/d98adffb4cc4629dbf2108208958708005333d0c/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py#L33-L47
**After**
https://github.com/azavea/raster-vision/blob/8b6a32a6b0f1de39968093b197d0e125cacdb976/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py#L35-L49

### Refactoring
- Moves the nodata threshold checking logic to a new `nodata_below_threshold()` function that is used by all pipelines.
- Moves it to a new `utils.py`.
- Moves `fill_no_data()` to `utils.py` too.

### Other
- Adds unit tests for `nodata_below_threshold()` and `fill_no_data()`.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
