### PR TITLE
Accept Immediate Geometries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ Features
 * Allow filtering out chips based on proportion of NODATA pixels `#1025 <https://github.com/azavea/raster-vision/pull/1025>`_
 * Allow ignore_last_class to take either a boolean or the literal 'force'; in the latter case validation of that argument is skipped so that it can be used with external loss functions `#1027 <https://github.com/azavea/raster-vision/pull/1027>`_
 * Add ability to crop raster source extent `#1030 <https://github.com/azavea/raster-vision/pull/1030>`_
+* Accept immediate geometries in SceneConfig `#1033 <https://github.com/azavea/raster-vision/pull/1033>`_
 
 Bug Fixes
 ~~~~~~~~~~~~


### PR DESCRIPTION
## Overview

This allows immediate AOI geometries to be passed directly into the scene config rather than having to be in a file.  This is useful for using "labeled footprints" in STAC files (the geometries are given in JSON files that incompatible with raster-vision rather than in GeoJSON files that are compatible with raster-vision).

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
