### PR TITLE
Fix incorrect F1 scores when aggregating evals for scenes in the `eval` stage

### DIFF
--- a/integration_tests/chip_classification/expected-output/eval.json
+++ b/integration_tests/chip_classification/expected-output/eval.json
@@ -1,34 +1,109 @@
-{"overall": [
-  {
-    "class_id": 1,
-    "recall": 1.0,
-    "class_name": "car",
-    "precision": 1.0,
-    "f1": 1.0,
-    "gt_count": 1.0
-  },
-  {
-    "class_id": 2,
-    "recall": 1.0,
-    "class_name": "building",
-    "precision": 1.0,
-    "f1": 1.0,
-    "gt_count": 1.0
-  },
-  {
-    "class_id": 3,
-    "recall": 1.0,
-    "class_name": "background",
-    "precision": 1.0,
-    "f1": 1.0,
-    "gt_count": 4.0
-  },
-  {
-    "class_id": null,
-    "recall": 1.0,
-    "class_name": "average",
-    "precision": 1.0,
-    "f1": 1.0,
-    "gt_count": 6.0
-  }
-]}
+{
+    "overall": [
+        {
+            "class_id": 0,
+            "class_name": "car",
+            "gt_count": 12,
+            "pred_count": 12,
+            "count_error": 0,
+            "relative_frequency": 0.21428571428571427,
+            "metrics": {
+                "recall": 1.0,
+                "precision": 1.0,
+                "f1": 1.0,
+                "sensitivity": 1.0,
+                "specificity": 1.0
+            },
+            "conf_mat": [
+                [
+                    44,
+                    0
+                ],
+                [
+                    0,
+                    12
+                ]
+            ]
+        },
+        {
+            "class_id": 1,
+            "class_name": "building",
+            "gt_count": 8,
+            "pred_count": 8,
+            "count_error": 0,
+            "relative_frequency": 0.14285714285714285,
+            "metrics": {
+                "recall": 1.0,
+                "precision": 1.0,
+                "f1": 1.0,
+                "sensitivity": 1.0,
+                "specificity": 1.0
+            },
+            "conf_mat": [
+                [
+                    48,
+                    0
+                ],
+                [
+                    0,
+                    8
+                ]
+            ]
+        },
+        {
+            "class_id": 2,
+            "class_name": "background",
+            "gt_count": 36,
+            "pred_count": 36,
+            "count_error": 0,
+            "relative_frequency": 0.6428571428571429,
+            "metrics": {
+                "recall": 1.0,
+                "precision": 1.0,
+                "f1": 1.0,
+                "sensitivity": 1.0,
+                "specificity": 1.0
+            },
+            "conf_mat": [
+                [
+                    20,
+                    0
+                ],
+                [
+                    0,
+                    36
+                ]
+            ]
+        },
+        {
+            "class_name": "average",
+            "metrics": {
+                "recall": 1.0,
+                "precision": 1.0,
+                "f1": 1.0,
+                "sensitivity": 1.0,
+                "specificity": 1.0
+            },
+            "gt_count": 56,
+            "pred_count": 56,
+            "count_error": 0,
+            "conf_mat": [
+                [
+                    12,
+                    0,
+                    0
+                ],
+                [
+                    0,
+                    8,
+                    0
+                ],
+                [
+                    0,
+                    0,
+                    36
+                ]
+            ]
+        }
+    ]
+}

--- a/integration_tests/integration_tests.py
+++ b/integration_tests/integration_tests.py
@@ -113,14 +113,14 @@ def check_eval_item(test_id: str, test_cfg: dict, expected_item: dict,
     f1_threshold = 0.05
     class_name = expected_item['class_name']
 
-    expected_f1 = expected_item['f1'] or 0.0
-    actual_f1 = actual_item['f1'] or 0.0
+    expected_f1 = expected_item['metrics']['f1'] or 0.0
+    actual_f1 = actual_item['metrics']['f1'] or 0.0
     if math.fabs(expected_f1 - actual_f1) > f1_threshold:
         errors.append(
             TestError(
                 test_id, 'F1 scores are not close enough',
-                'for class_name: {} expected f1: {}, actual f1: {}'.format(
-                    class_name, expected_item['f1'], actual_item['f1'])))
+                f'for class "{class_name}": '
+                f'expected f1: {expected_f1}, actual f1: {actual_f1}'))
 
     return errors
 

--- a/integration_tests/object_detection/expected-output/eval.json
+++ b/integration_tests/object_detection/expected-output/eval.json
@@ -1,29 +1,51 @@
-{"overall": [
-    {
-        "class_id": 0,
-        "precision": 1.0,
-        "class_name": "car",
-        "f1": 1.0,
-        "recall": 1.0,
-        "count_error": 0.0,
-        "gt_count": 3
-    },
-    {
-        "class_id": 1,
-        "precision": 1.0,
-        "class_name": "building",
-        "f1": 1.0,
-        "recall": 1.0,
-        "count_error": 0.0,
-        "gt_count": 4
-    },
-    {
-        "class_id": null,
-        "precision": 1.0,
-        "class_name": "average",
-        "f1": 1.0,
-        "recall": 1.0,
-        "count_error": 0.0,
-        "gt_count": 7
-    }
-]}
+{
+	"overall": [
+		{
+			"class_id": 0,
+			"class_name": "car",
+			"gt_count": 12.0,
+			"pred_count": 12.0,
+			"count_error": 0.0,
+			"metrics": {
+				"recall": 1.0,
+				"precision": 1.0,
+				"f1": 1.0,
+				"sensitivity": 1.0,
+				"specificity": null
+			},
+			"true_pos": 12.0,
+			"false_pos": 0.0,
+			"false_neg": 0.0
+		},
+		{
+			"class_id": 1,
+			"class_name": "building",
+			"gt_count": 16.0,
+			"pred_count": 16.0,
+			"count_error": 0.0,
+			"metrics": {
+				"recall": 1.0,
+				"precision": 1.0,
+				"f1": 1.0,
+				"sensitivity": 1.0,
+				"specificity": null
+			},
+			"true_pos": 16.0,
+			"false_pos": 0.0,
+			"false_neg": 0.0
+		},
+		{
+			"class_name": "average",
+			"metrics": {
+				"recall": 1.0,
+				"precision": 1.0,
+				"f1": 1.0,
+				"sensitivity": 1.0,
+				"specificity": 0.0
+			},
+			"gt_count": 28.0,
+			"pred_count": 28.0,
+			"count_error": 0.0
+		}
+	]
+}

--- a/integration_tests/semantic_segmentation/expected-output/eval.json
+++ b/integration_tests/semantic_segmentation/expected-output/eval.json
@@ -1,29 +1,109 @@
-{"overall": [
-    {
-        "count_error": 245,
-        "gt_count": 90000,
-        "f1": 0.9986370337403689,
-        "class_id": 0,
-        "precision": 1.0,
-        "recall": 0.9972777777777778,
-        "class_name": "red"
-    },
-    {
-        "count_error": 245,
-        "gt_count": 270000,
-        "f1": 0.9995465020499957,
-        "class_id": 1,
-        "precision": 0.9990934152343244,
-        "recall": 1.0,
-        "class_name": "green"
-    },
-    {
-        "count_error": 245.0,
-        "gt_count": 360000,
-        "f1": 0.999319134972589,
-        "class_id": null,
-        "precision": 0.9993200614257433,
-        "recall": 0.9993194444444444,
-        "class_name": "average"
-    }
-]}
+{
+    "overall": [
+        {
+            "class_id": 0,
+            "class_name": "red",
+            "gt_count": 360000.0,
+            "pred_count": 360000.0,
+            "count_error": 0.0,
+            "relative_frequency": 0.25,
+            "metrics": {
+                "recall": 1.0,
+                "precision": 1.0,
+                "f1": 1.0,
+                "sensitivity": 1.0,
+                "specificity": 1.0
+            },
+            "conf_mat": [
+                [
+                    1080000.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    360000.0
+                ]
+            ]
+        },
+        {
+            "class_id": 1,
+            "class_name": "green",
+            "gt_count": 1080000.0,
+            "pred_count": 1080000.0,
+            "count_error": 0.0,
+            "relative_frequency": 0.75,
+            "metrics": {
+                "recall": 1.0,
+                "precision": 1.0,
+                "f1": 1.0,
+                "sensitivity": 1.0,
+                "specificity": 1.0
+            },
+            "conf_mat": [
+                [
+                    360000.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    1080000.0
+                ]
+            ]
+        },
+        {
+            "class_id": 2,
+            "class_name": "null",
+            "gt_count": 0.0,
+            "pred_count": 0.0,
+            "count_error": 0.0,
+            "relative_frequency": 0.0,
+            "metrics": {
+                "recall": null,
+                "precision": null,
+                "f1": null,
+                "sensitivity": null,
+                "specificity": 1.0
+            },
+            "conf_mat": [
+                [
+                    1440000.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0
+                ]
+            ]
+        },
+        {
+            "class_name": "average",
+            "metrics": {
+                "recall": 1.0,
+                "precision": 1.0,
+                "f1": 1.0,
+                "sensitivity": 1.0,
+                "specificity": 1.0
+            },
+            "gt_count": 1440000.0,
+            "pred_count": 1440000.0,
+            "count_error": 0.0,
+            "conf_mat": [
+                [
+                    360000.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    1080000.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            ]
+        }
+    ]
+}

--- a/rastervision_core/rastervision/core/evaluation/chip_classification_evaluation.py
+++ b/rastervision_core/rastervision/core/evaluation/chip_classification_evaluation.py
@@ -1,31 +1,27 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
-from sklearn import metrics
+from sklearn.metrics import confusion_matrix
 
 from rastervision.core.evaluation import (ClassificationEvaluation,
                                           ClassEvaluationItem)
+if TYPE_CHECKING:
+    from rastervision.core.data import (ChipClassificationLabels, ClassConfig)
 
 
 class ChipClassificationEvaluation(ClassificationEvaluation):
-    def __init__(self, class_config):
+    def __init__(self, class_config: 'ClassConfig'):
         super().__init__()
         self.class_config = class_config
 
-    def compute(self, ground_truth_labels, prediction_labels):
-        self.class_to_eval_item = ChipClassificationEvaluation.compute_eval_items(
-            ground_truth_labels, prediction_labels, self.class_config)
-
-        self.compute_avg()
-
-    @staticmethod
-    def compute_eval_items(gt_labels, pred_labels, class_config):
-        nb_classes = len(class_config.names)
-        class_to_eval_item = {}
+    def compute(self, gt_labels: 'ChipClassificationLabels',
+                pred_labels: 'ChipClassificationLabels') -> None:
+        self.reset()
+        self.class_to_eval_item = {}
 
         gt_class_ids = []
         pred_class_ids = []
-
-        gt_cells = gt_labels.get_cells()
-        for gt_cell in gt_cells:
+        for gt_cell in gt_labels.get_cells():
             gt_class_id = gt_labels.get_cell_class_id(gt_cell)
             pred_class_id = pred_labels.get_cell_class_id(gt_cell)
 
@@ -33,18 +29,15 @@ class ChipClassificationEvaluation(ClassificationEvaluation):
                 gt_class_ids.append(gt_class_id)
                 pred_class_ids.append(pred_class_id)
 
-        sklabels = np.arange(nb_classes)
-        precision, recall, f1, support = metrics.precision_recall_fscore_support(
-            gt_class_ids, pred_class_ids, labels=sklabels, warn_for=())
+        labels = np.arange(len(self.class_config))
+        self.conf_mat = confusion_matrix(
+            gt_class_ids, pred_class_ids, labels=labels)
 
-        for class_id, class_name in enumerate(class_config.names):
-            eval_item = ClassEvaluationItem(
-                float(precision[class_id]),
-                float(recall[class_id]),
-                float(f1[class_id]),
-                gt_count=float(support[class_id]),
+        for class_id, class_name in enumerate(self.class_config.names):
+            eval_item = ClassEvaluationItem.from_multiclass_conf_mat(
+                conf_mat=self.conf_mat,
                 class_id=class_id,
                 class_name=class_name)
-            class_to_eval_item[class_id] = eval_item
+            self.class_to_eval_item[class_id] = eval_item
 
-        return class_to_eval_item
+        self.compute_avg()

--- a/rastervision_core/rastervision/core/evaluation/classification_evaluation.py
+++ b/rastervision_core/rastervision/core/evaluation/classification_evaluation.py
@@ -1,10 +1,14 @@
+from typing import TYPE_CHECKING, Any, Dict, Optional
 from abc import (ABC, abstractmethod)
 import copy
-
 import json
 
-from rastervision.core.evaluation import ClassEvaluationItem
+import numpy as np
+
 from rastervision.pipeline.file_system import str_to_file
+
+if TYPE_CHECKING:
+    from rastervision.core.evaluation import ClassEvaluationItem
 
 
 class ClassificationEvaluation(ABC):
@@ -14,14 +18,14 @@ class ClassificationEvaluation(ABC):
     """
 
     def __init__(self):
-        self.clear()
-        self._is_empty = True
+        self.reset()
 
-    def clear(self):
-        """Clear the Evaluation."""
-        self.class_to_eval_item = {}
-        self.scene_to_eval = {}
-        self.avg_item = None
+    def reset(self):
+        """Reset the Evaluation."""
+        self.class_to_eval_item: Dict[int, 'ClassEvaluationItem'] = {}
+        self.scene_to_eval: Dict[str, 'ClassificationEvaluation'] = {}
+        self.avg_item: Optional[Dict[str, Any]] = None
+        self.conf_mat: Optional[np.ndarray] = None
         self._is_empty = True
 
     def is_empty(self):
@@ -43,7 +47,7 @@ class ClassificationEvaluation(ABC):
         for eval_item in self.class_to_eval_item.values():
             json_rep.append(eval_item.to_json())
         if self.avg_item:
-            json_rep.append(self.avg_item.to_json())
+            json_rep.append(self.avg_item)
 
         if self.scene_to_eval:
             json_rep = {'overall': json_rep}
@@ -60,23 +64,28 @@ class ClassificationEvaluation(ABC):
         Args:
             output_uri: string URI for the file to write.
         """
-        json_str = json.dumps(self.to_json(), indent=4)
+        json_str = json.dumps(
+            ensure_json_serializable(self.to_json()), indent=4)
         str_to_file(json_str, output_uri)
 
-    def merge(self, evaluation, scene_id=None):
+    def merge(self, other: 'ClassificationEvaluation', scene_id=None) -> None:
         """Merge Evaluation for another Scene into this one.
 
         This is useful for computing the average metrics of a set of scenes.
         The results of the averaging are stored in this Evaluation.
 
         Args:
-            evaluation: Evaluation to merge into this one
+            other: Evaluation to merge into this one
         """
-        if len(self.class_to_eval_item) == 0:
-            self.class_to_eval_item = evaluation.class_to_eval_item
+        if self.conf_mat is None:
+            self.conf_mat = other.conf_mat
         else:
-            for key, other_eval_item in \
-                    evaluation.class_to_eval_item.items():
+            self.conf_mat += other.conf_mat
+
+        if len(self.class_to_eval_item) == 0:
+            self.class_to_eval_item = other.class_to_eval_item
+        else:
+            for key, other_eval_item in other.class_to_eval_item.items():
                 if self.has_id(key):
                     self.get_by_id(key).merge(other_eval_item)
                 else:
@@ -86,13 +95,40 @@ class ClassificationEvaluation(ABC):
         self.compute_avg()
 
         if scene_id is not None:
-            self.scene_to_eval[scene_id] = copy.deepcopy(evaluation)
+            self.scene_to_eval[scene_id] = copy.deepcopy(other)
 
     def compute_avg(self):
         """Compute average metrics over all keys."""
-        self.avg_item = ClassEvaluationItem(class_name='average')
-        for eval_item in self.class_to_eval_item.values():
-            self.avg_item.merge(eval_item)
+        if len(self.class_to_eval_item) == 0:
+            return
+        class_evals = [
+            eval_item.to_json()
+            for eval_item in self.class_to_eval_item.values()
+        ]
+        # compute weighted averages of metrics
+        class_counts = np.array([e['gt_count'] for e in class_evals])
+        class_weights = class_counts / class_counts.sum()
+        class_metrics = [e['metrics'] for e in class_evals]
+        metric_names = class_metrics[0].keys()
+        avg_metrics = {}
+        for k in metric_names:
+            metric_vals = np.array([m[k] for m in class_metrics], dtype=float)
+            avg_metrics[k] = np.nan_to_num(metric_vals * class_weights).sum()
+
+        # sum the counts
+        gt_count = sum(e['gt_count'] for e in class_evals)
+        pred_count = sum(e['pred_count'] for e in class_evals)
+        count_error = sum(e['count_error'] for e in class_evals)
+
+        self.avg_item = {
+            'class_name': 'average',
+            'metrics': avg_metrics,
+            'gt_count': gt_count,
+            'pred_count': pred_count,
+            'count_error': count_error
+        }
+        if self.conf_mat is not None:
+            self.avg_item['conf_mat'] = self.conf_mat.tolist()
 
     @abstractmethod
     def compute(self, ground_truth_labels, prediction_labels):
@@ -103,3 +139,23 @@ class ClassificationEvaluation(ABC):
             prediction_labels: The predicted labels to evaluate.
         """
         pass
+
+
+def ensure_json_serializable(obj: Any) -> dict:
+    if obj is None or isinstance(obj, (str, int, bool)):
+        return obj
+    if isinstance(obj, dict):
+        return {k: ensure_json_serializable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [ensure_json_serializable(o) for o in obj]
+    if isinstance(obj, np.ndarray):
+        return ensure_json_serializable(obj.tolist())
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, float):
+        if np.isnan(obj):
+            return None
+        return float(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    return obj

--- a/rastervision_core/rastervision/core/evaluation/object_detection_evaluation.py
+++ b/rastervision_core/rastervision/core/evaluation/object_detection_evaluation.py
@@ -1,48 +1,50 @@
+from typing import TYPE_CHECKING, Dict, Tuple
 import numpy as np
-import shapely
-import shapely.strtree
-import shapely.geometry
+from shapely.strtree import STRtree
 
-from rastervision.core.data import ObjectDetectionLabels
-from rastervision.core.evaluation import ClassEvaluationItem
-from rastervision.core.evaluation import ClassificationEvaluation
+from rastervision.core.evaluation import (ClassificationEvaluation,
+                                          ClassEvaluationItem)
+
+if TYPE_CHECKING:
+    from shapely.geometry import Polygon
+    from rastervision.core.data import ObjectDetectionLabels
+    from rastervision.core.data.class_config import ClassConfig
 
 
-def compute_metrics(gt_labels: ObjectDetectionLabels,
-                    pred_labels: ObjectDetectionLabels,
-                    num_classes: int,
-                    iou_thresh=0.5):
+def compute_metrics(
+        gt_labels: 'ObjectDetectionLabels',
+        pred_labels: 'ObjectDetectionLabels',
+        num_classes: int,
+        iou_thresh: float = 0.5) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     gt_geoms = [b.to_shapely() for b in gt_labels.get_boxes()]
     gt_classes = gt_labels.get_class_ids()
     pred_geoms = [b.to_shapely() for b in pred_labels.get_boxes()]
     pred_classes = pred_labels.get_class_ids()
 
-    for pred, class_id in zip(pred_geoms, pred_classes):
-        pred.class_id = class_id
-    pred_tree = shapely.strtree.STRtree(pred_geoms)
+    for pred_geom, class_id in zip(pred_geoms, pred_classes):
+        pred_geom.class_id = class_id
+    pred_tree = STRtree(pred_geoms)
 
-    def iou(a, b):
+    def iou(a: 'Polygon', b: 'Polygon') -> float:
         return a.intersection(b).area / a.union(b).area
 
-    def is_matched(geom):
+    def is_matched(geom) -> bool:
         return hasattr(geom, 'iou_matched')
 
     tp = np.zeros((num_classes, ))
     fp = np.zeros((num_classes, ))
     fn = np.zeros((num_classes, ))
 
-    for gt, gt_class in zip(gt_geoms, gt_classes):
-        matches = list(
-            filter(lambda g: (not is_matched(g)) and g.class_id == gt_class,
-                   pred_tree.query(gt)))
-        scores = [iou(m, gt) for m in matches]
-        if len(scores) > 0:
-            max_ind = np.argmax(scores)
-            if scores[max_ind] > iou_thresh:
-                matches[max_ind].iou_matched = True
-                tp[gt_class] += 1
-            else:
-                fn[gt_class] += 1
+    for gt_geom, gt_class in zip(gt_geoms, gt_classes):
+        matches = [
+            g for g in pred_tree.query(gt_geom)
+            if (not is_matched(g)) and (g.class_id == gt_class)
+        ]
+        ious = np.array([iou(m, gt_geom) for m in matches])
+        if (ious > iou_thresh).any():
+            max_ind = np.argmax(ious)
+            matches[max_ind].iou_matched = True
+            tp[gt_class] += 1
         else:
             fn[gt_class] += 1
 
@@ -54,58 +56,34 @@ def compute_metrics(gt_labels: ObjectDetectionLabels,
 
 
 class ObjectDetectionEvaluation(ClassificationEvaluation):
-    def __init__(self, class_config):
+    def __init__(self, class_config: 'ClassConfig', iou_thresh: float = 0.5):
         super().__init__()
         self.class_config = class_config
+        self.iou_thresh = iou_thresh
 
-    def compute(self, ground_truth_labels, prediction_labels):
+    def compute(self, ground_truth_labels: 'ObjectDetectionLabels',
+                prediction_labels: 'ObjectDetectionLabels'):
         self.class_to_eval_item = ObjectDetectionEvaluation.compute_eval_items(
-            ground_truth_labels, prediction_labels, self.class_config)
+            ground_truth_labels,
+            prediction_labels,
+            self.class_config,
+            iou_thresh=self.iou_thresh)
         self.compute_avg()
 
     @staticmethod
-    def compute_eval_items(gt_labels, pred_labels, class_config):
-        iou_thresh = 0.5
+    def compute_eval_items(
+            gt_labels: 'ObjectDetectionLabels',
+            pred_labels: 'ObjectDetectionLabels',
+            class_config: 'ClassConfig',
+            iou_thresh: float = 0.5) -> Dict[int, ClassEvaluationItem]:
         num_classes = len(class_config)
         tps, fps, fns = compute_metrics(gt_labels, pred_labels, num_classes,
                                         iou_thresh)
         class_to_eval_item = {}
-
         for class_id, (tp, fp, fn) in enumerate(zip(tps, fps, fns)):
-            gt_count = tp + fn
-            pred_count = tp + fp
             class_name = class_config.get_name(class_id)
-
-            if gt_count == 0:
-                eval_item = ClassEvaluationItem(
-                    class_id=class_id, class_name=class_name)
-            elif pred_count == 0:
-                eval_item = ClassEvaluationItem(
-                    precision=None,
-                    recall=0,
-                    gt_count=gt_count,
-                    class_id=class_id,
-                    class_name=class_name)
-            else:
-                prec = tp / (tp + fp)
-                recall = tp / (tp + fn)
-                f1 = 0.
-                if prec + recall != 0.0:
-                    f1 = 2 * (prec * recall) / (prec + recall)
-                count_err = pred_count - gt_count
-                norm_count_err = None
-                if gt_count > 0:
-                    norm_count_err = count_err / gt_count
-
-                eval_item = ClassEvaluationItem(
-                    precision=prec,
-                    recall=recall,
-                    f1=f1,
-                    count_error=norm_count_err,
-                    gt_count=gt_count,
-                    class_id=class_id,
-                    class_name=class_name)
-
+            eval_item = ClassEvaluationItem(
+                class_id=class_id, class_name=class_name, tp=tp, fp=fp, fn=fn)
             class_to_eval_item[class_id] = eval_item
 
         return class_to_eval_item

--- a/rastervision_core/rastervision/core/evaluation/semantic_segmentation_evaluation.py
+++ b/rastervision_core/rastervision/core/evaluation/semantic_segmentation_evaluation.py
@@ -1,4 +1,4 @@
-import math
+from typing import TYPE_CHECKING, Any, Iterable, List, Union
 import logging
 import json
 
@@ -8,10 +8,14 @@ import numpy as np
 from rastervision.core.evaluation import ClassEvaluationItem
 from rastervision.core.evaluation import ClassificationEvaluation
 
+if TYPE_CHECKING:
+    from rastervision.core.data import (
+        ClassConfig, SemanticSegmentationLabels, VectorOutputConfig)
+
 log = logging.getLogger(__name__)
 
 
-def is_geojson(data):
+def is_geojson(data: Any) -> bool:
     if isinstance(data, dict):
         return True
     else:
@@ -23,86 +27,56 @@ def is_geojson(data):
         return retval
 
 
-def get_class_eval_item(conf_mat, class_id, class_name, null_class_id):
-    if conf_mat.ravel().sum() == 0:
-        return ClassEvaluationItem(None, None, None, 0, 0, class_id,
-                                   class_name)
-
-    non_null_class_ids = list(range(conf_mat.shape[0]))
-    non_null_class_ids.remove(null_class_id)
-
-    true_pos = conf_mat[class_id, class_id]
-    false_pos = conf_mat[non_null_class_ids, class_id].sum() - true_pos
-    false_neg = conf_mat[class_id, :].sum() - true_pos
-    precision = float(true_pos) / (true_pos + false_pos)
-    recall = float(true_pos) / (true_pos + false_neg)
-    f1 = 2 * (precision * recall) / (precision + recall)
-    count_error = int(false_pos + false_neg)
-    gt_count = conf_mat[class_id, :].sum()
-
-    if math.isnan(precision):
-        precision = None
-    else:
-        precision = float(precision)
-    if math.isnan(recall):
-        recall = None
-    else:
-        recall = float(recall)
-    if math.isnan(f1):
-        f1 = None
-    else:
-        f1 = float(f1)
-
-    return ClassEvaluationItem(precision, recall, f1, count_error, gt_count,
-                               class_id, class_name, conf_mat[class_id, :])
-
-
 class SemanticSegmentationEvaluation(ClassificationEvaluation):
     """Evaluation for semantic segmentation."""
 
-    def __init__(self, class_config):
+    def __init__(self, class_config: 'ClassConfig'):
         super().__init__()
         self.class_config = class_config
 
-    def compute(self, gt_labels, pred_labels):
-        self.clear()
+    def compute(self, gt_labels: 'SemanticSegmentationLabels',
+                pred_labels: 'SemanticSegmentationLabels') -> None:
+        self.reset()
 
-        labels = np.arange(len(self.class_config.names))
-        conf_mat = np.zeros((len(labels), len(labels)))
+        # compute confusion matrix
+        num_classes = len(self.class_config)
+        labels = np.arange(num_classes)
+        self.conf_mat = np.zeros((num_classes, num_classes))
         for window in pred_labels.get_windows():
-            log.debug('Evaluating window: {}'.format(window))
+            log.debug(f'Evaluating window: {window}')
             gt_arr = gt_labels.get_label_arr(window).ravel()
             pred_arr = pred_labels.get_label_arr(window).ravel()
-            conf_mat += confusion_matrix(gt_arr, pred_arr, labels=labels)
+            self.conf_mat += confusion_matrix(gt_arr, pred_arr, labels=labels)
 
         for class_id, class_name in enumerate(self.class_config.names):
-            if class_id != self.class_config.get_null_class_id():
-                class_name = self.class_config.names[class_id]
-                self.class_to_eval_item[class_id] = get_class_eval_item(
-                    conf_mat, class_id, class_name,
-                    self.class_config.get_null_class_id())
+            eval_item = ClassEvaluationItem.from_multiclass_conf_mat(
+                conf_mat=self.conf_mat,
+                class_id=class_id,
+                class_name=class_name)
+            self.class_to_eval_item[class_id] = eval_item
 
         self.compute_avg()
 
-    def compute_vector(self, gt, pred, mode, class_id):
+    def compute_vector(self, gt: Union[str, dict],
+                       preds: Iterable[Union[str, dict]],
+                       vector_outputs: Iterable['VectorOutputConfig']) -> None:
         """Compute evaluation over vector predictions.
-            Args:
-                gt: Ground-truth GeoJSON.  Either a string (containing
-                    unparsed GeoJSON or a file name), or a dictionary
-                    containing parsed GeoJSON.
-                pred: GeoJSON for predictions.  Either a string
-                    (containing unparsed GeoJSON or a file name), or a
-                    dictionary containing parsed GeoJSON.
-                mode: A string containing either 'buildings' or
-                    'polygons'.
-                class_id: An integer containing the class id of
-                    interest.
+
+        Args:
+            gt (Union[str, dict]): Ground-truth GeoJSON. Either a string
+                (containing unparsed GeoJSON or a file name), or a dictionary
+                containing parsed GeoJSON.
+            preds (Iterable[Union[str, dict]]): Prediction GeoJSONs. Either a
+                string (containing unparsed GeoJSON or a file name), or a
+                dictionary containing parsed GeoJSON.
+            vector_outputs (Iterable[VectorOutputConfig]): VectorOutputConfig's
+                corresponding to each prediction in preds.
         """
         import mask_to_polygons.vectorification as vectorification
         import mask_to_polygons.processing.score as score
 
         # Ground truth as list of geometries
-        def get_geoms(x):
+        def get_geoms(x) -> List[dict]:
             if is_geojson(x):
                 _x = x
                 if 'features' in _x.keys():
@@ -119,33 +93,22 @@ class SemanticSegmentationEvaluation(ClassificationEvaluation):
             return geoms
 
         gt = get_geoms(gt)
-        pred = get_geoms(pred)
+        if len(gt) == 0:
+            return
 
-        if len(gt) > 0 and len(pred) > 0:
+        for pred, vo in zip(preds, vector_outputs):
+            pred = get_geoms(pred)
+            if len(pred) == 0:
+                continue
+            class_id = vo.class_id
             results = score.spacenet(pred, gt)
+            eval_item = ClassEvaluationItem(
+                class_id=class_id,
+                class_name=self.class_config.names[class_id],
+                tp=results['tp'],
+                fp=results['fp'],
+                fn=results['fn'],
+                mode=vo.get_mode())
+            self.class_to_eval_item[class_id] = eval_item
 
-            true_positives = results['tp']
-            false_positives = results['fp']
-            false_negatives = results['fn']
-            precision = float(true_positives) / (
-                true_positives + false_positives)
-            recall = float(true_positives) / (true_positives + false_negatives)
-            if precision + recall != 0:
-                f1 = 2 * (precision * recall) / (precision + recall)
-            else:
-                f1 = 0.0
-            count_error = int(false_positives + false_negatives)
-            gt_count = len(gt)
-            class_name = 'vector-{}-{}'.format(
-                mode, self.class_config.names[class_id])
-
-            evaluation_item = ClassEvaluationItem(precision, recall, f1,
-                                                  count_error, gt_count,
-                                                  class_id, class_name)
-
-            if hasattr(self, 'class_to_eval_item') and isinstance(
-                    self.class_to_eval_item, dict):
-                self.class_to_eval_item[class_id] = evaluation_item
-            else:
-                self.class_to_eval_item = {class_id: evaluation_item}
-            self.compute_avg()
+        self.compute_avg()

--- a/rastervision_core/rastervision/core/evaluation/semantic_segmentation_evaluator.py
+++ b/rastervision_core/rastervision/core/evaluation/semantic_segmentation_evaluator.py
@@ -1,17 +1,23 @@
+from typing import TYPE_CHECKING, Iterable, Iterator
 import logging
 
 from shapely.geometry import shape, mapping
 from shapely.strtree import STRtree
 
-from rastervision.core.data import ActivateMixin
+from rastervision.core.data import ActivateMixin, RasterizedSource
 from rastervision.core.data.vector_source import GeoJSONVectorSourceConfig
 from rastervision.core.evaluation import (ClassificationEvaluator,
                                           SemanticSegmentationEvaluation)
 
 log = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from rastervision.core.data import (Scene, ClassConfig,
+                                        SemanticSegmentationLabelSource,
+                                        SemanticSegmentationLabelStore)
 
-def filter_geojson_by_aoi(geojson, aoi_polygons):
+
+def filter_geojson_by_aoi(geojson: dict, aoi_polygons: list) -> dict:
     # Note that this ignores class_id but that's ok because each prediction GeoJSON file
     # covers a single class_id. But, this may change in the future.
     tree = STRtree([shape(f['geometry']) for f in geojson['features']])
@@ -34,23 +40,29 @@ class SemanticSegmentationEvaluator(ClassificationEvaluator):
     """Evaluates predictions for a set of scenes.
     """
 
-    def __init__(self, class_config, output_uri, vector_output_uri):
+    def __init__(self, class_config: 'ClassConfig', output_uri: str,
+                 vector_output_uri: str):
         super().__init__(class_config, output_uri)
         self.vector_output_uri = vector_output_uri
 
-    def create_evaluation(self):
+    def create_evaluation(self) -> SemanticSegmentationEvaluation:
         return SemanticSegmentationEvaluation(self.class_config)
 
-    def process(self, scenes, tmp_dir):
-        evaluation = self.create_evaluation()
-        vect_evaluation = self.create_evaluation()
+    def process(self, scenes: Iterable['Scene'], tmp_dir: str) -> None:
+        evaluation_global = self.create_evaluation()
+        vect_evaluation_global = self.create_evaluation()
         null_class_id = self.class_config.get_null_class_id()
 
         for scene in scenes:
-            log.info('Computing evaluation for scene {}...'.format(scene.id))
-            label_source = scene.ground_truth_label_source
-            label_store = scene.prediction_label_store
+            log.info(f'Computing evaluation for scene {scene.id}...')
+            label_source: 'SemanticSegmentationLabelSource' = (
+                scene.ground_truth_label_source)
+            label_store: 'SemanticSegmentationLabelStore' = (
+                scene.prediction_label_store)
             with ActivateMixin.compose(label_source, label_store):
+                # -----------
+                # raster eval
+                # -----------
                 ground_truth = label_source.get_labels()
                 predictions = label_store.get_labels()
 
@@ -60,38 +72,57 @@ class SemanticSegmentationEvaluator(ClassificationEvaluator):
                         scene.aoi_polygons, null_class_id)
                     predictions = predictions.filter_by_aoi(
                         scene.aoi_polygons, null_class_id)
-                scene_evaluation = self.create_evaluation()
-                scene_evaluation.compute(ground_truth, predictions)
-                evaluation.merge(scene_evaluation, scene_id=scene.id)
+                evaluation_scene = self.create_evaluation()
+                evaluation_scene.compute(ground_truth, predictions)
+                evaluation_global.merge(evaluation_scene, scene_id=scene.id)
 
-            if hasattr(label_source, 'raster_source') and hasattr(
-                    label_source.raster_source, 'vector_source') and hasattr(
-                        label_store, 'vector_output'):
-                gt_geojson = label_source.raster_source.vector_source.get_geojson(
-                )
-                for vo in label_store.vector_output:
-                    pred_geojson_uri = vo.uri
-                    mode = vo.get_mode()
-                    class_id = vo.class_id
-                    pred_geojson_source = GeoJSONVectorSourceConfig(
-                        uri=pred_geojson_uri, default_class_id=class_id).build(
-                            self.class_config,
-                            scene.raster_source.get_crs_transformer())
-                    pred_geojson = pred_geojson_source.get_geojson()
+                # -----------
+                # vector eval
+                # -----------
+                has_vector_gt = isinstance(label_source.raster_source,
+                                           RasterizedSource)
+                has_vector_preds = label_store.vector_outputs is not None
+                if not (has_vector_gt and has_vector_preds):
+                    continue
 
-                    if scene.aoi_polygons:
-                        gt_geojson = filter_geojson_by_aoi(
-                            gt_geojson, scene.aoi_polygons)
-                        pred_geojson = filter_geojson_by_aoi(
-                            pred_geojson, scene.aoi_polygons)
+                gt_geojson = (
+                    label_source.raster_source.vector_source.get_geojson())
+                if scene.aoi_polygons:
+                    gt_geojson = filter_geojson_by_aoi(gt_geojson,
+                                                       scene.aoi_polygons)
+                pred_geojsons = get_class_vector_preds(scene, label_store,
+                                                       self.class_config)
+                vect_evaluation_scene = self.create_evaluation()
+                vect_evaluation_scene.compute_vector(
+                    gt_geojson, pred_geojsons, label_store.vector_outputs)
+                vect_evaluation_global.merge(
+                    vect_evaluation_scene, scene_id=scene.id)
 
-                    vect_scene_evaluation = self.create_evaluation()
-                    vect_scene_evaluation.compute_vector(
-                        gt_geojson, pred_geojson, mode, class_id)
-                    vect_evaluation.merge(
-                        vect_scene_evaluation, scene_id=scene.id)
+        if not evaluation_global.is_empty():
+            evaluation_global.save(self.output_uri)
+        if not vect_evaluation_global.is_empty():
+            vect_evaluation_global.save(self.vector_output_uri)
 
-        if not evaluation.is_empty():
-            evaluation.save(self.output_uri)
-        if not vect_evaluation.is_empty():
-            vect_evaluation.save(self.vector_output_uri)
+
+def get_class_vector_preds(scene: 'Scene',
+                           label_store: 'SemanticSegmentationLabelStore',
+                           class_config: 'ClassConfig') -> Iterator[dict]:
+    """Returns a generator that yields pred geojsons from
+    label_store.vector_outputs."""
+    class_ids = [vo.class_id for vo in label_store.vector_outputs]
+    if len(set(class_ids)) < len(class_ids):
+        raise ValueError('SemanticSegmentationEvaluator expects there to be '
+                         'only one VectorOutputConfig per class.')
+    for vo in label_store.vector_outputs:
+        pred_geojson_uri = vo.uri
+        class_id = vo.class_id
+        pred_geojson_source_cfg = GeoJSONVectorSourceConfig(
+            uri=pred_geojson_uri, default_class_id=class_id)
+        pred_geojson_source = pred_geojson_source_cfg.build(
+            class_config, scene.raster_source.get_crs_transformer())
+        pred_geojson: dict = pred_geojson_source.get_geojson()
+
+        if scene.aoi_polygons:
+            pred_geojson = filter_geojson_by_aoi(pred_geojson,
+                                                 scene.aoi_polygons)
+        yield pred_geojson

--- a/tests/core/evaluation/test_chip_classification_evaluation.py
+++ b/tests/core/evaluation/test_chip_classification_evaluation.py
@@ -49,10 +49,11 @@ class TestChipClassificationEvaluation(unittest.TestCase):
         self.assertAlmostEqual(eval_item1.f1, 2 / 3, places=2)
 
         avg_item = eval.avg_item
-        self.assertEqual(avg_item.gt_count, 3)
-        self.assertAlmostEqual(avg_item.precision, 0.83, places=2)
-        self.assertAlmostEqual(avg_item.recall, 2 / 3, places=2)
-        self.assertAlmostEqual(avg_item.f1, 2 / 3, places=2)
+        self.assertEqual(avg_item['gt_count'], 3)
+        self.assertAlmostEqual(
+            avg_item['metrics']['precision'], 0.83, places=2)
+        self.assertAlmostEqual(avg_item['metrics']['recall'], 2 / 3, places=2)
+        self.assertAlmostEqual(avg_item['metrics']['f1'], 2 / 3, places=2)
 
     def test_compute_single_pred_null(self):
         class_config = self.make_class_config()

--- a/tests/core/evaluation/test_chip_classification_evaluator.py
+++ b/tests/core/evaluation/test_chip_classification_evaluator.py
@@ -45,7 +45,7 @@ class TestChipClassificationEvaluator(unittest.TestCase):
 
             overall = file_to_json(evaluator_cfg.get_output_uri())['overall']
             for item in overall:
-                self.assertEqual(item['f1'], 1.0)
+                self.assertEqual(item['metrics']['f1'], 1.0)
 
 
 if __name__ == '__main__':

--- a/tests/core/evaluation/test_class_evaluation_item.py
+++ b/tests/core/evaluation/test_class_evaluation_item.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 from rastervision.core.evaluation import ClassEvaluationItem
 
 
@@ -7,49 +9,113 @@ class TestClassEvaluationItem(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_merge_both_empty(self):
-        a = ClassEvaluationItem()
-        b = ClassEvaluationItem()
-        a.merge(b)
-        self.assertEqual(a.precision, None)
-        self.assertEqual(a.recall, None)
-        self.assertEqual(a.f1, None)
-        self.assertEqual(a.count_error, None)
-        self.assertEqual(a.gt_count, 0)
+    def test_with_tn(self):
+        conf_mat = np.random.randint(100, size=(2, 2))
+        [[tn, fp], [fn, tp]] = conf_mat
+        item = ClassEvaluationItem(
+            class_id=0, class_name='abc', tp=tp, fp=fp, fn=fn, tn=tn)
+        self.assertEqual(item.true_pos, tp)
+        self.assertEqual(item.true_neg, tn)
+        self.assertEqual(item.false_pos, fp)
+        self.assertEqual(item.false_neg, fn)
 
-    def test_merge_first_empty(self):
-        a = ClassEvaluationItem()
-        b = ClassEvaluationItem(
-            precision=1, recall=1, f1=1, count_error=0, gt_count=1)
-        a.merge(b)
-        self.assertEqual(a.precision, 1)
-        self.assertEqual(a.recall, 1)
-        self.assertEqual(a.f1, 1)
-        self.assertEqual(a.count_error, 0)
-        self.assertEqual(a.gt_count, 1)
+        recall = tp / (tp + fn)
+        precision = tp / (tp + fp)
+        self.assertEqual(item.gt_count, fn + tp)
+        self.assertEqual(item.pred_count, fp + tp)
+        self.assertEqual(item.recall, recall)
+        self.assertEqual(item.sensitivity, recall)
+        self.assertEqual(item.precision, precision)
+        self.assertEqual(item.specificity, tn / (tn + fp))
+        self.assertEqual(item.f1,
+                         2 * (precision * recall) / (precision + recall))
 
-    def test_merge_second_empty(self):
-        a = ClassEvaluationItem(
-            precision=1, recall=1, f1=1, count_error=0, gt_count=1)
-        b = ClassEvaluationItem()
-        a.merge(b)
-        self.assertEqual(a.precision, 1)
-        self.assertEqual(a.recall, 1)
-        self.assertEqual(a.f1, 1)
-        self.assertEqual(a.count_error, 0)
-        self.assertEqual(a.gt_count, 1)
+        json = item.to_json()
+        self.assertEqual(json['relative_frequency'],
+                         (fn + tp) / (fn + tp + fp + tn))
+        self.assertEqual(json['count_error'], abs((fn + tp) - (fp + tp)))
+        np.testing.assert_array_equal(np.array(json['conf_mat']), conf_mat)
+
+    def test_without_tn(self):
+        conf_mat = np.random.randint(100, size=(2, 2))
+        [[_, fp], [fn, tp]] = conf_mat
+        tn = None
+        item = ClassEvaluationItem(
+            class_id=0, class_name='abc', tp=tp, fp=fp, fn=fn, tn=tn)
+        self.assertEqual(item.true_pos, tp)
+        self.assertEqual(item.true_neg, None)
+        self.assertEqual(item.false_pos, fp)
+        self.assertEqual(item.false_neg, fn)
+
+        recall = tp / (tp + fn)
+        precision = tp / (tp + fp)
+        self.assertEqual(item.gt_count, fn + tp)
+        self.assertEqual(item.pred_count, fp + tp)
+        self.assertEqual(item.recall, recall)
+        self.assertEqual(item.sensitivity, recall)
+        self.assertEqual(item.precision, precision)
+        self.assertEqual(item.specificity, None)
+        self.assertEqual(item.f1,
+                         2 * (precision * recall) / (precision + recall))
+
+        json = item.to_json()
+        self.assertNotIn('relative_frequency', json)
+        self.assertIsNone(json['metrics']['specificity'])
+        self.assertEqual(json['true_pos'], tp)
+        self.assertEqual(json['false_pos'], fp)
+        self.assertEqual(json['false_neg'], fn)
 
     def test_merge(self):
-        a = ClassEvaluationItem(
-            precision=1, recall=1, f1=1, count_error=0, gt_count=1)
-        b = ClassEvaluationItem(
-            precision=0, recall=0, f1=0, count_error=1, gt_count=2)
-        a.merge(b)
-        self.assertEqual(a.precision, 1 / 3)
-        self.assertEqual(a.recall, 1 / 3)
-        self.assertEqual(a.f1, 1 / 3)
-        self.assertEqual(a.count_error, 2 / 3)
-        self.assertEqual(a.gt_count, 3)
+        conf_mat1 = np.random.randint(100, size=(2, 2))
+        [[tn, fp], [fn, tp]] = conf_mat1
+        item1 = ClassEvaluationItem(
+            class_id=0, class_name='abc', tp=tp, fp=fp, fn=fn, tn=tn)
+
+        conf_mat2 = np.random.randint(100, size=(2, 2))
+        [[tn, fp], [fn, tp]] = conf_mat2
+        item2 = ClassEvaluationItem(
+            class_id=0, class_name='abc', tp=tp, fp=fp, fn=fn, tn=tn)
+
+        item1.merge(item2)
+        np.testing.assert_array_equal(item1.conf_mat, conf_mat1 + conf_mat2)
+
+    def test_extra_info(self):
+        conf_mat = np.random.randint(100, size=(2, 2))
+        [[tn, fp], [fn, tp]] = conf_mat
+        item = ClassEvaluationItem(
+            class_id=0,
+            class_name='abc',
+            tp=tp,
+            fp=fp,
+            fn=fn,
+            tn=tn,
+            extra1='extra1',
+            extra2='extra2')
+        json = item.to_json()
+        self.assertEqual(json['extra1'], 'extra1')
+        self.assertEqual(json['extra2'], 'extra2')
+
+    def from_multiclass_conf_mat(self):
+        conf_mat = np.random.randint(100, size=(10, 10))
+        item = ClassEvaluationItem.from_multiclass_conf_mat(
+            class_id=3,
+            class_name='abc',
+            conf_mat=conf_mat,
+            extra1='extra1',
+            extra2='extra2')
+
+        tp = conf_mat[3, 3]
+        fp = conf_mat[:, 3].sum() - tp
+        fn = conf_mat[3, :].sum() - tp
+        tn = conf_mat.sum() - tp - fp - fn
+        self.assertEqual(item.true_pos, tp)
+        self.assertEqual(item.false_pos, fp)
+        self.assertEqual(item.false_neg, fn)
+        self.assertEqual(item.true_neg, tn)
+
+        json = item.to_json()
+        self.assertEqual(json['extra1'], 'extra1')
+        self.assertEqual(json['extra2'], 'extra2')
 
 
 if __name__ == '__main__':

--- a/tests/core/evaluation/test_object_detection_evaluation.py
+++ b/tests/core/evaluation/test_object_detection_evaluation.py
@@ -53,10 +53,10 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
         self.assertEqual(eval_item2.f1, 2 / 3)
 
         avg_item = eval.avg_item
-        self.assertEqual(avg_item.gt_count, 4)
-        self.assertAlmostEqual(avg_item.precision, 1.0)
-        self.assertEqual(avg_item.recall, 0.75)
-        self.assertAlmostEqual(avg_item.f1, 0.83, places=2)
+        self.assertEqual(avg_item['gt_count'], 4)
+        self.assertAlmostEqual(avg_item['metrics']['precision'], 1.0)
+        self.assertEqual(avg_item['metrics']['recall'], 0.75)
+        self.assertAlmostEqual(avg_item['metrics']['f1'], 0.83, places=2)
 
     def test_compute_no_preds(self):
         class_config = self.make_class_config()
@@ -67,21 +67,21 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
         eval.compute(gt_labels, pred_labels)
         eval_item1 = eval.class_to_eval_item[0]
         self.assertEqual(eval_item1.gt_count, 2)
-        self.assertEqual(eval_item1.precision, None)
+        self.assertTrue(np.isnan(eval_item1.precision))
         self.assertEqual(eval_item1.recall, 0.0)
-        self.assertEqual(eval_item1.f1, None)
+        self.assertTrue(np.isnan(eval_item1.f1))
 
         eval_item2 = eval.class_to_eval_item[1]
         self.assertEqual(eval_item2.gt_count, 2)
-        self.assertEqual(eval_item2.precision, None)
+        self.assertTrue(np.isnan(eval_item2.precision))
         self.assertEqual(eval_item2.recall, 0.0)
-        self.assertEqual(eval_item2.f1, None)
+        self.assertTrue(np.isnan(eval_item2.f1))
 
         avg_item = eval.avg_item
-        self.assertEqual(avg_item.gt_count, 4)
-        self.assertEqual(avg_item.precision, 0.0)
-        self.assertEqual(avg_item.recall, 0.0)
-        self.assertEqual(avg_item.f1, 0.0)
+        self.assertEqual(avg_item['gt_count'], 4)
+        self.assertEqual(avg_item['metrics']['precision'], 0.0)
+        self.assertEqual(avg_item['metrics']['recall'], 0.0)
+        self.assertEqual(avg_item['metrics']['f1'], 0.0)
 
     def test_compute_no_ground_truth(self):
         class_config = self.make_class_config()
@@ -92,21 +92,21 @@ class TestObjectDetectionEvaluation(unittest.TestCase):
         eval.compute(gt_labels, pred_labels)
         eval_item1 = eval.class_to_eval_item[0]
         self.assertEqual(eval_item1.gt_count, 0)
-        self.assertEqual(eval_item1.precision, None)
-        self.assertEqual(eval_item1.recall, None)
-        self.assertEqual(eval_item1.f1, None)
+        self.assertEqual(eval_item1.precision, 0)
+        self.assertTrue(np.isnan(eval_item1.recall))
+        self.assertTrue(np.isnan(eval_item1.f1))
 
         eval_item2 = eval.class_to_eval_item[1]
         self.assertEqual(eval_item2.gt_count, 0)
-        self.assertEqual(eval_item2.precision, None)
-        self.assertEqual(eval_item2.recall, None)
-        self.assertEqual(eval_item2.f1, None)
+        self.assertEqual(eval_item2.precision, 0)
+        self.assertTrue(np.isnan(eval_item2.recall))
+        self.assertTrue(np.isnan(eval_item2.f1))
 
         avg_item = eval.avg_item
-        self.assertEqual(avg_item.gt_count, 0)
-        self.assertEqual(avg_item.precision, None)
-        self.assertEqual(avg_item.recall, None)
-        self.assertEqual(avg_item.f1, None)
+        self.assertEqual(avg_item['gt_count'], 0)
+        self.assertEqual(avg_item['metrics']['precision'], 0.0)
+        self.assertEqual(avg_item['metrics']['recall'], 0.0)
+        self.assertEqual(avg_item['metrics']['f1'], 0.0)
 
 
 if __name__ == '__main__':

--- a/tests/core/evaluation/test_semantic_segmentation_evaluation.py
+++ b/tests/core/evaluation/test_semantic_segmentation_evaluation.py
@@ -2,9 +2,9 @@ import unittest
 
 import numpy as np
 
-from rastervision.core.data import ClassConfig
+from rastervision.core.data import (
+    ClassConfig, SemanticSegmentationLabelSource, PolygonVectorOutputConfig)
 from rastervision.core.evaluation import SemanticSegmentationEvaluation
-from rastervision.core.data import SemanticSegmentationLabelSource
 from tests.core.data.mock_raster_source import MockRasterSource
 from tests import data_file_path
 
@@ -35,57 +35,39 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         eval.compute(gt_label_source.get_labels(), p_label_source.get_labels())
 
         tp0 = 16 - 3  # 4*4 - 3 true positives for class 0
-        fp0 = 1  # 1 false positive (2,2) and one don't care at (0,0)
+        fp0 = 2  # 1 false positive (2,2) and one at (0,0)
         fn0 = 1  # one false negative (1,1)
         precision0 = float(tp0) / (tp0 + fp0)
         recall0 = float(tp0) / (tp0 + fn0)
         f10 = 2 * float(precision0 * recall0) / (precision0 + recall0)
 
+        eval_item0 = eval.class_to_eval_item[0]
+        self.assertAlmostEqual(precision0, eval_item0.precision)
+        self.assertAlmostEqual(recall0, eval_item0.recall)
+        self.assertAlmostEqual(f10, eval_item0.f1)
+
         tp1 = 0  # 0 true positives for class 1
         fn1 = 1  # one false negative (2,2)
         precision1 = 0  # float(tp1) / (tp1 + fp1) where fp1 == 1
         recall1 = float(tp1) / (tp1 + fn1)
-        f11 = None
 
-        self.assertAlmostEqual(precision0,
-                               eval.class_to_eval_item[0].precision)
-        self.assertAlmostEqual(recall0, eval.class_to_eval_item[0].recall)
-        self.assertAlmostEqual(f10, eval.class_to_eval_item[0].f1)
+        eval_item1 = eval.class_to_eval_item[1]
+        self.assertEqual(precision1, eval_item1.precision)
+        self.assertAlmostEqual(recall1, eval_item1.recall)
+        self.assertTrue(np.isnan(eval_item1.f1))
 
-        self.assertEqual(precision1, eval.class_to_eval_item[1].precision)
-        self.assertAlmostEqual(recall1, eval.class_to_eval_item[1].recall)
-        self.assertAlmostEqual(f11, eval.class_to_eval_item[1].f1)
+        recall2 = 0
+        eval_item2 = eval.class_to_eval_item[2]
+        self.assertEqual(recall2, eval_item2.recall)
+        self.assertTrue(np.isnan(eval_item2.precision))
+        self.assertTrue(np.isnan(eval_item2.f1))
 
-        avg_conf_mat = np.array([[0, 0, 0], [13., 1, 0], [1, 0, 0]])
-        avg_recall = (14 / 15) * recall0 + (1 / 15) * recall1
-        self.assertTrue(np.array_equal(avg_conf_mat, eval.avg_item.conf_mat))
-        self.assertEqual(avg_recall, eval.avg_item.recall)
-
-    def test_compute_ignore_class(self):
-        class_config = ClassConfig(names=['one', 'two'])
-        class_config.update()
-        class_config.ensure_null_class()
-        null_class_id = class_config.get_null_class_id()
-
-        gt_array = np.zeros((4, 4, 1), dtype=np.uint8)
-        gt_array[0, 0, 0] = 2
-        gt_raster = MockRasterSource([0], 1)
-        gt_raster.set_raster(gt_array)
-        gt_label_source = SemanticSegmentationLabelSource(
-            gt_raster, null_class_id)
-
-        pred_array = np.zeros((4, 4, 1), dtype=np.uint8)
-        pred_array[0, 0, 0] = 1
-        pred_raster = MockRasterSource([0], 1)
-        pred_raster.set_raster(pred_array)
-        pred_label_source = SemanticSegmentationLabelSource(
-            pred_raster, null_class_id)
-
-        eval = SemanticSegmentationEvaluation(class_config)
-        eval.compute(gt_label_source.get_labels(),
-                     pred_label_source.get_labels())
-        self.assertAlmostEqual(1.0, eval.class_to_eval_item[0].f1)
-        self.assertAlmostEqual(1.0, eval.avg_item.f1)
+        avg_conf_mat = np.array([[13., 1, 0], [1, 0, 0], [1, 0, 0]])
+        avg_recall = (
+            (14 / 16) * recall0 + (1 / 16) * recall1 + (1 / 16) * recall2)
+        np.testing.assert_array_equal(avg_conf_mat,
+                                      np.array(eval.avg_item['conf_mat']))
+        self.assertEqual(avg_recall, eval.avg_item['metrics']['recall'])
 
     def test_vector_compute(self):
         class_config = ClassConfig(names=['one', 'two'])
@@ -95,8 +77,10 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         gt_uri = data_file_path('2-gt-polygons.geojson')
         pred_uri = data_file_path('2-pred-polygons.geojson')
 
+        vo_cfg = PolygonVectorOutputConfig(class_id=0)
+
         eval = SemanticSegmentationEvaluation(class_config)
-        eval.compute_vector(gt_uri, pred_uri, 'polygons', 0)
+        eval.compute_vector(gt_uri, [pred_uri], vector_outputs=[vo_cfg])
 
         # NOTE: The  two geojson files referenced  above contain three
         # unique geometries total, each  file contains two geometries,
@@ -107,8 +91,10 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         precision = float(tp) / (tp + fp)
         recall = float(tp) / (tp + fn)
 
-        self.assertAlmostEqual(precision, eval.class_to_eval_item[0].precision)
-        self.assertAlmostEqual(recall, eval.class_to_eval_item[0].recall)
+        eval_item = eval.class_to_eval_item[0]
+        self.assertAlmostEqual(precision, eval_item.precision)
+        self.assertAlmostEqual(recall, eval_item.recall)
+        self.assertEqual(eval_item.to_json()['mode'], 'polygons')
 
 
 if __name__ == '__main__':

--- a/tests/core/evaluation/test_semantic_segmentation_evaluator.py
+++ b/tests/core/evaluation/test_semantic_segmentation_evaluator.py
@@ -78,6 +78,13 @@ class TestSemanticSegmentationEvaluator(unittest.TestCase):
     def test_evaluator(self):
         output_uri = join(self.tmp_dir.name, 'out.json')
         scenes = [self.get_scene(0), self.get_scene(1)]
+
+        # the mock scene returned by get_scene uses a label source in place of
+        # a label store, but an SS label store is expected to have a
+        # vector_outputs, so we add that here
+        scenes[0].label_store.vector_outputs = None
+        scenes[1].label_store.vector_outputs = None
+
         evaluator = SemanticSegmentationEvaluator(self.class_config,
                                                   output_uri, None)
         evaluator.process(scenes, self.tmp_dir.name)
@@ -109,7 +116,7 @@ class TestSemanticSegmentationEvaluator(unittest.TestCase):
             rasterizer_config=RasterizerConfig(background_class_id=1))
         pred_rs = config.build(self.class_config, crs_transformer, extent)
         pred_ls = SemanticSegmentationLabelSource(pred_rs, self.null_class_id)
-        pred_ls.vector_output = [
+        pred_ls.vector_outputs = [
             PolygonVectorOutputConfig(
                 uri=pred_uri, denoise=0, class_id=class_id)
         ]

--- a/tests/data_files/expected-eval.json
+++ b/tests/data_files/expected-eval.json
@@ -1,171 +1,324 @@
 {
     "overall": [
         {
-            "precision": 1,
-            "recall": 0.5,
-            "f1": 0.6666666666666666,
-            "count_error": 50,
-            "gt_count": 100,
-            "conf_mat": [
-                50,
-                50,
-                0
-            ],
             "class_id": 0,
-            "class_name": "one"
-        },
-        {
-            "precision": 1,
-            "recall": 0.5,
-            "f1": 0.6666666666666666,
-            "count_error": 50,
-            "gt_count": 100,
-            "conf_mat": [
-                50,
-                50,
-                0
-            ],
-            "class_id": 1,
-            "class_name": "two"
-        },
-        {
-            "precision": 1,
-            "recall": 0.5,
-            "f1": 0.6666666666666666,
-            "count_error": 50,
-            "gt_count": 200,
+            "class_name": "one",
+            "gt_count": 100.0,
+            "pred_count": 100.0,
+            "count_error": 0.0,
+            "relative_frequency": 0.5,
+            "metrics": {
+                "recall": 0.5,
+                "precision": 0.5,
+                "f1": 0.5,
+                "sensitivity": 0.5,
+                "specificity": 0.5
+            },
             "conf_mat": [
                 [
-                    0,
-                    0,
-                    0
+                    50.0,
+                    50.0
                 ],
                 [
-                    50,
-                    50,
-                    0
-                ],
-                [
-                    50,
-                    50,
-                    0
+                    50.0,
+                    50.0
                 ]
-            ],
-            "class_id": null,
-            "class_name": "average"
+            ]
+        },
+        {
+            "class_id": 1,
+            "class_name": "two",
+            "gt_count": 100.0,
+            "pred_count": 100.0,
+            "count_error": 0.0,
+            "relative_frequency": 0.5,
+            "metrics": {
+                "recall": 0.5,
+                "precision": 0.5,
+                "f1": 0.5,
+                "sensitivity": 0.5,
+                "specificity": 0.5
+            },
+            "conf_mat": [
+                [
+                    50.0,
+                    50.0
+                ],
+                [
+                    50.0,
+                    50.0
+                ]
+            ]
+        },
+        {
+            "class_id": 2,
+            "class_name": "null",
+            "gt_count": 0.0,
+            "pred_count": 0.0,
+            "count_error": 0.0,
+            "relative_frequency": 0.0,
+            "metrics": {
+                "recall": null,
+                "precision": null,
+                "f1": null,
+                "sensitivity": null,
+                "specificity": 1.0
+            },
+            "conf_mat": [
+                [
+                    200.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0
+                ]
+            ]
+        },
+        {
+            "class_name": "average",
+            "metrics": {
+                "recall": 0.5,
+                "precision": 0.5,
+                "f1": 0.5,
+                "sensitivity": 0.5,
+                "specificity": 0.5
+            },
+            "gt_count": 200.0,
+            "pred_count": 200.0,
+            "count_error": 0.0,
+            "conf_mat": [
+                [
+                    50.0,
+                    50.0,
+                    0.0
+                ],
+                [
+                    50.0,
+                    50.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            ]
         }
     ],
     "per_scene": {
         "0": [
             {
-                "precision": 1,
-                "recall": 0.5,
-                "f1": 0.6666666666666666,
-                "count_error": 50,
-                "gt_count": 100,
-                "conf_mat": [
-                    50,
-                    50,
-                    0
-                ],
                 "class_id": 0,
-                "class_name": "one"
-            },
-            {
-                "precision": 0,
-                "recall": null,
-                "f1": null,
-                "count_error": 50,
-                "gt_count": 0,
-                "conf_mat": [
-                    0,
-                    0,
-                    0
-                ],
-                "class_id": 1,
-                "class_name": "two"
-            },
-            {
-                "precision": 1,
-                "recall": 0.5,
-                "f1": 0.6666666666666666,
-                "count_error": 50,
-                "gt_count": 100,
+                "class_name": "one",
+                "gt_count": 100.0,
+                "pred_count": 50.0,
+                "count_error": 50.0,
+                "relative_frequency": 1.0,
+                "metrics": {
+                    "recall": 0.5,
+                    "precision": 1.0,
+                    "f1": 0.6666666666666666,
+                    "sensitivity": 0.5,
+                    "specificity": null
+                },
                 "conf_mat": [
                     [
-                        0,
-                        0,
-                        0
+                        0.0,
+                        0.0
                     ],
                     [
-                        50,
-                        50,
-                        0
-                    ],
-                    [
-                        0,
-                        0,
-                        0
+                        50.0,
+                        50.0
                     ]
-                ],
-                "class_id": null,
-                "class_name": "average"
+                ]
+            },
+            {
+                "class_id": 1,
+                "class_name": "two",
+                "gt_count": 0.0,
+                "pred_count": 50.0,
+                "count_error": 50.0,
+                "relative_frequency": 0.0,
+                "metrics": {
+                    "recall": null,
+                    "precision": 0.0,
+                    "f1": null,
+                    "sensitivity": null,
+                    "specificity": 0.5
+                },
+                "conf_mat": [
+                    [
+                        50.0,
+                        50.0
+                    ],
+                    [
+                        0.0,
+                        0.0
+                    ]
+                ]
+            },
+            {
+                "class_id": 2,
+                "class_name": "null",
+                "gt_count": 0.0,
+                "pred_count": 0.0,
+                "count_error": 0.0,
+                "relative_frequency": 0.0,
+                "metrics": {
+                    "recall": null,
+                    "precision": null,
+                    "f1": null,
+                    "sensitivity": null,
+                    "specificity": 1.0
+                },
+                "conf_mat": [
+                    [
+                        100.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0
+                    ]
+                ]
+            },
+            {
+                "class_name": "average",
+                "metrics": {
+                    "recall": 0.5,
+                    "precision": 1.0,
+                    "f1": 0.6666666666666666,
+                    "sensitivity": 0.5,
+                    "specificity": 0.0
+                },
+                "gt_count": 100.0,
+                "pred_count": 100.0,
+                "count_error": 100.0,
+                "conf_mat": [
+                    [
+                        50.0,
+                        50.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                ]
             }
         ],
         "1": [
             {
-                "precision": 0,
-                "recall": null,
-                "f1": null,
-                "count_error": 50,
-                "gt_count": 0,
-                "conf_mat": [
-                    0,
-                    0,
-                    0
-                ],
                 "class_id": 0,
-                "class_name": "one"
-            },
-            {
-                "precision": 1,
-                "recall": 0.5,
-                "f1": 0.6666666666666666,
-                "count_error": 50,
-                "gt_count": 100,
-                "conf_mat": [
-                    50,
-                    50,
-                    0
-                ],
-                "class_id": 1,
-                "class_name": "two"
-            },
-            {
-                "precision": 1,
-                "recall": 0.5,
-                "f1": 0.6666666666666666,
-                "count_error": 50,
-                "gt_count": 100,
+                "class_name": "one",
+                "gt_count": 0.0,
+                "pred_count": 50.0,
+                "count_error": 50.0,
+                "relative_frequency": 0.0,
+                "metrics": {
+                    "recall": null,
+                    "precision": 0.0,
+                    "f1": null,
+                    "sensitivity": null,
+                    "specificity": 0.5
+                },
                 "conf_mat": [
                     [
-                        0,
-                        0,
-                        0
+                        50.0,
+                        50.0
                     ],
                     [
-                        0,
-                        0,
-                        0
-                    ],
-                    [
-                        50,
-                        50,
-                        0
+                        0.0,
+                        0.0
                     ]
-                ],
-                "class_id": null,
-                "class_name": "average"
+                ]
+            },
+            {
+                "class_id": 1,
+                "class_name": "two",
+                "gt_count": 100.0,
+                "pred_count": 50.0,
+                "count_error": 50.0,
+                "relative_frequency": 1.0,
+                "metrics": {
+                    "recall": 0.5,
+                    "precision": 1.0,
+                    "f1": 0.6666666666666666,
+                    "sensitivity": 0.5,
+                    "specificity": null
+                },
+                "conf_mat": [
+                    [
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        50.0,
+                        50.0
+                    ]
+                ]
+            },
+            {
+                "class_id": 2,
+                "class_name": "null",
+                "gt_count": 0.0,
+                "pred_count": 0.0,
+                "count_error": 0.0,
+                "relative_frequency": 0.0,
+                "metrics": {
+                    "recall": null,
+                    "precision": null,
+                    "f1": null,
+                    "sensitivity": null,
+                    "specificity": 1.0
+                },
+                "conf_mat": [
+                    [
+                        100.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0
+                    ]
+                ]
+            },
+            {
+                "class_name": "average",
+                "metrics": {
+                    "recall": 0.5,
+                    "precision": 1.0,
+                    "f1": 0.6666666666666666,
+                    "sensitivity": 0.5,
+                    "specificity": 0.0
+                },
+                "gt_count": 100.0,
+                "pred_count": 100.0,
+                "count_error": 100.0,
+                "conf_mat": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        50.0,
+                        50.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                ]
             }
         ]
     }

--- a/tests/data_files/expected-vector-eval-with-aoi.json
+++ b/tests/data_files/expected-vector-eval-with-aoi.json
@@ -1,44 +1,70 @@
 {
+    "overall": [
+        {
+            "class_id": 0,
+            "class_name": "one",
+            "gt_count": 3,
+            "pred_count": 3,
+            "count_error": 0,
+            "metrics": {
+                "recall": 1.0,
+                "precision": 1.0,
+                "f1": 1.0,
+                "sensitivity": 1.0,
+                "specificity": null
+            },
+            "true_pos": 3,
+            "false_pos": 0,
+            "false_neg": 0,
+            "mode": "polygons"
+        },
+        {
+            "class_name": "average",
+            "metrics": {
+                "recall": 1.0,
+                "precision": 1.0,
+                "f1": 1.0,
+                "sensitivity": 1.0,
+                "specificity": 0.0
+            },
+            "gt_count": 3,
+            "pred_count": 3,
+            "count_error": 0
+        }
+    ],
     "per_scene": {
         "0": [
             {
-                "recall": 1.0,
                 "class_id": 0,
+                "class_name": "one",
                 "gt_count": 3,
-                "precision": 1.0,
-                "f1": 1.0,
-                "class_name": "vector-polygons-one",
-                "count_error": 0
+                "pred_count": 3,
+                "count_error": 0,
+                "metrics": {
+                    "recall": 1.0,
+                    "precision": 1.0,
+                    "f1": 1.0,
+                    "sensitivity": 1.0,
+                    "specificity": null
+                },
+                "true_pos": 3,
+                "false_pos": 0,
+                "false_neg": 0,
+                "mode": "polygons"
             },
             {
-                "recall": 1.0,
-                "class_id": null,
-                "gt_count": 3,
-                "precision": 1.0,
-                "f1": 1.0,
                 "class_name": "average",
+                "metrics": {
+                    "recall": 1.0,
+                    "precision": 1.0,
+                    "f1": 1.0,
+                    "sensitivity": 1.0,
+                    "specificity": 0.0
+                },
+                "gt_count": 3,
+                "pred_count": 3,
                 "count_error": 0
             }
         ]
-    },
-    "overall": [
-        {
-            "recall": 1.0,
-            "class_id": 0,
-            "gt_count": 3,
-            "precision": 1.0,
-            "f1": 1.0,
-            "class_name": "vector-polygons-one",
-            "count_error": 0
-        },
-        {
-            "recall": 1.0,
-            "class_id": null,
-            "gt_count": 3,
-            "precision": 1.0,
-            "f1": 1.0,
-            "class_name": "average",
-            "count_error": 0
-        }
-    ]
+    }
 }

--- a/tests/data_files/expected-vector-eval.json
+++ b/tests/data_files/expected-vector-eval.json
@@ -1,72 +1,120 @@
 {
     "overall": [
         {
-            "precision": 0.8333333333333334,
-            "recall": 0.8333333333333334,
-            "f1": 0.8333333333333334,
-            "count_error": 2,
-            "gt_count": 6,
             "class_id": 0,
-            "class_name": "vector-polygons-one"
+            "class_name": "one",
+            "gt_count": 6,
+            "pred_count": 6,
+            "count_error": 0,
+            "metrics": {
+                "recall": 0.8333333333333334,
+                "precision": 0.8333333333333334,
+                "f1": 0.8333333333333334,
+                "sensitivity": 0.8333333333333334,
+                "specificity": null
+            },
+            "true_pos": 5,
+            "false_pos": 1,
+            "false_neg": 1,
+            "mode": "polygons"
         },
         {
-            "precision": 0.8571428571428571,
-            "recall": 0.75,
-            "f1": 0.7999999999999999,
-            "count_error": 3,
-            "gt_count": 8,
             "class_id": 1,
-            "class_name": "vector-polygons-two"
+            "class_name": "two",
+            "gt_count": 8,
+            "pred_count": 7,
+            "count_error": 1,
+            "metrics": {
+                "recall": 0.75,
+                "precision": 0.8571428571428571,
+                "f1": 0.7999999999999999,
+                "sensitivity": 0.75,
+                "specificity": null
+            },
+            "true_pos": 6,
+            "false_pos": 1,
+            "false_neg": 2,
+            "mode": "polygons"
         },
         {
-            "precision": 0.846938775510204,
-            "recall": 0.7857142857142857,
-            "f1": 0.8142857142857143,
-            "count_error": 2.571428571428571,
+            "class_name": "average",
+            "metrics": {
+                "recall": 0.7857142857142857,
+                "precision": 0.846938775510204,
+                "f1": 0.8142857142857143,
+                "sensitivity": 0.7857142857142857,
+                "specificity": 0.0
+            },
             "gt_count": 14,
-            "class_id": null,
-            "class_name": "average"
+            "pred_count": 13,
+            "count_error": 1
         }
     ],
     "per_scene": {
         "0": [
             {
-                "precision": 0.8333333333333334,
-                "recall": 0.8333333333333334,
-                "f1": 0.8333333333333334,
-                "count_error": 2,
-                "gt_count": 6,
                 "class_id": 0,
-                "class_name": "vector-polygons-one"
+                "class_name": "one",
+                "gt_count": 6,
+                "pred_count": 6,
+                "count_error": 0,
+                "metrics": {
+                    "recall": 0.8333333333333334,
+                    "precision": 0.8333333333333334,
+                    "f1": 0.8333333333333334,
+                    "sensitivity": 0.8333333333333334,
+                    "specificity": null
+                },
+                "true_pos": 5,
+                "false_pos": 1,
+                "false_neg": 1,
+                "mode": "polygons"
             },
             {
-                "precision": 0.8333333333333334,
-                "recall": 0.8333333333333334,
-                "f1": 0.8333333333333334,
-                "count_error": 2,
+                "class_name": "average",
+                "metrics": {
+                    "recall": 0.8333333333333334,
+                    "precision": 0.8333333333333334,
+                    "f1": 0.8333333333333334,
+                    "sensitivity": 0.8333333333333334,
+                    "specificity": 0.0
+                },
                 "gt_count": 6,
-                "class_id": null,
-                "class_name": "average"
+                "pred_count": 6,
+                "count_error": 0
             }
         ],
         "1": [
             {
-                "precision": 0.8571428571428571,
-                "recall": 0.75,
-                "f1": 0.7999999999999999,
-                "count_error": 3,
-                "gt_count": 8,
                 "class_id": 1,
-                "class_name": "vector-polygons-two"
+                "class_name": "two",
+                "gt_count": 8,
+                "pred_count": 7,
+                "count_error": 1,
+                "metrics": {
+                    "recall": 0.75,
+                    "precision": 0.8571428571428571,
+                    "f1": 0.7999999999999999,
+                    "sensitivity": 0.75,
+                    "specificity": null
+                },
+                "true_pos": 6,
+                "false_pos": 1,
+                "false_neg": 2,
+                "mode": "polygons"
             },
             {
-                "precision": 0.8571428571428571,
-                "recall": 0.75,
-                "f1": 0.7999999999999999,
-                "count_error": 3,
+                "class_name": "average",
+                "metrics": {
+                    "recall": 0.75,
+                    "precision": 0.8571428571428571,
+                    "f1": 0.7999999999999999,
+                    "sensitivity": 0.75,
+                    "specificity": 0.0
+                },
                 "gt_count": 8,
-                "class_id": null,
-                "class_name": "average"
+                "pred_count": 7,
+                "count_error": 1
             }
         ]
     }


### PR DESCRIPTION
## Overview

Depends on #1375 

This PR modifies the evaluation code such that when aggregating metrics for the same class over different scenes, the confusion matrices (one from each scene) are summed and the metrics are re-calculated. Previously, the metrics were aggregated using a weighted average.

The 2 methods are equivalent for recall but not for precision (and therefore also F1).
```
w1 = (TP1 + FN1) / (TP1 + FN1 + TP2 + FN2)
w2 = (TP2 + FN2) / (TP1 + FN1 + TP2 + FN2)

recall_wa = (TP1 / (TP1 + FN1)) * w1 + (TP2 / (TP2 + FN2)) * w2
recall_cm = (TP1 + TP2) / (TP1 + FN1 + TP2 + FN2)
=> recall_wa == recall_cm

precision_wa = (TP1 / (TP1 + FP1)) * w1 + (TP2 / (TP2 + FP2)) * w2
precision_cm = (TP1 + TP2) / (TP1 + FP1 + TP2 + FP2)
=> precision_wa != precision_cm
```

The code for computing the metrics has been moved inside `ClassEvaluationItem` to avoid duplication.

### Change details
The main changes are to `ClassEvaluationItem`. `*Evaluation` classes have been updated to support this change.

The expected-eval JSON's used in unit and integration tests have also been updated.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness
