### PR TITLE
Add warning about WSL2 NAME environment variable

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -45,7 +45,7 @@ To run a Bash console in the PyTorch Docker container use:
 
 This will mount the ``$RASTER_VISION_DATA_DIR`` local directory to to ``/opt/data/`` inside the container.
 
-.. note::
+.. warning::
 
     Users running under WSL2 in Windows will need to unset the ``NAME`` environment variable. For example, instead of
     ``docker/run``, you would run ``NAME='' docker/run``. By default, WSL2 sets a ``NAME`` variable that matches the network

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -45,7 +45,7 @@ To run a Bash console in the PyTorch Docker container use:
 
 This will mount the ``$RASTER_VISION_DATA_DIR`` local directory to to ``/opt/data/`` inside the container.
 
-.. warning::
+.. note::
 
     Users running under WSL2 in Windows will need to unset the ``NAME`` environment variable. For example, instead of
     ``docker/run``, you would run ``NAME='' docker/run``. By default, WSL2 sets a ``NAME`` variable that matches the network

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -45,6 +45,12 @@ To run a Bash console in the PyTorch Docker container use:
 
 This will mount the ``$RASTER_VISION_DATA_DIR`` local directory to to ``/opt/data/`` inside the container.
 
+.. warning::
+
+    Users running under WSL2 in Windows will need to unset the ``NAME`` environment variable. For example, instead of
+    ``docker/run``, you would run ``NAME='' docker/run``. By default, WSL2 sets a ``NAME`` variable that matches the network
+    name of your computer. This environment variable collides with a variable in the ``docker/run`` script.
+
 This script also has options for forwarding AWS credentials, and running Jupyter notebooks which can be seen below.
 
 .. code-block:: terminal


### PR DESCRIPTION
## Overview

This PR adds a warning box to docs that calls out the environment variable collision I ran into a while ago.

### Checklist

- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

~I don't know how to build the docs locally, it's been years since I've touched sphinx. Any pointers about testing that this works as expected would be appreciated. I think it [should be fine](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/notes_warnings.html#warnings) based on the RST / Sphinx docs linked there but maybe `warning` is a non-standard directive? I know so little about RST.~ Thanks @lewfish turns out I don't need to 🎉

## Testing Instructions

* check out the built docs with the warning [here](https://raster-vision--1307.org.readthedocs.build/en/1307/setup.html#docker-scripts)

Closes #1274 
