### PR TITLE
Fix image plot by adding default plot transform

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -950,8 +950,8 @@ class Learner(ABC):
         # apply transform, if given
         if self.cfg.data.plot_options.transform is not None:
             tf = A.from_dict(self.cfg.data.plot_options.transform)
-            x = tf(image=x.numpy())['image']
-            x = torch.from_numpy(x)
+            imgs = [tf(image=img)['image'] for img in x.numpy()]
+            x = torch.from_numpy(np.stack(imgs))
 
         for i in range(batch_sz):
             ax = fig.add_subplot(grid[i])

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -17,6 +17,7 @@ from rastervision.pipeline.config import (Config, register_config, ConfigError,
 from rastervision.core.data import (Scene, DatasetConfig as SceneDatasetConfig)
 from rastervision.pytorch_learner.utils import (
     color_to_triple, validate_albumentation_transform)
+from rastervision.pytorch_learner.utils import MinMaxNormalize
 
 default_augmentors = ['RandomRotate90', 'HorizontalFlip', 'VerticalFlip']
 augmentors = [
@@ -237,11 +238,15 @@ class SolverConfig(Config):
 class PlotOptions(Config):
     """Config related to plotting."""
     transform: Optional[dict] = Field(
-        None,
+        A.to_dict(MinMaxNormalize()),
         description='An Albumentations transform serialized as a dict that '
         'will be applied to each image before it is plotted. Mainly useful '
         'for undoing any data transformation that you do not want included in '
-        'the plot, such as normalization.')
+        'the plot, such as normalization. The default value will shift and scale the '
+        'image so the values range from 0.0 to 1.0 which is the expected range for '
+        'the plotting function. This default is useful for cases where the values after '
+        'normalization are close to zero which makes the plot difficult to see.'
+    )
 
     # validators
     _tf = validator(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -215,12 +215,6 @@ class SemanticSegmentationLearner(Learner):
             x = tf(image=x.numpy())['image']
             x = torch.from_numpy(x)
 
-        # apply transform, if given
-        if self.cfg.data.plot_options.transform is not None:
-            tf = A.from_dict(self.cfg.data.plot_options.transform)
-            x = tf(image=x.numpy())['image']
-            x = torch.from_numpy(x)
-
         for i in range(batch_sz):
             ax = (fig, axes[i])
             if z is None:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -212,8 +212,8 @@ class SemanticSegmentationLearner(Learner):
         # apply transform, if given
         if self.cfg.data.plot_options.transform is not None:
             tf = A.from_dict(self.cfg.data.plot_options.transform)
-            x = tf(image=x.numpy())['image']
-            x = torch.from_numpy(x)
+            imgs = [tf(image=img)['image'] for img in x.numpy()]
+            x = torch.from_numpy(np.stack(imgs))
 
         for i in range(batch_sz):
             ax = (fig, axes[i])

--- a/tests/pytorch_learner/test_utils.py
+++ b/tests/pytorch_learner/test_utils.py
@@ -103,6 +103,15 @@ class TestMinMaxNormalize(unittest.TestCase):
         img = np.random.uniform(0.01, 0.02, (5, 5, 3))
         transform = MinMaxNormalize()
         out = transform(image=img)['image']
+        for i in range(3):
+            self.assertAlmostEqual(out[:, :, i].min(), 0.0, 6)
+            self.assertAlmostEqual(out[:, :, i].max(), 1.0, 6)
+            self.assertEqual(out.dtype, np.float32)
+
+    def test_tiny_floats_two_dims(self):
+        img = np.random.uniform(0.01, 0.02, (5, 5))
+        transform = MinMaxNormalize()
+        out = transform(image=img)['image']
         self.assertAlmostEqual(out.min(), 0.0, 6)
         self.assertAlmostEqual(out.max(), 1.0, 6)
         self.assertEqual(out.dtype, np.float32)
@@ -111,9 +120,10 @@ class TestMinMaxNormalize(unittest.TestCase):
         img = np.random.uniform(1, 10, (5, 5, 3)).round().astype(np.int32)
         transform = MinMaxNormalize()
         out = transform(image=img)['image']
-        self.assertAlmostEqual(out.min(), 0.0, 6)
-        self.assertAlmostEqual(out.max(), 1.0, 6)
-        self.assertEqual(out.dtype, np.float32)
+        for i in range(3):
+            self.assertAlmostEqual(out[:, :, i].min(), 0.0, 6)
+            self.assertAlmostEqual(out[:, :, i].max(), 1.0, 6)
+            self.assertEqual(out.dtype, np.float32)
 
 
 if __name__ == '__main__':

--- a/tests/pytorch_learner/test_utils.py
+++ b/tests/pytorch_learner/test_utils.py
@@ -1,9 +1,10 @@
 import unittest
 
 import torch
+import numpy as np
 
-from rastervision.pytorch_learner.utils import (compute_conf_mat,
-                                                compute_conf_mat_metrics)
+from rastervision.pytorch_learner.utils import (
+    compute_conf_mat, compute_conf_mat_metrics, MinMaxNormalize)
 
 
 class TestComputeConfMat(unittest.TestCase):
@@ -95,6 +96,24 @@ class TestComputeConfMatMetrics(unittest.TestCase):
             'b_f1': b_f1
         }
         self.assertDictEqual(round_dict(metrics), round_dict(exp_metrics))
+
+
+class TestMinMaxNormalize(unittest.TestCase):
+    def test_tiny_floats(self):
+        img = np.random.uniform(0.01, 0.02, (5, 5, 3))
+        transform = MinMaxNormalize()
+        out = transform(image=img)['image']
+        self.assertAlmostEqual(out.min(), 0.0, 6)
+        self.assertAlmostEqual(out.max(), 1.0, 6)
+        self.assertEqual(out.dtype, np.float32)
+
+    def test_tiny_ints(self):
+        img = np.random.uniform(1, 10, (5, 5, 3)).round().astype(np.int32)
+        transform = MinMaxNormalize()
+        out = transform(image=img)['image']
+        self.assertAlmostEqual(out.min(), 0.0, 6)
+        self.assertAlmostEqual(out.max(), 1.0, 6)
+        self.assertEqual(out.dtype, np.float32)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Overview

This PR fixes blank image plots by adding a default plot transform which normalizes the pixel values so that the minimum and maximum values are 0 and 1, respectively. This is to handle cases where the pixel values are small and cannot be seen, such as when a uint16 image with values close to 0 is normalized to 0-1. An example of this occurring is in the SpaceNet examples. 

### Notes

* Originally, I thought I would detect that the values were outside the 0-1 range and then correct them if needed. However, the the values are already within the 0-1 range and are just tiny.
* It's unclear how to detect that values are too small to see, so it seemed most straightforward to just scale things to be between 0 and 1. That will distort the image in some cases, but at least it should always be visible. If people really want, they can always set the `plot_transform` to None. 
* After this is merged we should make a bug fix release.

## Testing Instructions

* I inspected the plots for the following examples which seems to run the gamut: SpaceNet Vegas (uint16) with nochip=True and False, and COWC Potsdam (uint8) with nochip=True and False. The image plots are visible. Here are plots for the SpaceNet Vegas example which was the original motivation for this PR:
![train](https://user-images.githubusercontent.com/1896461/112497172-bbf70300-8d5b-11eb-8c5a-2c76d90234a8.png)
* I added a unit test for the `MinMaxTransform` which I added.

Closes #1132 
