### PR TITLE
Fix backward compatibility with v0.13 model bundles

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner.py
@@ -26,10 +26,14 @@ class ClassificationLearner(Learner):
         pretrained = self.cfg.model.pretrained
         num_classes = len(self.cfg.data.class_names)
         backbone_name = self.cfg.model.get_backbone_str()
+        in_channels = self.cfg.data.img_channels
+        if in_channels is None:
+            log.warn('DataConfig.img_channels is None. Defaulting to 3.')
+            in_channels = 3
 
         model = getattr(models, backbone_name)(pretrained=pretrained)
 
-        if self.cfg.data.img_channels != 3:
+        if in_channels != 3:
             if not backbone_name.startswith('resnet'):
                 raise ConfigError(
                     'All TorchVision backbones do not provide the same API '

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
@@ -39,6 +39,9 @@ class ObjectDetectionLearner(Learner):
         img_sz = self.cfg.data.img_sz
         num_classes = len(self.cfg.data.class_names)
         in_channels = self.cfg.data.img_channels
+        if in_channels is None:
+            log.warn('DataConfig.img_channels is None. Defaulting to 3.')
+            in_channels = 3
 
         backbone = resnet_fpn_backbone(backbone_arch, pretrained)
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
@@ -1,6 +1,7 @@
 from typing import Optional, Sequence
 import warnings
 from os.path import join
+import logging
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -20,6 +21,8 @@ from rastervision.pipeline.config import ConfigError
 
 warnings.filterwarnings('ignore')
 matplotlib.use('Agg')
+
+log = logging.getLogger(__name__)
 
 
 class RegressionModel(nn.Module):
@@ -52,6 +55,9 @@ class RegressionLearner(Learner):
         pretrained = self.cfg.model.pretrained
         backbone_name = self.cfg.model.get_backbone_str()
         in_channels = self.cfg.data.img_channels
+        if in_channels is None:
+            log.warn('DataConfig.img_channels is None. Defaulting to 3.')
+            in_channels = 3
         out_features = len(self.cfg.data.class_names)
         pos_out_inds = [
             self.cfg.data.class_names.index(class_name)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -30,6 +30,9 @@ class SemanticSegmentationLearner(Learner):
         backbone_name = self.cfg.model.get_backbone_str()
         num_classes = len(self.cfg.data.class_names)
         in_channels = self.cfg.data.img_channels
+        if in_channels is None:
+            log.warn('DataConfig.img_channels is None. Defaulting to 3.')
+            in_channels = 3
         if self.cfg.solver.ignore_last_class:
             num_classes -= 1
         model = models.segmentation.segmentation._segm_model(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
@@ -26,7 +26,6 @@ def ss_data_config_upgrader(cfg_dict: dict, version: int) -> dict:
     elif version < 3:
         try:
             # removed in version 3
-            del cfg_dict['img_channels']
             del cfg_dict['channel_display_groups']
         except KeyError:
             pass


### PR DESCRIPTION
## Overview

This PR fixes some backward compatibility issues introduced in #1255.

`SemanticSegmentationDataConfig`'s upgrader was wrongly deleting the `img_channels` field from the `DataConfig` which resulted in it being `None` in `Learner.build_model()`. This has been fixed.

This doesn't fix the problem with non-SS model bundles, however. For those, this PR adds an additional check in `build_model()` and defaults to `img_channels` = 3 if it is `None`.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* How to test this PR
- Download a bundle and sample image from https://docs.rastervision.io/en/latest/examples.html#semantic-segmentation-spacenet-vegas
- Run e.g.
```sh
rastervision predict \
    model-bundle.zip \
    sample-img-spacenet-vegas-roads-ss.tif \
    test/
```

Closes #1385 
