### PR TITLE
Make DataConfig.group_uris specifiable through the backend config + related fixes and improvements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,7 @@ Features
 * Allow ignore_last_class to take either a boolean or the literal 'force'; in the latter case validation of that argument is skipped so that it can be used with external loss functions `#1027 <https://github.com/azavea/raster-vision/pull/1027>`_
 * Add ability to crop raster source extent `#1030 <https://github.com/azavea/raster-vision/pull/1030>`_
 * Accept immediate geometries in SceneConfig `#1033 <https://github.com/azavea/raster-vision/pull/1033>`_
+* Make group_uris specifiable and add group_train_sz_rel `#1035 <https://github.com/azavea/raster-vision/pull/1035>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -5,7 +5,7 @@ from rastervision.pipeline.config import (register_config, Field, validator)
 from rastervision.core.backend import BackendConfig
 from rastervision.pytorch_learner.learner_config import (
     SolverConfig, ModelConfig, default_augmentors, augmentors as
-    augmentor_list, PlotOptions, CountOrProportion)
+    augmentor_list, PlotOptions, Proportion)
 from rastervision.pytorch_learner.utils import validate_albumentation_transform
 
 
@@ -53,14 +53,25 @@ class PyTorchLearnerBackendConfig(BackendConfig):
         4, description='The number of workers to use in PyTorch to read data.')
     group_uris: Optional[List[Union[str, List[str]]]] = Field(
         None,
-        description='This is passed on to DataConfig.group_uris and takes '
-        'precedence over chip_uri in the pipeline config. See DataConfig for '
-        'details.')
-    group_train_sz: Optional[Union[CountOrProportion, List[
-        CountOrProportion]]] = Field(
-            None,
-            description='If group_uris is set, this can be used to specify the '
-            'number of chips to use per group. See DataConfig for details.')
+        description=
+        'This can be set instead of uri in order to specify groups of chips. '
+        'Each element in the list is expected to be an object of the same '
+        'form accepted by the uri field. The purpose of separating chips into '
+        'groups is to be able to use the group_train_sz field.')
+    group_train_sz: Optional[Union[int, List[int]]] = Field(
+        None,
+        description='If group_uris is set, this can be used to specify the '
+        'number of chips to use per group. Only applies to training chips. '
+        'This can either be a single value that will be used for all groups '
+        'or a list of values (one for each group).')
+    group_train_sz_rel: Optional[Union[Proportion, List[Proportion]]] = Field(
+        None,
+        description='Relative version of group_train_sz. Must be a float '
+        'in [0, 1]. If group_uris is set, this can be used to specify the '
+        'proportion of the total chips in each group to use per group. '
+        'Only applies to training chips. This can either be a single value '
+        'that will be used for all groups or a list of values '
+        '(one for each group).')
 
     # validators
     _base_tf = validator(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -5,7 +5,7 @@ from rastervision.pipeline.config import (register_config, Field, validator)
 from rastervision.core.backend import BackendConfig
 from rastervision.pytorch_learner.learner_config import (
     SolverConfig, ModelConfig, default_augmentors, augmentors as
-    augmentor_list, PlotOptions)
+    augmentor_list, PlotOptions, CountOrProportion)
 from rastervision.pytorch_learner.utils import validate_albumentation_transform
 
 
@@ -56,10 +56,11 @@ class PyTorchLearnerBackendConfig(BackendConfig):
         description='This is passed on to DataConfig.group_uris and takes '
         'precedence over chip_uri in the pipeline config. See DataConfig for '
         'details.')
-    group_train_sz: Optional[int] = Field(
-        None,
-        description='If group_uris is set, this can be used to specify the '
-        'number of chips to use per group. See DataConfig for details.')
+    group_train_sz: Optional[Union[CountOrProportion, List[
+        CountOrProportion]]] = Field(
+            None,
+            description='If group_uris is set, this can be used to specify the '
+            'number of chips to use per group. See DataConfig for details.')
 
     # validators
     _base_tf = validator(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 from pydantic import PositiveInt
 
 from rastervision.pipeline.config import (register_config, Field, validator)
@@ -51,6 +51,15 @@ class PyTorchLearnerBackendConfig(BackendConfig):
         'dataset. Defaults to train_chip_sz in the pipeline config.')
     num_workers: int = Field(
         4, description='The number of workers to use in PyTorch to read data.')
+    group_uris: Optional[List[Union[str, List[str]]]] = Field(
+        None,
+        description='This is passed on to DataConfig.group_uris and takes '
+        'precedence over chip_uri in the pipeline config. See DataConfig for '
+        'details.')
+    group_train_sz: Optional[int] = Field(
+        None,
+        description='If group_uris is set, this can be used to specify the '
+        'number of chips to use per group. See DataConfig for details.')
 
     # validators
     _base_tf = validator(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -20,6 +20,7 @@ class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
             uri=pipeline.chip_uri,
             group_uris=self.group_uris,
             group_train_sz=self.group_train_sz,
+            group_train_sz_rel=self.group_train_sz_rel,
             class_names=pipeline.dataset.class_config.names,
             class_colors=pipeline.dataset.class_config.colors,
             img_sz=self.img_sz,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -18,6 +18,8 @@ class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
 
         data = SemanticSegmentationDataConfig(
             uri=pipeline.chip_uri,
+            group_uris=self.group_uris,
+            group_train_sz=self.group_train_sz,
             class_names=pipeline.dataset.class_config.names,
             class_colors=pipeline.dataset.class_config.colors,
             img_sz=self.img_sz,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -426,7 +426,10 @@ class Learner(ABC):
 
     def get_datasets(self) -> Tuple[Dataset, Dataset, Dataset]:
         """Returns train, validation, and test DataSets."""
-        if self.cfg.data.group_uris:
+        if self.cfg.data.group_uris is not None:
+            if self.cfg.data.uri is not None:
+                log.warn('Both DataConfig.uri and DataConfig.group_uris '
+                         'given. DataConfig.uri will be ignored.')
             train_ds_lst, valid_ds_lst, test_ds_lst = [], [], []
             for group_uri in self.cfg.data.group_uris:
                 train_ds, valid_ds, test_ds = self._get_datasets(group_uri)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -13,6 +13,7 @@ from subprocess import Popen
 import numbers
 import zipfile
 from typing import Optional, List, Tuple, Dict, Union, Any
+from pydantic.utils import sequence_like
 import random
 import uuid
 
@@ -429,16 +430,21 @@ class Learner(ABC):
         if self.cfg.data.group_uris is not None:
             if self.cfg.data.uri is not None:
                 log.warn('Both DataConfig.uri and DataConfig.group_uris '
-                         'given. DataConfig.uri will be ignored.')
+                         'specified. Only DataConfig.group_uris will be used.')
             train_ds_lst, valid_ds_lst, test_ds_lst = [], [], []
-            for group_uri in self.cfg.data.group_uris:
-                train_ds, valid_ds, test_ds = self._get_datasets(group_uri)
-                group_train_sz = self.cfg.data.group_train_sz
-                if group_train_sz is not None:
+
+            group_sizes = self.cfg.data.group_train_sz
+            if not sequence_like(group_sizes):
+                group_sizes = [group_sizes] * len(self.cfg.data.group_uris)
+            for uri, sz in zip(self.cfg.data.group_uris, group_sizes):
+                train_ds, valid_ds, test_ds = self._get_datasets(uri)
+                if sz is not None:
+                    if isinstance(sz, float):
+                        sz = int(len(train_ds) * sz)
                     train_inds = list(range(len(train_ds)))
                     random.seed(1234)
                     random.shuffle(train_inds)
-                    train_inds = train_inds[0:group_train_sz]
+                    train_inds = train_inds[:sz]
                     train_ds = Subset(train_ds, train_inds)
                 train_ds_lst.append(train_ds)
                 valid_ds_lst.append(valid_ds)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -433,9 +433,14 @@ class Learner(ABC):
                          'specified. Only DataConfig.group_uris will be used.')
             train_ds_lst, valid_ds_lst, test_ds_lst = [], [], []
 
-            group_sizes = self.cfg.data.group_train_sz
+            group_sizes = None
+            if self.cfg.data.group_train_sz is not None:
+                group_sizes = self.cfg.data.group_train_sz
+            elif self.cfg.data.group_train_sz_rel is not None:
+                group_sizes = self.cfg.data.group_train_sz_rel
             if not sequence_like(group_sizes):
                 group_sizes = [group_sizes] * len(self.cfg.data.group_uris)
+
             for uri, sz in zip(self.cfg.data.group_uris, group_sizes):
                 train_ds, valid_ds, test_ds = self._get_datasets(uri)
                 if sz is not None:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -264,7 +264,7 @@ class DataConfig(Config):
             None,
             description='If group_uris is set, this can be used to specify the '
             'number of chips to use per group. Only applies to training chips. '
-            'This can either be single value that will be used for all groups or '
+            'This can either be a single value that will be used for all groups or '
             'a list of values (one for each group). If an int, the value is '
             'interpreted as the exact number of chips. If a float between 0 and '
             '1, it is interpreted as the proportion of the total number of chips '

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -181,31 +181,32 @@ class SemanticSegmentationLearner(Learner):
             train_dir = join(data_dir, 'train')
             valid_dir = join(data_dir, 'valid')
 
+            _train_ds, _valid_ds, _test_ds = [], [], []
             if isdir(train_dir):
                 tf = transform if cfg.overfit_mode else aug_transform
-                ds = SemanticSegmentationDataset(
+                _train_ds = SemanticSegmentationDataset(
                     train_dir,
                     img_fmt=img_fmt,
                     label_fmt=label_fmt,
                     transform=tf)
-                train_ds.append(ds)
-
             if isdir(valid_dir):
-                valid_ds.append(
-                    SemanticSegmentationDataset(
-                        valid_dir,
-                        img_fmt=img_fmt,
-                        label_fmt=label_fmt,
-                        transform=transform))
-                test_ds.append(
-                    SemanticSegmentationDataset(
-                        valid_dir,
-                        img_fmt=img_fmt,
-                        label_fmt=label_fmt,
-                        transform=transform))
+                _valid_ds = SemanticSegmentationDataset(
+                    valid_dir,
+                    img_fmt=img_fmt,
+                    label_fmt=label_fmt,
+                    transform=transform)
+                _test_ds = SemanticSegmentationDataset(
+                    valid_dir,
+                    img_fmt=img_fmt,
+                    label_fmt=label_fmt,
+                    transform=transform)
+            train_ds.append(_train_ds)
+            valid_ds.append(_valid_ds)
+            test_ds.append(_test_ds)
 
-        train_ds, valid_ds, test_ds = \
-            ConcatDataset(train_ds), ConcatDataset(valid_ds), ConcatDataset(test_ds)
+        train_ds, valid_ds, test_ds = (ConcatDataset(train_ds),
+                                       ConcatDataset(valid_ds),
+                                       ConcatDataset(test_ds))
 
         return train_ds, valid_ds, test_ds
 

--- a/tests/pytorch_learner/test_dataconfig.py
+++ b/tests/pytorch_learner/test_dataconfig.py
@@ -1,0 +1,46 @@
+from typing import Callable
+import unittest
+
+from rastervision.pytorch_learner.learner_config import DataConfig
+from rastervision.pipeline.config import ConfigError
+
+
+class TestDataConfig(unittest.TestCase):
+    def fail_if_fails(self, fn: Callable, msg=''):
+        try:
+            fn()
+        except Exception:
+            self.fail(msg)
+
+    def test_group_uris(self):
+        group_uris = ['a', 'b', 'c']
+
+        # test missing group_uris
+        cfg = DataConfig(group_train_sz=1)
+        self.assertRaises(ConfigError, lambda: cfg.validate_config())
+        cfg = DataConfig(group_train_sz_rel=.5)
+        self.assertRaises(ConfigError, lambda: cfg.validate_config())
+        # test both group_train_sz and group_train_sz_rel specified
+        cfg = DataConfig(
+            group_uris=group_uris, group_train_sz=1, group_train_sz_rel=.5)
+        self.assertRaises(ConfigError, lambda: cfg.validate_config())
+        # test length check
+        cfg = DataConfig(group_uris=group_uris, group_train_sz=[1])
+        self.assertRaises(ConfigError, lambda: cfg.validate_config())
+        cfg = DataConfig(group_uris=group_uris, group_train_sz_rel=[.5])
+        self.assertRaises(ConfigError, lambda: cfg.validate_config())
+        # test valid configs
+        cfg = DataConfig(group_uris=group_uris, group_train_sz=1)
+        self.fail_if_fails(lambda: cfg.validate_config())
+        cfg = DataConfig(
+            group_uris=group_uris, group_train_sz=[1] * len(group_uris))
+        self.fail_if_fails(lambda: cfg.validate_config())
+        cfg = DataConfig(group_uris=group_uris, group_train_sz_rel=.1)
+        self.fail_if_fails(lambda: cfg.validate_config())
+        cfg = DataConfig(
+            group_uris=group_uris, group_train_sz_rel=[.1] * len(group_uris))
+        self.fail_if_fails(lambda: cfg.validate_config())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

- Add `group_train_sz_rel` - a relative version of `group_train_sz`.
  - `group_train_sz` and `group_train_sz_rel` also accept a list of values.
- Useful when you have one very large raster source divided into multiple disjoint scenes using `extent_crop`. In that case, this allows you to sample uniformly from all the scenes by specifying `group_train_sz_rel`.
- Modify `SemanticSegmentationLearner._get_datasets()` so that it doesn't break when any of the datasets is empty.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
