### PR TITLE
Simplify and refactor CastTransformer

### DIFF
--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
@@ -1,9 +1,8 @@
-import re
 
 from rastervision.core.data.raster_transformer.raster_transformer \
     import RasterTransformer
 
-import numpy as np  # noqa
+import numpy as np
 
 
 class CastTransformer(RasterTransformer):
@@ -16,11 +15,7 @@ class CastTransformer(RasterTransformer):
         Args:
             to_dtype: (str) Chips are casted to this dtype
         """
-        mo = re.search(r'np\.(u|)(int|float)[0-9]+', to_dtype)
-        if mo:
-            self.to_dtype = eval(mo.group(0))
-        else:
-            raise ValueError(f'Unsupported to_dtype {to_dtype}')
+        self.to_dtype = np.dtype(to_dtype)
 
     def transform(self, chip, channel_order=None):
         """Transform a chip.

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
@@ -17,6 +17,9 @@ class CastTransformer(RasterTransformer):
         """
         self.to_dtype = np.dtype(to_dtype)
 
+    def __repr__(self):
+        return f'CastTransformer(to_dtype="{self.to_dtype}")'
+
     def transform(self, chip: np.ndarray,
                   channel_order: Optional[list] = None) -> np.ndarray:
         """Cast chip to self.to_dtype.

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
@@ -1,3 +1,4 @@
+from typing import Optional
 
 from rastervision.core.data.raster_transformer.raster_transformer \
     import RasterTransformer
@@ -6,29 +7,24 @@ import numpy as np
 
 
 class CastTransformer(RasterTransformer):
-    """Removes Cast values from float raster
-    """
+    """ Casts chips to the specified dtype. """
 
     def __init__(self, to_dtype: str):
-        """Construct a new CastTransformer.
+        """Constructor.
 
         Args:
-            to_dtype: (str) Chips are casted to this dtype
+            to_dtype: (str) dtype to cast the chips to.
         """
         self.to_dtype = np.dtype(to_dtype)
 
-    def transform(self, chip, channel_order=None):
-        """Transform a chip.
-
-        Cast chip to the specified dtype.
+    def transform(self, chip: np.ndarray,
+                  channel_order: Optional[list] = None) -> np.ndarray:
+        """Cast chip to self.to_dtype.
 
         Args:
-            chip: ndarray of shape [height, width, channels] This is assumed to already
-                have the channel_order applied to it if channel_order is set. In other
-                words, channels should be equal to len(channel_order).
+            chip: ndarray of shape [height, width, channels]
 
         Returns:
             [height, width, channels] numpy array
-
         """
         return chip.astype(self.to_dtype)

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
@@ -9,7 +9,7 @@ class CastTransformer(RasterTransformer):
     """Removes Cast values from float raster
     """
 
-    def __init__(self, to_dtype: str = 'np.uint8'):
+    def __init__(self, to_dtype: str):
         """Construct a new CastTransformer.
 
         Args:

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer_config.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from rastervision.pipeline.config import register_config, Field
 from rastervision.core.data.raster_transformer.raster_transformer_config import (  # noqa
     RasterTransformerConfig)
@@ -9,12 +7,10 @@ from rastervision.core.data.raster_transformer.cast_transformer import (  # noqa
 
 @register_config('cast_transformer')
 class CastTransformerConfig(RasterTransformerConfig):
-    to_dtype: Optional[str] = Field(
-        'np.uint8', description=('dtype to cast raster to.'))
-
-    def update(self, pipeline=None, scene=None):
-        if pipeline is not None and self.to_dtype is None:
-            self.to_dtype = pipeline.to_dtype
+    to_dtype: str = Field(
+        ...,
+        description='dtype to cast raster to. Must be a valid Numpy dtype '
+        'e.g. "uint8", "float32", etc.')
 
     def build(self):
         return CastTransformer(to_dtype=self.to_dtype)

--- a/tests/core/data/raster_transformer/test_cast_transformer.py
+++ b/tests/core/data/raster_transformer/test_cast_transformer.py
@@ -1,0 +1,24 @@
+import unittest
+
+import numpy as np
+
+from rastervision.core.data.raster_transformer import CastTransformerConfig
+
+
+class TestCastTransformer(unittest.TestCase):
+    def test_cast_transformer(self):
+        in_chip = np.empty((10, 10, 3), dtype=np.float32)
+        tf = CastTransformerConfig(to_dtype='uint8').build()
+        out_chip = tf.transform(in_chip)
+        self.assertEqual(out_chip.dtype, np.uint8)
+        self.assertEqual(str(tf), 'CastTransformer(to_dtype="uint8")')
+
+        in_chip = np.empty((10, 10, 3), dtype=np.uint16)
+        tf = CastTransformerConfig(to_dtype='float32').build()
+        out_chip = tf.transform(in_chip)
+        self.assertEqual(out_chip.dtype, np.float32)
+        self.assertEqual(str(tf), 'CastTransformer(to_dtype="float32")')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Remove the need to `eval()` a string; instead, use `np.dtype()` to convert strings to numpy dtypes. Also add unit tests.