### PR TITLE
Make Number of Previews Independent of Batch Size 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ Features
 * Accept immediate geometries in SceneConfig `#1033 <https://github.com/azavea/raster-vision/pull/1033>`_
 * Only perform normalization on unsigned integer types `#1028 <https://github.com/azavea/raster-vision/pull/1028>`_
 * Make group_uris specifiable and add group_train_sz_rel `#1035 <https://github.com/azavea/raster-vision/pull/1035>`_
+* Make number of training and dataloader previews independent of batch size `#1038 <https://github.com/azavea/raster-vision/pull/1038>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
@@ -27,6 +27,7 @@ class PyTorchChipClassificationConfig(PyTorchLearnerBackendConfig):
         data.aug_transform = self.aug_transform
         data.plot_options = self.plot_options
         data.num_workers = self.num_workers
+        data.preview_batch_limit = self.preview_batch_limit
 
         learner = ClassificationLearnerConfig(
             data=data,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -72,6 +72,11 @@ class PyTorchLearnerBackendConfig(BackendConfig):
         'Only applies to training chips. This can either be a single value '
         'that will be used for all groups or a list of values '
         '(one for each group).')
+    preview_batch_limit: Optional[int] = Field(
+        None,
+        description=
+        ('Optional limit on the number of items in the preview plots produced '
+         'during training.'))
 
     # validators
     _base_tf = validator(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -27,6 +27,7 @@ class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
         data.aug_transform = self.aug_transform
         data.plot_options = self.plot_options
         data.num_workers = self.num_workers
+        data.preview_batch_limit = self.preview_batch_limit
 
         learner = ObjectDetectionLearnerConfig(
             data=data,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -32,7 +32,8 @@ class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
             base_transform=self.base_transform,
             aug_transform=self.aug_transform,
             plot_options=self.plot_options,
-            channel_display_groups=pipeline.channel_display_groups)
+            channel_display_groups=pipeline.channel_display_groups,
+            preview_batch_limit=self.preview_batch_limit)
 
         learner = SemanticSegmentationLearnerConfig(
             data=data,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -86,6 +86,8 @@ class Learner(ABC):
         self.cfg = cfg
         self.tmp_dir = tmp_dir
 
+        self.preview_batch_limit = self.cfg.data.preview_batch_limit
+
         # TODO make cache dirs configurable
         torch_cache_dir = '/opt/data/torch-cache'
         os.environ['TORCH_HOME'] = torch_cache_dir
@@ -157,7 +159,7 @@ class Learner(ABC):
         cfg = self.cfg
         self.log_data_stats()
         if not cfg.predict_mode:
-            self.plot_dataloaders()
+            self.plot_dataloaders(self.preview_batch_limit)
             if cfg.overfit_mode:
                 self.overfit()
             else:
@@ -800,7 +802,12 @@ class Learner(ABC):
         """
         pass
 
-    def plot_batch(self, x: Tensor, y, output_path: str, z=None):
+    def plot_batch(self,
+                   x: Tensor,
+                   y,
+                   output_path: str,
+                   z=None,
+                   batch_limit: Optional[int] = None):
         """Plot a whole batch in a grid using plot_xyz.
 
         Args:
@@ -808,8 +815,11 @@ class Learner(ABC):
             y: ground truth labels
             output_path: local path where to save plot image
             z: optional predicted labels
+            batch_limit: optional limit on (rendered) batch size
         """
         batch_sz = x.shape[0]
+        batch_sz = min(batch_sz,
+                       batch_limit) if batch_limit is not None else batch_sz
         ncols = nrows = math.ceil(math.sqrt(batch_sz))
         fig = plt.figure(
             constrained_layout=True, figsize=(3 * ncols, 3 * nrows))
@@ -835,36 +845,43 @@ class Learner(ABC):
         plt.savefig(output_path)
         plt.close()
 
-    def plot_predictions(self, split: str):
+    def plot_predictions(self, split: str, batch_limit: Optional[int] = None):
         """Plot predictions for a split.
 
         Uses the first batch for the corresponding DataLoader.
 
         Args:
             split: dataset split. Can be train, valid, or test.
+            batch_limit: optional limit on (rendered) batch size
         """
         log.info('Plotting predictions...')
         dl = self.get_dataloader(split)
         output_path = join(self.output_dir, '{}_preds.png'.format(split))
         x, y, z = self.predict_dataloader(dl, one_batch=True)
-        self.plot_batch(x, y, output_path, z=z)
+        self.plot_batch(x, y, output_path, z=z, batch_limit=batch_limit)
 
-    def plot_dataloader(self, dl: DataLoader, output_path: str):
+    def plot_dataloader(self,
+                        dl: DataLoader,
+                        output_path: str,
+                        batch_limit: Optional[int] = None):
         """Plot images and ground truth labels for a DataLoader."""
         x, y = next(iter(dl))
-        self.plot_batch(x, y, output_path)
+        self.plot_batch(x, y, output_path, batch_limit=batch_limit)
 
-    def plot_dataloaders(self):
+    def plot_dataloaders(self, batch_limit: Optional[int] = None):
         """Plot images and ground truth labels for all DataLoaders."""
         if self.train_dl:
             self.plot_dataloader(
-                self.train_dl, join(self.output_dir, 'dataloaders/train.png'))
+                self.train_dl, join(self.output_dir, 'dataloaders/train.png'),
+                batch_limit)
         if self.valid_dl:
             self.plot_dataloader(
-                self.valid_dl, join(self.output_dir, 'dataloaders/valid.png'))
+                self.valid_dl, join(self.output_dir, 'dataloaders/valid.png'),
+                batch_limit)
         if self.test_dl:
             self.plot_dataloader(self.test_dl,
-                                 join(self.output_dir, 'dataloaders/test.png'))
+                                 join(self.output_dir, 'dataloaders/test.png'),
+                                 batch_limit)
 
     @staticmethod
     def from_model_bundle(model_bundle_uri: str, tmp_dir: str):
@@ -1117,4 +1134,4 @@ class Learner(ABC):
         log.info('metrics: {}'.format(metrics))
         json_to_file(metrics,
                      join(self.output_dir, '{}_metrics.json'.format(split)))
-        self.plot_predictions(split)
+        self.plot_predictions(split, self.preview_batch_limit)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -309,6 +309,11 @@ class DataConfig(Config):
         'augmentors option is ignored.')
     plot_options: Optional[PlotOptions] = Field(
         PlotOptions(), description='Options to control plotting.')
+    preview_batch_limit: Optional[int] = Field(
+        None,
+        description=
+        ('Optional limit on the number of items in the preview plots produced '
+         'during training.'))
 
     # validators
     _base_tf = validator(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -251,7 +251,8 @@ class SemanticSegmentationLearner(Learner):
                    x: torch.Tensor,
                    y: Union[torch.Tensor, np.ndarray],
                    output_path: str,
-                   z: Optional[torch.Tensor] = None) -> None:
+                   z: Optional[torch.Tensor] = None,
+                   batch_limit: Optional[int] = None) -> None:
         """Plot a whole batch in a grid using plot_xyz.
 
         Args:
@@ -259,8 +260,11 @@ class SemanticSegmentationLearner(Learner):
             y: ground truth labels
             output_path: local path where to save plot image
             z: optional predicted labels
+            batch_limit: optional limit on (rendered) batch size
         """
         batch_sz, c, h, w = x.shape
+        batch_sz = min(batch_sz,
+                       batch_limit) if batch_limit is not None else batch_sz
         channel_groups = self.cfg.data.channel_display_groups
 
         nrows = batch_sz


### PR DESCRIPTION
## Overview

These changes allow one to specify a "number of previews" (generated by `matplotlib` during the training stage) that is smaller than the batch size.  `matplotlib` seems to have trouble scaling to large number of previews; this change allows one to still use large batches.

Depends on https://github.com/azavea/raster-vision/pull/1035
Closes https://github.com/azavea/raster-vision/issues/1036

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
