### PR TITLE
Downgrade sphinx to 3.5 to fix styling

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'pallets_sphinx_themes',
     'sphinxcontrib.programoutput',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
 ]
 
 # https://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'pallets_sphinx_themes',
-    'sphinxcontrib.programoutput',
     'sphinx.ext.napoleon',
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 Sphinx~=4.0.3
 Pallets-Sphinx-Themes~=1.1.0
 sphinxcontrib-programoutput==0.11
-sphinxcontrib-napoleon==0.7

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx~=4.0.3
-Pallets-Sphinx-Themes~=1.1.0
+Sphinx~=3.5.0
+Pallets-Sphinx-Themes~=2.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 Sphinx~=4.0.3
 Pallets-Sphinx-Themes~=1.1.0
-sphinxcontrib-programoutput==0.11


### PR DESCRIPTION
After upgrading Sphinx to >= 4.0, the styling of the docs broke. This seems to be due to the following change in 4.0:

"Support docutils-0.17. Please notice it changes the output of HTML builder. Some themes do not support it, and you need to update your custom CSS to upgrade it."

This issue discusses it: sphinx-doc/sphinx#9001 

I didn't see any obvious way to fix things, so I just downgraded, and I'm opening another issue to upgrade to 4.0.

Closes https://github.com/azavea/raster-vision/issues/1213