### PR TITLE
Add support for Albumentations' lambda transforms

### DIFF
--- a/rastervision_pipeline/rastervision/pipeline/file_system/utils.py
+++ b/rastervision_pipeline/rastervision/pipeline/file_system/utils.py
@@ -217,7 +217,7 @@ def list_paths(uri: str, ext: str = '',
 
 def upload_or_copy(src_path: str,
                    dst_uri: str,
-                   fs: Optional[FileSystem] = None) -> List[str]:
+                   fs: Optional[FileSystem] = None) -> None:
     """Upload or copy a file.
 
     If dst_uri is local, the file is copied. Otherwise, it is uploaded.

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -464,7 +464,7 @@ class Learner(ABC):
             aug_transform = deserialize_albumentation_transform(
                 cfg.data.aug_transform)
             aug_transform = A.Compose(
-                [aug_transform, base_transform], bbox_params=bbox_params)
+                [base_transform, aug_transform], bbox_params=bbox_params)
             return base_transform, aug_transform
 
         augmentors_dict = {
@@ -477,7 +477,7 @@ class Learner(ABC):
             'RGBShift': A.RGBShift(),
             'ToGray': A.ToGray()
         }
-        aug_transforms = []
+        aug_transforms = [base_transform]
         for augmentor in cfg.data.augmentors:
             try:
                 aug_transforms.append(augmentors_dict[augmentor])
@@ -485,7 +485,6 @@ class Learner(ABC):
                 log.warning(
                     f'{k} is an unknown augmentor. Continuing without {k}. '
                     f'Known augmentors are: {list(augmentors_dict.keys())}')
-        aug_transforms.append(base_transform)
         aug_transform = A.Compose(aug_transforms, bbox_params=bbox_params)
 
         return base_transform, aug_transform

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -390,6 +390,24 @@ class DataConfig(Config):
     def make_datasets(self) -> Tuple[Dataset, Dataset, Dataset]:
         raise NotImplementedError()
 
+    def get_custom_albumentations_transforms(self) -> List[dict]:
+        """This should return all serialized albumentations transforms with
+        a 'lambda_transforms_path' field contained in this
+        config or in any of its members no matter how deeply neseted.
+
+        The pupose is to make it easier to adjust their paths all at once while
+        saving to or loading from a bundle.
+        """
+        transforms_all = [
+            self.base_transform, self.aug_transform,
+            self.plot_options.transform
+        ]
+        transforms_with_lambdas = [
+            tf for tf in transforms_all if (tf is not None) and (
+                tf.get('lambda_transforms_path') is not None)
+        ]
+        return transforms_with_lambdas
+
 
 @register_config('image_data')
 class ImageDataConfig(DataConfig):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -323,7 +323,7 @@ def data_config_upgrader(cfg_dict: dict, version: int) -> dict:
 class DataConfig(Config):
     """Config related to dataset for training and testing."""
     class_names: List[str] = Field([], description='Names of classes.')
-    class_colors: Optional[Union[List[str], List[List]]] = Field(
+    class_colors: Optional[List[Union[str, Tuple[int, int, int]]]] = Field(
         None,
         description=('Colors used to display classes. '
                      'Can be color 3-tuples in list form.'))

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
@@ -83,7 +83,16 @@ def validate_albumentation_transform(tf_dict: Optional[dict]) -> dict:
     """
     if tf_dict is not None:
         try:
-            _ = deserialize_albumentation_transform(tf_dict)
+            lambda_transforms_path = tf_dict.get('lambda_transforms_path',
+                                                 None)
+            # hack: if this is being called while building the config from the
+            # bundle, skip the validation because the 'lambda_transforms_path's
+            # have not been adjusted yet
+            if (lambda_transforms_path is not None
+                    and lambda_transforms_path.startswith('model-bundle')):
+                return tf_dict
+            else:
+                _ = deserialize_albumentation_transform(tf_dict)
         except Exception:
             raise ConfigError('The given serialization is invalid. Use '
                               'A.to_dict(transform) to serialize.')

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
@@ -1,8 +1,11 @@
 from typing import Dict, Sequence, Tuple, Optional, Union, List, Iterable
+from tempfile import TemporaryDirectory
+from os.path import basename, join
 import logging
 
 import torch
 from torch import nn
+from torch.hub import import_module
 import numpy as np
 from PIL import ImageColor
 import albumentations as A
@@ -74,14 +77,95 @@ def compute_conf_mat_metrics(conf_mat, label_names, eps=1e-6):
     return metrics
 
 
-def validate_albumentation_transform(tf: dict):
-    """ Validate a serialized albumentation transform. """
-    if tf is not None:
+def validate_albumentation_transform(tf_dict: Optional[dict]) -> dict:
+    """ Validate a serialized albumentation transform by attempting to
+    deserialize it.
+    """
+    if tf_dict is not None:
         try:
-            A.from_dict(tf)
+            _ = deserialize_albumentation_transform(tf_dict)
         except Exception:
             raise ConfigError('The given serialization is invalid. Use '
                               'A.to_dict(transform) to serialize.')
+    return tf_dict
+
+
+def serialize_albumentation_transform(
+        tf: A.BasicTransform,
+        lambda_transforms_path: Optional[str] = None,
+        dst_dir: Optional[str] = None) -> dict:
+    """Serialize an albumentations transform to a dict.
+
+    If the transform includes a Lambda transform, a `lambda_transforms_path`
+    should be provided. This should be a path to a python file that defines a
+    dict named `lambda_transforms` as required by `A.from_dict()`. See
+    https://albumentations.ai/docs/examples/serialization/ for details. This
+    path is saved as a field in the returned dict so that it is available
+    at the time of deserialization.
+
+    Args:
+        tf (A.BasicTransform): The transform to serialize.
+        lambda_transforms_path (Optional[str], optional): Path to a python file
+            that defines a dict named `lambda_transforms` as required by
+            `A.from_dict()`. Defaults to None.
+        dst_dir (Optional[str], optional): Directory to copy the transforms
+            file to. Useful for copying the file to S3 when running on Batch.
+            Defaults to None.
+
+    Returns:
+        dict: The serialized transform.
+    """
+    tf_dict = A.to_dict(tf)
+
+    if lambda_transforms_path is not None:
+        if dst_dir is not None:
+            from rastervision.pipeline.file_system import upload_or_copy
+
+            filename = basename(lambda_transforms_path)
+            dst_uri = join(dst_dir, filename)
+            upload_or_copy(lambda_transforms_path, dst_uri)
+            lambda_transforms_path = dst_uri
+        # save the path in the dict so that it is available
+        # at deserialization time
+        tf_dict['lambda_transforms_path'] = lambda_transforms_path
+
+    return tf_dict
+
+
+def deserialize_albumentation_transform(tf_dict: dict) -> A.BasicTransform:
+    """Deserialize an albumentations transform serialized by
+    `serialize_albumentation_transform()`.
+
+    If the input dict contains a `lambda_transforms_path`, the
+    `lambda_transforms` dict is dynamically imported from it and passed to
+    `A.from_dict()`. See
+    https://albumentations.ai/docs/examples/serialization/ for details
+
+    Args:
+        tf_dict (dict): Serialized albumentations transform.
+
+    Returns:
+        A.BasicTransform: Deserialized transform.
+    """
+    lambda_transforms_path = tf_dict.get('lambda_transforms_path', None)
+    if lambda_transforms_path is not None:
+        from rastervision.pipeline.file_system import download_if_needed
+
+        with TemporaryDirectory() as tmp_dir:
+            filename = basename(lambda_transforms_path)
+            # download the transforms definition file into tmp_dir
+            lambda_transforms_path = download_if_needed(
+                lambda_transforms_path, tmp_dir)
+            # import it as a module
+            lambda_transforms_module = import_module(
+                name=filename, path=lambda_transforms_path)
+            # retrieve the lambda_transforms dict from the module
+            lambda_transforms: dict = getattr(lambda_transforms_module,
+                                              'lambda_transforms')
+            # de-serialize
+            tf = A.from_dict(tf_dict, nonserializable=lambda_transforms)
+    else:
+        tf = A.from_dict(tf_dict)
     return tf
 
 

--- a/scripts/test
+++ b/scripts/test
@@ -24,8 +24,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
                 "raster-vision-${IMAGE_TYPE}" \
                 /opt/src/scripts/style_tests
             docker run \
-                -w "$(pwd)" \
-                -v "$(pwd):$(pwd)" \
+                -w "/opt/src" \
+                -v "$(pwd):/opt/src" \
                 --rm -t \
                 "raster-vision-${IMAGE_TYPE}" \
                 /opt/src/scripts/unit_tests
@@ -36,8 +36,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
             # Create new coverage reports
             docker run \
-                -w "$(pwd)" \
-                -v "$(pwd):$(pwd)" \
+                -w "/opt/src" \
+                -v "$(pwd):/opt/src" \
                 --rm -t \
                 "raster-vision-${IMAGE_TYPE}" \
                 coverage xml

--- a/scripts/unit_tests
+++ b/scripts/unit_tests
@@ -6,6 +6,11 @@ if [[ -n "${RASTER_VISION_DEBUG}" ]]; then
     set -x
 fi
 
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+SRC_DIR="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
+
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
@@ -16,12 +21,13 @@ Run all unit tests.
 if [ "${1:-}" = "--help" ]; then
     usage
 else
+    echo "Running unit tests ..."
     # If the command `coverage` exists (provided by coverage.py), then
     # use it to run the unit tests.  Otherwise, use the normal Python
     # executable.
     if ! [ -x "$(command -v coverage)" ]; then
-	    python -m unittest discover tests -vf
+	    python -m unittest discover -t "$SRC_DIR" tests -vf
     else
-	    coverage run -m unittest discover tests -vf
+	    coverage run -m unittest discover -t "$SRC_DIR" tests -vf
     fi
 fi

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,11 @@
 import os
 
+# It is important for some tests that this import runs before unittest imports
+# any other tests so that the registry is set up correctly.
+# To ensure this file gets executed first, unit tests should be run using:
+# python -m unittest discover -t /opt/src tests -vf
+import rastervision.pipeline  # noqa
+
 
 def data_file_path(rel_path):
     data_dir = os.path.join(os.path.dirname(__file__), 'data_files')

--- a/tests/data_files/lambda_transforms.py
+++ b/tests/data_files/lambda_transforms.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+
+import albumentations as A
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+def ndvi(rgb_nir: 'np.array', **kwargs) -> 'np.array':
+    red = rgb_nir[..., 0]
+    nir = rgb_nir[..., 3]
+    ndvi = (nir - red) / (nir + red)
+    return ndvi
+
+
+def swap(image: 'np.array', **kwargs) -> 'np.array':
+    return image[..., [3, 4, 5, 0, 1, 2]]
+
+
+lambda_transforms = {
+    'ndvi': A.Lambda(name='ndvi', image=ndvi, always_apply=True),
+    'swap': A.Lambda(name='swap', image=swap, always_apply=True)
+}

--- a/tests/pytorch_learner/test_object_detection_learner.py
+++ b/tests/pytorch_learner/test_object_detection_learner.py
@@ -14,7 +14,7 @@ from rastervision.core.rv_pipeline import ObjectDetectionConfig
 from rastervision.pytorch_backend import PyTorchObjectDetectionConfig
 from rastervision.pytorch_learner import (
     ObjectDetectionModelConfig, SolverConfig, ObjectDetectionGeoDataConfig,
-    PlotOptions, GeoDataWindowConfig)
+    PlotOptions, GeoDataWindowConfig, Backbone)
 from tests import data_file_path
 
 
@@ -92,7 +92,8 @@ class TestObjectDetectionLearner(unittest.TestCase):
                 num_workers=0)
             backend_cfg = PyTorchObjectDetectionConfig(
                 data=data_cfg,
-                model=ObjectDetectionModelConfig(pretrained=False),
+                model=ObjectDetectionModelConfig(
+                    backbone=Backbone.resnet18, pretrained=False),
                 solver=SolverConfig(),
                 log_tensorboard=False)
             pipeline_cfg = ObjectDetectionConfig(


### PR DESCRIPTION
## Overview

This PR extends #1001 by making it possible to use [Albumentations' lambda transforms](https://albumentations.ai/docs/examples/serialization/) with Raster Vision. This was not possible before because lambda transforms cannot be de-serialized from the serialized dict alone and require an instance of the lambda transform to be available at de-serialization time. 

This PR makes it so that the path to the python file defining the lambda transforms can be specified and saved inside the serialized dict. At de-serialization time, Raster Vision retrieves this file using the path and loads the transform instance from it.

### Usage
From `tests/pytorch_learner/test_semantic_segmentation_learner.py`:

```python
from tests.data_files.lambda_transforms import lambda_transforms
...
tf = lambda_transforms['swap']
aug_tf = serialize_albumentation_transform(
    tf,
    lambda_transforms_path=data_file_path('lambda_transforms.py'),
    dst_dir=tmp_dir)

data_cfg = SemanticSegmentationGeoDataConfig(
    ...
    aug_transform=aug_tf)
```

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

- Also refactors parts of `Learner.save_model_bundle()` into separate smaller functions.

## Testing Instructions
- See new unit tests

