### PR TITLE
Make the semantic segmentation integration test more deterministic

### DIFF
--- a/integration_tests/semantic_segmentation/config.py
+++ b/integration_tests/semantic_segmentation/config.py
@@ -93,7 +93,7 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
         solver = SolverConfig(
             lr=1e-9,
             num_epochs=1,
-            batch_sz=2,
+            batch_sz=8,
             one_cycle=True,
             sync_interval=200)
     backend = PyTorchSemanticSegmentationConfig(


### PR DESCRIPTION
## Overview

The test loads a pretrained model, trains it for a single epoch with a batch of size `2` with a very small learning rate of `1e-9`, and then computes metrics. The small learning rate is intended to prevent too big a change in the model's weights (and the metrics). In practice, however, the model's performance occasionally drops enough for it to fail the test.

This has been tracked down to be due to the `running_mean` and `running_var` estimates in `BatchNorm` layers being affected during training. It is hypothesized that this is due to the small batch size (= 2) causing poor estimates of these statistics.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

- To test this fix, we can manually run the relevant part of the integration test. We can do this by using the `get_config()` of the existing test to instantiate a learner.
```python
from tempfile import TemporaryDirectory

from tqdm import tqdm
import numpy as np
import torch
from torch import nn
from torch.utils.data import DataLoader
import matplotlib.pyplot as plt

from rastervision.pipeline.file_system import download_if_needed
from integration_tests.semantic_segmentation.config import get_config

_tmp_dir = TemporaryDirectory()
tmp_dir = _tmp_dir.name

pipeline_cfg = get_config(None, tmp_dir, nochip=True)

pipeline_cfg.update()
pipeline = pipeline_cfg.build(tmp_dir)
backend = pipeline.config.backend.build(pipeline.config, pipeline.tmp_dir)
learner = backend.learner_cfg.build(backend.tmp_dir, training=True)
```

- Allow the Learner to be reset for each test run. Each test run involves training for one epoch and then validating. 
```python
weights_path = download_if_needed(learner.cfg.model.init_weights, tmp_dir)
init_weights = torch.load(weights_path, map_location=learner.device)

def reset_learner(learner, batch_sz):
    learner.model.load_state_dict(init_weights, strict=learner.cfg.model.load_strict)
    learner.start_epoch = 0
    learner.opt = learner.build_optimizer()
    learner.steps_per_epoch = len(learner.train_ds) // batch_sz
    learner.step_scheduler = learner.build_step_scheduler()
    learner.epoch_scheduler = learner.build_epoch_scheduler()
    
    if batch_sz != learner.cfg.solver.batch_sz:
        num_workers = learner.cfg.data.num_workers

        train_ds = learner.train_ds
        valid_ds = learner.valid_ds
        
        train_sampler = learner.get_train_sampler(learner.train_ds)
        train_shuffle = train_sampler is None

        collate_fn = learner.get_collate_fn()
        learner.train_dl = DataLoader(
            train_ds,
            shuffle=train_shuffle,
            batch_size=batch_sz,
            drop_last=True,
            num_workers=num_workers,
            pin_memory=True,
            collate_fn=collate_fn,
            sampler=train_sampler)
        learner.valid_dl = DataLoader(
            valid_ds,
            shuffle=True,
            batch_size=batch_sz,
            num_workers=num_workers,
            pin_memory=True,
            collate_fn=collate_fn)
        
def train_and_validate_epoch(learner):
    learner.train_epoch()
    metrics = learner.validate_epoch(learner.valid_dl)
    return metrics

def n_experiments(n, batch_sz):
    metrics = [None] * n
    with tqdm(range(n)) as bar:
        for i in bar:
            reset_learner(learner, batch_sz=batch_sz)
            metrics[i] = train_and_validate_epoch(learner)
    f1s = np.array([m['avg_f1'] for m in metrics])
    return metrics, f1s
```

- Reproduce the non-deterministically failing behavior of the existing configuration (i.e. `batch_sz = 2`). Do 30 test runs of the test. We see that the test fails about 10% of the time, which seems consistent with past experience.
```python
_, f1s_bsz_2 = n_experiments(n=30, batch_sz=2)
```
![bsz_2](https://user-images.githubusercontent.com/13014700/132230433-df3480be-7233-49b5-b08e-16d7dca9425f.png)


- Change the batch size to 8 and repeat the experiment. We see that the test never fails.
```python
_, f1s_bsz_8 = n_experiments(n=30, batch_sz=8)
```
![bsz_8](https://user-images.githubusercontent.com/13014700/132230610-057821e4-c513-44bf-8481-0750c9d59d14.png)


- To further test the hypothesis that this is due to the `BatchNorm` layers, we can repeat the experiment with these layers frozen. This results in a 100% success rate.
```python
def train_step(self, batch, batch_ind):
    for m in self.model.modules():
        if isinstance(m, nn.BatchNorm2d) or isinstance(m, nn.BatchNorm1d):
            m.eval()
    x, y = batch
    out = self.post_forward(self.model(x))
    return {'train_loss': self.loss(out, y)}

learner.train_step = train_step.__get__(learner, type(learner))

_, f1s_bn = n_experiments(n=30, batch_sz=2)
```
![bn](https://user-images.githubusercontent.com/13014700/132230642-937e4295-e85e-4b9f-b71e-24ecf2cb67c4.png)


Addresses the determinism part of #722 
