### PR TITLE
Fix OOM error on AWS Batch

### DIFF
--- a/.travis/build
+++ b/.travis/build
@@ -4,5 +4,5 @@ set -e
 source .travis/env
 
 if [ "$IMAGE_TYPE" = "pytorch" ]; then
-    docker build --build-arg CUDA_VERSION="10.0" -t raster-vision-pytorch -f Dockerfile .;
+    docker build --build-arg CUDA_VERSION="10.2" -t raster-vision-pytorch -f Dockerfile .;
 fi

--- a/docker/build
+++ b/docker/build
@@ -21,5 +21,5 @@ then
         exit
     fi
 
-    docker build --build-arg CUDA_VERSION="10.0" -t raster-vision-pytorch -f Dockerfile .
+    docker build --build-arg CUDA_VERSION="10.2" -t raster-vision-pytorch -f Dockerfile .
 fi

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,7 @@ Features
 * Allow reading directly from raster source during training without chipping `#1046 <https://github.com/azavea/raster-vision/pull/1046>`_
 * Remove external commands (obsoleted by external architectures and loss functions) `#1047 <https://github.com/azavea/raster-vision/pull/1047>`_
 * Allow saving SS predictions as probabilities `#1057 <https://github.com/azavea/raster-vision/pull/1057>`_
+* Update CUDA version from 10.1 to 10.2 `#1115 <https://github.com/azavea/raster-vision/pull/1115>`_
 
 Bug Fixes
 ~~~~~~~~~~~~

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -7,9 +7,11 @@ import datetime
 from abc import ABC, abstractmethod
 import shutil
 import os
+import sys
 import math
 import logging
-from subprocess import Popen
+from subprocess import Popen, call
+import psutil
 import numbers
 import zipfile
 from typing import Optional, List, Tuple, Dict, Union, Any
@@ -52,6 +54,37 @@ log = logging.getLogger(__name__)
 MetricDict = Dict[str, float]
 
 
+def log_system_details():
+    """Log some system details."""
+    # CPUs
+    log.info(f'Physical CPUs: {psutil.cpu_count(logical=False)}')
+    log.info(f'Logical CPUs: {psutil.cpu_count(logical=True)}')
+    # memory usage
+    mem_stats = psutil.virtual_memory()._asdict()
+    log.info(f'Total memory: {mem_stats["total"] / 2**30: .2f} GB')
+    # disk usage
+    disk_stats = psutil.disk_usage('/opt/data')._asdict()
+    log.info(
+        f'Size of /opt/data volume: {disk_stats["total"] / 2**30: .2f} GB')
+    # python
+    log.info(f'Python version: {sys.version}')
+    # nvidia GPU
+    log.info(os.popen("nvidia-smi").read())
+    log.info(os.popen("nvcc --version").read())
+    log.info('Devices')
+    call([
+        "nvidia-smi", "--format=csv",
+        "--query-gpu=index,name,driver_version,memory.total,memory.used,memory.free"
+    ])
+    # pytorch and CUDA
+    log.info(f'PyTorch version: {torch.__version__}')
+    log.info(f'CUDA version: {torch.version.cuda}')
+    log.info(f'CUDNN version: {torch.backends.cudnn.version()}')
+    log.info(f'Number CUDA Devices: {torch.cuda.device_count()}')
+    log.info(f'CUDA available: {torch.cuda.is_available()}')
+    log.info(f'Active CUDA Device: GPU {torch.cuda.current_device()}')
+
+
 class Learner(ABC):
     """Abstract training and prediction routines for a model.
 
@@ -90,6 +123,7 @@ class Learner(ABC):
                 and the loss function, optimizer, etc. are not initialized.
                 Defaults to True.
         """
+        log_system_details()
         self.cfg = cfg
         self.tmp_dir = tmp_dir
 
@@ -156,6 +190,7 @@ class Learner(ABC):
 
     def setup_training(self, loss_def_path=None):
         log.info(self.cfg)
+        log.info(f'Using device: {self.device}')
 
         # ds = dataset, dl = dataloader
         self.train_ds = None

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -70,21 +70,21 @@ def log_system_details():
     log.info(f'Python version: {sys.version}')
     # nvidia GPU
     try:
-        log.info(os.popen("nvidia-smi").read())
         log.info(os.popen("nvcc --version").read())
-        log.info('Devices')
+        log.info(os.popen("nvidia-smi").read())
+        log.info('Devices:')
         call([
             "nvidia-smi", "--format=csv",
             "--query-gpu=index,name,driver_version,memory.total,memory.used,memory.free"
         ])
     except FileNotFoundError:
-        log.info('nvidia-smi, nvcc commands not available.')
+        pass
     # pytorch and CUDA
     log.info(f'PyTorch version: {torch.__version__}')
     log.info(f'CUDA available: {torch.cuda.is_available()}')
     log.info(f'CUDA version: {torch.version.cuda}')
     log.info(f'CUDNN version: {torch.backends.cudnn.version()}')
-    log.info(f'Number CUDA Devices: {torch.cuda.device_count()}')
+    log.info(f'Number of CUDA devices: {torch.cuda.device_count()}')
     if torch.cuda.is_available():
         log.info(f'Active CUDA Device: GPU {torch.cuda.current_device()}')
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -1080,10 +1080,12 @@ class Learner(ABC):
                 batch = (x, y)
                 self.opt.zero_grad()
                 output = self.train_step(batch, batch_ind)
-                outputs.append(output)
-                loss = output['train_loss']
-                loss.backward()
+                output['train_loss'].backward()
                 self.opt.step()
+                # detach tensors in the output, if any, to avoid memory leaks
+                for k, v in output.items():
+                    output[k] = v.detach() if isinstance(v, Tensor) else v
+                outputs.append(output)
                 if self.step_scheduler:
                     self.step_scheduler.step()
                 num_samples += x.shape[0]

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -69,20 +69,24 @@ def log_system_details():
     # python
     log.info(f'Python version: {sys.version}')
     # nvidia GPU
-    log.info(os.popen("nvidia-smi").read())
-    log.info(os.popen("nvcc --version").read())
-    log.info('Devices')
-    call([
-        "nvidia-smi", "--format=csv",
-        "--query-gpu=index,name,driver_version,memory.total,memory.used,memory.free"
-    ])
+    try:
+        log.info(os.popen("nvidia-smi").read())
+        log.info(os.popen("nvcc --version").read())
+        log.info('Devices')
+        call([
+            "nvidia-smi", "--format=csv",
+            "--query-gpu=index,name,driver_version,memory.total,memory.used,memory.free"
+        ])
+    except FileNotFoundError:
+        log.info('nvidia-smi, nvcc commands not available.')
     # pytorch and CUDA
     log.info(f'PyTorch version: {torch.__version__}')
+    log.info(f'CUDA available: {torch.cuda.is_available()}')
     log.info(f'CUDA version: {torch.version.cuda}')
     log.info(f'CUDNN version: {torch.backends.cudnn.version()}')
     log.info(f'Number CUDA Devices: {torch.cuda.device_count()}')
-    log.info(f'CUDA available: {torch.cuda.is_available()}')
-    log.info(f'Active CUDA Device: GPU {torch.cuda.current_device()}')
+    if torch.cuda.is_available():
+        log.info(f'Active CUDA Device: GPU {torch.cuda.current_device()}')
 
 
 class Learner(ABC):

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -8,3 +8,4 @@ albumentations==0.5.*
 cython==0.28.*
 pycocotools==2.0.*
 future==0.18.*
+psutil==5.8.*


### PR DESCRIPTION
## Overview

Recently, we started encountering OOM errors when running training jobs on AWS Batch. The peculiar thing about it being that it could not be reproduced locally (at least on my machine) using the same command.

The cause of the error was tracked down to be composed of 2 things:
- Failure to use GPU on Batch due to incompatibility between the PyTorch version and CUDA version.
  - It did not occur locally because my CUDA version was high enough.
- A memory leak during training that only seems to manifests when using the CPU.

This PR
- Fixes the memory leak.
  - The fixes is general. So if it was affecting GPU memory too, that should be fixed as well.
- Updates CUDA version from 10.1 to 10.2.
- Adds some additional logging of system details at the start of training that should help debug similar problems in the future.
  - Code adapted from: https://github.com/Netflix/metaflow/issues/250

### Sample output of the newly added system details logging
```
Running train command...
--
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - Physical CPUs: 4
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - Logical CPUs: 8
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - Total memory:  59.96 GB
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - Size of /opt/data volume:  295.17 GB
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - Python version: 3.6.12 \|Anaconda, Inc.\| (default, Sep  8 2020, 23:10:56)
[GCC 7.3.0]
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - Fri Feb 19 15:45:39 2021
+-----------------------------------------------------------------------------+
\| NVIDIA-SMI 418.40.04    Driver Version: 418.40.04    CUDA Version: 10.2     \|
\|-------------------------------+----------------------+----------------------+
\| GPU  Name        Persistence-M\| Bus-Id        Disp.A \| Volatile Uncorr. ECC \|
\| Fan  Temp  Perf  Pwr:Usage/Cap\|         Memory-Usage \| GPU-Util  Compute M. \|
\|===============================+======================+======================\|
\|   0  Tesla V100-SXM2...  On   \| 00000000:00:1E.0 Off \|                    0 \|
\| N/A   27C    P0    23W / 300W \|      0MiB / 16130MiB \|      0%      Default \|
+-------------------------------+----------------------+----------------------+
 
+-----------------------------------------------------------------------------+
\| Processes:                                                       GPU Memory \|
\|  GPU       PID   Type   Process name                             Usage      \|
\|=============================================================================\|
\|  No running processes found                                                 \|
+-----------------------------------------------------------------------------+
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2019 NVIDIA Corporation
Built on Wed_Oct_23_19:24:38_PDT_2019
Cuda compilation tools, release 10.2, V10.2.89
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - Devices
index, name, driver_version, memory.total [MiB], memory.used [MiB], memory.free [MiB]
0, Tesla V100-SXM2-16GB, 418.40.04, 16130 MiB, 0 MiB, 16130 MiB
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - PyTorch version: 1.7.1
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - CUDA version: 10.2
2021-02-19 15:45:39:rastervision.pytorch_learner.learner: INFO - CUDNN version: 7605
2021-02-19 15:45:40:rastervision.pytorch_learner.learner: INFO - Number CUDA Devices: 1
2021-02-19 15:45:40:rastervision.pytorch_learner.learner: INFO - CUDA available: True
2021-02-19 15:45:40:rastervision.pytorch_learner.learner: INFO - Active CUDA Device: GPU 0
```

### Checklist

- [X] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [X] Ran scripts/format_code and committed any changes
- [X] Documentation updated if needed
- [X] PR has a name that won't get you publicly shamed for vagueness

### Notes

I used this code snippet to track disk and memory usage during training, by inserting it in the `Learner`'s `train_step()` method. Might be useful later.

```python
import psutil

# memory usage
mem_stats = psutil.virtual_memory()._asdict()
mem_stats['used'] /= 2**30
mem_stats['total'] /= 2**30
log.info(f'memory used (GB): {mem_stats["used"]} of {mem_stats["total"]} '
         f'({mem_stats["percent"]}%)')
# disk usage
disk_stats = psutil.disk_usage('/opt/data')._asdict()
disk_stats['used'] /= 2**30
disk_stats['total'] /= 2**30
log.info(f'disk used (GB): {disk_stats["used"]} of {disk_stats["total"]} '
         f'({disk_stats["percent"]}%)')
```
