### PR TITLE
Avoid shared memory-related errors when doing training with num_workers > 0

### DIFF
--- a/cookiecutter_template/{{cookiecutter.project_name}}/docker/run
+++ b/cookiecutter_template/{{cookiecutter.project_name}}/docker/run
@@ -95,7 +95,7 @@ fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
-    docker run --shm-size 8G ${RUNTIME} ${NAME} --rm -it \
+    docker run ${RUNTIME} ${NAME} --rm --ipc=host -it \
         -v "${HOME}"/.rastervision:/root/.rastervision \
         -v ${REPO_ROOT}/rastervision_{{cookiecutter.project_name}}:/opt/src/rastervision_{{cookiecutter.project_name}} \
         -v ${DATA_DIR}:/opt/data \

--- a/docker/run
+++ b/docker/run
@@ -107,7 +107,7 @@ fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
-    docker run ${RUNTIME} ${NAME} --rm -it \
+    docker run ${RUNTIME} ${NAME} --rm --ipc=host -it \
         -v "${HOME}"/.rastervision:/root/.rastervision \
         -v ${REPO_ROOT}/:/opt/src/ \
         -v ${RASTER_VISION_DATA_DIR}:/opt/data \

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,7 @@ Bug Fixes
 * Update all relevant saved URIs in config before instantiating Pipeline `#993 <https://github.com/azavea/raster-vision/pull/993>`_
 * Pass verbose flag to batch jobs `#988 <https://github.com/azavea/raster-vision/pull/988>`_
 * Fix: Ensure Integer class_id `#990 <https://github.com/azavea/raster-vision/pull/990>`_
+* Use ``--ipc=host`` by default when running the docker container `#1077 <https://github.com/azavea/raster-vision/pull/1077>`_
 
 Raster Vision 0.12
 -------------------


### PR DESCRIPTION
## Overview

Currently, running a training job with `num_workers > 0` leads to a cryptic error message from the `DataLoader`. This error is known to occur when the shared memory in the Docker container is insufficient. 

The PyTorch docs recommend (https://github.com/pytorch/pytorch#using-pre-built-images), running the docker container with either `--shm-size` which explicitly sets the shared memory size (e.g. `--shm-size 4G`) or with `--ipc=host` which makes the container use the host's shared memory.

This PR adds the `--ipc=host` to the `docker run` command in `docker/run`. This solution is preferred over `--shm-size` because it doesn't assume a specific value for the shared memory size, and is therefore more general.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Fixes #1071 
