### PR TITLE
Update quickstart docs to reflect dir structure after pipeline run

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -70,17 +70,15 @@ If you go to ``${RV_QUICKSTART_OUT_DIR}`` you should see a directory structure l
 
    > tree -L 3
     .
-    ├── analyze
-    │   └── stats.json
+    ├── Makefile
     ├── bundle
     │   └── model-bundle.zip
-    ├── chip
-    │   └── 3113ff8c-5c49-4d3c-8ca3-44d412968108.zip
     ├── eval
     │   └── eval.json
     ├── pipeline-config.json
     ├── predict
-    │   └── scene_25.tif
+    │   └── scene_25
+    │       └── labels.tif
     └── train
         ├── dataloaders
         │   ├── test.png
@@ -91,7 +89,7 @@ If you go to ``${RV_QUICKSTART_OUT_DIR}`` you should see a directory structure l
         ├── log.csv
         ├── model-bundle.zip
         ├── tb-logs
-        │   └── events.out.tfevents.1585513048.086fdd4c5530.214.0
+        │   └── events.out.tfevents.1633298131.e9c80eb53720.32.0
         ├── test_metrics.json
         └── test_preds.png
 


### PR DESCRIPTION
## Overview

The tutorial is working well for me, but the output at this step doesn't quite match what I see: Probably doesn't matter, and maybe there's something weird on my side, but I'm missing `analyze` and `chip`, and `predict` is structured differently.

### Checklist

- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
