### PR TITLE
Propagate quoted arguments in CLI wrapper

### DIFF
--- a/scripts/rastervision
+++ b/scripts/rastervision
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Run the rastervision cli
-python -m rastervision.pipeline.cli $@
+python -m rastervision.pipeline.cli "$@"


### PR DESCRIPTION
## Overview

This changes allows using quoted arguments with spaces when using `rastervision` bash wrapper.
See: https://tiswww.case.edu/php/chet/bash/bashref.html#Special-Parameters

### Checklist

-  Added `needs-backport` label if PR is bug fix that applies to previous minor release
-  Ran scripts/format_code and committed any changes
- Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Probably best way to verify the sanity of the change is to play with this minimal example:

`my_cli.py`
```python
#!/opt/local/bin/python

import click
from typing import List, Dict, Optional, Tuple

@click.command()
@click.option(
    '--arg',
    '-a',
    type=(str, str),
    multiple=True,
    metavar='KEY VALUE',
    help='Arguments to pass to get_config function')
def main(arg: List[Tuple[str, str]]):
    print(dict(arg))

if __name__ == '__main__':
    main()
```

`my_wrapper_old`:
```sh
#!/bin/bash
python -m my_cli $@
```

`my_wrapper`:
```sh
#!/bin/bash
python -m my_cli "$@"
```

```sh
/tmp ❯❯❯ ./my_wrapper -a name "first last"
{'name': 'first last'}
/tmp ❯❯❯ ./my_wrapper_old -a name "first last"
Usage: my_cli.py [OPTIONS]

Error: Got unexpected extra argument (last)
```




