### PR TITLE
Allow RGB Class Config to be None

### DIFF
--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
@@ -21,7 +21,8 @@ class SemanticSegmentationLabelSourceConfig(LabelSourceConfig):
 
     def update(self, pipeline=None, scene=None):
         super().update()
-        self.rgb_class_config.ensure_null_class()
+        if self.rgb_class_config:
+            self.rgb_class_config.ensure_null_class()
 
     def build(self, class_config, crs_transformer, extent, tmp_dir):
         if isinstance(self.raster_source, RasterizedSourceConfig):

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
@@ -21,7 +21,7 @@ class SemanticSegmentationLabelSourceConfig(LabelSourceConfig):
 
     def update(self, pipeline=None, scene=None):
         super().update()
-        if self.rgb_class_config:
+        if self.rgb_class_config is not None:
             self.rgb_class_config.ensure_null_class()
 
     def build(self, class_config, crs_transformer, extent, tmp_dir):


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

It seems as though `self.rgb_class_config` is formally allowed to be `None`, but the call to `ensure_null_class` assumes that it is non-null.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

