### PR TITLE
Avoid syncing train directory when not in train mode

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -108,7 +108,8 @@ class Learner(ABC):
         else:
             self.output_dir = get_local_path(cfg.output_uri, tmp_dir)
             make_dir(self.output_dir, force_empty=True)
-            if not cfg.overfit_mode:
+
+            if training and not cfg.overfit_mode:
                 self.sync_from_cloud()
 
         self.modules_dir = join(self.output_dir, MODULES_DIRNAME)


### PR DESCRIPTION
Previously, when a `Learner` model bundle (previously stored on S3) was used to instantiate a `Learner` with `train=False`, it would try to sync the associated training directory. This PR fixes this bug.