### PR TITLE
Fix formatting and defaults in spacenet_rio.py

### DIFF
--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -168,14 +168,18 @@ def get_config(runner,
     solver = SolverConfig(
         lr=1e-4,
         num_epochs=20,
-        test_num_epochs=20,
+        test_num_epochs=4,
         batch_sz=32,
         one_cycle=True,
         external_loss_def=external_loss_def)
 
     backend = PyTorchChipClassificationConfig(
-        data=data, model=model, solver=solver, test_mode=test, log_tensorboard=True,
-        run_tensorboard=True)
+        data=data,
+        model=model,
+        solver=solver,
+        test_mode=test,
+        log_tensorboard=True,
+        run_tensorboard=False)
 
     pipeline = ChipClassificationConfig(
         root_uri=root_uri,


### PR DESCRIPTION
Fix formatting and revert some changes to defaults committed here: https://github.com/azavea/raster-vision/commit/32e7efc329b0f2ad778779ed0180e6765382e0fe#diff-46d6796cf2d5727609c0b7ced0bd1f1c5fc85376bfc552139d5119e15d98f2f8