### PR TITLE
Add support for external models for object detection

### DIFF
--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
@@ -84,7 +84,7 @@ def get_config(runner,
         return SceneConfig(
             id=id, raster_source=raster_source, label_source=label_source)
 
-    class_config = ClassConfig(names=['vehicle'])
+    class_config = ClassConfig(names=['vehicle'], colors=['red'])
     scene_dataset = DatasetConfig(
         class_config=class_config,
         train_scenes=[make_scene(id) for id in train_ids],

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
@@ -113,8 +113,7 @@ class PyTorchObjectDetection(PyTorchLearnerBackend):
         batch_out = self.learner.numpy_predict(chips, raw_out=False)
         labels = ObjectDetectionLabels.make_empty()
 
-        for chip_ind, out in enumerate(batch_out):
-            window = windows[chip_ind]
+        for window, out in zip(windows, batch_out):
             boxes = out['boxes']
             class_ids = out['class_ids']
             scores = out['scores']

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -62,9 +62,6 @@ class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
 
     @validator('model')
     def validate_model_config(cls, v):
-        if v.external_def is not None:
-            raise ConfigError('external_def is currently not supported for '
-                              'Object Detection.')
         return v
 
     @validator('solver')

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -76,5 +76,11 @@ class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
         if v.external_loss_def is not None:
             raise ConfigError(
                 'external_loss_def is currently not supported for '
-                'Object Detection.')
+                'Object Detection. Raster Vision expects object '
+                'detection models to behave like TorchVision object detection '
+                'models, and these models compute losses internally. So, if '
+                'you want to use a custom loss function, you can create a '
+                'custom model that implements that loss function and use that '
+                'model via external_model_def. See cowc_potsdam.py for an '
+                'example of how to use a custom object detection model.')
         return v

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/transform.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/transform.py
@@ -157,7 +157,7 @@ def object_detection_transformer(
     if len(boxes) == 0:
         boxes = torch.empty((0, 4)).float()
 
-    y = BoxList(boxes, class_ids=class_ids)
+    y = BoxList(boxes, format='yxyx', class_ids=class_ids)
 
     return x, y
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -267,10 +267,7 @@ class Learner(ABC):
         """
         ext_cfg = self.cfg.model.external_def
         if ext_cfg is not None:
-            hubconf_dir = self._get_external_module_dir(
-                ext_cfg, model_def_path)
-            self.model = self.load_external_module(
-                ext_cfg=ext_cfg, hubconf_dir=hubconf_dir)
+            self.model = self.load_external_model(ext_cfg, model_def_path)
         else:
             self.model = self.build_model()
         self.model.to(self.device)
@@ -281,6 +278,21 @@ class Learner(ABC):
         """Build a PyTorch model."""
         pass
 
+    def load_external_model(self,
+                            ext_cfg: ExternalModuleConfig,
+                            model_def_path: Optional[str] = None) -> nn.Module:
+        """Load an external model via torch.hub.
+
+        Args:
+            ext_cfg (ExternalModuleConfig): Config describing the module.
+            model_def_path (str, optional): Model definition path. Will be
+            available when loading from a bundle. Defaults to None.
+        """
+        hubconf_dir = self._get_external_module_dir(ext_cfg, model_def_path)
+        model = self.load_external_module(
+            ext_cfg=ext_cfg, hubconf_dir=hubconf_dir)
+        return model
+
     def setup_loss(self, loss_def_path: Optional[str] = None) -> None:
         """Setup self.loss.
 
@@ -290,9 +302,7 @@ class Learner(ABC):
         """
         ext_cfg = self.cfg.solver.external_loss_def
         if ext_cfg is not None:
-            hubconf_dir = self._get_external_module_dir(ext_cfg, loss_def_path)
-            self.loss = self.load_external_module(
-                ext_cfg=ext_cfg, hubconf_dir=hubconf_dir)
+            self.loss = self.load_external_loss(ext_cfg, loss_def_path)
         else:
             self.loss = self.build_loss()
 
@@ -302,6 +312,21 @@ class Learner(ABC):
     def build_loss(self) -> nn.Module:
         """Build a loss Callable."""
         pass
+
+    def load_external_loss(self,
+                           ext_cfg: ExternalModuleConfig,
+                           loss_def_path: Optional[str] = None) -> nn.Module:
+        """Load an external loss function via torch.hub.
+
+        Args:
+            ext_cfg (ExternalModuleConfig): Config describing the module.
+            loss_def_path (str, optional): Loss definition path. Will be
+            available when loading from a bundle. Defaults to None.
+        """
+        hubconf_dir = self._get_external_module_dir(ext_cfg, loss_def_path)
+        loss = self.load_external_module(
+            ext_cfg=ext_cfg, hubconf_dir=hubconf_dir)
+        return loss
 
     def _get_external_module_dir(
             self,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
@@ -134,7 +134,14 @@ class ObjectDetectionLearner(Learner):
         return numpy_out
 
     def plot_xyz(self, ax, x, y, z=None):
-        plot_xyz(ax, x, y, self.cfg.data.class_names, z=z)
+        data_cfg = self.cfg.data
+        plot_xyz(
+            ax,
+            x,
+            y,
+            class_names=data_cfg.class_names,
+            class_colors=data_cfg.class_colors,
+            z=z)
 
     def prob_to_pred(self, x):
         return x

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/torch_hub.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/torch_hub.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 from pathlib import Path
-from os.path import join, isdir, samefile
+from os.path import join, isdir, realpath
 import shutil
 from glob import glob
 
@@ -84,6 +84,7 @@ def torch_hub_load_github(repo: str, hubconf_dir: str, tmp_dir: str,
     out = torch.hub.load(repo, entrypoint, *args, source='github', **kwargs)
 
     orig_dir = join(tmp_dir, _repo_name_to_dir_name(repo))
+    _remove_dir(hubconf_dir)
     shutil.move(orig_dir, hubconf_dir)
 
     return out
@@ -137,7 +138,7 @@ def torch_hub_load_uri(uri: str, hubconf_dir: str, entrypoint: str,
     # assume uri is local and attempt copying
     else:
         # only copy if needed
-        if not samefile(uri, hubconf_dir):
+        if realpath(uri) != realpath(hubconf_dir):
             _remove_dir(hubconf_dir)
             shutil.copytree(uri, hubconf_dir)
 

--- a/tests/pytorch_learner/test_object_detection_utils.py
+++ b/tests/pytorch_learner/test_object_detection_utils.py
@@ -1,0 +1,158 @@
+import unittest
+
+import numpy as np
+import torch
+from torch import nn
+from torchvision.ops import box_convert
+
+from rastervision.pytorch_learner.object_detection_utils import (
+    BoxList, collate_fn, TorchVisionODAdapter)
+
+
+class MockModel(nn.Module):
+    def __init__(self, num_classes: int) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+
+    def forward(self, x, y=None):
+        if self.training:
+            assert y is not None
+            return {'loss1': 0, 'loss2': 0}
+        else:
+            N = len(x)
+            nboxes = np.random.randint(0, 10)
+            outs = [{
+                'boxes': torch.rand((nboxes, 4)),
+                'labels': torch.randint(0, self.num_classes, (nboxes, )),
+                'scores': torch.rand((nboxes, )),
+            } for _ in range(N)]
+            return outs
+
+
+class TestTorchVisionODAdapter(unittest.TestCase):
+    def test_train_output(self):
+        true_num_classes = 3
+        model = TorchVisionODAdapter(
+            MockModel(num_classes=true_num_classes + 2),
+            ignored_output_inds=[0, true_num_classes + 1])
+        model.train()
+
+        N = 10
+        x = torch.empty(N, 3, 100, 100)
+        y = [
+            BoxList(
+                boxes=torch.rand((10, 4)),
+                class_ids=torch.randint(0, 5, (N, ))) for _ in range(N)
+        ]
+        self.assertRaises(Exception, lambda: model(x))
+        out = model(x, y)
+        self.assertIsInstance(out, dict)
+        self.assertIn('total_loss', out)
+
+    def test_eval_output_with_bogus_class(self):
+        true_num_classes = 3
+        model = TorchVisionODAdapter(
+            MockModel(num_classes=true_num_classes + 2),
+            ignored_output_inds=[0, true_num_classes + 1])
+        model.eval()
+
+        N = 10
+        x = torch.empty(N, 3, 100, 100)
+        outs = model(x)
+        for out in outs:
+            self.assertIsInstance(out, BoxList)
+            self.assertIn('class_ids', out)
+            self.assertIn('scores', out)
+            self.assertTrue(
+                all((0 <= c < true_num_classes)
+                    for c in out.get_field('class_ids')))
+
+    def test_eval_output_without_bogus_class(self):
+        true_num_classes = 3
+        model = TorchVisionODAdapter(
+            MockModel(num_classes=true_num_classes + 1),
+            ignored_output_inds=[0])
+        model.eval()
+
+        N = 10
+        x = torch.empty(N, 3, 100, 100)
+        outs = model(x)
+        for out in outs:
+            self.assertIsInstance(out, BoxList)
+            self.assertIn('class_ids', out)
+            self.assertIn('scores', out)
+            self.assertTrue(
+                all((0 <= c < true_num_classes)
+                    for c in out.get_field('class_ids')))
+
+
+class TestBoxList(unittest.TestCase):
+    def test_init(self):
+        boxes = torch.rand((10, 4))
+        # no conversion when format = xyxy
+        boxlist = BoxList(boxes)
+        self.assertTrue(torch.equal(boxlist.boxes, boxes))
+        boxlist = BoxList(boxes, format='xyxy')
+        self.assertTrue(torch.equal(boxlist.boxes, boxes))
+        # test correct conversion from yxyx to xyxy
+        boxlist = BoxList(boxes, format='yxyx')
+        self.assertTrue(torch.equal(boxlist.boxes, boxes[:, [1, 0, 3, 2]]))
+        # test correct conversion from other formats to xyxy
+        for in_fmt in ['xywh', 'cxcywh']:
+            boxlist = BoxList(boxes, format=in_fmt)
+            self.assertTrue(
+                torch.equal(boxlist.boxes, box_convert(boxes, in_fmt, 'xyxy')))
+
+    def test_get_field(self):
+        boxes = torch.rand((10, 4))
+        class_ids = torch.randint(0, 5, (10, ))
+        boxlist = BoxList(boxes, class_ids=class_ids)
+        self.assertTrue(torch.equal(boxlist.get_field('class_ids'), class_ids))
+
+    def test_map_extras(self):
+        boxes = torch.rand((10, 4))
+        class_ids = torch.randint(0, 3, (10, ))
+        scores = torch.rand((10, ))
+        class_names = np.array(['a', 'b', 'c'])[class_ids.numpy()]
+        boxlist = BoxList(
+            boxes, class_ids=class_ids, scores=scores, class_names=class_names)
+        boxlist = BoxList(
+            boxes,
+            **boxlist._map_extras(
+                func=lambda k, v: v[:-1],
+                cond=lambda k, v: torch.is_tensor(v)))
+        self.assertTrue(
+            torch.equal(boxlist.get_field('class_ids'), class_ids[:-1]))
+        self.assertTrue(torch.equal(boxlist.get_field('scores'), scores[:-1]))
+        self.assertTrue(all(class_names == boxlist.get_field('class_names')))
+
+    def test_to(self):
+        boxes = torch.rand((10, 4))
+        class_ids = torch.randint(0, 3, (10, ))
+        scores = torch.rand((10, ))
+        class_names = np.array(['a', 'b', 'c'])[class_ids.numpy()]
+        boxlist = BoxList(
+            boxes, class_ids=class_ids, scores=scores, class_names=class_names)
+        boxlist = boxlist.to(dtype=torch.float32)
+        self.assertTrue(
+            torch.equal(boxlist.get_field('class_ids'), class_ids.float()))
+        self.assertTrue(
+            torch.equal(boxlist.get_field('scores'), scores.float()))
+        self.assertTrue(all(class_names == boxlist.get_field('class_names')))
+
+    def test_collate_fn(self):
+        imgs = [torch.empty(3, 100, 100) for _ in range(4)]
+        boxlists = []
+        for _ in range(4):
+            boxes = torch.rand((10, 4))
+            class_ids = torch.randint(0, 3, (10, ))
+            boxlist = BoxList(boxes, class_ids=class_ids)
+            boxlists.append(boxlist)
+        x, y = collate_fn(zip(imgs, boxes))
+
+        self.assertEqual(x.shape, (4, 3, 100, 100))
+        self.assertTrue(all(b1 == b2 for b1, b2 in zip(boxlists, y)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

This PR
- Renames the `MyFasterRCNN` adapter to `TorchVisionODAdapter`.
- Moves backbone-creation code out of the adapter and into `ObjectDetectionLearner.build_model()`.
- Refactors `BoxList`. See commit body for details.
- Abstracts out the conversions to/from `BoxLists` into their own functions for clarity and easier testing.
- Adds unit tests for the new adapter and `BoxList`.

As a workaround for limitations of older versions of TorchVision, the adapter code previously used to add 2 extra classes to model. In newer TorchVision versions, only one such extra class is needed. However, to maintain backward compatibility with models trained with earlier Raster Vision versions, `build_model()` still adds 2 extra classes. External models, however, are not subject to this backward compatibility constraint and only need to add one extra class. The code assumes this to be true when dealing with external models.

Also updates the plotting function to make use of util functions provided by TorchVision. Results look like this:
![image](https://user-images.githubusercontent.com/13014700/153637229-4562f914-7d9c-4077-91d3-59bc38f29afd.png)


## Comparison with previous Faster RCNN implementation:
- Small speed up in average epoch training time (mm:ss): `01:47 --> 01:29`.
- No speed up in average validation time (mm:ss): `00:15 --> 00:16`.
- Slight, probably statistically insignificant, improvement in metrics:
```sh
python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
compare \
"s3://raster-vision/examples/0.13/output/cowc-potsdam-od/" \
"s3://raster-vision-ahassan/rvtest/od/cowc/"
```
![image](https://user-images.githubusercontent.com/13014700/153829594-aa8f1e49-0626-4eeb-904e-f04f3b417ec8.png)

## Comparison between Faster RCNN and SSD:
- SSD runs much faster with an average epoch training time of `01:00` (compared to `01:29` with ResNet-18 Faster RCNN).
- Average validation time of `00:11`.
- SSD performs considerably worse:
```sh
python "rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py" \
compare \
"s3://raster-vision-ahassan/rvtest/od/cowc/" \
"s3://raster-vision-ahassan/rvtest/od/cowc_ssd/"
```
![image](https://user-images.githubusercontent.com/13014700/153829770-da405387-0649-4374-89a2-37284e0a6fb4.png)

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
- Run `cowc_potsdam.py` with `-a external_model True`.

Closes #1256
