### PR TITLE
Pass training to RegressionLearner

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner_config.py
@@ -47,7 +47,8 @@ class RegressionLearnerConfig(LearnerConfig):
               tmp_dir,
               model_path=None,
               model_def_path=None,
-              loss_def_path=None):
+              loss_def_path=None,
+              training=True):
         from rastervision.pytorch_learner.regression_learner import (
             RegressionLearner)
         return RegressionLearner(
@@ -55,4 +56,5 @@ class RegressionLearnerConfig(LearnerConfig):
             tmp_dir,
             model_path=model_path,
             model_def_path=model_def_path,
-            loss_def_path=loss_def_path)
+            loss_def_path=loss_def_path,
+            training=training)


### PR DESCRIPTION
This fixes a tiny bug in the `RegressionLearner` -- previously the training parameter wasn't being passed to the constructor.