### PR TITLE
Add within argument to filter_by_aoi

### DIFF
--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -4,7 +4,7 @@ import math
 import random
 
 import numpy as np
-from shapely.geometry import box as ShapelyBox
+from shapely.geometry import box as ShapelyBox, Polygon
 
 NonNegInt = conint(ge=0)
 
@@ -341,20 +341,29 @@ class Box():
         return cls(d['ymin'], d['xmin'], d['ymax'], d['xmax'])
 
     @staticmethod
-    def filter_by_aoi(windows, aoi_polygons):
-        """Filters windows by a list of AOI polygons"""
+    def filter_by_aoi(windows: List['Box'],
+                      aoi_polygons: List[Polygon],
+                      within: bool = True):
+        """Filters windows by a list of AOI polygons
+
+        Args:
+            within: if True, windows are only kept if they lie fully within an
+                AOI polygon. Otherwise, windows are kept if they intersect an AOI
+                polygon.
+        """
         result = []
         for window in windows:
             w = window.to_shapely()
             for polygon in aoi_polygons:
-                if w.within(polygon):
+                if ((within and w.within(polygon))
+                        or ((not within) and w.intersects(polygon))):
                     result.append(window)
                     break
 
         return result
 
     @staticmethod
-    def within_aoi(window: 'Box', aoi_polygons: list) -> bool:
+    def within_aoi(window: 'Box', aoi_polygons: List[Polygon]) -> bool:
         """Check if window is within a list of AOI polygons."""
         w = window.to_shapely()
         for polygon in aoi_polygons:

--- a/tests/core/test_box.py
+++ b/tests/core/test_box.py
@@ -212,6 +212,16 @@ class TestBox(unittest.TestCase):
         box = Box(1, 2, 3, 4)
         self.assertEqual(box.__repr__(), 'Box(1, 2, 3, 4)')
 
+    def test_filter_by_aoi(self):
+        windows = [Box.make_square(0, 0, 2), Box.make_square(0, 2, 2)]
+        aoi_polygons = [Box.make_square(0, 0, 3).to_shapely()]
+
+        filt_windows = Box.filter_by_aoi(windows, aoi_polygons, within=False)
+        self.assertListEqual(filt_windows, windows)
+
+        filt_windows = Box.filter_by_aoi(windows, aoi_polygons, within=True)
+        self.assertListEqual(filt_windows, windows[0:1])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds a `within` argument to the `Box.filter_by_aoi` method, which is used in another project to include windows that merely intersect with the AOIs. It doesn't really make sense to add this an option to the config for classification, semantic segmentation, or object detection.
