### PR TITLE
Refactor prediction pipeline. Reroute prediction input through a Dataset/DataLoader so that the base_transform can be applied to it.

### DIFF
--- a/.travis/test
+++ b/.travis/test
@@ -6,5 +6,5 @@ if [ "$IMAGE_TYPE" = "pytorch" ]; then
     docker run -w $(pwd) -v $(pwd):$(pwd) --rm -it ${PYTORCH_IMAGE} rm -f $(pwd)/.coverage $(pwd)/coverage.xml
     docker run --rm -it ${PYTORCH_IMAGE} /opt/src/scripts/style_tests
     docker run --rm -it ${PYTORCH_IMAGE} /opt/src/scripts/unit_tests
-    docker run --rm -it ${PYTORCH_IMAGE} /opt/src/scripts/integration_tests
+    docker run --rm -it --ipc=host ${PYTORCH_IMAGE} /opt/src/scripts/integration_tests
 fi

--- a/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
+++ b/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
@@ -1,3 +1,7 @@
+from typing import Tuple, Union
+
+import numpy as np
+
 from rastervision.core.box import Box
 from rastervision.core.data.label import Labels
 
@@ -22,7 +26,15 @@ class ChipClassificationLabels(Labels):
         return result
 
     def __contains__(self, cell):
-        return cell.tuple_format() in self.cell_to_class_id
+        return cell in self.cell_to_class_id
+
+    def __setitem__(self, key: Box,
+                    item: Union[int, Tuple[int, np.ndarray]]) -> None:
+        if isinstance(item, (tuple, list)):
+            class_id, score = item
+            self.set_cell(cell=key, class_id=class_id, scores=score)
+        else:
+            self.set_cell(cell=key, class_id=item)
 
     def filter_by_aoi(self, aoi_polygons):
         result = ChipClassificationLabels()
@@ -45,7 +57,7 @@ class ChipClassificationLabels(Labels):
         """
         if scores is not None:
             scores = list(map(lambda x: float(x), list(scores)))
-        self.cell_to_class_id[cell.tuple_format()] = (class_id, scores)
+        self.cell_to_class_id[cell] = (class_id, scores)
 
     def get_cell_class_id(self, cell):
         """Return class_id for a cell.
@@ -53,7 +65,7 @@ class ChipClassificationLabels(Labels):
         Args:
             cell: (Box)
         """
-        result = self.cell_to_class_id.get(cell.tuple_format())
+        result = self.cell_to_class_id.get(cell)
         if result:
             return result[0]
         else:
@@ -65,7 +77,7 @@ class ChipClassificationLabels(Labels):
         Args:
             cell: (Box)
         """
-        result = self.cell_to_class_id.get(cell.tuple_format())
+        result = self.cell_to_class_id.get(cell)
         if result:
             return result[1]
         else:
@@ -77,7 +89,7 @@ class ChipClassificationLabels(Labels):
         Args:
             cell: (Box)
         """
-        return self.cell_to_class_id.get(cell.tuple_format())
+        return self.cell_to_class_id.get(cell)
 
     def get_singleton_labels(self, cell):
         """Return Labels object representing a single cell.

--- a/rastervision_core/rastervision/core/data/label/labels.py
+++ b/rastervision_core/rastervision/core/data/label/labels.py
@@ -28,3 +28,6 @@ class Labels(ABC):
     @abstractmethod
     def __eq__(self, other):
         pass
+
+    def __setitem__(self, key, item) -> None:
+        raise NotImplementedError()

--- a/rastervision_core/rastervision/core/data/label/object_detection_labels.py
+++ b/rastervision_core/rastervision/core/data/label/object_detection_labels.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import numpy as np
 from shapely.geometry import shape
 
@@ -41,6 +43,14 @@ class ObjectDetectionLabels(Labels):
     def __eq__(self, other):
         return (isinstance(other, ObjectDetectionLabels)
                 and self.to_dict() == other.to_dict())
+
+    def __setitem__(self, key: Any, preds: Dict[str, np.ndarray]):
+        boxes = preds['boxes']
+        class_ids = preds['class_ids']
+        scores = preds['scores']
+
+        new_data = {'boxes': boxes, 'classes': class_ids, 'scores': scores}
+        self.boxlist.extend_data(new_data)
 
     def assert_equal(self, expected_labels):
         np.testing.assert_array_equal(self.get_npboxes(),

--- a/rastervision_core/rastervision/core/data/label/tfod_utils/np_box_list.py
+++ b/rastervision_core/rastervision/core/data/label/tfod_utils/np_box_list.py
@@ -19,22 +19,22 @@ import numpy as np
 
 class BoxList(object):
     """Box collection.
-  BoxList represents a list of bounding boxes as numpy array, where each
-  bounding box is represented as a row of 4 numbers,
-  [y_min, x_min, y_max, x_max].  It is assumed that all bounding boxes within a
-  given list correspond to a single image.
-  Optionally, users can add additional related fields (such as
-  objectness/classification scores).
-  """
+    BoxList represents a list of bounding boxes as numpy array, where each
+    bounding box is represented as a row of 4 numbers,
+    [y_min, x_min, y_max, x_max].  It is assumed that all bounding boxes within a
+    given list correspond to a single image.
+    Optionally, users can add additional related fields (such as
+    objectness/classification scores).
+    """
 
     def __init__(self, data):
         """Constructs box collection.
-    Args:
-      data: a numpy array of shape [N, 4] representing box coordinates
-    Raises:
-      ValueError: if bbox data is not a numpy array
-      ValueError: if invalid dimensions for bbox data
-    """
+        Args:
+            data: a numpy array of shape [N, 4] representing box coordinates
+        Raises:
+            ValueError: if bbox data is not a numpy array
+            ValueError: if invalid dimensions for bbox data
+        """
         if not isinstance(data, np.ndarray):
             raise ValueError('data must be a numpy array.')
         if len(data.shape) != 2 or data.shape[1] != 4:
@@ -60,14 +60,15 @@ class BoxList(object):
 
     def add_field(self, field, field_data):
         """Add data to a specified field.
-    Args:
-      field: a string parameter used to speficy a related field to be accessed.
-      field_data: a numpy array of [N, ...] representing the data associated
-          with the field.
-    Raises:
-      ValueError: if the field is already exist or the dimension of the field
-          data does not matches the number of boxes.
-    """
+
+        Args:
+            field: a string parameter used to speficy a related field to be accessed.
+            field_data: a numpy array of [N, ...] representing the data associated
+                with the field.
+        Raises:
+            ValueError: if the field is already exist or the dimension of the field
+                data does not matches the number of boxes.
+        """
         if self.has_field(field):
             raise ValueError('Field ' + field + 'already exists')
         if len(field_data.shape) < 1 or field_data.shape[0] != self.num_boxes(
@@ -77,29 +78,32 @@ class BoxList(object):
 
     def get(self):
         """Convenience function for accesssing box coordinates.
-    Returns:
-      a numpy array of shape [N, 4] representing box corners
-    """
+
+        Returns:
+            a numpy array of shape [N, 4] representing box corners
+        """
         return self.get_field('boxes')
 
     def get_field(self, field):
         """Accesses data associated with the specified field in the box collection.
-    Args:
-      field: a string parameter used to speficy a related field to be accessed.
-    Returns:
-      a numpy 1-d array representing data of an associated field
-    Raises:
-      ValueError: if invalid field
-    """
+
+        Args:
+            field: a string parameter used to speficy a related field to be accessed.
+        Returns:
+            a numpy 1-d array representing data of an associated field
+        Raises:
+            ValueError: if invalid field
+        """
         if not self.has_field(field):
             raise ValueError('field {} does not exist'.format(field))
         return self.data[field]
 
     def get_coordinates(self):
         """Get corner coordinates of boxes.
-    Returns:
-     a list of 4 1-d numpy arrays [y_min, x_min, y_max, x_max]
-    """
+
+        Returns:
+            a list of 4 1-d numpy arrays [y_min, x_min, y_max, x_max]
+        """
         box_coordinates = self.get()
         y_min = box_coordinates[:, 0]
         x_min = box_coordinates[:, 1]
@@ -109,12 +113,12 @@ class BoxList(object):
 
     def _is_valid_boxes(self, data):
         """Check whether data fullfills the format of N*[ymin, xmin, ymax, xmin].
-    Args:
-      data: a numpy array of shape [N, 4] representing box coordinates
-    Returns:
-      a boolean indicating whether all ymax of boxes are equal or greater than
-          ymin, and all xmax of boxes are equal or greater than xmin.
-    """
+        Args:
+            data: a numpy array of shape [N, 4] representing box coordinates
+        Returns:
+            a boolean indicating whether all ymax of boxes are equal or greater than
+                ymin, and all xmax of boxes are equal or greater than xmin.
+        """
         if data.shape[0] > 0:
             for i in range(data.shape[0]):
                 if data[i, 0] > data[i, 2] or data[i, 1] > data[i, 3]:

--- a/rastervision_core/rastervision/core/data/label/tfod_utils/np_box_list.py
+++ b/rastervision_core/rastervision/core/data/label/tfod_utils/np_box_list.py
@@ -120,3 +120,9 @@ class BoxList(object):
                 if data[i, 0] > data[i, 2] or data[i, 1] > data[i, 3]:
                     return False
         return True
+
+    def extend_data(self, data: dict) -> None:
+        self.data = {
+            k: np.concatenate((self.data[k], v), axis=0)
+            for k, v in data.items()
+        }

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -239,7 +239,8 @@ class SemanticSegmentationLabelStore(LabelStore):
             labels: SemanticSegmentationLabels) -> None:
 
         num_bands = 1 if self.class_transformer is None else 3
-        out_profile.update({'count': num_bands, 'dtype': np.uint8})
+        dtype = np.uint8
+        out_profile.update({'count': num_bands, 'dtype': dtype})
 
         windows = labels.get_windows()
 
@@ -247,7 +248,7 @@ class SemanticSegmentationLabelStore(LabelStore):
         with rio.open(path, 'w', **out_profile) as dataset:
             with click.progressbar(windows) as bar:
                 for window in bar:
-                    label_arr = labels.get_label_arr(window)
+                    label_arr = labels.get_label_arr(window).astype(dtype)
                     window, label_arr = self._clip_to_extent(
                         self.extent, window, label_arr)
                     if self.class_transformer is not None:

--- a/rastervision_core/rastervision/core/data/scene.py
+++ b/rastervision_core/rastervision/core/data/scene.py
@@ -41,7 +41,7 @@ class Scene(ActivateMixin):
 
     def __getitem__(self, window: Box) -> Tuple[Any, Any]:
         x = self.raster_source[window]
-        y = self.label_source[window]
+        y = self.label_source[window] if self.label_source else None
         return x, y
 
     def _subcomponents_to_activate(self):

--- a/rastervision_core/rastervision/core/data/scene_config.py
+++ b/rastervision_core/rastervision/core/data/scene_config.py
@@ -18,7 +18,7 @@ class SceneConfig(Config):
     """Config for a Scene which comprises the raster data and labels for an AOI."""
     id: str
     raster_source: RasterSourceConfig
-    label_source: LabelSourceConfig
+    label_source: Optional[LabelSourceConfig] = None
     label_store: Optional[LabelStoreConfig] = None
     aoi_geometries: Optional[List[dict]] = Field(
         None,

--- a/rastervision_core/rastervision/core/rv_pipeline/chip_classification_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/chip_classification_config.py
@@ -1,12 +1,21 @@
 from rastervision.pipeline.config import register_config, ConfigError
-from rastervision.core.rv_pipeline import RVPipelineConfig
+from rastervision.core.rv_pipeline import RVPipelineConfig, PredictOptions
 from rastervision.core.data.label_store import (
     ChipClassificationGeoJSONStoreConfig)
 from rastervision.core.evaluation import ChipClassificationEvaluatorConfig
 
 
+@register_config('chip_classification_predict_options')
+class ChipClassificationPredictOptions(PredictOptions):
+    pass
+
+
 @register_config('chip_classification')
 class ChipClassificationConfig(RVPipelineConfig):
+
+    predict_options: ChipClassificationPredictOptions = \
+        ChipClassificationPredictOptions()
+
     def build(self, tmp_dir):
         from rastervision.core.rv_pipeline.chip_classification import ChipClassification
         return ChipClassification(self, tmp_dir)

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
@@ -154,14 +154,6 @@ class ObjectDetection(RVPipeline):
             ioa_thresh=self.config.chip_options.ioa_thresh,
             clip=True)
 
-    def get_predict_windows(self, extent):
-        # Use strided windowing to ensure that each object is fully visible (ie. not
-        # cut off) within some window. This means prediction takes 4x longer for object
-        # detection :(
-        chip_sz = self.config.train_chip_sz
-        stride = chip_sz // 2
-        return extent.get_windows(chip_sz, stride)
-
     def post_process_predictions(self, labels, scene):
         return ObjectDetectionLabels.prune_duplicates(
             labels,

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection_config.py
@@ -63,6 +63,13 @@ class ObjectDetectionConfig(RVPipelineConfig):
     predict_options: ObjectDetectionPredictOptions = ObjectDetectionPredictOptions(
     )
 
+    def update(self):
+        super().update()
+        # Use strided windowing to ensure that each object is fully visible (ie. not
+        # cut off) within some window. This means prediction takes 4x longer for object
+        # detection :(
+        self.predict_options.stride //= 2
+
     def build(self, tmp_dir):
         from rastervision.core.rv_pipeline.object_detection import ObjectDetection
         return ObjectDetection(self, tmp_dir)

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
@@ -130,10 +130,7 @@ class RVPipeline(Pipeline):
         return labels
 
     def predict(self, split_ind: int = 0, num_splits: int = 1) -> None:
-        """Make predictions over each validation and test scene.
-
-        This uses a sliding window.
-        """
+        """Make predictions over each validation and test scene."""
         # Cache backend so subsquent calls will be faster. This is useful for
         # the predictor.
         if self.backend is None:

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -158,10 +158,3 @@ class SemanticSegmentation(RVPipeline):
             labels.mask_fill(window, nodata_mask, fill_value=null_class_id)
 
         return labels
-
-    def get_predict_windows(self, extent: Box) -> List[Box]:
-        chip_sz = self.config.predict_chip_sz
-        stride = self.config.predict_options.stride
-        if stride is None:
-            stride = chip_sz
-        return extent.get_windows(chip_sz, stride)

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
@@ -60,12 +60,7 @@ class SemanticSegmentationChipOptions(Config):
 
 @register_config('semantic_segmentation_predict_options')
 class SemanticSegmentationPredictOptions(PredictOptions):
-    stride: Optional[int] = Field(
-        None,
-        description=
-        'Stride of windows across image. Allows aggregating multiple '
-        'predictions for each pixel if less than the chip size and outputting '
-        'smooth labels. Defaults to predict_chip_sz.')
+    pass
 
 
 @register_config('semantic_segmentation')

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification.py
@@ -1,12 +1,19 @@
+from typing import Dict, Callable
 from os.path import join
 import uuid
 
+import click
+
 from rastervision.pipeline.file_system import (make_dir)
-from rastervision.core.data.label import ChipClassificationLabels
+from rastervision.core.data import (ChipClassificationLabels, SceneConfig,
+                                    DatasetConfig)
+from rastervision.core.rv_pipeline import ChipClassificationPredictOptions
 from rastervision.core.utils.misc import save_img
 from rastervision.core.data_sample import DataSample
 from rastervision.pytorch_backend.pytorch_learner_backend import (
-    PyTorchLearnerSampleWriter, PyTorchLearnerBackend)
+    PyTorchLearnerSampleWriter, PyTorchLearnerBackend, chunk)
+from rastervision.pytorch_learner import (ClassificationGeoDataConfig,
+                                          GeoDataWindowConfig)
 
 
 class PyTorchChipClassificationSampleWriter(PyTorchLearnerSampleWriter):
@@ -38,15 +45,42 @@ class PyTorchChipClassification(PyTorchLearnerBackend):
         return PyTorchChipClassificationSampleWriter(
             output_uri, self.pipeline_cfg.dataset.class_config, self.tmp_dir)
 
-    def predict(self, scene, chips, windows):
-        if self.learner is None:
-            self.load_model()
+    def _get_predictions(
+            self,
+            predict_options: ChipClassificationPredictOptions,
+            hooks: Dict[str, Callable] = {}) -> ChipClassificationLabels:
+        ds = self.learner.test_ds.datasets[0]  # index into the ConcatDataset
+        dl = self.learner.test_dl
 
-        out = self.learner.numpy_predict(chips, raw_out=True)
-        labels = ChipClassificationLabels()
+        labels = ds.scene.label_store.empty_labels()
 
-        for class_probs, window in zip(out, windows):
-            class_id = class_probs.argmax()
-            labels.set_cell(window, class_id, class_probs)
+        windows = chunk(ds.windows, n=predict_options.batch_sz)
+        preds = self.learner.iter_predictions(dl, raw_out=True)
+
+        it = zip(windows, preds)
+        with click.progressbar(it, length=len(dl), label='Predicting') as bar:
+            for ws, (_, _, outs) in bar:
+                pred_ids = self.learner.prob_to_pred(outs).numpy()
+                outs = self.learner.output_to_numpy(outs)
+                for w, class_id, class_scores in zip(ws, pred_ids, outs):
+                    labels[w] = (class_id, class_scores)
 
         return labels
+
+    def _make_pred_data_config(
+            self,
+            predict_options: ChipClassificationPredictOptions,
+            scene_dataset: DatasetConfig,
+            window_opts: GeoDataWindowConfig,
+            scene: SceneConfig,
+            hooks: Dict[str, Callable] = {}) -> ClassificationGeoDataConfig:
+        cfg = self.learner.cfg.data
+        return ClassificationGeoDataConfig(
+            class_names=cfg.class_names,
+            class_colors=cfg.class_colors,
+            img_sz=cfg.img_sz,
+            num_workers=cfg.num_workers,
+            base_transform=cfg.base_transform,
+            plot_options=cfg.plot_options,
+            scene_dataset=scene_dataset,
+            window_opts=window_opts)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification.py
@@ -12,8 +12,8 @@ from rastervision.core.utils.misc import save_img
 from rastervision.core.data_sample import DataSample
 from rastervision.pytorch_backend.pytorch_learner_backend import (
     PyTorchLearnerSampleWriter, PyTorchLearnerBackend, chunk)
-from rastervision.pytorch_learner import (ClassificationGeoDataConfig,
-                                          GeoDataWindowConfig)
+from rastervision.pytorch_learner import (
+    ClassificationGeoDataConfig, GeoDataWindowConfig, get_base_datasets)
 
 
 class PyTorchChipClassificationSampleWriter(PyTorchLearnerSampleWriter):
@@ -49,7 +49,7 @@ class PyTorchChipClassification(PyTorchLearnerBackend):
             self,
             predict_options: ChipClassificationPredictOptions,
             hooks: Dict[str, Callable] = {}) -> ChipClassificationLabels:
-        ds = self.learner.test_ds.datasets[0]  # index into the ConcatDataset
+        ds = get_base_datasets(self.learner.test_ds)[0]
         dl = self.learner.test_dl
 
         labels = ds.scene.label_store.empty_labels()

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
@@ -1,4 +1,4 @@
-from typing import Dict, Callable
+from typing import Dict, Callable, Iterable
 from os.path import join
 import tempfile
 import gc
@@ -61,7 +61,7 @@ class PyTorchLearnerSampleWriter(SampleWriter):
         raise NotImplementedError()
 
 
-def chunk(iterable, n):
+def chunk(iterable: Iterable, n: int) -> Iterable:
     """Collect data into fixed-length chunks or blocks
     Adapted from: https://docs.python.org/3/library/itertools.html
     """
@@ -149,7 +149,7 @@ class PyTorchLearnerBackend(Backend):
 
     def _get_predictions(self,
                          predict_options: PredictOptions,
-                         hooks: Dict[str, Callable] = {}):
+                         hooks: Dict[str, Callable] = {}) -> Labels:
         ds = self.learner.test_ds.datasets[0]  # index into the ConcatDataset
         dl = self.learner.test_dl
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
@@ -15,7 +15,8 @@ from rastervision.core.data import (ClassConfig, SceneConfig, Labels,
                                     DatasetConfig)
 from rastervision.core.rv_pipeline import RVPipelineConfig, PredictOptions
 from rastervision.pytorch_learner import (Learner, LearnerConfig,
-                                          GeoDataWindowConfig, GeoDataConfig)
+                                          GeoDataWindowConfig, GeoDataConfig,
+                                          get_base_datasets)
 
 
 class PyTorchLearnerSampleWriter(SampleWriter):
@@ -150,7 +151,7 @@ class PyTorchLearnerBackend(Backend):
     def _get_predictions(self,
                          predict_options: PredictOptions,
                          hooks: Dict[str, Callable] = {}) -> Labels:
-        ds = self.learner.test_ds.datasets[0]  # index into the ConcatDataset
+        ds = get_base_datasets(self.learner.test_ds)[0]
         dl = self.learner.test_dl
 
         labels = ds.scene.label_store.empty_labels()

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
@@ -12,8 +12,8 @@ from rastervision.core.utils.misc import save_img
 from rastervision.core.data_sample import DataSample
 from rastervision.pytorch_backend.pytorch_learner_backend import (
     PyTorchLearnerSampleWriter, PyTorchLearnerBackend, chunk)
-from rastervision.pytorch_learner import (ObjectDetectionGeoDataConfig,
-                                          GeoDataWindowConfig)
+from rastervision.pytorch_learner import (
+    ObjectDetectionGeoDataConfig, GeoDataWindowConfig, get_base_datasets)
 
 
 class PyTorchObjectDetectionSampleWriter(PyTorchLearnerSampleWriter):
@@ -108,7 +108,7 @@ class PyTorchObjectDetection(PyTorchLearnerBackend):
             self,
             predict_options: ObjectDetectionPredictOptions,
             hooks: Dict[str, Callable] = {}) -> ObjectDetectionLabels:
-        ds = self.learner.test_ds.datasets[0]  # index into the ConcatDataset
+        ds = get_base_datasets(self.learner.test_ds)[0]
         dl = self.learner.test_dl
 
         labels = ds.scene.label_store.empty_labels()

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
@@ -15,8 +15,8 @@ from rastervision.core.utils.misc import save_img
 from rastervision.core.data_sample import DataSample
 from rastervision.pytorch_backend.pytorch_learner_backend import (
     PyTorchLearnerSampleWriter, PyTorchLearnerBackend, chunk)
-from rastervision.pytorch_learner import (GeoDataWindowConfig,
-                                          SemanticSegmentationGeoDataConfig)
+from rastervision.pytorch_learner import (
+    GeoDataWindowConfig, SemanticSegmentationGeoDataConfig, get_base_datasets)
 
 
 class PyTorchSemanticSegmentationSampleWriter(PyTorchLearnerSampleWriter):
@@ -95,7 +95,7 @@ class PyTorchSemanticSegmentation(PyTorchLearnerBackend):
                          predict_options: PredictOptions,
                          hooks: Dict[str, Callable] = {}
                          ) -> SemanticSegmentationLabels:
-        ds = self.learner.test_ds.datasets[0]  # index into the ConcatDataset
+        ds = get_base_datasets(self.learner.test_ds)[0]
         dl = self.learner.test_dl
 
         raw_out = ds.scene.label_store.smooth_output

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
@@ -14,6 +14,7 @@ from rastervision.pytorch_learner.semantic_segmentation_learner import *
 from rastervision.pytorch_learner.object_detection_learner_config import *
 from rastervision.pytorch_learner.object_detection_learner import *
 from rastervision.pytorch_learner.dataset import *
+from rastervision.pytorch_learner.utils import *
 
 
 def register_plugin(registry):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -46,12 +46,9 @@ class ClassificationImageDataConfig(ClassificationDataConfig, ImageDataConfig):
 @register_config('classification_geo_data')
 class ClassificationGeoDataConfig(ClassificationDataConfig, GeoDataConfig):
     def build_scenes(self, tmp_dir: str):
-        for s in self.scene_dataset.train_scenes:
-            s.label_source.lazy = True
-        for s in self.scene_dataset.validation_scenes:
-            s.label_source.lazy = True
-        for s in self.scene_dataset.test_scenes:
-            s.label_source.lazy = True
+        for s in self.scene_dataset.get_all_scenes():
+            if s.label_source is not None:
+                s.label_source.lazy = True
         return super().build_scenes(tmp_dir=tmp_dir)
 
     def scene_to_dataset(self,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/classification_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/classification_dataset.py
@@ -20,7 +20,8 @@ class ClassificationSlidingWindowGeoDataset(SlidingWindowGeoDataset):
 
     def init_windows(self):
         super().init_windows()
-        self.scene.label_source.populate_labels(cells=self.windows)
+        if self.scene.label_source is not None:
+            self.scene.label_source.populate_labels(cells=self.windows)
 
 
 class ClassificationRandomWindowGeoDataset(RandomWindowGeoDataset):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -842,6 +842,19 @@ class Learner(ABC):
 
     def iter_predictions(self, dl: DataLoader, raw_out: bool = False
                          ) -> Iterator[Tuple[Tensor, Tensor, Tensor]]:
+        """Returns a generator that generates 3-tuples of the form
+        (input, target, output), where each item is batched as per the
+        batch size of the DataLoader.
+
+        Args:
+            dl (DataLoader): A dataloader.
+            raw_out (bool, optional): Return raw output scores.
+                Defaults to False.
+
+        Yields:
+            Iterator[Tuple[Tensor, Tensor, Tensor]]: 3-tuples of the form
+                (input, target, output)
+        """
         self.model.eval()
 
         with torch.no_grad():

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -538,21 +538,22 @@ class Learner(ABC):
 
         train_ds, valid_ds, test_ds = self.get_datasets()
 
-        if cfg.overfit_mode:
-            train_ds = Subset(train_ds, range(batch_sz))
-            valid_ds = train_ds
-            test_ds = train_ds
-        elif cfg.test_mode:
-            train_ds = Subset(train_ds, range(batch_sz))
-            valid_ds = Subset(valid_ds, range(batch_sz))
-            test_ds = Subset(test_ds, range(batch_sz))
+        if training:
+            if cfg.overfit_mode:
+                train_ds = Subset(train_ds, range(batch_sz))
+                valid_ds = train_ds
+                test_ds = train_ds
+            elif cfg.test_mode:
+                train_ds = Subset(train_ds, range(batch_sz))
+                valid_ds = Subset(valid_ds, range(batch_sz))
+                test_ds = Subset(test_ds, range(batch_sz))
 
-        if cfg.data.train_sz is not None:
-            train_inds = list(range(len(train_ds)))
-            random.seed(1234)
-            random.shuffle(train_inds)
-            train_inds = train_inds[0:cfg.data.train_sz]
-            train_ds = Subset(train_ds, train_inds)
+            if cfg.data.train_sz is not None:
+                train_inds = list(range(len(train_ds)))
+                random.seed(1234)
+                random.shuffle(train_inds)
+                train_inds = train_inds[0:cfg.data.train_sz]
+                train_ds = Subset(train_ds, train_inds)
 
         collate_fn = self.get_collate_fn()
         train_dl, valid_dl, test_dl = None, None, None

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -615,7 +615,6 @@ class LearnerConfig(Config):
         if self.test_mode:
             self.solver.num_epochs = self.solver.test_num_epochs
             self.solver.batch_sz = self.solver.test_batch_sz
-            self.data.img_sz = self.data.img_sz // 2
             self.data.num_workers = 0
 
         self.model.update(learner=self)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -532,9 +532,6 @@ class GeoDataConfig(DataConfig):
         """
         train_scenes, val_scenes, test_scenes = self.build_scenes(tmp_dir)
 
-        if len(test_scenes) == 0:
-            test_scenes = val_scenes
-
         train_ds_list = [
             self.scene_to_dataset(s, train_tf, **kwargs) for s in train_scenes
         ]

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -152,6 +152,7 @@ class SemanticSegmentationLearner(Learner):
 
     def iter_predictions(self, dl: DataLoader, raw_out: bool = False
                          ) -> Iterator[Tuple[Tensor, Tensor, Tensor]]:
+        """Convert logits to probabilities if raw_out=True."""
         self.model.eval()
 
         with torch.no_grad():

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
@@ -1,7 +1,9 @@
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Union, List
+from itertools import chain
 
 import torch
 from torch import nn
+from torch.utils.data import Dataset, Subset, ConcatDataset, ChainDataset
 
 import numpy as np
 from PIL import ImageColor
@@ -113,3 +115,20 @@ class AddTensors(nn.Module):
 
     def forward(self, xs):
         return sum(xs)
+
+
+def get_base_datasets(
+        ds: Union[list, tuple, Subset, ConcatDataset, ChainDataset]
+) -> List[Dataset]:
+    """Extract the base dataset objects from inside nested collections or
+    subsets.
+    """
+    if isinstance(ds, Subset):
+        return get_base_datasets(ds.dataset)
+    if isinstance(ds, ConcatDataset):
+        return get_base_datasets(list(ds.datasets))
+    if isinstance(ds, ChainDataset):
+        return get_base_datasets(list(ds.datasets))
+    if isinstance(ds, (list, tuple)):
+        return list(chain(*[get_base_datasets(d) for d in ds]))
+    return [ds]

--- a/tests/pytorch_learner/test_utils.py
+++ b/tests/pytorch_learner/test_utils.py
@@ -1,9 +1,10 @@
 import unittest
 
 import torch
+from torch.utils.data import Dataset, Subset, ConcatDataset
 
-from rastervision.pytorch_learner.utils import (compute_conf_mat,
-                                                compute_conf_mat_metrics)
+from rastervision.pytorch_learner.utils import (
+    compute_conf_mat, compute_conf_mat_metrics, get_base_datasets)
 
 
 class TestComputeConfMat(unittest.TestCase):
@@ -95,6 +96,18 @@ class TestComputeConfMatMetrics(unittest.TestCase):
             'b_f1': b_f1
         }
         self.assertDictEqual(round_dict(metrics), round_dict(exp_metrics))
+
+
+class TestOther(unittest.TestCase):
+    def test_get_base_datasets(self):
+        ds0 = Dataset()
+        ds1 = Subset(ds0, [0])
+        ds2 = ConcatDataset([ds1, ds1])
+        ds3 = Subset(ds2, [0])
+        self.assertEqual(get_base_datasets(ds0)[0], ds0)
+        self.assertEqual(get_base_datasets(ds1)[0], ds0)
+        self.assertEqual(get_base_datasets(ds2)[0], ds0)
+        self.assertEqual(get_base_datasets(ds3)[0], ds0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Overview

This PR
- moves the bulk of the prediction logic from `RVPipeline` to the learner backend
  - where a `SlidingWindowGeoDataset` is used to traverse the scene
  - this dataset is created via the `Learner`, so has access to the `base_transform` transform
- makes prediction params (`chip_sz`, `batch_sz`, `stride`) configurable using `RVPipeline.predict_options`
  - these override `predict_chip_sz` and `predict_batch_sz` if specified
- adds an `iter_predictions()` method to the `Learner` that returns a generator of predictions from a `DataLoader`
  - motivation: avoid possibly storing all the predictions of a scene in memory twice (once as the return values of `predict_dataloader()` and then as `Labels`)
- adds a `__setitem__` to the `Labels` subclasses for ease of use with the new prediction code
- adds `--ipc=host` to the `docker run` command used for CI testing (`.travis/test`)

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes #1053 
