### PR TITLE
Ensure At Least One Sliding Window

### DIFF
--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -75,11 +75,15 @@ def get_train_windows(scene: Scene,
 
     if co.window_method == SemanticSegmentationWindowMethod.sliding:
         stride = co.stride or int(round(chip_size / 2))
-        windows = list(filter_windows((extent.get_windows(chip_size, stride))))
-        a_window = windows[0]
-        windows = list(filter(should_use_window, windows))
-        if len(windows) == 0:
-            windows = [a_window]
+        unfiltered_windows = extent.get_windows(chip_size, stride)
+        windows = list(filter_windows(unfiltered_windows))
+        if len(windows) > 0:
+            a_window = windows[0]
+            windows = list(filter(should_use_window, windows))
+            if len(windows) == 0:
+                windows = [a_window]
+        elif len(windows) == 0:
+            return [unfiltered_windows[0]]
     elif co.window_method == SemanticSegmentationWindowMethod.random_sample:
         windows = []
         attempts = 0


### PR DESCRIPTION
## Overview

This change ensures that there is at least one semantic segmentation (sliding) window.  This is useful to avoid failure when nodata filtering and/or AOI filtering is in use.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes #1039 
