### PR TITLE
Set runtime flag according to docker version

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -11,6 +11,15 @@ while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 DOCKER_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 REPO_ROOT="$( cd -P "$( dirname "$DOCKER_DIR" )" && pwd )"
 
+DOCKER_VERSION=$(docker version -f "{{.Server.Version}}")
+DOCKER_MAJOR=$(echo "$DOCKER_VERSION"| cut -d'.' -f 1)
+
+if [ "${DOCKER_MAJOR}" -ge 19 ]; then
+    runtime="--gpus=all"
+else
+    runtime="--runtime=nvidia"
+fi
+
 function usage() {
     echo -n \
          "Usage: $(basename "$0") <options> <command>
@@ -61,7 +70,7 @@ do
         shift # past argument
         ;;
         --gpu)
-        RUNTIME="--runtime=nvidia"
+        RUNTIME=$runtime
         shift # past argument
         ;;
         --name)


### PR DESCRIPTION
Running `docker/run  --gpu` fails with docker>=19.03 the following error:

```
docker: Error response from daemon: OCI runtime create failed: unable to retrieve OCI runtime error (open /run/containerd/io.containerd.runtime.v1.linux/moby/723d7848a6cf4e0c20006d6f3e0cc4b3ccc01be12b468e61235e8b54bc6771c0/log.json: no such file or directory): exec: "nvidia-container-runtime": executable file not found in $PATH: : unknown.
```
This is due to docker deprecating the `runtime` argument post v19.03. This PR addresses this by first checking the docker version and setting runtime flag accordingly
