### PR TITLE
Update examples, use "nochip" by default, add integration tests, improve test.py, and some bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ deployment/ansible/*.retry
 ./data
 ./notebooks
 .vscode/
+
+# dir that is mounted to /opt/data
+data/

--- a/integration_tests/chip_classification/config.py
+++ b/integration_tests/chip_classification/config.py
@@ -56,9 +56,7 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
     chip_sz = 200
     img_sz = chip_sz
 
-    if not nochip:
-        data = ClassificationImageDataConfig(img_sz=img_sz, augmentors=[])
-    else:
+    if nochip:
         window_opts = GeoDataWindowConfig(
             method=GeoDataWindowMethod.sliding, stride=chip_sz, size=chip_sz)
 
@@ -67,6 +65,8 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
             window_opts=window_opts,
             img_sz=img_sz,
             augmentors=[])
+    else:
+        data = ClassificationImageDataConfig(img_sz=img_sz, augmentors=[])
 
     if full_train:
         model = ClassificationModelConfig(backbone=Backbone.resnet18)

--- a/integration_tests/chip_classification/config.py
+++ b/integration_tests/chip_classification/config.py
@@ -6,12 +6,14 @@ from rastervision.core.data import (
     GeoJSONVectorSourceConfig, RasterioSourceConfig, StatsTransformerConfig,
     SceneConfig, DatasetConfig)
 from rastervision.pytorch_backend import PyTorchChipClassificationConfig
-from rastervision.pytorch_learner import (Backbone, SolverConfig,
-                                          ClassificationModelConfig,
-                                          ClassificationImageDataConfig)
+from rastervision.pytorch_learner import (
+    Backbone, SolverConfig, ClassificationModelConfig,
+    ClassificationImageDataConfig, ClassificationGeoDataConfig,
+    GeoDataWindowConfig, GeoDataWindowMethod)
 
 
-def get_config(runner, root_uri, data_uri=None, full_train=False):
+def get_config(runner, root_uri, data_uri=None, full_train=False,
+               nochip=False):
     def get_path(part):
         if full_train:
             return join(data_uri, part)
@@ -53,7 +55,18 @@ def get_config(runner, root_uri, data_uri=None, full_train=False):
 
     chip_sz = 200
     img_sz = chip_sz
-    data = ClassificationImageDataConfig(img_sz=img_sz, augmentors=[])
+
+    if not nochip:
+        data = ClassificationImageDataConfig(img_sz=img_sz, augmentors=[])
+    else:
+        window_opts = GeoDataWindowConfig(
+            method=GeoDataWindowMethod.sliding, stride=chip_sz, size=chip_sz)
+
+        data = ClassificationGeoDataConfig(
+            scene_dataset=scene_dataset,
+            window_opts=window_opts,
+            img_sz=img_sz,
+            augmentors=[])
 
     if full_train:
         model = ClassificationModelConfig(backbone=Backbone.resnet18)

--- a/integration_tests/object_detection/config.py
+++ b/integration_tests/object_detection/config.py
@@ -51,9 +51,7 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
 
     chip_options = ObjectDetectionChipOptions(neg_ratio=1.0, ioa_thresh=1.0)
 
-    if not nochip:
-        data = ObjectDetectionImageDataConfig(img_sz=img_sz, augmentors=[])
-    else:
+    if nochip:
         window_opts = ObjectDetectionGeoDataWindowConfig(
             method=GeoDataWindowMethod.sliding,
             stride=chip_sz,
@@ -66,6 +64,8 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
             window_opts=window_opts,
             img_sz=img_sz,
             augmentors=[])
+    else:
+        data = ObjectDetectionImageDataConfig(img_sz=img_sz, augmentors=[])
 
     if full_train:
         model = ObjectDetectionModelConfig(backbone=Backbone.resnet18)

--- a/integration_tests/object_detection/config.py
+++ b/integration_tests/object_detection/config.py
@@ -7,12 +7,14 @@ from rastervision.core.data import (
     ClassConfig, ObjectDetectionLabelSourceConfig, GeoJSONVectorSourceConfig,
     RasterioSourceConfig, SceneConfig, DatasetConfig)
 from rastervision.pytorch_backend import PyTorchObjectDetectionConfig
-from rastervision.pytorch_learner import (Backbone, SolverConfig,
-                                          ObjectDetectionModelConfig,
-                                          ObjectDetectionImageDataConfig)
+from rastervision.pytorch_learner import (
+    Backbone, SolverConfig, ObjectDetectionModelConfig,
+    ObjectDetectionImageDataConfig, ObjectDetectionGeoDataConfig,
+    ObjectDetectionGeoDataWindowConfig, GeoDataWindowMethod)
 
 
-def get_config(runner, root_uri, data_uri=None, full_train=False):
+def get_config(runner, root_uri, data_uri=None, full_train=False,
+               nochip=False):
     def get_path(part):
         if full_train:
             return join(data_uri, part)
@@ -35,7 +37,35 @@ def get_config(runner, root_uri, data_uri=None, full_train=False):
 
     chip_sz = 300
     img_sz = chip_sz
-    data = ObjectDetectionImageDataConfig(img_sz=img_sz, augmentors=[])
+
+    scenes = [
+        make_scene('od_test', get_path('scene/image.tif'),
+                   get_path('scene/labels.json')),
+        make_scene('od_test-2', get_path('scene/image2.tif'),
+                   get_path('scene/labels2.json'))
+    ]
+    scene_dataset = DatasetConfig(
+        class_config=class_config,
+        train_scenes=scenes,
+        validation_scenes=scenes)
+
+    chip_options = ObjectDetectionChipOptions(neg_ratio=1.0, ioa_thresh=1.0)
+
+    if not nochip:
+        data = ObjectDetectionImageDataConfig(img_sz=img_sz, augmentors=[])
+    else:
+        window_opts = ObjectDetectionGeoDataWindowConfig(
+            method=GeoDataWindowMethod.sliding,
+            stride=chip_sz,
+            size=chip_sz,
+            neg_ratio=chip_options.neg_ratio,
+            ioa_thresh=chip_options.ioa_thresh)
+
+        data = ObjectDetectionGeoDataConfig(
+            scene_dataset=scene_dataset,
+            window_opts=window_opts,
+            img_sz=img_sz,
+            augmentors=[])
 
     if full_train:
         model = ObjectDetectionModelConfig(backbone=Backbone.resnet18)
@@ -64,18 +94,6 @@ def get_config(runner, root_uri, data_uri=None, full_train=False):
         log_tensorboard=False,
         run_tensorboard=False)
 
-    scenes = [
-        make_scene('od_test', get_path('scene/image.tif'),
-                   get_path('scene/labels.json')),
-        make_scene('od_test-2', get_path('scene/image2.tif'),
-                   get_path('scene/labels2.json'))
-    ]
-    scene_dataset = DatasetConfig(
-        class_config=class_config,
-        train_scenes=scenes,
-        validation_scenes=scenes)
-
-    chip_options = ObjectDetectionChipOptions(neg_ratio=1.0, ioa_thresh=1.0)
     predict_options = ObjectDetectionPredictOptions(
         merge_thresh=0.1, score_thresh=0.5)
 

--- a/integration_tests/semantic_segmentation/config.py
+++ b/integration_tests/semantic_segmentation/config.py
@@ -60,10 +60,7 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
     chip_options = SemanticSegmentationChipOptions(
         window_method=SemanticSegmentationWindowMethod.sliding, stride=chip_sz)
 
-    if not nochip:
-        data = SemanticSegmentationImageDataConfig(
-            img_sz=img_sz, augmentors=[])
-    else:
+    if nochip:
         window_opts = GeoDataWindowConfig(
             method=GeoDataWindowMethod.sliding,
             stride=chip_options.stride,
@@ -74,6 +71,9 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
             window_opts=window_opts,
             img_sz=img_sz,
             augmentors=[])
+    else:
+        data = SemanticSegmentationImageDataConfig(
+            img_sz=img_sz, augmentors=[])
 
     if full_train:
         model = SemanticSegmentationModelConfig(backbone=Backbone.resnet50)

--- a/integration_tests/semantic_segmentation/config.py
+++ b/integration_tests/semantic_segmentation/config.py
@@ -8,12 +8,14 @@ from rastervision.core.rv_pipeline import (SemanticSegmentationChipOptions,
                                            SemanticSegmentationWindowMethod,
                                            SemanticSegmentationConfig)
 from rastervision.pytorch_backend import PyTorchSemanticSegmentationConfig
-from rastervision.pytorch_learner import (Backbone, SolverConfig,
-                                          SemanticSegmentationModelConfig,
-                                          SemanticSegmentationImageDataConfig)
+from rastervision.pytorch_learner import (
+    Backbone, SolverConfig, SemanticSegmentationModelConfig,
+    SemanticSegmentationImageDataConfig, SemanticSegmentationGeoDataConfig,
+    GeoDataWindowConfig, GeoDataWindowMethod)
 
 
-def get_config(runner, root_uri, data_uri=None, full_train=False):
+def get_config(runner, root_uri, data_uri=None, full_train=False,
+               nochip=False):
     def get_path(part):
         if full_train:
             return join(data_uri, part)
@@ -43,7 +45,35 @@ def get_config(runner, root_uri, data_uri=None, full_train=False):
 
     chip_sz = 300
     img_sz = chip_sz
-    data = SemanticSegmentationImageDataConfig(img_sz=img_sz, augmentors=[])
+
+    scenes = [
+        make_scene('test-scene', get_path('scene/image.tif'),
+                   get_path('scene/labels.tif')),
+        make_scene('test-scene2', get_path('scene/image2.tif'),
+                   get_path('scene/labels2.tif'))
+    ]
+    scene_dataset = DatasetConfig(
+        class_config=class_config,
+        train_scenes=scenes,
+        validation_scenes=scenes)
+
+    chip_options = SemanticSegmentationChipOptions(
+        window_method=SemanticSegmentationWindowMethod.sliding, stride=chip_sz)
+
+    if not nochip:
+        data = SemanticSegmentationImageDataConfig(
+            img_sz=img_sz, augmentors=[])
+    else:
+        window_opts = GeoDataWindowConfig(
+            method=GeoDataWindowMethod.sliding,
+            stride=chip_options.stride,
+            size=chip_sz)
+
+        data = SemanticSegmentationGeoDataConfig(
+            scene_dataset=scene_dataset,
+            window_opts=window_opts,
+            img_sz=img_sz,
+            augmentors=[])
 
     if full_train:
         model = SemanticSegmentationModelConfig(backbone=Backbone.resnet50)
@@ -71,20 +101,6 @@ def get_config(runner, root_uri, data_uri=None, full_train=False):
         solver=solver,
         log_tensorboard=False,
         run_tensorboard=False)
-
-    scenes = [
-        make_scene('test-scene', get_path('scene/image.tif'),
-                   get_path('scene/labels.tif')),
-        make_scene('test-scene2', get_path('scene/image2.tif'),
-                   get_path('scene/labels2.tif'))
-    ]
-    scene_dataset = DatasetConfig(
-        class_config=class_config,
-        train_scenes=scenes,
-        validation_scenes=scenes)
-
-    chip_options = SemanticSegmentationChipOptions(
-        window_method=SemanticSegmentationWindowMethod.sliding, stride=chip_sz)
 
     return SemanticSegmentationConfig(
         root_uri=root_uri,

--- a/rastervision_core/rastervision/core/backend/backend_config.py
+++ b/rastervision_core/rastervision/core/backend/backend_config.py
@@ -24,3 +24,7 @@ class BackendConfig(Config):
 
     def update(self, pipeline: Optional['RVPipeline'] = None):  # noqa
         pass
+
+    def filter_commands(self, commands: List[str]) -> List[str]:
+        """Filter out any commands that are not needed or supported."""
+        return commands

--- a/rastervision_core/rastervision/core/data/scene_config.py
+++ b/rastervision_core/rastervision/core/data/scene_config.py
@@ -40,7 +40,7 @@ class SceneConfig(Config):
             from copy import deepcopy
             d = deepcopy(self.__dict__)
             for g in d['aoi_geometries']:
-                if 'coordinates' in g['geometry']:
+                if ('geometry' in g) and ('coordinates' in g['geometry']):
                     coords = g['geometry']['coordinates']
                     g['geometry']['coordinates'] = f'{coords!r:100.100} ...'
             return d.items()

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
@@ -47,7 +47,12 @@ class RVPipeline(Pipeline):
 
     @property
     def commands(self):
-        return self.config.backend.filter_commands(ALL_COMMANDS)
+        commands = ALL_COMMANDS[:]
+        if len(self.config.analyzers) == 0 and 'analyze' in commands:
+            commands.remove('analyze')
+            click.secho("Skipping 'analyze' command...", fg='green', bold=True)
+        commands = self.config.backend.filter_commands(commands)
+        return commands
 
     @property
     def split_commands(self):

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
@@ -4,6 +4,7 @@ import tempfile
 import shutil
 from typing import TYPE_CHECKING, Optional, List
 
+import click
 import numpy as np
 
 from rastervision.pipeline.pipeline import Pipeline
@@ -20,6 +21,10 @@ log = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from rastervision.core.rv_pipeline.rv_pipeline_config import RVPipelineConfig  # noqa
 
+ALL_COMMANDS = ['analyze', 'chip', 'train', 'predict', 'eval', 'bundle']
+SPLITTABLE_COMMANDS = ['chip', 'predict']
+GPU_COMMANDS = ['train', 'predict']
+
 
 class RVPipeline(Pipeline):
     """Base class of all Raster Vision Pipelines.
@@ -34,14 +39,23 @@ class RVPipeline(Pipeline):
         - bundle: bundle containing model and any other files needed to make predictions
             using the Predictor
     """
-    commands = ['analyze', 'chip', 'train', 'predict', 'eval', 'bundle']
-    split_commands = ['chip', 'predict']
-    gpu_commands = ['train', 'predict']
 
     def __init__(self, config: 'RVPipelineConfig', tmp_dir: str):
         super().__init__(config, tmp_dir)
         self.backend: Optional['Backend'] = None
         self.config: 'RVPipelineConfig'
+
+    @property
+    def commands(self):
+        return self.config.backend.filter_commands(ALL_COMMANDS)
+
+    @property
+    def split_commands(self):
+        return self.config.backend.filter_commands(SPLITTABLE_COMMANDS)
+
+    @property
+    def gpu_commands(self):
+        return self.config.backend.filter_commands(GPU_COMMANDS)
 
     def analyze(self):
         """Run each analyzer over training scenes."""

--- a/rastervision_pipeline/rastervision/pipeline/cli.py
+++ b/rastervision_pipeline/rastervision/pipeline/cli.py
@@ -209,11 +209,11 @@ def _run_command(cfg_json_uri: str,
     if num_splits is not None and num_splits > 1:
         msg = 'Running {} command split {}/{}...'.format(
             command, split_ind + 1, num_splits)
-        click.echo(click.style(msg, fg='green'))
+        click.secho(msg, fg='green', bold=True)
         command_fn(split_ind=split_ind, num_splits=num_splits)
     else:
         msg = 'Running {} command...'.format(command)
-        click.echo(click.style(msg, fg='green'))
+        click.secho(msg, fg='green', bold=True)
         command_fn()
 
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/README.md
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/README.md
@@ -1,0 +1,80 @@
+# `test.py`
+The `test.py` script provides some useful commands for running the examples and checking their outputs.
+
+It supports the following commands:
+- `run` - run an example either remotely or locally
+- `compare` - compare the outputs of the `eval` stage of two runs of the same example
+- `collect` - dowload the output of one or more commands (like `train`, `eval`, `bundle`, etc.) produced by a run of an example
+- `predict` - download the model bundle produced by a run of an example and use it to make predictions on a sample image
+- `upload` - upload model bundle, eval, sample image, sample predictions, and training logs to the model zoo
+
+Details such as the URI's of inputs and outputs to the examples are hard-coded into the script, but can be overridden by supplying the `-o` option to any of the commands (only works when running one example at a time currently). For example: 
+```bash
+python \
+"rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+run "spacenet-rio-cc" \
+-o "remote.processed_uri" "s3://raster-vision-ahassan/rv/0.13/examples/processed/spacenet/rio" \
+-o "remote.root_uri" "s3://raster-vision-ahassan/rv/0.13/examples/output/cc/spacenet-rio/" \
+```
+
+## Usage
+
+### Run
+A specific example:
+```bash
+python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+run "spacenet-rio-cc" \
+--remote
+```
+All examples:
+```bash
+python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+run --remote
+```
+
+### Compare runs
+This currently only compares the respective `eval.json`'s, but can be extended in the future to compare other properties/outputs of the runs too.
+```bash
+python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+compare \
+"s3://raster-vision-lf-dev/examples/0.12/spacenet-rio-cc/output_6_27c/" \
+"s3://raster-vision/examples/0.13/output/spacenet-rio-cc/"
+```
+
+### Collect
+A specific example:
+```bash
+python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+collect "spacenet-rio-cc" \
+--remote
+```
+All examples:
+```bash
+python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+collect --remote
+```
+
+### Predict
+A specific example:
+```bash
+python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+predict "spacenet-rio-cc" \
+--remote
+```
+All examples:
+```bash
+python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+predict --remote
+```
+
+### Upload
+A specific example:
+```bash
+python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+upload "spacenet-rio-cc"
+```
+All examples:
+```bash
+python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
+upload
+```

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
@@ -84,9 +84,7 @@ def get_config(runner,
 
     chip_options = ObjectDetectionChipOptions(neg_ratio=1.0, ioa_thresh=0.8)
 
-    if not nochip:
-        data = ObjectDetectionImageDataConfig(img_sz=img_sz, num_workers=4)
-    else:
+    if nochip:
         window_opts = ObjectDetectionGeoDataWindowConfig(
             method=GeoDataWindowMethod.random,
             size=chip_sz,
@@ -101,6 +99,8 @@ def get_config(runner,
             window_opts=window_opts,
             img_sz=img_sz,
             augmentors=[])
+    else:
+        data = ObjectDetectionImageDataConfig(img_sz=img_sz, num_workers=4)
 
     predict_options = ObjectDetectionPredictOptions(
         merge_thresh=0.1, score_thresh=0.5)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
@@ -9,10 +9,39 @@ from rastervision.core.data import *
 from rastervision.core.analyzer import *
 from rastervision.pytorch_backend import *
 from rastervision.pytorch_learner import *
-from rastervision.pytorch_backend.examples.utils import get_scene_info, save_image_crop
+from rastervision.pytorch_backend.examples.utils import (get_scene_info,
+                                                         save_image_crop)
 
 
-def get_config(runner, raw_uri, processed_uri, root_uri, test=False):
+def get_config(runner,
+               raw_uri: str,
+               processed_uri: str,
+               root_uri: str,
+               nochip: bool = True,
+               test: bool = False) -> ObjectDetectionConfig:
+    """Generate the pipeline config for this task. This function will be called
+    by RV, with arguments from the command line, when this example is run.
+
+    Args:
+        runner (Runner): Runner for the pipeline. Will be provided by RV.
+        raw_uri (str): Directory where the raw data resides
+        processed_uri (str): Directory for storing processed data. 
+                             E.g. crops for testing.
+        root_uri (str): Directory where all the output will be written.
+        nochip (bool, optional): If True, read directly from the TIFF during
+            training instead of from pre-generated chips. The analyze and chip
+            commands should not be run, if this is set to True. Defaults to
+            False.
+        test (bool, optional): If True, does the following simplifications:
+            (1) Uses only the first 2 scenes.
+            (2) Uses only a 2000x2000 crop of the scenes.
+            (3) Enables test mode in the learner, which makes it use the
+                test_batch_sz and test_num_epochs, among other things.
+            Defaults to False.
+
+    Returns:
+        ObjectDetectionConfig: A pipeline config.
+    """
     train_scene_info = get_scene_info(join(processed_uri, 'train-scenes.csv'))
     val_scene_info = get_scene_info(join(processed_uri, 'val-scenes.csv'))
     if test:
@@ -27,7 +56,7 @@ def get_config(runner, raw_uri, processed_uri, root_uri, test=False):
         if test:
             crop_uri = join(processed_uri, 'crops',
                             os.path.basename(raster_uri))
-            save_image_crop(raster_uri, crop_uri, size=600, min_features=5)
+            save_image_crop(raster_uri, crop_uri, size=2000, min_features=5)
             raster_uri = crop_uri
 
         id = os.path.splitext(os.path.basename(raster_uri))[0]
@@ -45,17 +74,39 @@ def get_config(runner, raw_uri, processed_uri, root_uri, test=False):
     train_scenes = [make_scene(info) for info in train_scene_info]
     val_scenes = [make_scene(info) for info in val_scene_info]
     class_config = ClassConfig(names=['vehicle'], colors=['red'])
-    chip_sz = 300
-    dataset = DatasetConfig(
+    scene_dataset = DatasetConfig(
         class_config=class_config,
         train_scenes=train_scenes,
         validation_scenes=val_scenes)
+
+    chip_sz = 300
+    img_sz = chip_sz
+
     chip_options = ObjectDetectionChipOptions(neg_ratio=1.0, ioa_thresh=0.8)
+
+    if not nochip:
+        data = ObjectDetectionImageDataConfig(img_sz=img_sz, num_workers=4)
+    else:
+        window_opts = ObjectDetectionGeoDataWindowConfig(
+            method=GeoDataWindowMethod.random,
+            size=chip_sz,
+            size_lims=(chip_sz, chip_sz + 1),
+            max_windows=200,
+            clip=True,
+            neg_ratio=chip_options.neg_ratio,
+            ioa_thresh=chip_options.ioa_thresh)
+
+        data = ObjectDetectionGeoDataConfig(
+            scene_dataset=scene_dataset,
+            window_opts=window_opts,
+            img_sz=img_sz,
+            augmentors=[])
+
     predict_options = ObjectDetectionPredictOptions(
         merge_thresh=0.1, score_thresh=0.5)
 
     backend = PyTorchObjectDetectionConfig(
-        data=ObjectDetectionImageDataConfig(img_sz=chip_sz, num_workers=4),
+        data=data,
         model=ObjectDetectionModelConfig(backbone=Backbone.resnet50),
         solver=SolverConfig(
             lr=1e-4,
@@ -69,7 +120,7 @@ def get_config(runner, raw_uri, processed_uri, root_uri, test=False):
 
     return ObjectDetectionConfig(
         root_uri=root_uri,
-        dataset=dataset,
+        dataset=scene_dataset,
         backend=backend,
         train_chip_sz=chip_sz,
         predict_chip_sz=chip_sz,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
@@ -52,7 +52,7 @@ def get_config(runner,
             available in the raster source will be used. If False, only
             IR, R, G (in that order) will be used. Defaults to False.
         external_model (bool, optional): If True, use an external model defined
-            by the ExternalModuleConfig. Defaults to False.
+            by the ExternalModuleConfig. Defaults to True.
         augment (bool, optional): If True, use custom data augmentation
             transforms. Some basic data augmentation is done even if this is
             False. To completely disable, specify augmentors=[] is the dat

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
@@ -35,9 +35,9 @@ def get_config(runner,
                processed_uri: str,
                root_uri: str,
                multiband: bool = False,
-               external_model: bool = False,
+               external_model: bool = True,
                augment: bool = False,
-               nochip: bool = False,
+               nochip: bool = True,
                test: bool = False):
     """Generate the pipeline config for this task. This function will be called
     by RV, with arguments from the command line, when this example is run.
@@ -60,12 +60,12 @@ def get_config(runner,
         nochip (bool, optional): If True, read directly from the TIFF during
             training instead of from pre-generated chips. The analyze and chip
             commands should not be run, if this is set to True. Defaults to
-            False.
+            True.
         test (bool, optional): If True, does the following simplifications:
             (1) Uses only the first 2 scenes
             (2) Uses only a 600x600 crop of the scenes
             (3) Enables test mode in the learner, which makes it use the
-                test_batch_sz and test_num_epochs, and also halves the img_sz.
+                test_batch_sz and test_num_epochs, among other things.
             Defaults to False.
 
     Returns:
@@ -103,15 +103,6 @@ def get_config(runner,
         aug_transform = None
         base_transform = None
         plot_transform = None
-
-    chip_sz = 300
-    img_sz = chip_sz
-    if nochip:
-        chip_options = SemanticSegmentationChipOptions()
-    else:
-        chip_options = SemanticSegmentationChipOptions(
-            window_method=SemanticSegmentationWindowMethod.sliding,
-            stride=chip_sz)
 
     class_config = ClassConfig(names=CLASS_NAMES, colors=CLASS_COLORS)
     class_config.ensure_null_class()
@@ -162,25 +153,27 @@ def get_config(runner,
         train_scenes=[make_scene(id) for id in train_ids],
         validation_scenes=[make_scene(id) for id in val_ids])
 
+    chip_sz = 300
+    img_sz = chip_sz
+
+    chip_options = SemanticSegmentationChipOptions(
+        window_method=SemanticSegmentationWindowMethod.sliding, stride=chip_sz)
+
     if nochip:
         window_opts = {}
         # set window configs for training scenes
         for s in scene_dataset.train_scenes:
             window_opts[s.id] = GeoDataWindowConfig(
-                # method=GeoDataWindowMethod.sliding,
-                method=GeoDataWindowMethod.random,
-                size=img_sz,
-                # size_lims=(200, 300),
-                h_lims=(200, 300),
-                w_lims=(200, 300),
-                max_windows=2209,
-            )
+                method=GeoDataWindowMethod.sliding,
+                size=chip_sz,
+                stride=chip_options.stride)
+
         # set window configs for validation scenes
         for s in scene_dataset.validation_scenes:
             window_opts[s.id] = GeoDataWindowConfig(
                 method=GeoDataWindowMethod.sliding,
-                size=img_sz,
-                stride=img_sz // 2)
+                size=chip_sz,
+                stride=chip_options.stride)
 
         data = SemanticSegmentationGeoDataConfig(
             scene_dataset=scene_dataset,
@@ -188,11 +181,13 @@ def get_config(runner,
             img_sz=img_sz,
             img_channels=len(channel_order),
             num_workers=4,
-            channel_display_groups=channel_display_groups)
+            channel_display_groups=channel_display_groups,
+            base_transform=base_transform,
+            aug_transform=aug_transform,
+            plot_options=PlotOptions(transform=plot_transform))
     else:
         data = SemanticSegmentationImageDataConfig(
             img_sz=img_sz,
-            img_channels=len(channel_order),
             num_workers=4,
             channel_display_groups=channel_display_groups,
             base_transform=base_transform,
@@ -202,11 +197,11 @@ def get_config(runner,
     if external_model:
         model = SemanticSegmentationModelConfig(
             external_def=ExternalModuleConfig(
-                github_repo='AdeelH/pytorch-fpn',
+                github_repo='AdeelH/pytorch-fpn:0.2',
                 name='fpn',
-                entrypoint='make_segm_fpn_resnet',
+                entrypoint='make_fpn_resnet',
                 entrypoint_kwargs={
-                    'name': 'resnet18',
+                    'name': 'resnet50',
                     'fpn_type': 'panoptic',
                     'num_classes': len(class_config.names),
                     'fpn_channels': 256,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -85,7 +85,7 @@ def get_config(runner,
     Args:
         runner (Runner): Runner for the pipeline.
         raw_uri (str): Directory where the raw data resides
-        processed_uri (str): Directory for storing processed data. 
+        processed_uri (str): Directory for storing processed data.
                              E.g. crops for testing.
         root_uri (str): Directory where all the output will be written.
         nochip (bool, optional): If True, read directly from the TIFF during

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -1,6 +1,3 @@
-# flake8: noqa
-
-from pathlib import Path
 from functools import partial
 from typing import Tuple, Union
 
@@ -15,9 +12,11 @@ from rastervision.core.data import (
 
 from rastervision.pytorch_backend import (PyTorchSemanticSegmentationConfig,
                                           SemanticSegmentationModelConfig)
-from rastervision.pytorch_learner import (Backbone, SolverConfig)
-from rastervision.pytorch_backend.examples.utils import (get_scene_info,
-                                                         save_image_crop)
+from rastervision.pytorch_backend.examples.utils import (save_image_crop)
+from rastervision.pytorch_learner import (
+    Backbone, SolverConfig, SemanticSegmentationImageDataConfig,
+    SemanticSegmentationGeoDataConfig, GeoDataWindowConfig,
+    GeoDataWindowMethod)
 
 # -----------------------
 # Input files and paths
@@ -26,9 +25,9 @@ RGBIR_DIR = '4_Ortho_RGBIR'
 ELEVATION_DIR = 'elevation'
 LABEL_DIR = '5_Labels_for_participants'
 
-RGBIR_FNAME = lambda scene_id: f'top_potsdam_{scene_id}_RGBIR.tif'
-ELEVATION_FNAME = lambda scene_id: f'{scene_id}.jpg'
-LABEL_FNAME = lambda scene_id: f'top_potsdam_{scene_id}_label.tif'
+RGBIR_FNAME = lambda scene_id: f'top_potsdam_{scene_id}_RGBIR.tif'  # noqa
+ELEVATION_FNAME = lambda scene_id: f'{scene_id}.jpg'  # noqa
+LABEL_FNAME = lambda scene_id: f'top_potsdam_{scene_id}_label.tif'  # noqa
 
 TRAIN_IDS = [
     '2_10', '2_11', '3_10', '3_11', '4_10', '4_11', '4_12', '5_10', '5_11',
@@ -47,6 +46,7 @@ CLASS_COLORS = [
     '#ffff00', '#0000ff', '#00ffff', '#00ff00', '#ffffff', '#ff0000'
 ]
 CHIP_SIZE = 300
+CHANNEL_ORDER = [0, 1, 2, 3, 4]
 
 # -----------------
 # Training
@@ -77,6 +77,7 @@ def get_config(runner,
                raw_uri: str,
                processed_uri: str,
                root_uri: str,
+               nochip: bool = True,
                test: bool = False) -> SemanticSegmentationConfig:
     """Generate the pipeline config for this task. This function will be called
     by RV, with arguments from the command line, when this example is run.
@@ -87,7 +88,16 @@ def get_config(runner,
         processed_uri (str): Directory for storing processed data. 
                              E.g. crops for testing.
         root_uri (str): Directory where all the output will be written.
-        test (bool, optional): Whether to run in test mode. Defaults to False.
+        nochip (bool, optional): If True, read directly from the TIFF during
+            training instead of from pre-generated chips. The analyze and chip
+            commands should not be run, if this is set to True. Defaults to
+            True.
+        test (bool, optional): If True, does the following simplifications:
+            (1) Uses only the first 2 scenes
+            (2) Uses only a 600x600 crop of the scenes
+            (3) Enables test mode in the learner, which makes it use the
+                test_batch_sz and test_num_epochs, among other things.
+            Defaults to False.
 
     Returns:
         SemanticSegmentationConfig: A pipeline config.
@@ -105,17 +115,36 @@ def get_config(runner,
     # -------------------------------
     class_config = ClassConfig(names=CLASS_NAMES, colors=CLASS_COLORS)
 
-    chip_options = SemanticSegmentationChipOptions(
-        window_method=SemanticSegmentationWindowMethod.sliding,
-        stride=CHIP_SIZE)
-
     _make_scene = partial(
         make_scene, raw_uri, processed_uri, class_config, test_mode=test)
 
     dataset_config = DatasetConfig(
         class_config=class_config,
         train_scenes=[_make_scene(scene_id) for scene_id in train_ids],
-        validation_scenes=[_make_scene(scene_id) for scene_id in val_ids])
+        validation_scenes=[_make_scene(scene_id) for scene_id in val_ids],
+        img_channels=5)
+
+    chip_options = SemanticSegmentationChipOptions(
+        window_method=SemanticSegmentationWindowMethod.sliding,
+        stride=CHIP_SIZE)
+
+    if nochip:
+        window_opts = GeoDataWindowConfig(
+            method=GeoDataWindowMethod.sliding,
+            size=CHIP_SIZE,
+            stride=chip_options.stride)
+
+        data = SemanticSegmentationGeoDataConfig(
+            scene_dataset=dataset_config,
+            window_opts=window_opts,
+            img_sz=CHIP_SIZE,
+            num_workers=4,
+            channel_display_groups=CHANNEL_DISPLAY_GROUPS)
+    else:
+        data = SemanticSegmentationImageDataConfig(
+            img_sz=CHIP_SIZE,
+            num_workers=4,
+            channel_display_groups=CHANNEL_DISPLAY_GROUPS)
 
     # --------------------------------------------
     # Configure PyTorch backend and training
@@ -131,6 +160,7 @@ def get_config(runner,
         one_cycle=ONE_CYCLE)
 
     backend_config = PyTorchSemanticSegmentationConfig(
+        data=data,
         model=model_config,
         solver=solver_config,
         log_tensorboard=LOG_TENSORBOARD,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
@@ -97,7 +97,6 @@ def build_scene(spacenet_cfg: SpacenetConfig,
     image_uri = spacenet_cfg.get_raster_source_uri(id)
     label_uri = spacenet_cfg.get_geojson_uri(id)
 
-    # Need to use stats_transformer because imagery is uint16.
     raster_source = RasterioSourceConfig(
         uris=[image_uri], channel_order=channel_order)
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+from typing import Optional
 import re
 import random
 import os
@@ -90,15 +91,15 @@ class VegasBuildings(SpacenetConfig):
         return {0: ['has', 'building']}
 
 
-def build_scene(spacenet_cfg, id, channel_order=None):
+def build_scene(spacenet_cfg: SpacenetConfig,
+                id: str,
+                channel_order: Optional[list] = None) -> SceneConfig:
     image_uri = spacenet_cfg.get_raster_source_uri(id)
     label_uri = spacenet_cfg.get_geojson_uri(id)
 
     # Need to use stats_transformer because imagery is uint16.
     raster_source = RasterioSourceConfig(
-        uris=[image_uri],
-        channel_order=channel_order,
-        transformers=[StatsTransformerConfig()])
+        uris=[image_uri], channel_order=channel_order)
 
     # Set a line buffer to convert line strings to polygons.
     vector_source = GeoJSONVectorSourceConfig(
@@ -111,11 +112,8 @@ def build_scene(spacenet_cfg, id, channel_order=None):
             vector_source=vector_source,
             rasterizer_config=RasterizerConfig(background_class_id=1)))
 
-    # Generate polygon output for segmented buildings.
-    label_store = None
-    if isinstance(spacenet_cfg, VegasBuildings):
-        label_store = SemanticSegmentationLabelStoreConfig(
-            vector_output=[PolygonVectorOutputConfig(class_id=0, denoise=3)])
+    label_store = SemanticSegmentationLabelStoreConfig(
+        vector_output=[PolygonVectorOutputConfig(class_id=0, denoise=3)])
 
     return SceneConfig(
         id=id,
@@ -124,7 +122,34 @@ def build_scene(spacenet_cfg, id, channel_order=None):
         label_store=label_store)
 
 
-def get_config(runner, raw_uri, root_uri, target=BUILDINGS, test=False):
+def get_config(runner,
+               raw_uri: str,
+               root_uri: str,
+               target: str = BUILDINGS,
+               nochip: bool = True,
+               test: bool = False) -> SemanticSegmentationConfig:
+    """Generate the pipeline config for this task. This function will be called
+    by RV, with arguments from the command line, when this example is run.
+
+    Args:
+        runner (Runner): Runner for the pipeline. Will be provided by RV.
+        raw_uri (str): Directory where the raw data resides
+        root_uri (str): Directory where all the output will be written.
+        target (str): "buildings" | "roads". Defaults to "buildings".
+        nochip (bool, optional): If True, read directly from the TIFF during
+            training instead of from pre-generated chips. The analyze and chip
+            commands should not be run, if this is set to True. Defaults to
+            True.
+        test (bool, optional): If True, does the following simplifications:
+            (1) Uses only a small subset of training and validation scenes.
+            (2) Enables test mode in the learner, which makes it use the
+                test_batch_sz and test_num_epochs, among other things.
+            Defaults to False.
+
+    Returns:
+        SemanticSegmentationConfig: An pipeline config.
+    """
+
     spacenet_cfg = SpacenetConfig.create(raw_uri, target)
     scene_ids = spacenet_cfg.get_scene_ids()
     if len(scene_ids) == 0:
@@ -138,18 +163,16 @@ def get_config(runner, raw_uri, root_uri, target=BUILDINGS, test=False):
     # Workaround to handle scene 1000 missing on S3.
     if '1000' in scene_ids:
         scene_ids.remove('1000')
+
     split_ratio = 0.8
     num_train_ids = round(len(scene_ids) * split_ratio)
-    train_ids = scene_ids[0:num_train_ids]
+    train_ids = scene_ids[:num_train_ids]
     val_ids = scene_ids[num_train_ids:]
 
-    num_train_scenes = len(train_ids)
-    num_val_scenes = len(val_ids)
     if test:
-        num_train_scenes = 16
-        num_val_scenes = 4
-    train_ids = train_ids[0:num_train_scenes]
-    val_ids = val_ids[0:num_val_scenes]
+        train_ids = train_ids[:16]
+        val_ids = val_ids[:4]
+
     channel_order = [0, 1, 2]
 
     class_config = spacenet_cfg.get_class_config()
@@ -164,23 +187,31 @@ def get_config(runner, raw_uri, root_uri, target=BUILDINGS, test=False):
         train_scenes=train_scenes,
         validation_scenes=val_scenes)
 
-    train_chip_sz = 325
-    predict_chip_sz = 650
-    chip_options = SemanticSegmentationChipOptions(
-        window_method=SemanticSegmentationWindowMethod.sliding,
-        stride=train_chip_sz)
-    num_epochs = 5
+    chip_sz = 325
+    img_sz = chip_sz
 
-    img_sz = train_chip_sz
-    data = SemanticSegmentationImageDataConfig(
-        img_sz=img_sz, img_channels=len(channel_order), num_workers=4)
+    chip_options = SemanticSegmentationChipOptions(
+        window_method=SemanticSegmentationWindowMethod.sliding, stride=chip_sz)
+
+    if nochip:
+        data = SemanticSegmentationGeoDataConfig(
+            scene_dataset=scene_dataset,
+            window_opts=GeoDataWindowConfig(
+                method=GeoDataWindowMethod.sliding,
+                size=chip_sz,
+                stride=chip_options.stride),
+            img_sz=img_sz,
+            num_workers=4)
+    else:
+        data = SemanticSegmentationImageDataConfig(
+            img_sz=img_sz, num_workers=4)
 
     backend = PyTorchSemanticSegmentationConfig(
         data=data,
         model=SemanticSegmentationModelConfig(backbone=Backbone.resnet50),
         solver=SolverConfig(
             lr=1e-4,
-            num_epochs=num_epochs,
+            num_epochs=5,
             test_num_epochs=2,
             batch_sz=8,
             one_cycle=True),
@@ -192,6 +223,7 @@ def get_config(runner, raw_uri, root_uri, target=BUILDINGS, test=False):
         root_uri=root_uri,
         dataset=scene_dataset,
         backend=backend,
-        train_chip_sz=train_chip_sz,
-        predict_chip_sz=predict_chip_sz,
+        train_chip_sz=chip_sz,
+        predict_chip_sz=chip_sz,
+        img_format='npy',
         chip_options=chip_options)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
@@ -368,7 +368,7 @@ def _predict(exp_cfg: dict, collect_dir: str) -> None:
         exit(1)
 
     pred_dir = join(collect_dir, 'sample-predictions')
-    sample_uri = exp_cfg["sample_img"]
+    sample_uri = exp_cfg['sample_img']
     _, sample_ext = splitext(basename(sample_uri))
     sample_final_uri = join(pred_dir, f'sample-img-{key}{sample_ext}')
     if not exists(sample_final_uri):

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
@@ -532,6 +532,8 @@ def flatten_dict(d: Union[dict, list], sep: str = '.') -> dict:
             if isinstance(v, dict):
                 for _k, _v in v.items():
                     flat_d[f'{i}{sep}{_k}'] = _v
+            else:
+                flat_d[i] = v
     else:
         for k, v in d.items():
             v = flatten_dict(v)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
@@ -1,149 +1,337 @@
-# flake8: noqa
-
-import pprint
+from genericpath import exists
+import os
+from typing import List, Optional, Union
+from pprint import pformat
 import subprocess
-from os.path import join, basename, dirname
+from os.path import basename, isdir, isfile, join, normpath, relpath, splitext
+from tempfile import TemporaryDirectory
+import shutil
 
 import click
 
-from rastervision.pipeline.file_system import (
-    list_paths, download_or_copy, file_exists, make_dir, file_to_json)
+from rastervision.pipeline.file_system import (file_to_json, sync_from_dir,
+                                               upload_or_copy)
+from rastervision.pipeline.file_system.utils import (download_or_copy,
+                                                     sync_to_dir)
 
-# Configuration for the examples. Each key is the name of the example.
+EXAMPLES_MODULE_ROOT = 'rastervision.pytorch_backend.examples'
+EXAMPLES_PATH_ROOT = ('/opt/src/rastervision_pytorch_backend/'
+                      'rastervision/pytorch_backend/examples')
+REMOTE_PROCESSED_ROOT = 's3://raster-vision/examples/0.13/processed-data'
+REMOTE_OUTPUT_ROOT = 's3://raster-vision/examples/0.13/output'
+LOCAL_RAW_ROOT = '/opt/data/raw-data'
+LOCAL_PROCESSED_ROOT = '/opt/data/examples/processed-data'
+LOCAL_OUTPUT_ROOT = '/opt/data/examples/output'
+LOCAL_COLLECT_ROOT = '/opt/data/examples/collect'
+ZOO_UPLOAD_ROOT = (
+    's3://azavea-research-public-data/raster-vision/examples/model-zoo-0.13')
+SAMPLE_IMG_ROOT = (
+    's3://azavea-research-public-data/raster-vision/examples/model-zoo-0.12')
+
+######################
+# Default configuration for the examples.
+# Each key is the name of the example.
+######################
 cfg = [
     {
-        'key':
-        'spacenet-rio-cc',
-        'module':
-        'rastervision.pytorch_backend.examples.chip_classification.spacenet_rio',
+        'key': 'spacenet-rio-cc',
+        'task': 'cc',
+        'pred_ext': '.json',
+        'module': f'{EXAMPLES_MODULE_ROOT}.chip_classification.spacenet_rio',
         'local': {
-            'raw_uri': '/opt/data/raw-data/spacenet-dataset',
-            'processed_uri': '/opt/data/examples/spacenet/rio/processed-data',
-            'root_uri': '/opt/data/examples/spacenet-rio-cc'
+            'raw_uri': f'{LOCAL_RAW_ROOT}/spacenet-dataset',
+            'processed_uri': f'{LOCAL_PROCESSED_ROOT}/spacenet-rio-cc',
+            'root_uri': f'{LOCAL_OUTPUT_ROOT}/spacenet-rio-cc'
         },
         'remote': {
-            'raw_uri':
-            's3://spacenet-dataset/',
-            'processed_uri':
-            's3://raster-vision-lf-dev/examples/spacenet/rio/processed-data',
-            'root_uri':
-            's3://raster-vision-lf-dev/examples/spacenet-rio-cc'
+            'raw_uri': 's3://spacenet-dataset/',
+            'processed_uri': f'{REMOTE_PROCESSED_ROOT}/spacenet-rio-cc',
+            'root_uri': f'{REMOTE_OUTPUT_ROOT}/spacenet-rio-cc'
         },
         'sample_img':
-        'https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo-0.12/spacenet-rio-cc/013022223130_sample.tif'
+        f'{SAMPLE_IMG_ROOT}/spacenet-rio-cc/013022223130_sample.tif'
     },
     {
-        'key':
-        'isprs-potsdam-ss',
+        'key': 'isprs-potsdam-ss',
+        'task': 'ss',
+        'pred_ext': '',
         'module':
-        'rastervision.pytorch_backend.examples.semantic_segmentation.isprs_potsdam',
+        f'{EXAMPLES_MODULE_ROOT}.semantic_segmentation.isprs_potsdam',
         'local': {
-            'raw_uri': '/opt/data/raw-data/isprs-potsdam/',
-            'processed_uri': '/opt/data/examples/potsdam/processed-data',
-            'root_uri': '/opt/data/examples/isprs-potsdam-ss/'
+            'raw_uri': f'{LOCAL_RAW_ROOT}/isprs-potsdam/',
+            'processed_uri': f'{LOCAL_PROCESSED_ROOT}/isprs-potsdam-ss',
+            'root_uri': f'{LOCAL_OUTPUT_ROOT}/isprs-potsdam-ss/'
         },
         'remote': {
-            'raw_uri':
-            's3://raster-vision-raw-data/isprs-potsdam',
-            'processed_uri':
-            's3://raster-vision-lf-dev/examples/potsdam/processed-data',
-            'root_uri':
-            's3://raster-vision-lf-dev/examples/isprs-potsdam-ss'
+            'raw_uri': 's3://raster-vision-raw-data/isprs-potsdam',
+            'processed_uri': f'{REMOTE_PROCESSED_ROOT}/isprs-potsdam-ss',
+            'root_uri': f'{REMOTE_OUTPUT_ROOT}/isprs-potsdam-ss'
         },
-        'sample_img':
-        'https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo-0.12/isprs-potsdam-ss/3_12_sample.tif'
+        'sample_img': f'{SAMPLE_IMG_ROOT}/isprs-potsdam-ss/3_12_sample.tif'
     },
     {
-        'key':
-        'spacenet-vegas-buildings-ss',
+        'key': 'spacenet-vegas-buildings-ss',
+        'task': 'ss',
+        'pred_ext': '',
         'module':
-        'rastervision.pytorch_backend.examples.semantic_segmentation.spacenet_vegas',
+        f'{EXAMPLES_MODULE_ROOT}.semantic_segmentation.spacenet_vegas',
         'local': {
             'raw_uri': 's3://spacenet-dataset/',
-            'root_uri': '/opt/data/examples/spacenet-vegas-buildings-ss'
+            'root_uri': f'{LOCAL_OUTPUT_ROOT}/spacenet-vegas-buildings-ss'
         },
         'remote': {
-            'raw_uri':
-            's3://spacenet-dataset/',
-            'root_uri':
-            's3://raster-vision-lf-dev/examples/spacenet-vegas-buildings-ss'
+            'raw_uri': 's3://spacenet-dataset/',
+            'root_uri': f'{REMOTE_OUTPUT_ROOT}/spacenet-vegas-buildings-ss'
         },
         'extra_args': [['target', 'buildings']],
-        'sample_img':
-        'https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo-0.12/spacenet-vegas-buildings-ss/1929.tif'
+        'sample_img': f'{SAMPLE_IMG_ROOT}/spacenet-vegas-buildings-ss/1929.tif'
     },
     {
-        'key':
-        'spacenet-vegas-roads-ss',
+        'key': 'spacenet-vegas-roads-ss',
+        'task': 'ss',
+        'pred_ext': '',
         'module':
-        'rastervision.pytorch_backend.examples.semantic_segmentation.spacenet_vegas',
+        f'{EXAMPLES_MODULE_ROOT}.semantic_segmentation.spacenet_vegas',
         'local': {
             'raw_uri': 's3://spacenet-dataset/',
-            'root_uri': '/opt/data/examples/spacenet-vegas-roads-ss'
+            'root_uri': f'{LOCAL_OUTPUT_ROOT}/spacenet-vegas-roads-ss'
         },
         'remote': {
-            'raw_uri':
-            's3://spacenet-dataset/',
-            'root_uri':
-            's3://raster-vision-lf-dev/examples/spacenet-vegas-roads-ss'
+            'raw_uri': 's3://spacenet-dataset/',
+            'root_uri': f'{REMOTE_OUTPUT_ROOT}/spacenet-vegas-roads-ss'
         },
         'extra_args': [['target', 'roads']],
-        'sample_img':
-        'https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo-0.12/spacenet-vegas-roads-ss/524.tif'
+        'sample_img': f'{SAMPLE_IMG_ROOT}/spacenet-vegas-roads-ss/524.tif'
     },
     {
-        'key':
-        'cowc-potsdam-od',
-        'module':
-        'rastervision.pytorch_backend.examples.object_detection.cowc_potsdam',
+        'key': 'cowc-potsdam-od',
+        'task': 'od',
+        'pred_ext': '.json',
+        'module': f'{EXAMPLES_MODULE_ROOT}.object_detection.cowc_potsdam',
         'local': {
-            'raw_uri': '/opt/data/raw-data/isprs-potsdam',
-            'processed_uri': '/opt/data/examples/cowc-potsdam/processed-data',
-            'root_uri': '/opt/data/examples/cowc-potsdam-od'
+            'raw_uri': f'{LOCAL_RAW_ROOT}/isprs-potsdam',
+            'processed_uri': f'{LOCAL_PROCESSED_ROOT}/cowc-potsdam-od',
+            'root_uri': f'{LOCAL_OUTPUT_ROOT}/cowc-potsdam-od'
         },
         'remote': {
-            'raw_uri':
-            's3://raster-vision-raw-data/isprs-potsdam',
-            'processed_uri':
-            's3://raster-vision-lf-dev/examples/cowc-potsdam/processed-data',
-            'root_uri':
-            's3://raster-vision-lf-dev/examples/cowc-potsdam-od'
+            'raw_uri': 's3://raster-vision-raw-data/isprs-potsdam',
+            'processed_uri': f'{REMOTE_PROCESSED_ROOT}/cowc-potsdam-od',
+            'root_uri': f'{REMOTE_OUTPUT_ROOT}/cowc-potsdam-od'
         },
-        'sample_img':
-        'https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo-0.12/cowc-potsdam-od/3_10_sample.tif'
+        'sample_img': f'{SAMPLE_IMG_ROOT}/cowc-potsdam-od/3_10_sample.tif'
     },
     {
-        'key':
-        'xview-od',
-        'module':
-        'rastervision.pytorch_backend.examples.object_detection.xview',
+        'key': 'xview-od',
+        'task': 'od',
+        'pred_ext': '.json',
+        'module': f'{EXAMPLES_MODULE_ROOT}.object_detection.xview',
         'local': {
             'raw_uri': 's3://raster-vision-xview-example/raw-data',
-            'processed_uri': '/opt/data/examples/xview/processed-data',
-            'root_uri': '/opt/data/examples/xview-od'
+            'processed_uri': f'{LOCAL_PROCESSED_ROOT}/xview-od',
+            'root_uri': f'{LOCAL_OUTPUT_ROOT}/xview-od'
         },
         'remote': {
-            'raw_uri':
-            's3://raster-vision-xview-example/raw-data',
-            'processed_uri':
-            's3://raster-vision-lf-dev/examples/xview/processed-data',
-            'root_uri':
-            's3://raster-vision-lf-dev/examples/xview-od'
+            'raw_uri': 's3://raster-vision-xview-example/raw-data',
+            'processed_uri': f'{REMOTE_PROCESSED_ROOT}/xview-od',
+            'root_uri': f'{REMOTE_OUTPUT_ROOT}/xview-od'
         },
-        'sample_img':
-        'https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo-0.12/xview-od/1124-sample.tif'
+        'sample_img': f'{SAMPLE_IMG_ROOT}/xview-od/1124-sample.tif'
     },
 ]
 
 
-def validate_keys(keys):
-    exp_keys = [exp_cfg['key'] for exp_cfg in cfg]
-    invalid_keys = set(keys).difference(exp_keys)
-    if invalid_keys:
-        raise ValueError('{} are invalid keys'.format(', '.join(invalid_keys)))
+######################
+# commands
+######################
+@click.group()
+def test():
+    pass
 
 
-def _run(exp_cfg, output_dir, test=True, remote=False, commands=None):
+# --------------------
+# run
+# --------------------
+@test.command()
+@click.argument('keys', nargs=-1)
+@click.option('--test', is_flag=True, help='Do short test run')
+@click.option('--remote', is_flag=True, default=False)
+@click.option(
+    '--commands',
+    help='Space-separated string with RV commansd to run.',
+    default=None)
+@click.option(
+    '--overrides',
+    '-o',
+    type=(str, str),
+    multiple=True,
+    metavar='KEY VALUE',
+    default=[],
+    help='Override experiment config.')
+def run(keys=[], test=True, remote=False, commands=None, overrides=[]):
+    """Run RV on a set of examples.
+
+    Args:
+        keys: the names of the examples.
+    """
+    overrides = dict(overrides)
+
+    run_all = len(keys) == 0
+    validate_keys(keys)
+
+    if commands is not None:
+        commands = commands.split(' ')
+    for exp_cfg in cfg:
+        if run_all or exp_cfg['key'] in keys:
+            if len(keys) == 1:
+                override_cfg(exp_cfg, overrides)
+            _run(exp_cfg, test=test, remote=remote, commands=commands)
+
+
+# --------------------
+# collect
+# --------------------
+@test.command()
+@click.argument('keys', nargs=-1)
+@click.option('--collect_dir', default=LOCAL_COLLECT_ROOT)
+@click.option('--remote', is_flag=True)
+@click.option(
+    '--commands',
+    '-c',
+    help='Space-separated string with RV commansd to run.',
+    default=None)
+@click.option(
+    '--overrides',
+    '-o',
+    type=(str, str),
+    multiple=True,
+    metavar='KEY VALUE',
+    default=[],
+    help='Override experiment config.')
+def collect(keys, collect_dir, remote, commands, overrides=[]):
+    """Download outputs of commands for each example. By default, only
+    downloads eval and bundle.
+    """
+    overrides = dict(overrides)
+    if commands is None:
+        commands = ['eval', 'bundle']
+    else:
+        commands = commands.split(' ')
+
+    run_all = len(keys) == 0
+    validate_keys(keys)
+
+    dirs = {}
+    for exp_cfg in cfg:
+        key = exp_cfg['key']
+        if run_all or key in keys:
+            if len(keys) == 1:
+                override_cfg(exp_cfg, overrides)
+            dirs[key] = {}
+            uris = exp_cfg['remote'] if remote else exp_cfg['local']
+            root_uri = uris['root_uri']
+            for cmd in commands:
+                dirs[key][cmd] = fetch_cmd_dir(root_uri, cmd,
+                                               join(collect_dir, key))
+    console_info(pformat(dirs))
+
+
+# --------------------
+# predict
+# --------------------
+@test.command()
+@click.argument('keys', nargs=-1)
+@click.option('--collect_dir', default=LOCAL_COLLECT_ROOT)
+@click.option('--remote', is_flag=True)
+@click.option(
+    '--overrides',
+    '-o',
+    type=(str, str),
+    multiple=True,
+    metavar='KEY VALUE',
+    default=[],
+    help='Override experiment config.')
+def predict(keys, collect_dir, remote, overrides=[]):
+    """Test model bundles using predict command using output of collect command."""
+    overrides = dict(overrides)
+
+    run_all = len(keys) == 0
+    validate_keys(keys)
+
+    for exp_cfg in cfg:
+        key = exp_cfg['key']
+        if run_all or key in keys:
+            if len(keys) == 1:
+                override_cfg(exp_cfg, overrides)
+            uris = exp_cfg['remote'] if remote else exp_cfg['local']
+            root_uri = uris['root_uri']
+            _collect_dir = join(collect_dir, key)
+            fetch_cmd_dir(root_uri, 'bundle', _collect_dir)
+            _predict(exp_cfg, _collect_dir)
+
+
+# --------------------
+# compare
+# --------------------
+@test.command()
+@click.argument('root_uri_old')
+@click.argument('root_uri_new')
+@click.option('--download_dir', '-d', default=None)
+def compare(root_uri_old: str, root_uri_new: str,
+            download_dir: Optional[str]) -> None:
+    """Compare different runs of the same example."""
+    if root_uri_old != '/':
+        root_uri_old = root_uri_old.rstrip('/')
+    if root_uri_new != '/':
+        root_uri_new = root_uri_new.rstrip('/')
+    if download_dir is not None:
+        return _compare_runs(root_uri_old, root_uri_new, download_dir)
+
+    with TemporaryDirectory(dir='/opt/data/tmp') as tmp_dir:
+        return _compare_runs(root_uri_old, root_uri_new, tmp_dir)
+
+
+# --------------------
+# upload to model zoo
+# --------------------
+@test.command()
+@click.argument('keys', nargs=-1)
+@click.option('--collect_dir', default=LOCAL_COLLECT_ROOT)
+@click.option('--upload_dir', default=ZOO_UPLOAD_ROOT)
+@click.option(
+    '--overrides',
+    '-o',
+    type=(str, str),
+    multiple=True,
+    metavar='KEY VALUE',
+    default=[],
+    help='Override experiment config.')
+def upload(keys, collect_dir, upload_dir, overrides=[]):
+    """Upload eval, bundle, and sample predictions to the target dir."""
+    overrides = dict(overrides)
+
+    run_all = len(keys) == 0
+    validate_keys(keys)
+
+    for exp_cfg in cfg:
+        key = exp_cfg['key']
+        if run_all or key in keys:
+            if len(keys) == 1:
+                override_cfg(exp_cfg, overrides)
+            _collect_dir = join(collect_dir, key)
+            _upload_dir = join(upload_dir, key)
+            _upload_to_zoo(exp_cfg, _collect_dir, _upload_dir)
+
+
+######################
+# utils
+######################
+def _run(exp_cfg: dict,
+         test: bool = True,
+         remote: bool = False,
+         commands: List[str] = None) -> None:
+    """Builds a command from the params in exp_cfg and otehr arguments and
+    then executes it.
+    """
     uris = exp_cfg['remote'] if remote else exp_cfg['local']
     cmd = ['rastervision']
     rv_profile = exp_cfg.get('rv_profile')
@@ -155,8 +343,7 @@ def _run(exp_cfg, output_dir, test=True, remote=False, commands=None):
     cmd += ['-a', 'raw_uri', uris['raw_uri']]
     if 'processed_uri' in uris:
         cmd += ['-a', 'processed_uri', uris['processed_uri']]
-    root_uri = join(uris['root_uri'], output_dir)
-    cmd += ['-a', 'root_uri', root_uri]
+    cmd += ['-a', 'root_uri', uris['root_uri']]
     cmd += ['-a', 'test', 'True' if test else 'False']
     extra_args = exp_cfg.get('extra_args')
     if extra_args:
@@ -164,128 +351,273 @@ def _run(exp_cfg, output_dir, test=True, remote=False, commands=None):
             cmd += ['-a', str(k), str(v)]
     if remote:
         cmd += ['--splits', '3']
+    cmd += ['--pipeline-run-name', exp_cfg['key']]
+    run_command(cmd)
 
-    print('running command:')
-    print(' '.join(cmd))
+
+def _predict(exp_cfg: dict, collect_dir: str) -> None:
+    """Download sample image and make predictions on it using the model bundle.
+    """
+    key = exp_cfg['key']
+    console_heading(f'Testing model bundle for {key}...')
+
+    model_bundle_uri = join(collect_dir, 'bundle', 'model-bundle.zip')
+    if not exists(model_bundle_uri):
+        console_failure(
+            f'Bundle does not exist: {model_bundle_uri}', bold=True)
+        exit(1)
+
+    pred_dir = join(collect_dir, 'sample-predictions')
+    sample_uri = exp_cfg["sample_img"]
+    _, sample_ext = splitext(basename(sample_uri))
+    sample_final_uri = join(pred_dir, f'sample-img-{key}{sample_ext}')
+    if not exists(sample_final_uri):
+        # downloads to <pred_dir>/[s3|http]/.../<sample> and returns that path
+        sample_downloaded_uri = download_or_copy(sample_uri, pred_dir)
+        # ... also copies <sample> to <pred_dir>/<sample>
+        sample_copied_uri = join(pred_dir, basename(sample_uri))
+        # delete  <pred_dir>/[s3|http]/
+        dl_dir = normpath(relpath(sample_downloaded_uri,
+                                  pred_dir)).split(os.sep)[0]
+        shutil.rmtree(join(pred_dir, dl_dir))
+        # rename <sample>
+        if sample_copied_uri != sample_final_uri:
+            os.rename(sample_copied_uri, sample_final_uri)
+
+    pred_ext = exp_cfg['pred_ext']
+    out_uri = join(pred_dir, f'sample-pred-{key}{pred_ext}')
+    cmd = [
+        'rastervision', 'predict', model_bundle_uri, sample_final_uri, out_uri
+    ]
+    run_command(cmd)
+
+
+def _upload_to_zoo(exp_cfg: dict, collect_dir: str, upload_dir: str) -> None:
+    src_uris = {}
+    dst_uris = {}
+
+    src_uris['eval'] = join(collect_dir, 'eval', 'eval.json')
+    src_uris['bundle'] = join(collect_dir, 'bundle', 'model-bundle.zip')
+    src_uris['sample_predictions'] = join(collect_dir, 'sample-predictions')
+
+    dst_uris['eval'] = join(upload_dir, 'eval.json')
+    dst_uris['bundle'] = join(upload_dir, 'model-bundle.zip')
+    dst_uris['sample_predictions'] = join(upload_dir, 'sample-predictions')
+
+    assert len(src_uris) == len(dst_uris)
+
+    for k, src in src_uris.items():
+        dst = dst_uris[k]
+        if not exists(src):
+            console_failure(f'{k}: {src} not found.')
+        if isfile(src):
+            console_info(f'Uploading {k} file: {src} to {dst}.')
+            upload_or_copy(src, dst)
+        elif isdir(src):
+            console_info(f'Syncing {k} dir: {src} to {dst}.')
+            sync_to_dir(src, dst)
+        else:
+            raise ValueError()
+
+
+def _compare_runs(root_uri_old: str,
+                  root_uri_new: str,
+                  download_dir: Optional[str],
+                  commands=['eval']) -> None:
+    """Compare outputs of commands for two runs of an example.
+    Currently only supports eval, but can be extended to include others.
+    """
+    for cmd in commands:
+        key_old = basename(root_uri_old)
+        key_new = basename(root_uri_new)
+        cmd_root_uri_old_local = fetch_cmd_dir(root_uri_old, cmd,
+                                               join(download_dir, key_old))
+        cmd_root_uri_new_local = fetch_cmd_dir(root_uri_new, cmd,
+                                               join(download_dir, key_new))
+        if cmd == 'eval':
+            _compare_evals(cmd_root_uri_old_local, cmd_root_uri_new_local)
+
+
+def _compare_evals(
+        root_uri_old: str,
+        root_uri_new: str,
+        float_tol: float = 1e-3,
+        exclude_keys: list = ['conf_mat', 'count_error', 'per_scene']) -> None:
+    """Compare outputs of the eval command for two runs of an example."""
+    console_heading('Comparing keys and values in eval.json files...')
+    eval_json_old = join(root_uri_old, 'eval.json')
+    eval_json_new = join(root_uri_new, 'eval.json')
+    eval_old = file_to_json(eval_json_old)
+    eval_new = file_to_json(eval_json_new)
+    _compare_dicts(
+        eval_old, eval_new, float_tol=float_tol, exclude_keys=exclude_keys)
+
+
+def validate_keys(keys: List[str]) -> None:
+    exp_keys = [exp_cfg['key'] for exp_cfg in cfg]
+    invalid_keys = set(keys).difference(exp_keys)
+    if invalid_keys:
+        raise ValueError('{} are invalid keys'.format(', '.join(invalid_keys)))
+
+
+def run_command(cmd: str) -> None:
+    """Run a command in a sub-process."""
+    cmd_str = ' '.join(cmd)
+    console_info(f'Running command:\n{cmd_str}')
     proc = subprocess.run(cmd)
     if proc.returncode != 0:
-        print('failure!')
-        print(' '.join(cmd))
+        console_failure(
+            f'Error: process returned {proc.returncode}', bold=True)
         exit()
 
 
-@click.group()
-def test():
-    pass
+def override_cfg(cfg: dict, overrides: dict, sep='.') -> None:
+    """Recursively update values in cfg with corresponding values in
+    overrides. overrides is expected to be a flattened dict.
+    """
+    for key_path, v in overrides.items():
+        _cfg = cfg
+        key_crumbs = key_path.split(sep)
+        for _k in key_crumbs[:-1]:
+            _cfg = _cfg[_k]
+        _cfg[key_crumbs[-1]] = v
 
 
-@test.command()
-@click.argument('output_dir')
-@click.argument('keys', nargs=-1)
-@click.option('--test', is_flag=True, help='Do short test run')
-@click.option('--remote', is_flag=True)
-@click.option(
-    '--commands', help='Space-separated string with RV commansd to run.')
-def run(output_dir, keys, test, remote, commands):
-    """Run RV on a set of examples.
+def to_local_uri(uri: str, local_root: str, full_path: bool = False) -> str:
+    """Convert an S3 URI to a suitable local URI. Do nothing if the URI is
+    already local.
+    """
+    if uri.startswith('s3://'):
+        if full_path:
+            uri = join(local_root, relpath(uri, 's3://'))
+        else:
+            uri = join(local_root, basename(uri))
+    return uri
+
+
+def fetch_cmd_dir(root_uri: str, cmd: str, download_dir: str) -> str:
+    """Download the output directory of a particular RV command, located at
+    root_uri/cmd (e.g. root_uri/eval) to the download_dir directory.
+    """
+    cmd_root_uri = join(root_uri, cmd)
+    console_info(f'Fetching {cmd} directory: {cmd_root_uri}')
+    cmd_root_uri_local = to_local_uri(
+        cmd_root_uri, download_dir, full_path=False)
+    sync_from_dir(cmd_root_uri, cmd_root_uri_local)
+    return cmd_root_uri_local
+
+
+def flatten_dict(d: Union[dict, list], sep: str = '.') -> dict:
+    """Flatten a dict so that it does not have any nested dicts or lists.
+    Nested keys will ba concatenated using the separator, sep. For example,
+    {'a': {'b': ['x', 10]}} becomes {'a.b.0': 'x', 'a.b.1': 10}.
+    This makes it simpler to compare dicts.
 
     Args:
-        keys: the names of the examples.
+        d (Union[dict, list]): A dict or list.
+        sep (str, optional): Separator to use for concatenating nested keys.
+            Defaults to '.'.
+
+    Returns:
+        dict: The flattened dict.
     """
-    run_all = len(keys) == 0
-    validate_keys(keys)
+    if not isinstance(d, (dict, list)):
+        return d
 
-    if commands is not None:
-        commands = commands.split(' ')
-    for exp_cfg in cfg:
-        if run_all or exp_cfg['key'] in keys:
-            _run(
-                exp_cfg,
-                output_dir,
-                test=test,
-                remote=remote,
-                commands=commands)
+    flat_d = {}
 
-
-def _collect(key, root_uri, output_dir, collect_dir, get_model_bundle=False):
-    print('\nCollecting experiment {}...\n'.format(key))
-
-    model_bundle_uri = join(root_uri, output_dir, 'bundle', 'model-bundle.zip')
-    eval_uri = join(root_uri, output_dir, 'eval', 'eval.json')
-
-    if not file_exists(eval_uri):
-        print('Missing eval!')
-        return
-
-    if not file_exists(model_bundle_uri):
-        print('Missing model bundle!')
-        return
-
-    make_dir(join(collect_dir, key))
-    if get_model_bundle:
-        download_or_copy(model_bundle_uri, join(collect_dir, key))
-
-    download_or_copy(eval_uri, join(collect_dir, key))
-
-    eval_json = file_to_json(join(collect_dir, key, 'eval.json'))
-    pprint.pprint(eval_json['overall'], indent=4)
+    if isinstance(d, list):
+        for i, v in enumerate(d):
+            v = flatten_dict(v)
+            if isinstance(v, dict):
+                for _k, _v in v.items():
+                    flat_d[f'{i}{sep}{_k}'] = _v
+    else:
+        for k, v in d.items():
+            v = flatten_dict(v)
+            if isinstance(v, dict):
+                for _k, _v in v.items():
+                    flat_d[f'{k}{sep}{_k}'] = _v
+            else:
+                flat_d[k] = v
+    return flat_d
 
 
-@test.command()
-@click.argument('output_dir')
-@click.argument('collect_dir')
-@click.argument('keys', nargs=-1)
-@click.option('--remote', is_flag=True)
-@click.option('--get-model-bundle', is_flag=True)
-def collect(output_dir, collect_dir, keys, remote, get_model_bundle):
-    """Download eval and optionally model bundle for each example."""
-    run_all = len(keys) == 0
-    validate_keys(keys)
+def _compare_dicts(dict_old: dict,
+                   dict_new: dict,
+                   float_tol: float = 1e-3,
+                   exclude_keys: list = []) -> None:
+    """Compare the keys and vaues of the two dicts.
 
-    for exp_cfg in cfg:
-        if run_all or exp_cfg['key'] in keys:
-            key = exp_cfg['key']
-            uris = exp_cfg['remote'] if remote else exp_cfg['local']
-            root_uri = uris['root_uri']
-            _collect(key, root_uri, output_dir, collect_dir, get_model_bundle)
+    Args:
+        dict_old (dict): A dict.
+        dict_new (dict): A dict.
+        float_tol (float, optional): Count float values as different if the
+            abs difference exceeds this threshold. Defaults to 1e-3.
+        exclude_keys (list, optional): Ignore the following keys when
+            comparing values. Defaults to [].
+    """
+    dict_old = flatten_dict(dict_old)
+    dict_new = flatten_dict(dict_new)
+    keys_old, keys_new = set(dict_old.keys()), set(dict_new.keys())
+    diff1, diff2 = keys_new - keys_old, keys_old - keys_new
+    if len(diff1) > 0:
+        console_failure(f'Missing keys in old: {keys_new - keys_old}')
+    if len(diff2) > 0:
+        console_failure(f'Missing keys in new: {keys_old - keys_new}')
+    if len(diff1) + len(diff2) == 0:
+        console_success(f'All keys match')
+    intersection = keys_old.intersection(keys_new)
+    if len(intersection) == 0:
+        console_failure('No matching keys found:')
+    else:
+        console_success(f'{len(intersection)} matching keys found')
+    diff_count = 0
+    console_info(f'Ignoring keys that contain {exclude_keys}')
+    console_info(f'Float comparison tolerance: {float_tol}')
+    for k in sorted(intersection):
+        if any(_k in k for _k in exclude_keys):
+            continue
+        v_old, v_new = dict_old[k], dict_new[k]
+        if isinstance(v_new, float):
+            if abs(v_new - v_old) > float_tol:
+                diff_count += 1
+                console_failure(
+                    f'diff: {k}: '
+                    f'{v_new:.6f} - {v_old:.6f}  = {v_new - v_old:.6f}')
+        elif isinstance(v_new, int):
+            if v_old != v_new:
+                diff_count += 1
+                console_failure(
+                    f'diff: {k}: {v_new} - {v_old}  = {v_new - v_old}')
+        else:
+            if v_old != v_new:
+                diff_count += 1
+                console_failure(f'diff: {k}: {v_new} != {v_old}')
+    if diff_count > 0:
+        console_failure(f'Number of non-matching values: {diff_count}')
+    else:
+        console_success(f'All values within tolerance')
 
 
-def _predict(key, sample_img, collect_dir):
-    print('\nTesting model bundle for {}...\n'.format(key))
-
-    model_bundle_uri = join(collect_dir, key, 'model-bundle.zip')
-    if not file_exists(model_bundle_uri):
-        print('Bundle does not exist!')
-        return
-
-    sample_img = download_or_copy(sample_img, join(collect_dir, key))
-
-    exts = {'cc': 'json', 'ss': 'tif', 'od': 'json'}
-    for task, ext in exts.items():
-        if key.endswith(task):
-            break
-
-    out_uri = join(collect_dir, key, 'predictions.{}'.format(ext))
-    cmd = ['rastervision', 'predict', model_bundle_uri, sample_img, out_uri]
-    proc = subprocess.run(cmd)
-    if proc.returncode != 0:
-        print('failure!')
-        print(' '.join(cmd))
-        exit()
+def console_info(msg: str, **kwargs) -> None:
+    click.secho(msg, fg='yellow', **kwargs)
 
 
-@test.command()
-@click.argument('collect_dir')
-@click.argument('keys', nargs=-1)
-def predict(collect_dir, keys):
-    """Test model bundles using predict command using output of collect command."""
-    run_all = len(keys) == 0
-    validate_keys(keys)
+def console_heading(msg: str, **kwargs) -> None:
+    click.secho(msg, fg='magenta', bold=True, **kwargs)
 
-    for exp_cfg in cfg:
-        if run_all or exp_cfg['key'] in keys:
-            key = exp_cfg['key']
-            _predict(key, exp_cfg['sample_img'], collect_dir)
+
+def console_warning(msg: str, **kwargs) -> None:
+    click.secho(f'Warning: {msg}', fg='red', **kwargs)
+
+
+def console_failure(msg: str, **kwargs) -> None:
+    click.secho(msg, fg='red', err=True, **kwargs)
+
+
+def console_success(msg: str, **kwargs) -> None:
+    click.secho(msg, fg='cyan', **kwargs)
 
 
 if __name__ == '__main__':

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
@@ -329,7 +329,7 @@ def _run(exp_cfg: dict,
          test: bool = True,
          remote: bool = False,
          commands: List[str] = None) -> None:
-    """Builds a command from the params in exp_cfg and otehr arguments and
+    """Builds a command from the params in exp_cfg and other arguments and
     then executes it.
     """
     uris = exp_cfg['remote'] if remote else exp_cfg['local']
@@ -509,7 +509,7 @@ def fetch_cmd_dir(root_uri: str, cmd: str, download_dir: str) -> str:
 
 def flatten_dict(d: Union[dict, list], sep: str = '.') -> dict:
     """Flatten a dict so that it does not have any nested dicts or lists.
-    Nested keys will ba concatenated using the separator, sep. For example,
+    Nested keys will be concatenated using the separator, sep. For example,
     {'a': {'b': ['x', 10]}} becomes {'a.b.0': 'x', 'a.b.1': 10}.
     This makes it simpler to compare dicts.
 
@@ -547,7 +547,7 @@ def _compare_dicts(dict_old: dict,
                    dict_new: dict,
                    float_tol: float = 1e-3,
                    exclude_keys: list = []) -> None:
-    """Compare the keys and vaues of the two dicts.
+    """Compare the keys and values of the two dicts.
 
     Args:
         dict_old (dict): A dict.

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
@@ -24,7 +24,6 @@ def get_config(runner) -> SemanticSegmentationConfig:
     def make_scene(scene_id: str, image_uri: str,
                    label_uri: str) -> SceneConfig:
         """
-        - StatsTransformer is used to convert uint16 values to uint8.
         - The GeoJSON does not have a class_id property for each geom,
           so it is inferred as 0 (ie. building) because the default_class_id
           is set to 0.

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
@@ -1,7 +1,5 @@
 # flake8: noqa
 
-from os.path import join
-
 from rastervision.core.rv_pipeline import *
 from rastervision.core.backend import *
 from rastervision.core.data import *
@@ -9,21 +7,22 @@ from rastervision.pytorch_backend import *
 from rastervision.pytorch_learner import *
 
 
-def get_config(runner):
+def get_config(runner) -> SemanticSegmentationConfig:
     root_uri = '/opt/data/output/'
     base_uri = ('https://s3.amazonaws.com/azavea-research-public-data/'
                 'raster-vision/examples/spacenet')
-    train_image_uri = '{}/RGB-PanSharpen_AOI_2_Vegas_img205.tif'.format(
-        base_uri)
-    train_label_uri = '{}/buildings_AOI_2_Vegas_img205.geojson'.format(
-        base_uri)
-    val_image_uri = '{}/RGB-PanSharpen_AOI_2_Vegas_img25.tif'.format(base_uri)
-    val_label_uri = '{}/buildings_AOI_2_Vegas_img25.geojson'.format(base_uri)
+
+    train_image_uri = f'{base_uri}/RGB-PanSharpen_AOI_2_Vegas_img205.tif'
+    train_label_uri = f'{base_uri}/buildings_AOI_2_Vegas_img205.geojson'
+    val_image_uri = f'{base_uri}/RGB-PanSharpen_AOI_2_Vegas_img25.tif'
+    val_label_uri = f'{base_uri}/buildings_AOI_2_Vegas_img25.geojson'
+
     channel_order = [0, 1, 2]
     class_config = ClassConfig(
         names=['building', 'background'], colors=['red', 'black'])
 
-    def make_scene(scene_id, image_uri, label_uri):
+    def make_scene(scene_id: str, image_uri: str,
+                   label_uri: str) -> SceneConfig:
         """
         - StatsTransformer is used to convert uint16 values to uint8.
         - The GeoJSON does not have a class_id property for each geom,
@@ -35,9 +34,7 @@ def get_config(runner):
           to 1 because background_class_id is set to 1.
         """
         raster_source = RasterioSourceConfig(
-            uris=[image_uri],
-            channel_order=channel_order,
-            transformers=[StatsTransformerConfig()])
+            uris=[image_uri], channel_order=channel_order)
         vector_source = GeoJSONVectorSourceConfig(
             uri=label_uri, default_class_id=0, ignore_crs_field=True)
         label_source = SemanticSegmentationLabelSourceConfig(
@@ -49,7 +46,7 @@ def get_config(runner):
             raster_source=raster_source,
             label_source=label_source)
 
-    dataset = DatasetConfig(
+    scene_dataset = DatasetConfig(
         class_config=class_config,
         train_scenes=[
             make_scene('scene_205', train_image_uri, train_label_uri)
@@ -61,16 +58,19 @@ def get_config(runner):
     # Use the PyTorch backend for the SemanticSegmentation pipeline.
     chip_sz = 300
     backend = PyTorchSemanticSegmentationConfig(
+        data=SemanticSegmentationGeoDataConfig(
+            scene_dataset=scene_dataset,
+            window_opts=GeoDataWindowConfig(
+                method=GeoDataWindowMethod.random,
+                size=chip_sz,
+                size_lims=(chip_sz, chip_sz + 1),
+                max_windows=10)),
         model=SemanticSegmentationModelConfig(backbone=Backbone.resnet50),
         solver=SolverConfig(lr=1e-4, num_epochs=1, batch_sz=2))
-    chip_options = SemanticSegmentationChipOptions(
-        window_method=SemanticSegmentationWindowMethod.random_sample,
-        chips_per_scene=10)
 
     return SemanticSegmentationConfig(
         root_uri=root_uri,
-        dataset=dataset,
+        dataset=scene_dataset,
         backend=backend,
         train_chip_sz=chip_sz,
-        predict_chip_sz=chip_sz,
-        chip_options=chip_options)
+        predict_chip_sz=chip_sz)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -1,10 +1,10 @@
-from typing import Optional
+from typing import Optional, List
 
 from rastervision.pipeline.config import (register_config, Field)
 from rastervision.core.backend import BackendConfig
 from rastervision.core.rv_pipeline import RVPipeline
 from rastervision.pytorch_learner.learner_config import (
-    SolverConfig, ModelConfig, DataConfig, ImageDataConfig)
+    SolverConfig, ModelConfig, DataConfig, ImageDataConfig, GeoDataConfig)
 
 
 @register_config('pytorch_learner_backend')
@@ -43,3 +43,9 @@ class PyTorchLearnerBackendConfig(BackendConfig):
 
     def build(self, pipeline: Optional[RVPipeline], tmp_dir: str):
         raise NotImplementedError()
+
+    def filter_commands(self, commands: List[str]) -> List[str]:
+        nochip = isinstance(self.data, GeoDataConfig)
+        if nochip and 'chip' in commands:
+            commands = [c for c in commands if c != 'chip']
+        return commands

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -50,6 +50,9 @@ class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
         super().update(pipeline=pipeline)
         dcfg = self.data
         pcfg = pipeline
+
+        dcfg.img_channels = pcfg.dataset.img_channels
+
         if isinstance(dcfg, SemanticSegmentationImageDataConfig):
             if (dcfg.img_format is not None) and (dcfg.img_format !=
                                                   pcfg.img_format):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
@@ -310,8 +310,10 @@ class RandomWindowGeoDataset(GeoDataset):
     def sample_window_size(self) -> Tuple[int, int]:
         """Randomly sample the window size."""
         if self.size_lims is not None:
-            hmin, hmax = self.size_lims
-            size = torch.randint(low=hmin, high=hmax, size=(1, )).item()
+            sz_min, sz_max = self.size_lims
+            if sz_max == sz_min + 1:
+                return sz_min, sz_min
+            size = torch.randint(low=sz_min, high=sz_max, size=(1, )).item()
             return size, size
         hmin, hmax = self.h_lims
         wmin, wmax = self.w_lims

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -70,12 +70,12 @@ def log_system_details():
     log.info(f'Python version: {sys.version}')
     # nvidia GPU
     try:
-        log.info(os.popen("nvcc --version").read())
-        log.info(os.popen("nvidia-smi").read())
+        log.info(os.popen('nvcc --version').read())
+        log.info(os.popen('nvidia-smi').read())
         log.info('Devices:')
         call([
-            "nvidia-smi", "--format=csv",
-            "--query-gpu=index,name,driver_version,memory.total,memory.used,memory.free"
+            'nvidia-smi', '--format=csv',
+            '--query-gpu=index,name,driver_version,memory.total,memory.used,memory.free'
         ])
     except FileNotFoundError:
         pass

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -498,6 +498,9 @@ class Learner(ABC):
         train_dirs = [join(d, 'train') for d in data_dirs if isdir(d)]
         val_dirs = [join(d, 'valid') for d in data_dirs if isdir(d)]
 
+        train_dirs = [d for d in train_dirs if isdir(d)]
+        val_dirs = [d for d in val_dirs if isdir(d)]
+
         base_transform, aug_transform = self.get_data_transforms()
         train_tf = aug_transform if not cfg.overfit_mode else base_transform
         val_tf, test_tf = base_transform, base_transform

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -926,6 +926,8 @@ class Learner(ABC):
         batch_sz = x.shape[0]
         batch_sz = min(batch_sz,
                        batch_limit) if batch_limit is not None else batch_sz
+        if batch_sz == 0:
+            return
         ncols = nrows = math.ceil(math.sqrt(batch_sz))
         fig = plt.figure(
             constrained_layout=True, figsize=(3 * ncols, 3 * nrows))

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -440,9 +440,11 @@ class GeoDataWindowConfig(Config):
         'the edges of the raster source.')
     size_lims: Optional[Tuple[PosInt, PosInt]] = Field(
         None,
-        description='[min, max] interval from which window sizes will be '
-        'uniformly randomly sampled. Only used if method = random. Must '
-        'specify either size_lims or h and w lims, bu not both.')
+        description='[min, max) interval from which window sizes will be '
+        'uniformly randomly sampled. The upper limit is exclusive. To fix the '
+        'size to a constant value, use size_lims = (sz, sz + 1). '
+        'Only used if method = random. Must specify either size_lims or '
+        'h and w lims, but not both.')
     h_lims: Optional[Tuple[PosInt, PosInt]] = Field(
         None,
         description='[min, max] interval from which window heights will be '

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -618,7 +618,6 @@ class LearnerConfig(Config):
         if self.test_mode:
             self.solver.num_epochs = self.solver.test_num_epochs
             self.solver.batch_sz = self.solver.test_batch_sz
-            self.data.img_sz = self.data.img_sz // 2
             self.data.num_workers = 0
 
         self.model.update(learner=self)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -206,6 +206,12 @@ class SemanticSegmentationLearner(Learner):
             x = tf(image=x.numpy())['image']
             x = torch.from_numpy(x)
 
+        # apply transform, if given
+        if self.cfg.data.plot_options.transform is not None:
+            tf = A.from_dict(self.cfg.data.plot_options.transform)
+            x = tf(image=x.numpy())['image']
+            x = torch.from_numpy(x)
+
         for i in range(batch_sz):
             ax = (fig, axes[i])
             if z is None:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -200,16 +200,9 @@ class SemanticSegmentationLearner(Learner):
         fig, axes = plt.subplots(
             nrows=nrows,
             ncols=ncols,
+            squeeze=False,
             constrained_layout=True,
             figsize=(3 * ncols, 3 * nrows))
-
-        # plt.subplots only returns a single AxesSubplot object
-        # if nrows * ncols = 1
-        if not isinstance(axes, np.ndarray):
-            axes = np.array([[axes]])
-        # plt.subplots returns a 1D array if nrows = 1 or  ncols = 1
-        if axes.ndim == 1:
-            axes = axes.reshape((nrows, ncols))
 
         assert axes.shape == (nrows, ncols)
 

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -1,4 +1,5 @@
 rastervision_pipeline==0.12.*
+rastervision_core==0.12.*
 numpy<1.17
 pillow==5.0.*
 torch==1.7.*


### PR DESCRIPTION
## Overview

This PR updates all examples in preparation for the 0.13 release. It also includes multiple fixes.

Most of the 'additions' are in `test.py` and its corresponding readme.

### Major changes
- Auto skip `chip` stage when using a `GeoDataConfig`
- Add integration tests for testing `GeoDataConfig`
- Update examples
- Refactor/update `test.py`
  - Add new `compare_runs` command for comparing evals of two runs of an example. See example outputs below.
  - Add new `upload` command for uploading results to model zoo.
  - Add a readme that describes usage

### Minor changes
- Auto skip `analyze` stage when no analyzers are present
- Do not halve `img_sz` in test_mode
  - not really useful
  - causes unnecessary errors
- Add `data/` to .gitignore
  - this is the dir mounted to `/opt/data`

### Fixes
- Propagate `img_channels` to `DataConfig` (#1114)
- Fix bug in `Learner.plot_batch()` (#1114)
- Resize SS prediction output to match input shape
  - to undo any resizing due to img_sz
- Add a small sanity check in `SceneConfig.__repr_args__()`
- Add `rastervision_core` as a dependency for `rastervision_pytorch_learner`
- Do not assume both train and valid dirs are present in each chip zip file (#1117)

## Eval comparisons to 0.12
Diff format is  `new - old`.

### Spacenet Rio
![image](https://user-images.githubusercontent.com/13014700/109033700-bb316980-76e8-11eb-984b-689dd2d0a0a0.png)

### ISPRS Potsdam
![image](https://user-images.githubusercontent.com/13014700/109033759-cb494900-76e8-11eb-8814-3071a37e265a.png)

### Spacenet Vegas - Buildings
![image](https://user-images.githubusercontent.com/13014700/109037614-b969a500-76ec-11eb-8840-c0c9170d7d78.png)

### Spacenet Vegas - Roads
![image](https://user-images.githubusercontent.com/13014700/109033901-e916ae00-76e8-11eb-9623-c6ca5a74a212.png)

### COWC Potsdam
![image](https://user-images.githubusercontent.com/13014700/109033964-f6339d00-76e8-11eb-876b-a9aa4bd1dd5a.png)

### Xview
![image](https://user-images.githubusercontent.com/13014700/109034014-0186c880-76e9-11eb-85c8-4a82b5111b63.png)



### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness


Fixes #1114 
Fixes #1117 
Makes progress towards #1085 
