### PR TITLE
Fix rastervision_pipeline entry point to ensure commands from other plugins are available

### DIFF
--- a/rastervision_pipeline/rastervision/pipeline/cli.py
+++ b/rastervision_pipeline/rastervision/pipeline/cli.py
@@ -240,9 +240,11 @@ def run_command(cfg_json_uri: str, command: str, split_ind: Optional[int],
         runner=runner)
 
 
-# This has to go here and nowhere else :)
-for pc in registry.get_plugin_commands():
-    main.add_command(pc)
+def _main():
+    for pc in registry.get_plugin_commands():
+        main.add_command(pc)
+    main()
+
 
 if __name__ == '__main__':
-    main()
+    _main()

--- a/rastervision_pipeline/setup.py
+++ b/rastervision_pipeline/setup.py
@@ -34,6 +34,6 @@ setup(
     zip_safe=False,
     entry_points='''
         [console_scripts]
-        rastervision=rastervision.pipeline.cli:main
+        rastervision=rastervision.pipeline.cli:_main
     ''',
 )


### PR DESCRIPTION
## Overview

This PR fixes the problem of the `predict` command not being available if RV is installed via `setup.y`. See #1246 for a detailed discussion. In summary, the problem was caused by `registry.get_plugin_commands()` being called before the plugins had been loaded.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

Create a docker image, with RV installed vai pip, using the Dockerfile below.

<details>
<summary>Dockerfile</summary>

```Dockerfile
FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu16.04

RUN apt-get update && apt-get install -y software-properties-common python-software-properties
RUN add-apt-repository ppa:ubuntugis/ppa && \
	apt-get update && \
	apt-get install -y wget=1.* git=1:2.* python-protobuf=2.* python3-tk=3.* \
	jq=1.5* \
	build-essential libsqlite3-dev=3.11.* zlib1g-dev=1:1.2.* \
	libopencv-dev=2.4.* python-opencv=2.4.* unzip curl && \
	apt-get autoremove && apt-get autoclean && apt-get clean

# See https://github.com/mapbox/rasterio/issues/1289
ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

# Install Python 3.6
RUN wget -q -O ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh && \
	chmod +x ~/miniconda.sh && \
	~/miniconda.sh -b -p /opt/conda && \
	rm ~/miniconda.sh
ENV PATH /opt/conda/bin:$PATH
ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
RUN conda install -y python=3.6
RUN python -m pip install --upgrade pip
RUN conda install -y -c conda-forge gdal=3.0.4

# Setup GDAL_DATA directory, rasterio needs it.
ENV GDAL_DATA=/opt/conda/lib/python3.6/site-packages/rasterio/gdal_data/

WORKDIR /opt/src/
COPY ./raster-vision/ /opt/src/raster-vision

RUN pip install rastervision==0.13

# Needed for click to work
ENV LC_ALL C.UTF-8
ENV LANG C.UTF-8
ENV PROJ_LIB /opt/conda/share/proj/

CMD ["bash"]
```
</details>

```sh
DOCKER_BUILDKIT=1 docker build -t rvtest -f Dockerfile .

docker run --gpus=all --rm --ipc=host -it rvtest
```
Verify that the problem is caused by `rastervision-aws-batch`
```sh
rastervision
# Usage: rastervision [OPTIONS] COMMAND [ARGS]...

#   The main click command.

#   Sets the profile, verbosity, and tmp_dir in RVConfig.

# Options:
#   -p, --profile TEXT  Sets the configuration profile name to use.
#   -v, --verbose       Increment the verbosity level.
#   --tmpdir TEXT       Root of temporary directories to use.
#   --help              Show this message and exit.

# Commands:
#   run          Run sequence of commands within pipeline(s).
#   run_command  Run an individual command within a pipeline.

pip uninstall rastervision-aws-batch -y

rastervision
# Usage: rastervision [OPTIONS] COMMAND [ARGS]...

#   The main click command.

#   Sets the profile, verbosity, and tmp_dir in RVConfig.

# Options:
#   -p, --profile TEXT  Sets the configuration profile name to use.
#   -v, --verbose       Increment the verbosity level.
#   --tmpdir TEXT       Root of temporary directories to use.
#   --help              Show this message and exit.

# Commands:
#   predict      Use a model bundle to predict on new images.
#   run          Run sequence of commands within pipeline(s).
#   run_command  Run an individual command within a pipeline.

pip install rastervision-aws-batch

rastervision
# Usage: rastervision [OPTIONS] COMMAND [ARGS]...

#   The main click command.

#   Sets the profile, verbosity, and tmp_dir in RVConfig.

# Options:
#   -p, --profile TEXT  Sets the configuration profile name to use.
#   -v, --verbose       Increment the verbosity level.
#   --tmpdir TEXT       Root of temporary directories to use.
#   --help              Show this message and exit.

# Commands:
#   run          Run sequence of commands within pipeline(s).
#   run_command  Run an individual command within a pipeline.
```
Test PR
```sh
git clone https://github.com/azavea/raster-vision.git
cd raster-vision/
git fetch https://github.com/AdeelH/raster-vision.git cli_predict
git checkout FETCH_HEAD
pip install -e rastervision_pipeline/ --upgrade

rastervision
# Usage: rastervision [OPTIONS] COMMAND [ARGS]...

#   The main click command.

#   Sets the profile, verbosity, and tmp_dir in RVConfig.

# Options:
#   -p, --profile TEXT  Sets the configuration profile name to use.
#   -v, --verbose       Increment the verbosity level.  [x>=0]
#   --tmpdir TEXT       Root of temporary directories to use.
#   --help              Show this message and exit.

# Commands:
#   predict      Use a model bundle to predict on new images.
#   run          Run sequence of commands within pipeline(s).
#   run_command  Run an individual command within a pipeline.

```

Closes #1246 
