### PR TITLE
Rename `MultiRasterSourceConfig.crs_source` to `MultiRasterSourceConfig.primary_source_idx` and use its CRS, dtype, and extent as that of the entire `MultiRasterSource`

### DIFF
--- a/rastervision_core/rastervision/core/__init__.py
+++ b/rastervision_core/rastervision/core/__init__.py
@@ -16,7 +16,7 @@ import rastervision.core.evaluation
 
 
 def register_plugin(registry):
-    registry.set_plugin_version('rastervision.core', 1)
+    registry.set_plugin_version('rastervision.core', 2)
     registry.set_plugin_aliases('rastervision.core', ['rastervision2.core'])
     from rastervision.core.cli import predict
     registry.add_plugin_command(predict)


### PR DESCRIPTION
## Overview

This PR
- renames `MultiRasterSourceConfig.crs_source` to `MultiRasterSourceConfig.primary_source_idx`
- makes `MultiRasterSource` use the `primary_source_idx`-th raster source as the source of the CRS, dtype, and extent of the entire `MultiRasterSource`
- allows initializing `MultiRasterSource` with `raw_channel_order=None`

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions
See mew unit tests.
