### PR TITLE
Update yapf to 0.23

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ flake8==4.0.*
 moto==3.0.6
 coverage==5.5
 codecov==2.1.12
-yapf==0.22.*
+yapf==0.23.*
 unify==0.5
 sphinx==4.0.*
 sphinx-autobuild==2021.3.*

--- a/scripts/format_code
+++ b/scripts/format_code
@@ -30,5 +30,5 @@ else
     find . -name '*.py' -print0 | xargs -0 $UNIFY
 
     echo "Running yapf..."
-    yapf -ipr "$SRC_DIR" -e "**/conf.py" -e "**/setup.py" -e "**/cookiecutter_template/**" -e "*tfod_utils*"
+    yapf -ipr "$SRC_DIR" -e "*.git*" -e "*build*" -e "*cookiecutter_template*" -e "*tfod_utils*" -e "**/conf.py" -e "**/setup.py" -e "*.history*"
 fi

--- a/scripts/style_tests
+++ b/scripts/style_tests
@@ -29,9 +29,7 @@ else
     # Exit code of 1 if yapf has a non-empty diff
     # (ie. scripts/format_code needs to be run)
     echo "Checking that code is consistent with yapf..."
-    if !(yapf -dpr -e "*cookiecutter_template*" -e "*tfod_utils*" -e "**/conf.py" -e "**/setup.py" "$SRC_DIR" > /dev/null &&
-             yapf -dpr "$SRC_DIR/tests" > /dev/null &&
-             yapf -dpr "$SRC_DIR/integration_tests" > /dev/null); then
+    if !(yapf -dpr -e "*.git*" -e "*build*" -e "*cookiecutter_template*" -e "*tfod_utils*" -e "**/conf.py" -e "**/setup.py" -e "*.history*" "$SRC_DIR" > /dev/null); then
         echo "Code has not been formatted by yapf. Need to run ./scripts/format_code."
         exit 1
     fi


### PR DESCRIPTION
## Overview

Depends on #1359.

Versions higher than this seem to cause problems. They sometimes produce bad indentations that not only look bad but also conflict with flake8's E126.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

