### PR TITLE
Remove External Command Functionality

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,7 @@ Features
 * Make group_uris specifiable and add group_train_sz_rel `#1035 <https://github.com/azavea/raster-vision/pull/1035>`_
 * Make number of training and dataloader previews independent of batch size `#1038 <https://github.com/azavea/raster-vision/pull/1038>`_
 * Allow continuing training from a model bundle `#1022 <https://github.com/azavea/raster-vision/pull/1022>`_
+* Remove external commands (obsoleted by external architectures and loss functions) `#1047 <https://github.com/azavea/raster-vision/pull/1047>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_pipeline/rastervision/pipeline/config.py
+++ b/rastervision_pipeline/rastervision/pipeline/config.py
@@ -147,46 +147,7 @@ def build_config(x: Union[dict, List[Union[dict, Config]], Config]
             new_x[k] = build_config(v)
         type_hint = new_x.get('type_hint')
         if type_hint is not None:
-            # The following try/except logic has the following
-            # motivation.  If one has an custom raster-vision pipeline
-            # but wants to be able to run internal raster-vision
-            # commands in processes or containers that do not have
-            # that pipeline loaded in (e.g. in a "stock" raster-vision
-            # container on AWS) then this code enables that.
-            #
-            # When a pipeline config is being loaded here, the first
-            # attempt is to load it using the normal `type_hint` field
-            # found within it.  If that succeeds, then everything
-            # proceeds.
-            #
-            # If the the attempt fails but the pipeline config
-            # contains a `fallback_type_hint`, then that is used,
-            # instead.
-            #
-            # What that allows one to do is create a custom pipeline,
-            # derived from a stock pipeline, and tell raster-vision to
-            # treat it as a stock pipeline -- for purposes of the
-            # present function -- if the custom pipeline has not been
-            # registered.
-            #
-            # Please see https://github.com/azavea/raster-vision/pull/914
-            try:
-                # Try to use the given type hint
-                config_cls = registry.get_config(type_hint)
-            except Exception as e:
-                # ... if that fails, try to downgrade to fallback type
-                try:
-                    type_hint = new_x.get('fallback_type_hint')
-                    config_cls = registry.get_config(type_hint)
-                    new_x['type_hint'] = type_hint
-                    permitted_keys = config_cls().__dict__.keys()
-                    current_keys = set(new_x.keys())
-                    for k in current_keys:
-                        if k not in permitted_keys:
-                            del new_x[k]
-                # ... if that fails, throw the original exception
-                except Exception:
-                    raise e
+            config_cls = registry.get_config(type_hint)
             new_x = config_cls(**new_x)
         return new_x
     elif isinstance(x, list):

--- a/rastervision_pipeline/rastervision/pipeline/runner/inprocess_runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/inprocess_runner.py
@@ -1,6 +1,3 @@
-import subprocess
-from inspect import signature
-
 from rastervision.pipeline.cli import _run_command
 from rastervision.pipeline.runner.runner import Runner
 
@@ -19,36 +16,10 @@ class InProcessRunner(Runner):
             commands,
             num_splits=1,
             pipeline_run_name: str = 'raster-vision'):
+
         for command in commands:
-
-            # detect external command
-            if hasattr(pipeline, command):
-                fn = getattr(pipeline, command)
-                params = signature(fn).parameters
-                external = hasattr(fn, 'external') and len(params) in {0, 1}
+            if command in pipeline.split_commands and num_splits > 1:
+                for split_ind in range(num_splits):
+                    _run_command(cfg_json_uri, command, split_ind, num_splits)
             else:
-                external = False
-
-            if not external:
-                if command in pipeline.split_commands and num_splits > 1:
-                    for split_ind in range(num_splits):
-                        _run_command(cfg_json_uri, command, split_ind,
-                                     num_splits)
-                else:
-                    _run_command(cfg_json_uri, command, 0, 1)
-            else:
-                if len(params) == 0:
-                    # No-parameter external command
-                    cmds = [fn()]
-                elif len(params) == 1 and command in pipeline.split_commands:
-                    # One-paramater split external command
-                    cmds = fn(num_splits)
-                elif len(params
-                         ) == 1 and command not in pipeline.split_commands:
-                    # One-paramater unsplit external command
-                    cmds = fn(1)
-                else:
-                    # No command
-                    cmds = []
-                for cmd in cmds:
-                    subprocess.run(cmd, check=True)
+                _run_command(cfg_json_uri, command, 0, 1)

--- a/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
@@ -1,5 +1,4 @@
 import sys
-from inspect import signature
 from os.path import dirname, join
 from subprocess import Popen
 
@@ -41,61 +40,29 @@ class LocalRunner(Runner):
         curr_command_ind = 0
         for command in commands:
 
-            # detect external command
-            if hasattr(pipeline, command):
-                fn = getattr(pipeline, command)
-                params = signature(fn).parameters
-                external = hasattr(fn, 'external') and len(params) in {0, 1}
-            else:
-                external = False
-
             curr_command_inds = []
-            if not external:
-                if command in pipeline.split_commands and num_splits > 1:
-                    for split_ind in range(num_splits):
-                        makefile += '{}: '.format(curr_command_ind)
-                        makefile += ' '.join(
-                            [str(ci) for ci in prev_command_inds])
-                        makefile += '\n'
-                        invocation = (
-                            'python -m rastervision.pipeline.cli run_command '
-                            '{} {} --split-ind {} --num-splits {}').format(
-                                cfg_json_uri, command, split_ind, num_splits)
-                        makefile += '\t{}\n\n'.format(invocation)
-                        curr_command_inds.append(curr_command_ind)
-                        curr_command_ind += 1
-                else:
+            if command in pipeline.split_commands and num_splits > 1:
+                for split_ind in range(num_splits):
                     makefile += '{}: '.format(curr_command_ind)
                     makefile += ' '.join([str(ci) for ci in prev_command_inds])
                     makefile += '\n'
                     invocation = (
                         'python -m rastervision.pipeline.cli run_command '
-                        '{} {}'.format(cfg_json_uri, command))
+                        '{} {} --split-ind {} --num-splits {}').format(
+                            cfg_json_uri, command, split_ind, num_splits)
                     makefile += '\t{}\n\n'.format(invocation)
                     curr_command_inds.append(curr_command_ind)
                     curr_command_ind += 1
             else:
-                if len(params) == 0:
-                    # No-parameter external command
-                    cmds = [fn()]
-                elif len(params) == 1 and command in pipeline.split_commands:
-                    # One-paramater split external command
-                    cmds = fn(num_splits)
-                elif len(params
-                         ) == 1 and command not in pipeline.split_commands:
-                    # One-paramater unsplit external command
-                    cmds = fn(1)
-                else:
-                    # No command
-                    cmds = []
-                for cmd in cmds:
-                    makefile += '{}: '.format(curr_command_ind)
-                    makefile += ' '.join([str(ci) for ci in prev_command_inds])
-                    makefile += '\n'
-                    invocation = (' '.join(cmd))
-                    makefile += '\t{}\n\n'.format(invocation)
-                    curr_command_inds.append(curr_command_ind)
-                    curr_command_ind += 1
+                makefile += '{}: '.format(curr_command_ind)
+                makefile += ' '.join([str(ci) for ci in prev_command_inds])
+                makefile += '\n'
+                invocation = (
+                    'python -m rastervision.pipeline.cli run_command '
+                    '{} {}'.format(cfg_json_uri, command))
+                makefile += '\t{}\n\n'.format(invocation)
+                curr_command_inds.append(curr_command_ind)
+                curr_command_ind += 1
 
             prev_command_inds = curr_command_inds
 


### PR DESCRIPTION
## Overview

External command functionality is removed; this is mostly handled by external architectures and external loss functions.  #1040 will go even further.

### Checklist

- [x] Updated `docs/changelog.rst`
- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Connects #1044 
Connects #930 

