### PR TITLE
Allow saving SS predictions as probabilities

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,7 @@ Features
 * Allow continuing training from a model bundle `#1022 <https://github.com/azavea/raster-vision/pull/1022>`_
 * Allow reading directly from raster source during training without chipping `#1046 <https://github.com/azavea/raster-vision/pull/1046>`_
 * Remove external commands (obsoleted by external architectures and loss functions) `#1047 <https://github.com/azavea/raster-vision/pull/1047>`_
+* Allow saving SS predictions as probabilities `#1057 <https://github.com/azavea/raster-vision/pull/1057>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -104,6 +104,9 @@ class Box():
     def __repr__(self):  # pragma: no cover
         return f'{type(self).__name__}{self.tuple_format()}'
 
+    def __hash__(self):
+        return hash(self.tuple_format())
+
     def geojson_coordinates(self):
         """Return Box as GeoJSON coordinates."""
         # Compass directions:

--- a/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
+++ b/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
@@ -1,4 +1,5 @@
-from typing import Tuple, Optional, List, Any, Dict
+from abc import abstractmethod
+from typing import Tuple, Optional, List, Any
 
 from rastervision.core.data.label import Labels
 
@@ -10,249 +11,54 @@ from rastervision.core.box import Box
 
 
 class SemanticSegmentationLabels(Labels):
-    """Representation of Semantic Segmentation labels.
+    """Representation of Semantic Segmentation labels."""
 
-    These labels can be either discrete or smooth.
-
-    If smooth, they store the scores for each class, for each pixel.
-    They also store the number of "hits" (initially equal to 0) for each pixel
-    that are used to divide the values for that pixel to get an average.
-    This allows one to do multiple updates to the same pixel
-    (the hits will be automatically incremented by 1 each time)
-    and have its final value be the average of all the updates.
-
-    If discrete, the labels are stored as a dict, mapping windows to label
-    arrays.
-
-    """
-
-    def __init__(self,
-                 smooth: bool = False,
-                 extent: Optional[Box] = None,
-                 num_classes: Optional[int] = None):
-        """Constructor.
-
-        Args:
-            smooth (bool, optional): If True, labels are stored as continuous
-                values representing class scores instead of discrete labels.
-                These values will be stored as a (C, H, W) array. If False,
-                the labels are stored as a mapping of windows to label arrays.
-                Defaults to False.
-            extent (Optional[Box], optional): The extent of the region to which
-                the labels belong, in global coordinates. Only used if
-                smooth=True. Defaults to None.
-            num_classes (Optional[int], optional): Number of classes.
-                Only used if smooth=True. Defaults to None.
-
-        Raises:
-            ValueError: if num_classes and extent are not specified, but
-                smooth=True.
-        """
-        self.smooth = smooth
-
-        if not self.smooth:
-            self.window_to_label_arr: Dict[Box, np.ndarray] = {}
-        else:
-            if extent is None:
-                raise ValueError('extent must be specified if smooth=True.')
-            if num_classes is None:
-                raise ValueError(
-                    'num_classes must be specified if smooth=True.')
-
-            self.local_extent = extent
-            self.num_classes = num_classes
-            self.ymin, self.xmin, _, _ = extent
-            self.height, self.width = extent.size
-
-            # store as float16 instead of float32 to save memory
-            self.dtype = np.float16
-
-            self.pixel_scores = np.zeros(
-                (num_classes, self.height, self.width), dtype=self.dtype)
-            self.pixel_hits = np.zeros(
-                (self.height, self.width), dtype=np.uint8)
-
-    def _to_local_coords(self, window: Box) -> Tuple[int, int, int, int]:
-        """Convert to coordinates of the local arrays."""
-        ymin, xmin, ymax, xmax = window
-        ymax = min(ymax, self.height)
-        xmax = min(xmax, self.width)
-        return (ymin - self.ymin, xmin - self.xmin, ymax, xmax)
-
+    @abstractmethod
     def __add__(self, other) -> 'SemanticSegmentationLabels':
-        """Merge self with other labels.
+        """Merge self with other labels."""
+        pass
 
-        If not smooth, update the window-to-label mapping. This will overwrite
-        self's values for any windows that are shared.
-
-        If smooth, add the pixel scores and hits.
-        """
-        if not self.smooth:
-            self.window_to_label_arr.update(other.window_to_label_arr)
-            return self
-
-        smooths_equal = self.smooth == other.smooth
-        extents_equal = self.local_extent == other.local_extent
-        coords_equal = (self.ymin, self.xmin) == (other.ymin, other.xmin)
-        if not (smooths_equal and extents_equal and coords_equal):
-            raise ValueError()
-
-        self.pixel_scores += other.pixel_scores
-        self.pixel_hits += other.pixel_hits
-        return self
-
+    @abstractmethod
     def __eq__(self, other: 'SemanticSegmentationLabels') -> bool:
-        if self.smooth != other.smooth:
-            return False
+        pass
 
-        if not self.smooth:
-            # check if windows are same
-            self_windows = set(self.window_to_label_arr.keys())
-            other_windows = set(other.window_to_label_arr.keys())
-            if self_windows != other_windows:
-                return False
-            # check if windows values are same
-            for w in self_windows:
-                arr1 = self.get_label_arr(w)
-                arr2 = other.get_label_arr(w)
-                if not np.array_equal(arr1, arr2):
-                    return False
-            return True
-
-        extents_equal = self.local_extent == other.local_extent
-        coords_equal = (self.ymin, self.xmin) == (other.ymin, other.xmin)
-        if not (extents_equal and coords_equal):
-            return False
-        scores_equal = np.allclose(self.pixel_scores, other.pixel_scores)
-        hits_equal = np.array_equal(self.pixel_hits, other.pixel_hits)
-        return (scores_equal and hits_equal)
-
+    @abstractmethod
     def __setitem__(self, window: Box, values: np.ndarray) -> None:
-        """Set labels for the given window.
-
-        If not smooth, update the window-to-label mapping. This will overwrite
-        self's values (if they have been previously set) for this window.
-
-        If smooth, overwrite the pixel scores and reset pixel hits to 1.
-        This will overwrite self's values (if they have been previously set)
-        for this window.
+        """Set labels for the given window, overriding current values, if any.
         """
-        if not self.smooth:
-            self.window_to_label_arr[window] = values
-        else:
-            values = values.astype(self.dtype)
-            y0, x0, y1, x1 = self._to_local_coords(window)
-            h, w = y1 - y0, x1 - x0
-            self.pixel_scores[..., y0:y1, x0:x1] = values[..., :h, :w]
-            self.pixel_hits[..., y0:y1, x0:x1] = 1
+        pass
 
+    @abstractmethod
     def __delitem__(self, window: Box) -> None:
-        """Delete labels for the given window.
+        """Delete labels for the given window."""
+        pass
 
-        If not smooth, delete window from dict.
-
-        If smooth, reset pixel scores and pixel hits to 0.
-        """
-        if not self.smooth:
-            del self.window_to_label_arr[window]
-        else:
-            y0, x0, y1, x1 = self._to_local_coords(window)
-            self.pixel_scores[..., y0:y1, x0:x1] = 0
-            self.pixel_hits[..., y0:y1, x0:x1] = 0
-
+    @abstractmethod
     def __getitem__(self, window: Box) -> np.ndarray:
-        if self.smooth:
-            return self.get_score_arr(window)
-        return self.get_label_arr(window)
+        """Get labels for the given window."""
+        pass
 
+    @abstractmethod
     def get_windows(self, **kwargs) -> List[Box]:
-        """Get windows.
-
-        If not smooth, return all the windows in the dict.
-
-        If smooth, generate sliding windows over the local extent. The window
-        specifications can be configured by providing chip_sz, stride, and
-        padding as keyword arguments.
-        """
-        if not self.smooth:
-            return list(self.window_to_label_arr.keys())
-
-        chip_sz: Optional[int] = kwargs.pop('chip_sz', None)
-        if chip_sz is None:
-            return [self.local_extent]
-        return self.local_extent.get_windows(chip_sz, chip_sz, **kwargs)
-
-    def add_window(self, window: Box, values: np.ndarray) -> None:
-        """Add a window and its values.
-
-        If not smooth, update the window-to-label mapping. This will overwrite
-        self's values for any windows that are shared.
-
-        If smooth, add the pixel scores and hits.
-        """
-        if not self.smooth:
-            self.window_to_label_arr[window] = values
-        else:
-            values = values.astype(self.dtype)
-            y0, x0, y1, x1 = self._to_local_coords(window)
-            h, w = y1 - y0, x1 - x0
-            self.pixel_scores[..., y0:y1, x0:x1] += values[..., :h, :w]
-            self.pixel_hits[y0:y1, x0:x1] += 1
-
-    def get_score_arr(self, window: Box, null_class_id=None) -> np.ndarray:
-        """Get scores.
-
-        Note: The output array is not guaranteed to be the same size as the
-        input window.
-        """
-        if not self.smooth:
-            return NotImplementedError(
-                'get_score_arr() not supported for smooth=False.')
-
-        y0, x0, y1, x1 = self._to_local_coords(window)
-        scores = self.pixel_scores[..., y0:y1, x0:x1]
-        hits = self.pixel_hits[y0:y1, x0:x1]
-        avg_scores = scores / hits
-        return avg_scores
-
-    def get_label_arr(self, window: Box) -> np.ndarray:
-        """Get discrete labels.
-
-        If smooth, the scores are argmax'd to get discrete labels.
-        """
-        if not self.smooth:
-            return self.window_to_label_arr[window]
-
-        y0, x0, y1, x1 = self._to_local_coords(window)
-        avg_scores = self.get_score_arr(window)
-        labels = np.argmax(avg_scores, axis=0)
-        return labels
+        """Get windows, optionally parameterized by keyword args."""
+        pass
 
     def filter_by_aoi(self, aoi_polygons: list, null_class_id: int,
                       **kwargs) -> 'SemanticSegmentationLabels':
-        """Keep only the values that lie inside the AOI.
-        """
+        """Keep only the values that lie inside the AOI."""
         if not aoi_polygons:
             return self
-
-        if not self.smooth:
-            for window in self.get_windows(**kwargs):
-                self._filter_window_by_aoi(window, aoi_polygons, null_class_id)
-        else:
-            self._filter_window_by_aoi(self.local_extent, aoi_polygons,
-                                       null_class_id)
+        for window in self.get_windows(**kwargs):
+            self._filter_window_by_aoi(window, aoi_polygons, null_class_id)
         return self
 
+    @abstractmethod
     def mask_fill(self, window: Box, mask: np.ndarray,
                   fill_value: Any) -> None:
-        if not self.smooth:
-            self.window_to_label_arr[window][mask] = fill_value
-        else:
-            y0, x0, y1, x1 = self._to_local_coords(window)
-            h, w = y1 - y0, x1 - x0
-            mask = mask[:h, :w]
-            self.pixel_scores[..., y0:y1, x0:x1][..., mask] = fill_value
-            self.pixel_hits[y0:y1, x0:x1][mask] = 1
+        """Given a window and a binary mask, set all the pixels in the window
+        for which the mask is ON to the fill_value.
+        """
+        pass
 
     def _filter_window_by_aoi(self, window: Box, aoi_polygons: list,
                               null_class_id: int) -> None:
@@ -279,10 +85,204 @@ class SemanticSegmentationLabels(Labels):
             # AOI polygon to 0 so they are ignored during eval.
             mask = rasterize(
                 [(p, 0) for p in window_aois],
-                out_shape=label_arr.shape,
+                out_shape=label_arr.shape[-2:],
                 fill=1,
                 dtype=np.uint8)
             mask = mask.astype(np.bool)
             self.mask_fill(window, mask, null_class_id)
         else:
             del self[window]
+
+    @classmethod
+    def build(self,
+              smooth: bool = False,
+              extent: Optional[Box] = None,
+              num_classes: Optional[int] = None):
+        """Constructor.
+
+        Args:
+            smooth (bool, optional): If True, creates a
+                SemanticSegmentationSmoothLabels object. If False, creates a
+                SemanticSegmentationDiscreteLabels object.
+            extent (Optional[Box], optional): The extent of the region to which
+                the labels belong, in global coordinates. Only used if
+                smooth=True. Defaults to None.
+            num_classes (Optional[int], optional): Number of classes.
+                Only used if smooth=True. Defaults to None.
+
+        Raises:
+            ValueError: if num_classes and extent are not specified, but
+                smooth=True.
+        """
+        if not smooth:
+            return SemanticSegmentationDiscreteLabels()
+        else:
+            if extent is None:
+                raise ValueError('extent must be specified if smooth=True.')
+            if num_classes is None:
+                raise ValueError(
+                    'num_classes must be specified if smooth=True.')
+            return SemanticSegmentationSmoothLabels(
+                extent=extent, num_classes=num_classes)
+
+
+class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
+    def __init__(self):
+        self.window_to_label_arr = {}
+
+    def __add__(self, other) -> 'SemanticSegmentationDiscreteLabels':
+        """Merge self with other labels by importing all window-array pairs
+        into self.
+
+        Note: This will overwrite self's values for any windows that are common
+        to both self and other.
+        """
+        self.window_to_label_arr.update(other.window_to_label_arr)
+        return self
+
+    def __eq__(self, other: 'SemanticSegmentationDiscreteLabels') -> bool:
+        # check if windows are same
+        self_windows = set(self.window_to_label_arr.keys())
+        other_windows = set(other.window_to_label_arr.keys())
+        if self_windows != other_windows:
+            return False
+        # check if windows values are same
+        for w in self_windows:
+            arr1 = self.get_label_arr(w)
+            arr2 = other.get_label_arr(w)
+            if not np.array_equal(arr1, arr2):
+                return False
+        return True
+
+    def __setitem__(self, window: Box, values: np.ndarray) -> None:
+        self.window_to_label_arr[window] = values
+
+    def __delitem__(self, window: Box) -> None:
+        del self.window_to_label_arr[window]
+
+    def __getitem__(self, window: Box) -> np.ndarray:
+        return self.get_label_arr(window)
+
+    def get_windows(self, **kwargs) -> List[Box]:
+        return list(self.window_to_label_arr.keys())
+
+    def get_label_arr(self, window: Box) -> np.ndarray:
+        return self.window_to_label_arr[window]
+
+    def mask_fill(self, window: Box, mask: np.ndarray,
+                  fill_value: Any) -> None:
+        self.window_to_label_arr[window][mask] = fill_value
+
+
+class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
+    def __init__(self, extent: Box, num_classes: int):
+        """Constructor.
+
+        Args:
+            extent (Box): The extent of the region to which
+                the labels belong, in global coordinates.
+            num_classes (int): Number of classes.
+        """
+        self.local_extent = extent
+        self.num_classes = num_classes
+        self.ymin, self.xmin, _, _ = extent
+        self.height, self.width = extent.size
+
+        # store as float16 instead of float32 to save memory
+        self.dtype = np.float16
+
+        self.pixel_scores = np.zeros(
+            (num_classes, self.height, self.width), dtype=self.dtype)
+        self.pixel_hits = np.zeros((self.height, self.width), dtype=np.uint8)
+
+    def _to_local_coords(self, window: Box) -> Tuple[int, int, int, int]:
+        """Convert to coordinates of the local arrays."""
+        ymin, xmin, ymax, xmax = window
+        ymax = min(ymax, self.height)
+        xmax = min(xmax, self.width)
+        return (ymin - self.ymin, xmin - self.xmin, ymax, xmax)
+
+    def __add__(self, other) -> 'SemanticSegmentationSmoothLabels':
+        """Merge self with other labels by adding the pixel scores and hits.
+        """
+        extents_equal = self.local_extent == other.local_extent
+        coords_equal = (self.ymin, self.xmin) == (other.ymin, other.xmin)
+        if not (extents_equal and coords_equal):
+            raise ValueError()
+
+        self.pixel_scores += other.pixel_scores
+        self.pixel_hits += other.pixel_hits
+        return self
+
+    def __eq__(self, other: 'SemanticSegmentationSmoothLabels') -> bool:
+        extents_equal = self.local_extent == other.local_extent
+        coords_equal = (self.ymin, self.xmin) == (other.ymin, other.xmin)
+        if not (extents_equal and coords_equal):
+            return False
+        scores_equal = np.allclose(self.pixel_scores, other.pixel_scores)
+        hits_equal = np.array_equal(self.pixel_hits, other.pixel_hits)
+        return (scores_equal and hits_equal)
+
+    def __setitem__(self, window: Box, values: np.ndarray) -> None:
+        self.add_window(window, values)
+
+    def __delitem__(self, window: Box) -> None:
+        """Reset scores and hits for pixels in the window."""
+        y0, x0, y1, x1 = self._to_local_coords(window)
+        self.pixel_scores[..., y0:y1, x0:x1] = 0
+        self.pixel_hits[..., y0:y1, x0:x1] = 0
+
+    def __getitem__(self, window: Box) -> np.ndarray:
+        return self.get_score_arr(window)
+
+    def get_windows(self, **kwargs) -> List[Box]:
+        """Generate sliding windows over the local extent. The keyword args
+        are passed to Box.get_windows() and can therefore be used to control
+        the specifications of the windows.
+
+        If the keyword args do not contain chip_sz, a list of length 1,
+        containing the full extent is returned.
+        """
+        chip_sz: Optional[int] = kwargs.pop('chip_sz', None)
+        if chip_sz is None:
+            return [self.local_extent]
+        return self.local_extent.get_windows(chip_sz, chip_sz, **kwargs)
+
+    def add_window(self, window: Box, values: np.ndarray) -> None:
+        values = values.astype(self.dtype)
+        y0, x0, y1, x1 = self._to_local_coords(window)
+        h, w = y1 - y0, x1 - x0
+        self.pixel_scores[..., y0:y1, x0:x1] += values[..., :h, :w]
+        self.pixel_hits[y0:y1, x0:x1] += 1
+
+    def get_score_arr(self, window: Box) -> np.ndarray:
+        """Get scores.
+
+        Note: The output array is not guaranteed to be the same size as the
+        input window.
+        """
+        y0, x0, y1, x1 = self._to_local_coords(window)
+        scores = self.pixel_scores[..., y0:y1, x0:x1]
+        hits = self.pixel_hits[y0:y1, x0:x1]
+        avg_scores = scores / hits
+        return avg_scores
+
+    def get_label_arr(self, window: Box) -> np.ndarray:
+        """Get discrete labels by argmax'ing the scoress."""
+        y0, x0, y1, x1 = self._to_local_coords(window)
+        avg_scores = self.get_score_arr(window)
+        labels = np.argmax(avg_scores, axis=0)
+        return labels
+
+    def mask_fill(self, window: Box, mask: np.ndarray,
+                  fill_value: Any) -> None:
+        """Treat fill_value as a class id. Set that class's score to 1 and
+        all others to zero.
+        """
+        class_id = fill_value
+        y0, x0, y1, x1 = self._to_local_coords(window)
+        h, w = y1 - y0, x1 - x0
+        mask = mask[:h, :w]
+        self.pixel_scores[..., y0:y1, x0:x1][..., mask] = 0
+        self.pixel_scores[class_id, y0:y1, x0:x1][mask] = 1
+        self.pixel_hits[y0:y1, x0:x1][mask] = 1

--- a/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
+++ b/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
@@ -15,7 +15,7 @@ class SemanticSegmentationLabels(Labels):
     These labels can be either discrete or smooth.
 
     If smooth, they store the scores for each class, for each pixel.
-    They also store the number of "hits" (initially equal to 1) for each pixel
+    They also store the number of "hits" (initially equal to 0) for each pixel
     that are used to divide the values for that pixel to get an average.
     This allows one to do multiple updates to the same pixel
     (the hits will be automatically incremented by 1 each time)
@@ -45,7 +45,8 @@ class SemanticSegmentationLabels(Labels):
                 Only used if smooth=True. Defaults to None.
 
         Raises:
-            ValueError: [description]
+            ValueError: if num_classes and extent are not specified, but
+                smooth=True.
         """
         self.smooth = smooth
 
@@ -215,7 +216,7 @@ class SemanticSegmentationLabels(Labels):
         return avg_scores
 
     def get_label_arr(self, window: Box) -> np.ndarray:
-        """Get discret labels.
+        """Get discrete labels.
 
         If smooth, the scores are argmax'd to get discrete labels.
         """

--- a/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
+++ b/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
@@ -1,3 +1,5 @@
+from typing import Tuple, Optional, List, Any, Dict
+
 from rastervision.core.data.label import Labels
 
 import numpy as np
@@ -8,75 +10,278 @@ from rastervision.core.box import Box
 
 
 class SemanticSegmentationLabels(Labels):
-    """A set of spatially referenced semantic segmentation labels."""
+    """Representation of Semantic Segmentation labels.
 
-    def __init__(self):
-        self.window_to_label_arr = {}
+    These labels can be either discrete or smooth.
 
-    def __add__(self, other):
-        """Add labels to these labels.
+    If smooth, they store the scores for each class, for each pixel.
+    They also store the number of "hits" (initially equal to 1) for each pixel
+    that are used to divide the values for that pixel to get an average.
+    This allows one to do multiple updates to the same pixel
+    (the hits will be automatically incremented by 1 each time)
+    and have its final value be the average of all the updates.
 
-        Returns a concatenation of this and the other labels.
+    If discrete, the labels are stored as a dict, mapping windows to label
+    arrays.
+
+    """
+
+    def __init__(self,
+                 smooth: bool = False,
+                 extent: Optional[Box] = None,
+                 num_classes: Optional[int] = None):
+        """Constructor.
+
+        Args:
+            smooth (bool, optional): If True, labels are stored as continuous
+                values representing class scores instead of discrete labels.
+                These values will be stored as a (C, H, W) array. If False,
+                the labels are stored as a mapping of windows to label arrays.
+                Defaults to False.
+            extent (Optional[Box], optional): The extent of the region to which
+                the labels belong, in global coordinates. Only used if
+                smooth=True. Defaults to None.
+            num_classes (Optional[int], optional): Number of classes.
+                Only used if smooth=True. Defaults to None.
+
+        Raises:
+            ValueError: [description]
         """
-        self.window_to_label_arr.update(other.window_to_label_arr)
+        self.smooth = smooth
+
+        if not self.smooth:
+            self.window_to_label_arr: Dict[Box, np.ndarray] = {}
+        else:
+            if extent is None:
+                raise ValueError('extent must be specified if smooth=True.')
+            if num_classes is None:
+                raise ValueError(
+                    'num_classes must be specified if smooth=True.')
+
+            self.local_extent = extent
+            self.num_classes = num_classes
+            self.ymin, self.xmin, _, _ = extent
+            self.height, self.width = extent.size
+
+            # store as float16 instead of float32 to save memory
+            self.dtype = np.float16
+
+            self.pixel_scores = np.zeros(
+                (num_classes, self.height, self.width), dtype=self.dtype)
+            self.pixel_hits = np.zeros(
+                (self.height, self.width), dtype=np.uint8)
+
+    def _to_local_coords(self, window: Box) -> Tuple[int, int, int, int]:
+        """Convert to coordinates of the local arrays."""
+        ymin, xmin, ymax, xmax = window
+        ymax = min(ymax, self.height)
+        xmax = min(xmax, self.width)
+        return (ymin - self.ymin, xmin - self.xmin, ymax, xmax)
+
+    def __add__(self, other) -> 'SemanticSegmentationLabels':
+        """Merge self with other labels.
+
+        If not smooth, update the window-to-label mapping. This will overwrite
+        self's values for any windows that are shared.
+
+        If smooth, add the pixel scores and hits.
+        """
+        if not self.smooth:
+            self.window_to_label_arr.update(other.window_to_label_arr)
+            return self
+
+        smooths_equal = self.smooth == other.smooth
+        extents_equal = self.local_extent == other.local_extent
+        coords_equal = (self.ymin, self.xmin) == (other.ymin, other.xmin)
+        if not (smooths_equal and extents_equal and coords_equal):
+            raise ValueError()
+
+        self.pixel_scores += other.pixel_scores
+        self.pixel_hits += other.pixel_hits
         return self
 
-    def __eq__(self, other):
-        self_windows = set([w.tuple_format() for w in self.get_windows()])
-        other_windows = set([w.tuple_format() for w in other.get_windows()])
-        if self_windows != other_windows:
+    def __eq__(self, other: 'SemanticSegmentationLabels') -> bool:
+        if self.smooth == other.smooth:
             return False
 
-        for w in self.get_windows():
-            if not np.array_equal(
-                    self.get_label_arr(w), other.get_label_arr(w)):
+        if not self.smooth:
+            # check if windows are same
+            self_windows = set(self.window_to_label_arr.keys())
+            other_windows = set(other.window_to_label_arr.keys())
+            if self_windows != other_windows:
                 return False
+            # check if windows values are same
+            for w in self_windows:
+                arr1 = self.get_label_arr(w)
+                arr2 = other.get_label_arr(w)
+                if not np.array_equal(arr1, arr2):
+                    return False
+            return True
 
-        return True
+        extents_equal = self.local_extent == other.local_extent
+        coords_equal = (self.ymin, self.xmin) == (other.ymin, other.xmin)
+        if not (extents_equal and coords_equal):
+            return False
+        scores_equal = np.array_equal(self.pixel_scores, other.pixel_scores)
+        hits_equal = np.array_equal(self.pixel_hits, other.pixel_hits)
+        return (scores_equal and hits_equal)
 
-    def get_windows(self):
-        return [Box.from_tuple(w) for w in self.window_to_label_arr.keys()]
+    def __setitem__(self, window: Box, values: np.ndarray) -> None:
+        """Set labels for the given window.
 
-    def set_label_arr(self, window, label_arr):
-        self.window_to_label_arr[window.tuple_format()] = label_arr
+        If not smooth, update the window-to-label mapping. This will overwrite
+        self's values (if they have been previously set) for this window.
 
-    def get_label_arr(self, window):
-        return self.window_to_label_arr[window.tuple_format()]
+        If smooth, overwrite the pixel scores and reset pixel hits to 1.
+        This will overwrite self's values (if they have been previously set)
+        for this window.
+        """
+        if not self.smooth:
+            self.window_to_label_arr[window] = values
+        else:
+            values = values.astype(self.dtype)
+            y0, x0, y1, x1 = self._to_local_coords(window)
+            h, w = y1 - y0, x1 - x0
+            self.pixel_scores[..., y0:y1, x0:x1] = values[..., :h, :w]
+            self.pixel_hits[..., y0:y1, x0:x1] = 1
 
-    def filter_by_aoi(self, aoi_polygons, null_class_id):
-        new_labels = SemanticSegmentationLabels()
+    def __delitem__(self, window: Box) -> None:
+        """Delete labels for the given window.
 
-        for window in self.get_windows():
-            window_geom = window.to_shapely()
-            label_arr = self.get_label_arr(window)
+        If not smooth, delete window from dict.
 
-            if not aoi_polygons:
-                return self
-            else:
-                # For each aoi_polygon, intersect with window, and put in window frame of
-                # reference.
-                window_aois = []
-                for aoi in aoi_polygons:
-                    window_aoi = aoi.intersection(window_geom)
-                    if not window_aoi.is_empty:
+        If smooth, reset pixel scores and pixel hits to 0.
+        """
+        if not self.smooth:
+            del self.window_to_label_arr[window]
+        else:
+            y0, x0, y1, x1 = self._to_local_coords(window)
+            self.pixel_scores[..., y0:y1, x0:x1] = 0
+            self.pixel_hits[..., y0:y1, x0:x1] = 0
 
-                        def transform_shape(x, y, z=None):
-                            return (x - window.xmin, y - window.ymin)
+    def __getitem__(self, window: Box) -> np.ndarray:
+        if self.smooth:
+            return self.get_score_arr(window)
+        return self.get_label_arr(window)
 
-                        window_aoi = transform(transform_shape, window_aoi)
-                        window_aois.append(window_aoi)
+    def get_windows(self, **kwargs) -> List[Box]:
+        """Get windows.
 
-                # If window does't overlap with any AOI, then it won't be in
-                # new_labels.
-                if window_aois:
-                    # If window intersects with AOI, set pixels outside the
-                    # AOI polygon to 0 so they are ignored during eval.
-                    mask = rasterize(
-                        [(p, 0) for p in window_aois],
-                        out_shape=label_arr.shape,
-                        fill=1,
-                        dtype=np.uint8)
-                    label_arr[mask.astype(np.bool)] = null_class_id
-                    new_labels.set_label_arr(window, label_arr)
+        If not smooth, return all the windows in the dict.
 
-        return new_labels
+        If smooth, generate sliding windows over the local extent. The window
+        specifications can be configured by providing chip_sz, stride, and
+        padding as keyword arguments.
+        """
+        if not self.smooth:
+            return list(self.window_to_label_arr.keys())
+
+        chip_sz: Optional[int] = kwargs.pop('chip_sz', None)
+        if chip_sz is None:
+            return [self.local_extent]
+        return self.local_extent.get_windows(chip_sz, chip_sz, **kwargs)
+
+    def add_window(self, window: Box, values: np.ndarray) -> None:
+        """Add a window and its values.
+
+        If not smooth, update the window-to-label mapping. This will overwrite
+        self's values for any windows that are shared.
+
+        If smooth, add the pixel scores and hits.
+        """
+        if not self.smooth:
+            self.window_to_label_arr[window] = values
+        else:
+            values = values.astype(self.dtype)
+            y0, x0, y1, x1 = self._to_local_coords(window)
+            h, w = y1 - y0, x1 - x0
+            self.pixel_scores[..., y0:y1, x0:x1] += values[..., :h, :w]
+            self.pixel_hits[y0:y1, x0:x1] += 1
+
+    def get_score_arr(self, window: Box, null_class_id=None) -> np.ndarray:
+        """Get scores.
+
+        Note: The output array is not guaranteed to be the same size as the
+        input window.
+        """
+        if not self.smooth:
+            return NotImplementedError(
+                'get_score_arr() not supported for smooth=False.')
+
+        y0, x0, y1, x1 = self._to_local_coords(window)
+        scores = self.pixel_scores[..., y0:y1, x0:x1]
+        hits = self.pixel_hits[y0:y1, x0:x1]
+        avg_scores = scores / hits
+        return avg_scores
+
+    def get_label_arr(self, window: Box) -> np.ndarray:
+        """Get discret labels.
+
+        If smooth, the scores are argmax'd to get discrete labels.
+        """
+        if not self.smooth:
+            return self.window_to_label_arr[window]
+
+        y0, x0, y1, x1 = self._to_local_coords(window)
+        avg_scores = self.get_score_arr(window)
+        labels = np.argmax(avg_scores, axis=0)
+        return labels
+
+    def filter_by_aoi(self, aoi_polygons: list, null_class_id: int,
+                      **kwargs) -> 'SemanticSegmentationLabels':
+        """Keep only the values that lie inside the AOI.
+        """
+        if not aoi_polygons:
+            return self
+
+        if not self.smooth:
+            for window in self.get_windows(**kwargs):
+                self._filter_window_by_aoi(window, aoi_polygons, null_class_id)
+        else:
+            self._filter_window_by_aoi(self.local_extent, aoi_polygons,
+                                       null_class_id)
+        return self
+
+    def mask_fill(self, window: Box, mask: np.ndarray,
+                  fill_value: Any) -> None:
+        if not self.smooth:
+            self.window_to_label_arr[window][mask] = fill_value
+        else:
+            y0, x0, y1, x1 = self._to_local_coords(window)
+            h, w = y1 - y0, x1 - x0
+            mask = mask[:h, :w]
+            self.pixel_scores[..., y0:y1, x0:x1][..., mask] = fill_value
+            self.pixel_hits[y0:y1, x0:x1][mask] = 1
+
+    def _filter_window_by_aoi(self, window: Box, aoi_polygons: list,
+                              null_class_id: int) -> None:
+        window_geom = window.to_shapely()
+        label_arr = self[window]
+
+        # For each aoi_polygon, intersect with window, and
+        # put in window frame of reference.
+        window_aois = []
+        for aoi in aoi_polygons:
+            window_aoi = aoi.intersection(window_geom)
+            if not window_aoi.is_empty:
+
+                def transform_shape(x, y, z=None):
+                    return (x - window.xmin, y - window.ymin)
+
+                window_aoi = transform(transform_shape, window_aoi)
+                window_aois.append(window_aoi)
+
+        # If window does't overlap with any AOI, then it won't be in
+        # new_labels.
+        if window_aois:
+            # If window intersects with AOI, set pixels outside the
+            # AOI polygon to 0 so they are ignored during eval.
+            mask = rasterize(
+                [(p, 0) for p in window_aois],
+                out_shape=label_arr.shape,
+                fill=1,
+                dtype=np.uint8)
+            mask = mask.astype(np.bool)
+            self.mask_fill(window, mask, null_class_id)
+        else:
+            del self[window]

--- a/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
+++ b/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
@@ -102,7 +102,7 @@ class SemanticSegmentationLabels(Labels):
         return self
 
     def __eq__(self, other: 'SemanticSegmentationLabels') -> bool:
-        if self.smooth == other.smooth:
+        if self.smooth != other.smooth:
             return False
 
         if not self.smooth:
@@ -123,7 +123,7 @@ class SemanticSegmentationLabels(Labels):
         coords_equal = (self.ymin, self.xmin) == (other.ymin, other.xmin)
         if not (extents_equal and coords_equal):
             return False
-        scores_equal = np.array_equal(self.pixel_scores, other.pixel_scores)
+        scores_equal = np.allclose(self.pixel_scores, other.pixel_scores)
         hits_equal = np.array_equal(self.pixel_hits, other.pixel_hits)
         return (scores_equal and hits_equal)
 

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -93,7 +93,7 @@ class SemanticSegmentationLabelSource(ActivateMixin, LabelSource):
         Returns:
              SemanticSegmentationLabels
         """
-        labels = SemanticSegmentationLabels()
+        labels = SemanticSegmentationLabels.build()
         window = window or self.raster_source.get_extent()
         raw_labels = self.raster_source.get_chip(window)
         label_arr = (np.squeeze(raw_labels) if self.class_transformer is None

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -102,7 +102,7 @@ class SemanticSegmentationLabelSource(ActivateMixin, LabelSource):
         label_arr = fill_edge(label_arr, window,
                               self.raster_source.get_extent(),
                               self.null_class_id)
-        labels.set_label_arr(window, label_arr)
+        labels[window] = label_arr
         return labels
 
     def _subcomponents_to_activate(self):
@@ -115,4 +115,4 @@ class SemanticSegmentationLabelSource(ActivateMixin, LabelSource):
         pass
 
     def __getitem__(self, window: Box) -> np.ndarray:
-        return self.get_labels(window).get_label_arr(window)
+        return self.get_labels(window)[window]

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -98,8 +98,6 @@ class SemanticSegmentationLabelStore(LabelStore):
 
                 if extents_equal and bands_equal and dtypes_equal:
                     self.score_raster_source = raster_source
-                else:
-                    del raster_source
 
     def _subcomponents_to_activate(self):
         components = []

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -124,7 +124,7 @@ class SemanticSegmentationLabelStore(LabelStore):
         else:
             label_arr = self.class_transformer.rgb_to_class(raw_labels)
 
-        labels = SemanticSegmentationLabels()
+        labels = self.empty_labels()
         labels[extent] = label_arr
         return labels
 
@@ -337,7 +337,7 @@ class SemanticSegmentationLabelStore(LabelStore):
 
     def empty_labels(self) -> SemanticSegmentationLabels:
         """Returns an empty SemanticSegmentationLabels object."""
-        labels = SemanticSegmentationLabels(
+        labels = SemanticSegmentationLabels.build(
             smooth=self.smooth_output,
             extent=self.extent,
             num_classes=len(self.class_config))

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -142,7 +142,12 @@ class SemanticSegmentationLabelStore(LabelStore):
         score_arr = self.score_raster_source.get_chip(extent)
         # (H, W, C) --> (C, H, W)
         score_arr = score_arr.transpose(2, 0, 1)
-        hits_arr = np.load(self.hits_uri)
+        try:
+            hits_arr = np.load(self.hits_uri)
+        except FileNotFoundError:
+            log.warn(f'Pixel hits array not found at {self.hits_uri}.'
+                     'Setting all pixels to 1.')
+            hits_arr = np.ones(score_arr.shape[-2:], dtype=np.uint8)
 
         # convert to float
         if score_arr.dtype == np.uint8:

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -113,7 +113,7 @@ class SemanticSegmentationLabelStore(LabelStore):
             SemanticSegmentationLabels
         """
         if self.label_raster_source is None:
-            raise Exception(
+            raise FileNotFoundError(
                 f'Raster source at {self.label_uri} does not exist.')
 
         extent = self.label_raster_source.get_extent()
@@ -135,7 +135,8 @@ class SemanticSegmentationLabelStore(LabelStore):
         """
         if self.score_raster_source is None:
             raise Exception(
-                f'Raster source at {self.score_uri} does not exist.')
+                f'Raster source at {self.score_uri} does not exist '
+                'or is not consistent with the current params.')
 
         extent = self.score_raster_source.get_extent()
         score_arr = self.score_raster_source.get_chip(extent)

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
@@ -117,7 +117,7 @@ class SemanticSegmentationLabelStoreConfig(LabelStoreConfig):
             extent,
             crs_transformer,
             tmp_dir,
-            vector_output=self.vector_output,
+            vector_outputs=self.vector_output,
             class_config=class_config,
             save_as_rgb=self.rgb,
             smooth_output=self.smooth_output,

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection_config.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from rastervision.pipeline.config import register_config, Config, Field
-from rastervision.core.rv_pipeline import RVPipelineConfig
+from rastervision.core.rv_pipeline import RVPipelineConfig, PredictOptions
 from rastervision.core.data.label_store import ObjectDetectionGeoJSONStoreConfig
 from rastervision.core.evaluation import ObjectDetectionEvaluatorConfig
 
@@ -42,7 +42,7 @@ class ObjectDetectionChipOptions(Config):
 
 
 @register_config('object_detection_predict_options')
-class ObjectDetectionPredictOptions(Config):
+class ObjectDetectionPredictOptions(PredictOptions):
     merge_thresh: float = Field(
         0.5,
         description=

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
@@ -182,7 +182,7 @@ class RVPipeline(Pipeline):
         def predict_batch(chips, windows):
             nonlocal labels
             chips = np.array(chips)
-            batch_labels = backend.predict(chips, windows)
+            batch_labels = backend.predict(scene, chips, windows)
             batch_labels = self.post_process_batch(windows, chips,
                                                    batch_labels)
             labels += batch_labels

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
@@ -9,10 +9,16 @@ from rastervision.core.analyzer import StatsAnalyzerConfig
 from rastervision.core.backend import BackendConfig
 from rastervision.core.evaluation import EvaluatorConfig
 from rastervision.core.analyzer import AnalyzerConfig
-from rastervision.pipeline.config import register_config, Field
+from rastervision.pipeline.config import (register_config, Field, Config)
 
 if TYPE_CHECKING:
     from rastervision.core.backend.backend import Backend  # noqa
+
+
+@register_config('predict_options')
+class PredictOptions(Config):
+    # TODO: predict_chip_sz and predict_batch_sz should probably be moved here
+    pass
 
 
 @register_config('rv_pipeline')

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -158,3 +158,10 @@ class SemanticSegmentation(RVPipeline):
             labels.mask_fill(window, nodata_mask, fill_value=null_class_id)
 
         return labels
+
+    def get_predict_windows(self, extent: Box) -> List[Box]:
+        chip_sz = self.config.predict_chip_sz
+        stride = self.config.predict_options.stride
+        if stride is None:
+            stride = chip_sz
+        return extent.get_windows(chip_sz, stride)

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -154,8 +154,7 @@ class SemanticSegmentation(RVPipeline):
         # Fill in null class for any NODATA pixels.
         null_class_id = self.config.dataset.class_config.get_null_class_id()
         for window, chip in zip(windows, chips):
-            label_arr = labels.get_label_arr(window)
-            label_arr[np.sum(chip, axis=2) == 0] = null_class_id
-            labels.set_label_arr(window, label_arr)
+            nodata_mask = np.sum(chip, axis=2) == 0
+            labels.mask_fill(window, nodata_mask, fill_value=null_class_id)
 
         return labels

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
@@ -3,7 +3,8 @@ from enum import Enum
 
 from rastervision.pipeline.config import (register_config, Config, ConfigError,
                                           Field)
-from rastervision.core.rv_pipeline import RVPipelineConfig
+from rastervision.core.rv_pipeline.rv_pipeline_config import (RVPipelineConfig,
+                                                              PredictOptions)
 from rastervision.core.data import SemanticSegmentationLabelStoreConfig
 from rastervision.core.evaluation import SemanticSegmentationEvaluatorConfig
 
@@ -57,10 +58,22 @@ class SemanticSegmentationChipOptions(Config):
          'the sliding_window method.'))
 
 
+@register_config('semantic_segmentation_predict_options')
+class SemanticSegmentationPredictOptions(PredictOptions):
+    stride: Optional[int] = Field(
+        None,
+        description=
+        'Stride of windows across image. Allows aggregating multiple '
+        'predictions for each pixel if less than the chip size and outputting '
+        'smooth labels. Defaults to predict_chip_sz.')
+
+
 @register_config('semantic_segmentation')
 class SemanticSegmentationConfig(RVPipelineConfig):
-    chip_options: SemanticSegmentationChipOptions = SemanticSegmentationChipOptions(
-    )
+    chip_options: SemanticSegmentationChipOptions = \
+        SemanticSegmentationChipOptions()
+    predict_options: SemanticSegmentationPredictOptions = \
+        SemanticSegmentationPredictOptions()
 
     channel_display_groups: Optional[Union[dict, list, tuple]] = Field(
         None,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification.py
@@ -38,7 +38,7 @@ class PyTorchChipClassification(PyTorchLearnerBackend):
         return PyTorchChipClassificationSampleWriter(
             output_uri, self.pipeline_cfg.dataset.class_config, self.tmp_dir)
 
-    def predict(self, chips, windows):
+    def predict(self, scene, chips, windows):
         if self.learner is None:
             self.load_model()
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
@@ -97,7 +97,7 @@ class PyTorchObjectDetection(PyTorchLearnerBackend):
         return PyTorchObjectDetectionSampleWriter(
             output_uri, self.pipeline_cfg.dataset.class_config, self.tmp_dir)
 
-    def predict(self, chips, windows):
+    def predict(self, scene, chips, windows):
         """Return predictions for a chip using model.
 
         Args:

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
@@ -94,6 +94,6 @@ class PyTorchSemanticSegmentation(PyTorchLearnerBackend):
 
         labels = scene.label_store.empty_labels()
         for out, window in zip(batch_out, windows):
-            labels.add_window(window, out)
+            labels[window] = out
 
         return labels

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
@@ -92,6 +92,6 @@ class PyTorchSemanticSegmentation(PyTorchLearnerBackend):
         batch_out = self.learner.numpy_predict(chips, raw_out=False)
         labels = SemanticSegmentationLabels()
         for out, window in zip(batch_out, windows):
-            labels.set_label_arr(window, out)
+            labels.add_window(window, out)
 
         return labels

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
@@ -85,12 +85,14 @@ class PyTorchSemanticSegmentation(PyTorchLearnerBackend):
             img_format=self.pipeline_cfg.img_format,
             label_format=self.pipeline_cfg.label_format)
 
-    def predict(self, chips, windows):
+    def predict(self, scene, chips, windows) -> SemanticSegmentationLabels:
         if self.learner is None:
             self.load_model()
 
-        batch_out = self.learner.numpy_predict(chips, raw_out=False)
-        labels = SemanticSegmentationLabels()
+        raw_out = scene.label_store.smooth_output
+        batch_out = self.learner.numpy_predict(chips, raw_out=raw_out)
+
+        labels = scene.label_store.empty_labels()
         for out, window in zip(batch_out, windows):
             labels.add_window(window, out)
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -137,6 +137,18 @@ class SemanticSegmentationLearner(Learner):
             return x['out']
         return x
 
+    def predict(self, x: torch.Tensor, raw_out: bool = False) -> torch.Tensor:
+        x = self.to_batch(x).float()
+        x = self.to_device(x, self.device)
+        with torch.no_grad():
+            out = self.model(x)
+            out = self.post_forward(out)
+            out = out.softmax(dim=1)
+            if not raw_out:
+                out = self.prob_to_pred(out)
+        out = self.to_device(out, 'cpu')
+        return out
+
     def prob_to_pred(self, x):
         return x.argmax(1)
 

--- a/tests/core/data/label/test_semantic_segmentation_labels.py
+++ b/tests/core/data/label/test_semantic_segmentation_labels.py
@@ -3,15 +3,36 @@ import unittest
 import numpy as np
 
 from rastervision.core.box import Box
-from rastervision.core.data.label import SemanticSegmentationLabels
+from rastervision.core.data.label import (SemanticSegmentationLabels,
+                                          SemanticSegmentationDiscreteLabels,
+                                          SemanticSegmentationSmoothLabels)
 
 
 class TestSemanticSegmentationLabels(unittest.TestCase):
+    def test_build(self):
+        self.assertIsInstance(
+            SemanticSegmentationLabels.build(smooth=False),
+            SemanticSegmentationDiscreteLabels)
+
+        self.assertRaises(
+            ValueError, lambda: SemanticSegmentationLabels.build(smooth=True))
+
+        self.assertRaises(
+            ValueError, lambda: SemanticSegmentationLabels.build(
+                smooth=True, extent=Box(0, 0, 10, 10)))
+
+        self.assertIsInstance(
+            SemanticSegmentationLabels.build(
+                smooth=True, extent=Box(0, 0, 10, 10), num_classes=2),
+            SemanticSegmentationSmoothLabels)
+
+
+class TestSemanticSegmentationDiscreteLabels(unittest.TestCase):
     def setUp(self):
         self.windows = [Box.make_square(0, 0, 10), Box.make_square(0, 10, 10)]
         self.label_arr0 = np.random.choice([0, 1], (10, 10))
         self.label_arr1 = np.random.choice([0, 1], (10, 10))
-        self.labels = SemanticSegmentationLabels()
+        self.labels = SemanticSegmentationDiscreteLabels()
         self.labels[self.windows[0]] = self.label_arr0
         self.labels[self.windows[1]] = self.label_arr1
 
@@ -30,6 +51,91 @@ class TestSemanticSegmentationLabels(unittest.TestCase):
         label_arr = labels.get_label_arr(self.windows[1])
         np.testing.assert_array_equal(label_arr, exp_label_arr)
         self.assertEqual(1, len(labels.window_to_label_arr))
+
+
+def make_random_scores(num_classes, h, w):
+    arr = np.random.normal(size=(num_classes, h, w))
+    # softmax
+    arr = np.exp(arr, out=arr)
+    arr /= arr.sum(axis=0)
+    return arr
+
+
+class TestSemanticSegmentationSmoothLabels(unittest.TestCase):
+    def setUp(self):
+        self.windows = [
+            Box.make_square(0, 0, 10),
+            Box.make_square(0, 5, 10),
+            Box.make_square(0, 10, 10)
+        ]
+        self.num_classes = 3
+        self.scores_left = make_random_scores(self.num_classes, 10, 10)
+        self.scores_mid = make_random_scores(self.num_classes, 10, 10)
+        self.scores_right = make_random_scores(self.num_classes, 10, 10)
+
+        self.scores_left = self.scores_left.astype(np.float16)
+        self.scores_mid = self.scores_mid.astype(np.float16)
+        self.scores_right = self.scores_right.astype(np.float16)
+
+        self.extent = Box(0, 0, 10, 20)
+        self.labels = SemanticSegmentationSmoothLabels(
+            extent=self.extent, num_classes=self.num_classes)
+        self.labels[self.windows[0]] = self.scores_left
+        self.labels[self.windows[1]] = self.scores_mid
+        self.labels[self.windows[2]] = self.scores_right
+
+        arr = np.zeros((self.num_classes, 10, 20), dtype=np.float16)
+        arr[..., :10] += self.scores_left
+        arr[..., 5:15] += self.scores_mid
+        arr[..., 10:] += self.scores_right
+        self.expected_scores = arr
+
+        hits = np.zeros((10, 20), dtype=np.uint8)
+        hits[..., :10] += 1
+        hits[..., 5:15] += 1
+        hits[..., 10:] += 1
+        self.expected_hits = hits
+
+    def test_pixel_scores(self):
+        np.testing.assert_array_almost_equal(self.expected_scores,
+                                             self.labels.pixel_scores)
+
+    def test_get_scores_arr(self):
+        avg_scores = self.expected_scores / self.expected_hits
+        np.testing.assert_array_almost_equal(
+            avg_scores, self.labels.get_score_arr(self.extent))
+
+    def test_get_label_arr(self):
+        avg_scores = self.expected_scores / self.expected_hits
+        labels = np.argmax(avg_scores, axis=0)
+        np.testing.assert_array_equal(labels,
+                                      self.labels.get_label_arr(self.extent))
+
+    def test_pixel_hits(self):
+        np.testing.assert_array_equal(self.expected_hits,
+                                      self.labels.pixel_hits)
+
+    def test_eq(self):
+        labels = SemanticSegmentationSmoothLabels(
+            extent=self.extent, num_classes=self.num_classes)
+        labels.pixel_hits = self.expected_hits
+        labels.pixel_scores = self.expected_scores
+        self.assertTrue(labels == self.labels)
+
+    def test_get_with_aoi(self):
+        null_class_id = 2
+
+        aoi = Box.make_square(5, 15, 2)
+        aoi_polygons = [aoi.to_shapely()]
+        exp_label_arr = self.labels.get_label_arr(self.windows[2])
+        exp_label_arr[:] = null_class_id
+        y0, x0, y1, x1 = aoi
+        x0, x1 = x0 - 10, x1 - 10
+        exp_label_arr[y0:y1, x0:x1] = self.labels.get_label_arr(aoi)
+
+        labels = self.labels.filter_by_aoi(aoi_polygons, null_class_id)
+        label_arr = labels.get_label_arr(self.windows[2])
+        np.testing.assert_array_equal(label_arr, exp_label_arr)
 
 
 if __name__ == '__main__':

--- a/tests/core/data/label/test_semantic_segmentation_labels.py
+++ b/tests/core/data/label/test_semantic_segmentation_labels.py
@@ -12,8 +12,8 @@ class TestSemanticSegmentationLabels(unittest.TestCase):
         self.label_arr0 = np.random.choice([0, 1], (10, 10))
         self.label_arr1 = np.random.choice([0, 1], (10, 10))
         self.labels = SemanticSegmentationLabels()
-        self.labels.set_label_arr(self.windows[0], self.label_arr0)
-        self.labels.set_label_arr(self.windows[1], self.label_arr1)
+        self.labels[self.windows[0]] = self.label_arr0
+        self.labels[self.windows[1]] = self.label_arr1
 
     def test_get(self):
         np.testing.assert_array_equal(


### PR DESCRIPTION
## Overview

- Allows `SemanticSegmentationLabels` to hold continuous values (class probabilities).
  - Allows multiple updates for each pixel that can be averaged.
  - Allows stride < chip_sz during prediction.
- Allows `SemanticSegmentationLabelStore` to save continuous values.
  - The continuous values can optionally be quantized and saved as 1-byte uint8 (0-255) to save space.
- Allows `SemanticSegmentationLabelStore` to merge scores with scores from an existing file.
  - This allows re-running the predict step multiple times with different configurations (chip size, stride, models, etc.) to keep refining the predictions.

### Checklist

- [X] Updated `docs/changelog.rst`
- [X] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [X] Ran scripts/format_code and committed any changes
- [X] Documentation updated if needed
- [X] PR has a name that won't get you publicly shamed for vagueness

## Notes
In the code, the world "smooth" is used to refer to continuous values and to distinguish them from discrete labels which are the default. I'm open to suggestion for refactoring `smooth*` to `raw*` or something else if it sounds better. I avoided `raw*` because it is used elsewhere in RV in a different context.

## Testing Instructions

* How to test this PR
  - In `isprs_potsdam.py`, make the following changes:
    ```python3
    label_store = SemanticSegmentationLabelStoreConfig(
            rgb=True,
            vector_output=[PolygonVectorOutputConfig(class_id=0)],
            smooth_output=True,
            smooth_as_uint8=True)
    ```
    ```python3
    pipeline = SemanticSegmentationConfig(
        ...,
        predict_options=SemanticSegmentationPredictOptions(stride=128),
        ...,)
    ```

Closes #1055 
