### PR TITLE
Multiple minor bug fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,13 @@
-./data/
+data/
+build/
+
 .git/
+.github/
+.vscode/
+
+**/__pycache__/
+**/.ipynb_checkpoints/
+**/*.pth
+
+**/build/
+**/dist/

--- a/integration_tests/semantic_segmentation/config.py
+++ b/integration_tests/semantic_segmentation/config.py
@@ -23,7 +23,6 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
             return join(dirname(__file__), part)
 
     class_config = ClassConfig(names=['red', 'green'], colors=['red', 'green'])
-    class_config.ensure_null_class()
 
     def make_scene(id, img_path, label_path):
         raster_source = RasterioSourceConfig(

--- a/rastervision_core/rastervision/core/data/class_config.py
+++ b/rastervision_core/rastervision/core/data/class_config.py
@@ -42,8 +42,9 @@ class ClassConfig(Config):
         """Add a null class if one isn't set."""
         if self.null_class is None:
             self.null_class = 'null'
-            self.names.append('null')
-            self.colors.append('black')
+            if self.null_class not in self.names:
+                self.names.append('null')
+                self.colors.append('black')
 
     def update(self, pipeline=None):
         if not self.colors:

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
@@ -19,6 +19,10 @@ class SemanticSegmentationLabelSourceConfig(LabelSourceConfig):
         ('If set, will infer the class_ids for the labels using the colors field. This '
          'assumes the labels are stored as RGB rasters.'))
 
+    def update(self, pipeline=None, scene=None):
+        super().update()
+        self.rgb_class_config.ensure_null_class()
+
     def build(self, class_config, crs_transformer, extent, tmp_dir):
         if isinstance(self.raster_source, RasterizedSourceConfig):
             rs = self.raster_source.build(class_config, crs_transformer,

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
@@ -24,12 +24,13 @@ class VectorOutputConfig(Config):
          'the image.'))
 
     def update(self, pipeline=None, scene=None):
-        if pipeline and scene:
-            mode = self.get_mode()
-            class_id = self.class_id
-            filename = f'{mode}-{class_id}.json'
-            self.uri = join(pipeline.predict_uri, scene.id, 'vector_output',
-                            filename)
+        if self.uri is None:
+            if pipeline and scene:
+                mode = self.get_mode()
+                class_id = self.class_id
+                filename = f'{mode}-{class_id}.json'
+                self.uri = join(pipeline.predict_uri, scene.id,
+                                'vector_output', filename)
 
     def get_mode(self):
         raise NotImplementedError()

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -4,7 +4,10 @@ shapely==1.6.*
 pillow==8.3.*
 pyproj==2.6.*
 rasterio==1.0.7
-scikit-learn==0.24.*
 imageio==2.3.*
 pystac==1.0.*
 mask-to-polygons==0.0.2
+scikit-learn==0.24.*
+scipy>=0.19.1
+joblib>=0.11
+threadpoolctl>=2.0.0

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
@@ -105,7 +105,6 @@ def get_config(runner,
         plot_transform = None
 
     class_config = ClassConfig(names=CLASS_NAMES, colors=CLASS_COLORS)
-    class_config.ensure_null_class()
 
     def make_scene(id) -> SceneConfig:
         id = id.replace('-', '_')
@@ -195,6 +194,8 @@ def get_config(runner,
             plot_options=PlotOptions(transform=plot_transform))
 
     if external_model:
+        class_config.ensure_null_class()
+        num_classes = len(class_config)
         model = SemanticSegmentationModelConfig(
             external_def=ExternalModuleConfig(
                 github_repo='AdeelH/pytorch-fpn:0.2',
@@ -203,7 +204,7 @@ def get_config(runner,
                 entrypoint_kwargs={
                     'name': 'resnet50',
                     'fpn_type': 'panoptic',
-                    'num_classes': len(class_config.names),
+                    'num_classes': num_classes,
                     'fpn_channels': 256,
                     'in_channels': len(channel_order),
                     'out_size': (img_sz, img_sz)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -443,7 +443,9 @@ class GeoDataWindowConfig(Config):
         ...,
         description='If method = sliding, this is the size of sliding window. '
         'If method = random, this is the size that all the windows are '
-        'resized to before they are returned.')
+        'resized to before they are returned. If method = random and neither '
+        'size_lims nor h_lims and w_lims have been specified, then size_lims '
+        'is set to (size, size + 1).')
     stride: Optional[Union[PosInt, Tuple[PosInt, PosInt]]] = Field(
         None,
         description='Stride of sliding window. Only used if method = sliding.')
@@ -456,8 +458,10 @@ class GeoDataWindowConfig(Config):
         description='[min, max) interval from which window sizes will be '
         'uniformly randomly sampled. The upper limit is exclusive. To fix the '
         'size to a constant value, use size_lims = (sz, sz + 1). '
-        'Only used if method = random. Must specify either size_lims or '
-        'h and w lims, but not both.')
+        'Only used if method = random. Specify either size_lims or '
+        'h_lims and w_lims, but not both. If neither size_lims nor h_lims '
+        'and w_lims have been specified, then this will be set to '
+        '(size, size + 1).')
     h_lims: Optional[Tuple[PosInt, PosInt]] = Field(
         None,
         description='[min, max] interval from which window heights will be '
@@ -498,6 +502,14 @@ class GeoDataWindowConfig(Config):
                 raise ConfigError('Specify either size_lims or h and w lims.')
             if has_h_lims != has_w_lims:
                 raise ConfigError('h_lims and w_lims must both be specified')
+
+    def update(self, *args, **kwargs):
+        super().update(*args, **kwargs)
+
+        has_size_lims = self.size_lims is not None
+        has_h_lims = self.h_lims is not None
+        if not (has_size_lims or has_h_lims):
+            self.size_lims = (self.size, self.size + 1)
 
 
 @register_config('geo_data')

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -518,7 +518,7 @@ class GeoDataConfig(DataConfig):
     window_opts: Union[GeoDataWindowConfig, Dict[str, GeoDataWindowConfig]]
 
     def validate_config(self, *args, **kwargs):
-        super().update(*args, **kwargs)
+        super().validate_config(*args, **kwargs)
         if isinstance(self.window_opts, dict):
             scenes = self.scene_dataset.get_all_scenes()
             for s in scenes:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ sphinx-autobuild==2021.3.*
 ptvsd==4.3.*
 jupyter==1.0.*
 shapely==1.6.*
+scipy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,4 @@ sphinx-autobuild==2021.3.*
 ptvsd==4.3.*
 jupyter==1.0.*
 shapely==1.6.*
-scipy
+scipy>=0.19.1

--- a/tests/core/data/label_source/test_semantic_segmentation_label_source.py
+++ b/tests/core/data/label_source/test_semantic_segmentation_label_source.py
@@ -3,8 +3,21 @@ import unittest
 import numpy as np
 
 from rastervision.core import Box
-from rastervision.core.data import ClassConfig, SemanticSegmentationLabelSource
+from rastervision.core.data import (
+    ClassConfig, SemanticSegmentationLabelSource,
+    SemanticSegmentationLabelSourceConfig, RasterioSourceConfig)
 from tests.core.data.mock_raster_source import MockRasterSource
+
+
+class TestSemanticSegmentationLabelSourceConfig(unittest.TestCase):
+    def test_rgb_class_config_null_class(self):
+        raster_source_cfg = RasterioSourceConfig(uris=['/abc/def.tif'])
+        rgb_class_config = ClassConfig(names=['a'], colors=['#010101'])
+        cfg = SemanticSegmentationLabelSourceConfig(
+            raster_source=raster_source_cfg, rgb_class_config=rgb_class_config)
+        cfg.update()
+        self.assertEqual(len(cfg.rgb_class_config), 2)
+        self.assertIn('null', cfg.rgb_class_config.names)
 
 
 class TestSemanticSegmentationLabelSource(unittest.TestCase):

--- a/tests/core/data/label_store/test_semantic_segmentation_label_store.py
+++ b/tests/core/data/label_store/test_semantic_segmentation_label_store.py
@@ -1,0 +1,66 @@
+import unittest
+from os.path import realpath
+
+from rastervision.core.data.label_store import (
+    VectorOutputConfig, PolygonVectorOutputConfig, BuildingVectorOutputConfig,
+    SemanticSegmentationLabelStoreConfig)
+
+
+class MockPipelineConfig():
+    predict_uri = '/abc/def'
+
+
+class MockSceneConfig():
+    id = 'scene-0'
+
+
+class TestSemanticSegmentationLabelStoreConfig(unittest.TestCase):
+    def test_vector_output_config(self):
+        # uri not updated if no pipeline and scene
+        cfg = VectorOutputConfig(class_id=0)
+        cfg.update()
+        self.assertIsNone(cfg.uri)
+
+    def test_polygon_vector_output_config(self):
+        cfg = PolygonVectorOutputConfig(class_id=1)
+        cfg.update(pipeline=MockPipelineConfig(), scene=MockSceneConfig())
+
+        # correct mode
+        self.assertEqual(cfg.get_mode(), 'polygons')
+        # uri updated based on pipeline and scene
+        self.assertEqual(cfg.uri,
+                         '/abc/def/scene-0/vector_output/polygons-1.json')
+
+    def test_building_vector_output_config(self):
+        cfg = BuildingVectorOutputConfig(class_id=2)
+        cfg.update(pipeline=MockPipelineConfig(), scene=MockSceneConfig())
+
+        # correct mode
+        self.assertEqual(cfg.get_mode(), 'buildings')
+        # uri updated based on pipeline and scene
+        self.assertEqual(cfg.uri,
+                         '/abc/def/scene-0/vector_output/buildings-2.json')
+
+    def test_semantic_segmentation_label_store_config(self):
+        # uri not updated if no pipeline and scene
+        cfg = SemanticSegmentationLabelStoreConfig()
+        cfg.update()
+        self.assertIsNone(cfg.uri)
+
+        cfg = SemanticSegmentationLabelStoreConfig(vector_output=[
+            PolygonVectorOutputConfig(class_id=1),
+            BuildingVectorOutputConfig(class_id=2)
+        ])
+        cfg.update(pipeline=MockPipelineConfig(), scene=MockSceneConfig())
+        # uri updated based on pipeline and scene
+        self.assertEqual(realpath(cfg.uri), '/abc/def/scene-0')
+
+        # vector outputs updated
+        self.assertEqual(cfg.vector_output[0].uri,
+                         '/abc/def/scene-0/vector_output/polygons-1.json')
+        self.assertEqual(cfg.vector_output[1].uri,
+                         '/abc/def/scene-0/vector_output/buildings-2.json')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/pytorch_learner/test_dataconfig.py
+++ b/tests/pytorch_learner/test_dataconfig.py
@@ -60,7 +60,7 @@ class TestDataConfig(unittest.TestCase):
 
 
 class TestImageDataConfig(unittest.TestCase):
-    def fail_if_fails(self, fn: Callable, msg=''):
+    def assertNoError(self, fn: Callable, msg=''):
         try:
             fn()
         except Exception:
@@ -85,19 +85,19 @@ class TestImageDataConfig(unittest.TestCase):
         self.assertRaises(ConfigError, lambda: cfg.validate_config())
         # test valid configs
         cfg = ImageDataConfig(group_uris=group_uris, group_train_sz=1)
-        self.fail_if_fails(lambda: cfg.validate_config())
+        self.assertNoError(lambda: cfg.validate_config())
         cfg = ImageDataConfig(
             group_uris=group_uris, group_train_sz=[1] * len(group_uris))
-        self.fail_if_fails(lambda: cfg.validate_config())
+        self.assertNoError(lambda: cfg.validate_config())
         cfg = ImageDataConfig(group_uris=group_uris, group_train_sz_rel=.1)
-        self.fail_if_fails(lambda: cfg.validate_config())
+        self.assertNoError(lambda: cfg.validate_config())
         cfg = ImageDataConfig(
             group_uris=group_uris, group_train_sz_rel=[.1] * len(group_uris))
-        self.fail_if_fails(lambda: cfg.validate_config())
+        self.assertNoError(lambda: cfg.validate_config())
 
 
 class TestGeoDataConfig(unittest.TestCase):
-    def fail_if_fails(self, fn: Callable, msg=''):
+    def assertNoError(self, fn: Callable, msg=''):
         try:
             fn()
         except Exception:
@@ -109,7 +109,9 @@ class TestGeoDataConfig(unittest.TestCase):
         self.assertRaises(ConfigError, lambda: cfg.validate_config())
 
         cfg = GeoDataWindowConfig(method=GeoDataWindowMethod.random, size=10)
-        self.assertRaises(ConfigError, lambda: cfg.validate_config())
+        cfg.update()
+        self.assertEqual(cfg.size_lims, (10, 11))
+        self.assertNoError(lambda: cfg.validate_config())
 
         cfg = GeoDataWindowConfig(
             method=GeoDataWindowMethod.random,


### PR DESCRIPTION
## Overview

This PR makes the following changes:
- Fixes problems with `ClassConfig.ensure_null_class()` (#1259)
- `GeoDtaConfig.size_lims` now automatically defaults to `(size, size+1)` (fixed size) if not specified and `method` = random, saving the user some typing. Also adds unit test for this.
- `GeoDtaConfig.validate_config()` previously used to incorrectly call `super().update()` instead of `super().validate_config()`. This has been fixed.
- Adds scipy to `requirements-dev.txt`. Should have been added in #1225.
- Explicitly adds scikit-learn dependencies to the requirements of rastervision core. Scikit-learn 0.24.* doesn't have a `requirements.txt` of its own, but specifies these dependencies in its readme. (#996)
- updates `.dockerignore` to ignore more stuff
- Fixes bug described in this comment: https://github.com/azavea/raster-vision/issues/1133#issuecomment-797293800
- Adds unit test for the above.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Fixes #1259 
Fixes #996
