### PR TITLE
Fix OpenCV compatibility problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN add-apt-repository ppa:ubuntugis/ppa && \
     apt-get install -y wget=1.* git=1:2.* python-protobuf=2.* python3-tk=3.* \
                        jq=1.5* \
                        build-essential libsqlite3-dev=3.11.* zlib1g-dev=1:1.2.* \
-                       libopencv-dev=2.4.* python-opencv=2.4.* unzip curl && \
+                       unzip curl && \
     apt-get autoremove && apt-get autoclean && apt-get clean
 
 # See https://github.com/mapbox/rasterio/issues/1289

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -12,3 +12,4 @@ scipy>=0.19.1
 joblib>=0.11
 threadpoolctl>=2.0.0
 opencv-python==4.1.*
+opencv-python-headless<4.3

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -11,3 +11,4 @@ scikit-learn==0.24.*
 scipy>=0.19.1
 joblib>=0.11
 threadpoolctl>=2.0.0
+opencv-python==4.1.*

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -11,3 +11,4 @@ pycocotools==2.0.*
 future==0.18.*
 psutil==5.8.*
 triangle==20200424
+opencv-python==4.1.*

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -12,3 +12,4 @@ future==0.18.*
 psutil==5.8.*
 triangle==20200424
 opencv-python==4.1.*
+opencv-python-headless<4.3


### PR DESCRIPTION
## Overview

This PR fixes the below error
```
  File "/opt/conda/lib/python3.7/site-packages/cv2/__init__.py", line 9, in <module>
    from .cv2 import _registerMatType
ImportError: cannot import name '_registerMatType' from 'cv2.cv2' (/opt/conda/lib/python3.7/site-packages/cv2/cv2.cpython-37m-x86_64-linux-gnu.so)
```

that started cropping up in recent builds during unit testing, even though no OpenCV-related changes have been made recently.

See other discussions of this error below:
- https://github.com/opencv/opencv-python/issues/591
- https://stackoverflow.com/questions/70537488/cannot-import-name-registermattype-from-cv2-cv2

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* build Docker image
* Run unit tests
* If unit tests succeed, the issue has been resolved.
