### PR TITLE
Make RandomWindowGeoDataset more efficient when sampling chips from scenes with AOIs

### DIFF
--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -272,3 +272,23 @@ class RasterioSource(ActivateMixin, RasterSource):
 
             window = Box(ymin4, xmin4, ymin4 + height, xmin4 + width)
         return window
+
+    def get_transformed_window(self, window: Box,
+                               inverse: bool = False) -> Box:
+        """Apply the CRS transform to the window.
+
+        Args:
+            window (Box): A window in pixel coordinates.
+
+        Returns:
+            Box: A window in world coordinates.
+        """
+        if inverse:
+            tf = self.crs_transformer.map_to_pixel
+        else:
+            tf = self.crs_transformer.pixel_to_map
+        ymin, xmin, ymax, xmax = window
+        xmin, ymin = tf((xmin, ymin))
+        xmax, ymax = tf((xmax, ymax))
+        window = Box(ymin, xmin, ymax, xmax)
+        return window

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -80,6 +80,7 @@ class ClassificationGeoDataConfig(ClassificationDataConfig, GeoDataConfig):
                 padding=opts.padding,
                 max_windows=opts.max_windows,
                 max_sample_attempts=opts.max_sample_attempts,
+                efficient_aoi_sampling=opts.efficient_aoi_sampling,
                 transform=transform)
         else:
             raise NotImplementedError()

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/__init__.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/__init__.py
@@ -2,6 +2,7 @@
 
 from rastervision.pytorch_learner.dataset.dataset import *
 from rastervision.pytorch_learner.dataset.transform import *
+from rastervision.pytorch_learner.dataset.utils import *
 from rastervision.pytorch_learner.dataset.classification_dataset import *
 from rastervision.pytorch_learner.dataset.object_detection_dataset import *
 from rastervision.pytorch_learner.dataset.semantic_segmentation_dataset import *

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
@@ -121,7 +121,7 @@ class GeoDataset(AlbumentationsDataset):
 T = TypeVar('T')
 
 
-def _to_tuple(x: T, n: int = 2) -> Tuple[T, T]:
+def _to_tuple(x: T, n: int = 2) -> Tuple[T, ...]:
     """Convert to n-tuple if not already an n-tuple."""
     if isinstance(x, tuple):
         if len(x) != n:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/utils.py
@@ -1,0 +1,195 @@
+from typing import Sequence, Tuple
+
+import numpy as np
+from shapely.geometry import Polygon, LinearRing, MultiPolygon
+from shapely.ops import unary_union
+from triangle import triangulate
+
+
+class AoiSampler():
+    """Given a set of polygons representing the AOI, allows efficiently
+    sampling points inside the AOI uniformly at random.
+
+    To achieve this, each polygon is first partitioned into triangles
+    (triangulation). Then, to sample a single point, we first sample a triangle
+    at random with probability proportional to its area and then sample a point
+    within that triangle uniformly at random.
+    """
+
+    def __init__(self, polygons: Sequence[Polygon]) -> None:
+        # merge overlapping polygons, if any
+        merged_polygons = unary_union(polygons)
+        if isinstance(merged_polygons, Polygon):
+            merged_polygons = [merged_polygons]
+        self.polygons = MultiPolygon(merged_polygons)
+        self.triangulate(self.polygons)
+
+    def triangulate(self, polygons) -> dict:
+        triangulations = [self.triangulate_polygon(p) for p in polygons]
+        self.triangulations = triangulations
+        self.origins = np.vstack([t['origins'] for t in triangulations])
+        self.vec_AB = np.vstack([t['bases'][0] for t in triangulations])
+        self.vec_AC = np.vstack([t['bases'][1] for t in triangulations])
+        areas = np.concatenate([t['areas'] for t in triangulations])
+        self.weights = areas / areas.sum()
+        self.ntriangles = len(self.origins)
+
+    def sample(self, n: int = 1) -> np.ndarray:
+        """Sample a random point within the AOI, using the following algorithm:
+            - Randomly sample one triangle (ABC) with probability proportional
+            to its area.
+            - Starting at A, travel a random distance along vectors AB and AC.
+            - Return the final position.
+
+        Args:
+            n (int, optional): Number of points to sample. Defaults to 1.
+
+        Returns:
+            np.ndarray: (n, 2) 2D coordinates of the sampled points.
+        """
+        tri_idx = np.random.choice(self.ntriangles, p=self.weights, size=n)
+        origin = self.origins[tri_idx]
+        vec_AB = self.vec_AB[tri_idx]
+        vec_AC = self.vec_AC[tri_idx]
+        # the fractions to travel along each of the two vectors
+        r, s = np.random.uniform(size=(2, n, 1))
+        # If the fractions will land us in the wrong half of the parallelogram
+        # defined by vec AB and vec AC, reflect them into the correct half.
+        mask = (r + s) > 1
+        r[mask] = 1 - r[mask]
+        s[mask] = 1 - s[mask]
+        loc = origin + (r * vec_AB + s * vec_AC)
+        return loc
+
+    def triangulate_polygon(self, polygon: Polygon) -> dict:
+        """Extract vertices and edges from the polygon (and its holes, if any)
+        and pass them to the Triangle library for triangulation.
+        """
+        vertices, edges = self.polygon_to_graph(polygon.exterior)
+
+        holes = polygon.interiors
+        if not holes:
+            args = {
+                'vertices': vertices,
+                'segments': edges,
+            }
+        else:
+            for hole in holes:
+                hole_vertices, hole_edges = self.polygon_to_graph(hole)
+                # make the indices point to entries in the global vertex list
+                hole_edges += len(vertices)
+                # append hole vertices to the global vertex list
+                vertices = np.vstack([vertices, hole_vertices])
+                edges = np.vstack([edges, hole_edges])
+
+            # the triangulation algorithm requires a sample point inside each
+            # hole
+            hole_centroids = np.stack([hole.centroid for hole in holes])
+
+            args = {
+                'vertices': vertices,
+                'segments': edges,
+                'holes': hole_centroids
+            }
+
+        tri = triangulate(args, opts='p')
+        simplices = tri['triangles']
+        vertices = np.array(tri['vertices'])
+        origins, bases = self.triangle_origin_and_basis(vertices, simplices)
+
+        out = {
+            'vertices': vertices,
+            'simplices': simplices,
+            'origins': origins,
+            'bases': bases,
+            'areas': self.triangle_area(vertices, simplices)
+        }
+        return out
+
+    def polygon_to_graph(self,
+                         polygon: LinearRing) -> Tuple[np.ndarray, np.ndarray]:
+        """Given the exterior of a polygon, return its graph representation.
+
+        Args:
+            polygon (LinearRing): The exterior of a polygon.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: An (N, 2) array of vertices and
+            an (N, 2) array of indices to vertices representing edges.
+        """
+        vertices = np.array(polygon)
+        # Discard the last vertex - it is a duplicate of the first vertex and
+        # duplicates cause problems for the Triangle library.
+        vertices = vertices[:-1]
+
+        N = len(vertices)
+        # Tuples of indices to vertices representing edges.
+        # mod N ensures edge from last vertex to first vertex by making the
+        # last tuple [N-1, 0].
+        edges = np.column_stack([np.arange(0, N), np.arange(1, N + 1)]) % N
+
+        return vertices, edges
+
+    def triangle_side_lengths(self, vertices: np.ndarray, simplices: np.ndarray
+                              ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Calculate lengths of all 3 sides of each triangle specified by the
+        simplices array.
+
+        Args:
+            vertices (np.ndarray): (N, 2) array of vertex coords in 2D.
+            simplices (np.ndarray): (N, 3) array of indexes to entries in the
+                vertices array. Each row represents one triangle.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray, np.ndarray]: ||AB||, ||BC||, ||AC||
+        """
+        A = vertices[simplices[:, 0]]
+        B = vertices[simplices[:, 1]]
+        C = vertices[simplices[:, 2]]
+        AB, AC, BC = B - A, C - A, C - B
+        ab = np.linalg.norm(AB, axis=1)
+        bc = np.linalg.norm(BC, axis=1)
+        ac = np.linalg.norm(AC, axis=1)
+        return ab, bc, ac
+
+    def triangle_origin_and_basis(
+            self, vertices: np.ndarray, simplices: np.ndarray
+    ) -> Tuple[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+        """For each triangle ABC, return point A, vector AB, and vector AC.
+
+        Args:
+            vertices (np.ndarray): (N, 2) array of vertex coords in 2D.
+            simplices (np.ndarray): (N, 3) array of indexes to entries in the
+                vertices array. Each row represents one triangle.
+
+        Returns:
+            Tuple[np.ndarray, Tuple[np.ndarray, np.ndarray]]: 3 arrays of shape
+                (N, 2), organized into tuples like so:
+                (point A, (vector AB, vector AC)).
+        """
+        A = vertices[simplices[:, 0]]
+        B = vertices[simplices[:, 1]]
+        C = vertices[simplices[:, 2]]
+        AB = B - A
+        AC = C - A
+        return A, (AB, AC)
+
+    def triangle_area(self, vertices: np.ndarray,
+                      simplices: np.ndarray) -> np.ndarray:
+        """Calculate area of each triangle specified by the simplices array
+        using Heron's formula.
+
+        Args:
+            vertices (np.ndarray): (N, 2) array of vertex coords in 2D.
+            simplices (np.ndarray): (N, 3) array of indexes to entries in the
+                vertices array. Each row represents one triangle.
+
+        Returns:
+            np.ndarray: (N,) array of areas
+        """
+        a, b, c = self.triangle_side_lengths(vertices, simplices)
+        p = (a + b + c) * 0.5
+        area = p * (p - a) * (p - b) * (p - c)
+        area[area < 0] = 0
+        area = np.sqrt(area)
+        return area

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -475,6 +475,15 @@ class GeoDataWindowConfig(Config):
         description='Max attempts when trying to find a window within the AOI '
         'of a scene. Only used if method = random and the scene has '
         'aoi_polygons specified.')
+    efficient_aoi_sampling: bool = Field(
+        True,
+        description='If the scene has AOIs, sampling windows at random '
+        'anywhere in the extent and then checking if they fall within any of '
+        'the AOIs can be very inefficient. This flag enables the use of an '
+        'alternate algorithm that only samples window locations inside the '
+        'AOIs. Only used if method = random and the scene has aoi_polygons '
+        'specified. Defaults to True',
+    )
 
     def validate_config(self):
         if self.method == GeoDataWindowMethod.sliding:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -102,12 +102,13 @@ class ObjectDetectionGeoDataConfig(ObjectDetectionDataConfig, GeoDataConfig):
                 padding=opts.padding,
                 max_windows=opts.max_windows,
                 max_sample_attempts=opts.max_sample_attempts,
-                transform=transform,
                 bbox_params=bbox_params,
                 ioa_thresh=opts.ioa_thresh,
                 clip=opts.clip,
                 neg_ratio=opts.neg_ratio,
-                neg_ioa_thresh=opts.neg_ioa_thresh)
+                neg_ioa_thresh=opts.neg_ioa_thresh,
+                efficient_aoi_sampling=opts.efficient_aoi_sampling,
+                transform=transform)
         else:
             raise NotImplementedError()
         return ds

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner_config.py
@@ -85,6 +85,7 @@ class RegressionGeoDataConfig(RegressionDataConfig, GeoDataConfig):
                 padding=opts.padding,
                 max_windows=opts.max_windows,
                 max_sample_attempts=opts.max_sample_attempts,
+                efficient_aoi_sampling=opts.efficient_aoi_sampling,
                 transform=transform)
         else:
             raise NotImplementedError()

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
@@ -111,6 +111,7 @@ class SemanticSegmentationGeoDataConfig(SemanticSegmentationDataConfig,
                 padding=opts.padding,
                 max_windows=opts.max_windows,
                 max_sample_attempts=opts.max_sample_attempts,
+                efficient_aoi_sampling=opts.efficient_aoi_sampling,
                 transform=transform)
         else:
             raise NotImplementedError()

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -10,3 +10,4 @@ cython==0.29.*
 pycocotools==2.0.*
 future==0.18.*
 psutil==5.8.*
+triangle==20200424

--- a/tests/pytorch_learner/dataset/test_aoi_sampler.py
+++ b/tests/pytorch_learner/dataset/test_aoi_sampler.py
@@ -1,0 +1,69 @@
+import unittest
+from itertools import product
+
+import numpy as np
+from scipy.stats import chisquare
+from shapely.geometry import Polygon, MultiPolygon, MultiPoint
+
+from rastervision.pytorch_learner.dataset.utils import AoiSampler
+
+
+class TestAoiSampler(unittest.TestCase):
+    def test_sampler(self, nsamples: int = 200):
+        """This test attempts to check if the points are distributed uniformly
+        within the AOI.
+
+        To do this, it performs the following steps:
+        - Create an AOI in the form of a plus-sign shape centered in a 6x6
+        grid.
+        - Create an AoiSampler for this AOI.
+        - Break the AOI up into small 1x1 blocks.
+        - Use the AoiSampler to sample nsamples points.
+        - Count the points that fall in each block.
+        - Perform a Chi-squared test to see how the counts compare to the
+        expected counts (= nsamples / nblocks).
+
+        The null hypothesis for the Chi-squared test is that the counts are
+        distributed identically to the expected counts. A low enough p-value
+        (lower than the significance level) would indicate that the null
+        hypothesis must be rejected, meaning the points are not distributed
+        uniformly inside the AOI. This will cause this unit test to fail. We
+        use a significance level of 0.05 here.
+
+        Args:
+            nsamples (int, optional): Number of points to sample. It is
+                important for the sample size to not be too large or the test
+                will become over-powered.
+                Defaults to 200.
+        """
+        np.random.seed(0)
+
+        # create a polygon shaped like a plus-sign
+        hbar = Polygon.from_bounds(xmin=0, ymin=2, xmax=6, ymax=4)
+        vbar = Polygon.from_bounds(xmin=2, ymin=0, xmax=4, ymax=6)
+        polygons = MultiPolygon([hbar, vbar])
+
+        aoi_sampler = AoiSampler(polygons)
+
+        # break the polygon up into small blocks of 1x1
+        blocks = []
+        sz = 1
+        for x, y in product(np.arange(0, 6, sz), np.arange(0, 6, sz)):
+            b = Polygon.from_bounds(x, y, x + sz, y + sz)
+            if b.within(hbar) or b.within(vbar):
+                blocks.append(b)
+        blocks = MultiPolygon(blocks)
+
+        points = MultiPoint(aoi_sampler.sample(n=nsamples))
+        # number of points in each block
+        counts = np.array(
+            [len(block.intersection(points)) for block in blocks])
+
+        p_value = chisquare(counts).pvalue
+
+        self.assertEqual(counts.sum(), nsamples)
+        self.assertGreaterEqual(p_value, 0.05)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

Makes the sampling of random windows from scenes with AOIs more efficient. The previous approach was to sample a random window from anywhere within the scene and check to see if it falls within the AOI. In contrast, this approach is able to generate random window locations that are always inside the AOI. We still need to check if the window is fully contained within the AOI, since sampled windows near the boundaries of the AOI will occasionally overflow the AOI.

The algorithm can be summarized as:
- Partition the AOI polygons into triangles (triangulation).
    - This procedure is also able to account for holes inside polygons (see example below).
- When sampling, pick a triangle (`ABC`) at random with probability proportional to its area.
- Starting at `A`, travel a random distance along vectors `AB` and `AC`.
- Return the final position.

### Visualizations

#### Example AOI
![aoi](https://user-images.githubusercontent.com/13014700/127647160-76ffc1ad-ab80-4256-9959-cc042daeffea.png)

#### Old sampling approach
![random_chips](https://user-images.githubusercontent.com/13014700/127647177-1ccf6f85-a354-4723-a5fb-cd599a03f47d.png)

#### New sampling approach
##### triangulation
![triangulation](https://user-images.githubusercontent.com/13014700/127646818-123b06e3-81eb-4f82-9ee8-600d0dc4ca20.png)
##### sampled windows
![aoi_chips](https://user-images.githubusercontent.com/13014700/127647191-7a700a7b-9002-4fc9-8e29-ae1845177add.png)


### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

- New dependency added: [triangle](https://github.com/drufat/triangle)

## Testing Instructions
- Rebuild docker image to install new dependency.
- Run an example that has an AOI, while using a `GeoDataWindowConfig` with `method=GeoDataWindowMethod.random`.

Closes #1219 
