### PR TITLE
Pin protobuf to 3.20.*

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ seaborn==0.11.*
 jupyter==1.*
 jupyterlab==3.*
 jupyter_contrib_nbextensions==0.5.*
+protobuf==3.20.*


### PR DESCRIPTION
## Overview

This fixes the error described in: https://github.com/protocolbuffers/protobuf/issues/10051

CI builds were breaking during the unit testing step with that error.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

`scripts/unit_tests` should work.
