### PR TITLE
Downgrade gdal/rasterio

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,32 +3,32 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/rastervision_pipeline"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/rastervision_aws_s3"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/rastervision_aws_batch"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/rastervision_core"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/rastervision_pytorch_learner"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/rastervision_pytorch_backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/rastervision_gdal_vsi"
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV PATH /opt/conda/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
 RUN conda install -y python=3.7
 RUN python -m pip install --upgrade pip
-RUN conda install -y -c conda-forge gdal=3.3.1
+RUN conda install -y -c conda-forge gdal=3.0.4
 
 # Setup GDAL_DATA directory, rasterio needs it.
 ENV GDAL_DATA=/opt/conda/lib/python3.6/site-packages/rasterio/gdal_data/

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -3,7 +3,7 @@ numpy<1.22
 shapely==1.6.*
 pillow==8.3.*
 pyproj==2.6.*
-rasterio==1.2.6
+rasterio==1.0.7
 scikit-learn==0.24.*
 imageio==2.3.*
 pystac==0.5.6

--- a/rastervision_gdal_vsi/requirements.txt
+++ b/rastervision_gdal_vsi/requirements.txt
@@ -1,2 +1,2 @@
 rastervision_pipeline==0.13
-gdal==3.3.1
+gdal==3.0.4


### PR DESCRIPTION
After closing a bunch of dependabot PRs, I found that running the train step of the classification example on Batch crashes. I isolated this to the upgrade of gdal and rasterio, so I'm downgrading those. 