### PR TITLE
Add progress bars to downloads and uploads in HttpFileSystem and S3FileSystem

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ build/
 .git/
 .github/
 .vscode/
+.history/
 
 **/__pycache__/
 **/.ipynb_checkpoints/

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ deployment/ansible/*.retry
 /data/
 /notebooks/
 /.vscode/
+/.history/

--- a/rastervision_aws_s3/requirements.txt
+++ b/rastervision_aws_s3/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.17.*
 rastervision_pipeline==0.13
 awscli==1.19.*
+tqdm==4.62

--- a/rastervision_pipeline/rastervision/pipeline/file_system/http_file_system.py
+++ b/rastervision_pipeline/rastervision/pipeline/file_system/http_file_system.py
@@ -64,10 +64,7 @@ class HttpFileSystem(FileSystem):
     def file_exists(uri: str, include_dir: bool = True) -> bool:
         try:
             response = urllib.request.urlopen(uri)
-            if response.getcode() == 200:
-                return int(response.headers['content-length']) > 0
-            else:
-                return False  # pragma: no cover
+            return response.getcode() == 200
         except urllib.error.URLError:
             return False
 

--- a/rastervision_pipeline/rastervision/pipeline/file_system/http_file_system.py
+++ b/rastervision_pipeline/rastervision/pipeline/file_system/http_file_system.py
@@ -1,12 +1,55 @@
+from typing import ContextManager
 import os
+import io
 import shutil
 import urllib
 import urllib.request
+from urllib.parse import urlparse
+import requests
 from datetime import datetime
+from functools import partial
+
+from tqdm import tqdm
 
 from rastervision.pipeline.file_system import (FileSystem, NotReadableError,
                                                NotWritableError)
-from urllib.parse import urlparse
+
+
+def get_file_obj(uri: str, with_progress: bool = True) -> ContextManager:
+    """Returns a context manager for a file-like object that supports buffered
+    reads. If with_progress is True, wraps the read() method of the object in
+    a function that updates a tqdm progress bar.
+
+    Usage:
+    ```
+    with get_file_obj(uri) as f:
+        ...
+    ```
+
+    Adapted from https://stackoverflow.com/a/63831344/5908685.
+    """
+    r = requests.get(uri, stream=True, allow_redirects=True)
+    if r.status_code != 200:
+        r.raise_for_status()  # Will only raise for 4xx codes, so...
+        raise RuntimeError(
+            f'Request to {uri} returned status code {r.status_code}')
+    file_obj = r.raw
+    # Decompress if needed
+    file_obj.read = partial(file_obj.read, decode_content=True)
+    if not with_progress:
+        return file_obj
+    file_size = int(r.headers.get('Content-Length', 0))
+    desc = '(Unknown total file size)' if file_size == 0 else ''
+    # put a wrapper around file_obj's read() method that updates the
+    # progress bar
+    file_obj_wrapped = tqdm.wrapattr(
+        file_obj,
+        'read',
+        total=file_size,
+        desc=desc,
+        bytes=True,
+        mininterval=0.5)
+    return file_obj_wrapped
 
 
 class HttpFileSystem(FileSystem):
@@ -34,8 +77,9 @@ class HttpFileSystem(FileSystem):
 
     @staticmethod
     def read_bytes(uri: str) -> bytes:
-        with urllib.request.urlopen(uri) as req:
-            return req.read()
+        with get_file_obj(uri) as in_file, io.BytesIO() as write_buffer:
+            shutil.copyfileobj(in_file, write_buffer)
+            return write_buffer.getvalue()
 
     @staticmethod
     def write_str(uri: str, data: str) -> None:
@@ -62,12 +106,9 @@ class HttpFileSystem(FileSystem):
 
     @staticmethod
     def copy_from(src_uri: str, dst_path: str) -> None:
-        with urllib.request.urlopen(src_uri) as response:
-            with open(dst_path, 'wb') as out_file:
-                try:
-                    shutil.copyfileobj(response, out_file)
-                except Exception:  # pragma: no cover
-                    raise NotReadableError('Could not read {}'.format(src_uri))
+        with get_file_obj(src_uri) as in_file, open(dst_path,
+                                                    'wb') as out_file:
+            shutil.copyfileobj(in_file, out_file)
 
     @staticmethod
     def local_path(uri: str, download_dir: str) -> None:

--- a/rastervision_pipeline/rastervision/pipeline/file_system/local_file_system.py
+++ b/rastervision_pipeline/rastervision/pipeline/file_system/local_file_system.py
@@ -28,9 +28,11 @@ def make_dir(path, check_empty=False, force_empty=False, use_dirname=False):
 
     os.makedirs(directory, exist_ok=True)
 
-    if check_empty and any(os.scandir(directory)):
-        raise ValueError(
-            '{} needs to be an empty directory!'.format(directory))
+    if check_empty:
+        with os.scandir(directory) as it:
+            if any(it):
+                raise ValueError(
+                    f'{directory} needs to be an empty directory!')
 
 
 class LocalFileSystem(FileSystem):

--- a/rastervision_pipeline/rastervision/pipeline/file_system/utils.py
+++ b/rastervision_pipeline/rastervision/pipeline/file_system/utils.py
@@ -155,7 +155,7 @@ def download_if_needed(uri: str,
     make_dir(path, use_dirname=True)
 
     if path != uri:
-        log.debug('Downloading {} to {}'.format(uri, path))
+        log.info(f'Downloading {uri} to {path}')
 
     fs.copy_from(uri, path)
 

--- a/rastervision_pipeline/requirements.txt
+++ b/rastervision_pipeline/requirements.txt
@@ -4,3 +4,4 @@ typing_extensions==3.10.0.0
 everett==1.0.3
 six==1.16.*
 everett[ini]==1.0.3
+tqdm==4.62

--- a/scripts/unit_tests
+++ b/scripts/unit_tests
@@ -20,7 +20,7 @@ else
     # use it to run the unit tests.  Otherwise, use the normal Python
     # executable.
     if ! [ -x "$(command -v coverage)" ]; then
-	    python -m unittest discover tests
+	    python -m unittest discover tests -vf
     else
 	    coverage run -m unittest discover tests -vf
     fi

--- a/tests/pipeline/test_file_system.py
+++ b/tests/pipeline/test_file_system.py
@@ -239,6 +239,12 @@ class TestS3Misc(unittest.TestCase):
         self.tmp_dir.cleanup()
         self.mock_s3.stop()
 
+    def test_parse_uri(self):
+        s3_path = f's3://{self.bucket_name}/lorem1.txt'
+        fs = FileSystem.get_file_system(s3_path, 'r')
+        bucket, key = fs.parse_uri(s3_path)
+        self.assertEqual((bucket, key), (self.bucket_name, 'lorem1.txt'))
+
     def test_last_modified_s3(self):
         path = os.path.join(self.tmp_dir.name, 'lorem', 'ipsum1.txt')
         s3_path = 's3://{}/lorem1.txt'.format(self.bucket_name)

--- a/tests/pipeline/test_file_system.py
+++ b/tests/pipeline/test_file_system.py
@@ -406,6 +406,9 @@ class TestHttpMisc(unittest.TestCase):
         http_path = ('https://raw.githubusercontent.com/tensorflow/models/'
                      '17fa52864bfc7a7444a8b921d8a8eb1669e14ebd/README.md')
         self.assertTrue(file_exists(http_path))
+        http_path = ('https://github.com/azavea/raster-vision/archive/refs/'
+                     'heads/0.13.zip')
+        self.assertTrue(file_exists(http_path))
 
     def test_file_exists_http_false(self):
         http_path = ('https://raw.githubusercontent.com/tensorflow/models/'


### PR DESCRIPTION
## Overview

This PR
- adds progress bars to downloads and uploads in HttpFileSystem and S3FileSystem via `tqdm`
- adds `tqdm` as a requirement to `rastervision_pipeline` and `rastervision_aws_s3`
- fixes #1344 
- fixes a warning raised in `LocalFileSystem.make_dir()`
- makes some other minor housekeeping edits

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

### How to test this PR
- Run the following in a python/ipython shell. You should see a progress bar for each of these:
```python
import os
from os.path import join
from rastervision.pipeline.file_system import (str_to_file, file_to_str, download_if_needed, upload_or_copy)
from tempfile import TemporaryDirectory

# S3
s3_root = 's3://raster-vision-ahassan/rvtest/pr_1343'

s = 'a' * 100_000
str_to_file(s, join(s3_root, 's.txt'))
_ = file_to_str(join(s3_root, 's.txt'))

with TemporaryDirectory() as tmp_dir:
    path = download_if_needed(join(s3_root, 's.txt'), tmp_dir)
    upload_or_copy(path, join(s3_root, 's_copy.txt'))

# HTTP
_ = file_to_str('https://raw.githubusercontent.com/dwyl/english-words/master/words_alpha.txt')
with TemporaryDirectory() as tmp_dir:
    _ = download_if_needed('https://github.com/azavea/raster-vision-data/releases/download/v0.12/object-detection.pth',  tmp_dir)
```
- You should also see progress bars when running `python tests/pipeline/test_file_system.py`.

Closes #1344 
