### PR TITLE
Fix bug in SemanticSegmentationLabelStore

### DIFF
--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -351,7 +351,7 @@ class SemanticSegmentationLabelStore(LabelStore):
                         extent: Box,
                         window: Box,
                         arr: Optional[np.ndarray] = None
-                        ) -> Tuple[Box, np.ndarray]:
+                        ) -> Tuple[Box, Optional[np.ndarray]]:
         clipped_window = window.intersection(extent)
         if arr is not None:
             h, w = clipped_window.size


### PR DESCRIPTION
Closes #1073 by fixing a bug introduced in #1057, plus some minor refactoring.

The fix involves fetching the window labels from `SemanticSegmentationDiscreteLabels` before clipping the window to the label store's extent, rather than the other way round (which can cause a `KeyError`).