### PR TITLE
Documentation updated to indicate backward compatibility of bundles.

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -267,6 +267,8 @@ Note that the input file is assumed to have the same channel order and statistic
 
 When unzipped, the model bundle contains a ``model.pth`` file which can be used for fine-tuning.
 
+.. note:: The model bundles linked below are only compatible with Raster Vision version ``0.12`` or greater.
+
 .. list-table:: Model Zoo
    :header-rows: 1
 


### PR DESCRIPTION
## Overview

This PR updates the documentation by adding a note about about the backwards compatibility issues with _Model Zoo_. The note is introduced here in this [section](https://docs.rastervision.io/en/0.13/examples.html#model-zoo), where the user can know about this.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes
I don't know if `needs-backport` label is required for documentation change.

## Testing Instructions

* _Documentation change_

Closes #1338 
