### PR TITLE
Fix bug in semantic segmentation transform

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/transform.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/transform.py
@@ -23,10 +23,11 @@ def classification_transformer(inp: Tuple[Any, Any],
                                ) -> Tuple[np.ndarray, np.ndarray]:
     """Apply transform to image only."""
     x, y = inp
-    x, y = np.array(x), np.array(y, dtype=np.long)
+    x, y = np.array(x), np.array(y)
     if transform is not None:
         out = transform(image=x)
         x = out['image']
+    y = y.astype(np.long)
     return x, y
 
 
@@ -166,10 +167,11 @@ def semantic_segmentation_transformer(inp: Tuple[Any, Any],
                                       ) -> Tuple[np.ndarray, np.ndarray]:
     """Apply transform to image and mask."""
     x, y = inp
-    x, y = np.array(x), np.array(y, dtype=np.long)
+    x, y = np.array(x), np.array(y)
     if transform is not None:
         out = transform(image=x, mask=y)
         x, y = out['image'], out['mask']
+    y = y.astype(np.long)
     return x, y
 
 


### PR DESCRIPTION
Fix for bug introduced in semantic segmentation by #1056 as a side effect of moving the type casting of `y` to before the transform is applied. Passing the mask to an albumentations transform as an `np.long` array turns it into an `np.int32`, which is incompatible with PyTorch's loss functions.

This was not caught by the semantic segmentation integration test because of `chip_sz` being equal to `img_sz` which causes the `Resize` transform to do nothing and return the mask as is. To reproduce the error, set `img_sz` to something different (in `integration_tests/semantic_segmentation/config.py`).