### PR TITLE
Apply base transform during prediction

### DIFF
--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -239,7 +239,8 @@ class SemanticSegmentationLabelStore(LabelStore):
             labels: SemanticSegmentationLabels) -> None:
 
         num_bands = 1 if self.class_transformer is None else 3
-        out_profile.update({'count': num_bands, 'dtype': np.uint8})
+        dtype = np.uint8
+        out_profile.update({'count': num_bands, 'dtype': dtype})
 
         windows = labels.get_windows()
 
@@ -247,7 +248,7 @@ class SemanticSegmentationLabelStore(LabelStore):
         with rio.open(path, 'w', **out_profile) as dataset:
             with click.progressbar(windows) as bar:
                 for window in bar:
-                    label_arr = labels.get_label_arr(window)
+                    label_arr = labels.get_label_arr(window).astype(dtype)
                     window, label_arr = self._clip_to_extent(
                         self.extent, window, label_arr)
                     if self.class_transformer is not None:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -732,7 +732,7 @@ class Learner(ABC):
             x with extra batch dimension of length 1 if needed
         """
         if x.ndim == 3:
-            x = x.unsqueeze(0)
+            x = x[None, ...]
         return x
 
     def normalize_input(self, x: np.ndarray) -> np.ndarray:
@@ -797,9 +797,11 @@ class Learner(ABC):
         Returns:
             predictions using numpy arrays
         """
+        transform, _ = self.get_data_transforms()
         x = self.normalize_input(x)
-        x = torch.tensor(x)
         x = self.to_batch(x)
+        x = np.stack([transform(image=img)['image'] for img in x])
+        x = torch.from_numpy(x)
         x = x.permute((0, 3, 1, 2))
         out = self.predict(x, raw_out=raw_out)
         return self.output_to_numpy(out)


### PR DESCRIPTION
## Overview

This PR makes it so that the `base_transform` returned by `Learner.get_data_transforms()` is applied to the input in `Learner.numpy_predict()` before it is passed to the model.

It also fixes a bug in `SemanticSegmentationLabelStor` related to a `dtype` mismatch when writing predictions to disk.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness


Closes #1053 
