### PR TITLE
Type cast before saving chips

### DIFF
--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
@@ -78,12 +78,13 @@ class SemanticSegmentationConfig(RVPipelineConfig):
         None, description='The filetype of the training images.')
     label_format: str = Field(
         'png', description='The filetype of the training labels.')
-    img_dtype: Optional[type] = Field(
+    img_dtype: Optional[str] = Field(
         None,
         description='The dtype that the training images should be cast to. '
         'Values are clipped to the max value of this dtype before casting. '
-        'Use case: the original image is uint16 but except for a few noisy '
-        'pixels, the values are all less than 256.')
+        'Must be passed as a str e.g. "uint8". Use case: the original image '
+        'is uint16 but except for a few noisy pixels, the values are all less '
+        'than 256.')
 
     def build(self, tmp_dir):
         from rastervision.core.rv_pipeline.semantic_segmentation import (

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
@@ -78,6 +78,12 @@ class SemanticSegmentationConfig(RVPipelineConfig):
         None, description='The filetype of the training images.')
     label_format: str = Field(
         'png', description='The filetype of the training labels.')
+    img_dtype: Optional[type] = Field(
+        None,
+        description='The dtype that the training images should be cast to. '
+        'Values are clipped to the max value of this dtype before casting. '
+        'Use case: the original image is uint16 but except for a few noisy '
+        'pixels, the values are all less than 256.')
 
     def build(self, tmp_dir):
         from rastervision.core.rv_pipeline.semantic_segmentation import (

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
@@ -1,6 +1,7 @@
 from os.path import join
 from pathlib import Path
 import uuid
+from typing import Optional
 
 import numpy as np
 
@@ -20,7 +21,7 @@ class PyTorchSemanticSegmentationSampleWriter(PyTorchLearnerSampleWriter):
                  tmp_dir: str,
                  img_format: str = 'png',
                  label_format: str = 'png',
-                 img_dtype: type = None):
+                 img_dtype: Optional[str] = None):
         """Constructor.
 
         Args:
@@ -63,7 +64,7 @@ class PyTorchSemanticSegmentationSampleWriter(PyTorchLearnerSampleWriter):
         img_path = img_dir / img_filename
 
         if self.img_dtype is not None:
-            new_dtype = self.img_dtype
+            new_dtype = np.dtype(self.img_dtype)
             if np.issubdtype(new_dtype, np.unsignedinteger):
                 max_val = np.iinfo(new_dtype).max
                 img = img.clip(max=max_val)


### PR DESCRIPTION
## Overview

This is a workaround for a problem encountered in the WB project where the tifs were uint16, but almost all the pixel values were < 256, with the rest few being larger.

### Checklist

- [ ] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
