### PR TITLE
Add new GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/how-to.md
+++ b/.github/ISSUE_TEMPLATE/how-to.md
@@ -1,0 +1,26 @@
+---
+name: "\U0001F914 How-to"
+about: How do I do XYZ using Raster Vision?
+
+---
+
+## Description of what you want to do
+
+<!-- A clear and concise description of what you want to achieve. -->
+
+## Environment
+
+Running Raster Vision directly in Windows is not supported, and we recommend that you run it from within a Docker container.
+
+<!-- Please fill in the following. -->
+
+ - How you installed and are running Raster Vision (pip install on local vs. inside Docker image):
+ - Raster Vision version or commit:
+ - OS (e.g., Linux):
+ - Python version:
+ - CUDA/cuDNN version if running on GPU:
+ - Any other relevant information:
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/questions-help-support.md
+++ b/.github/ISSUE_TEMPLATE/questions-help-support.md
@@ -1,6 +1,6 @@
 ---
-name: "❓Questions/Help/Support"
-about: Do you need support? We have resources.
+name: "❓ Questions/Help/Support"
+about: Use this template if your question does not fit any other category.
 
 ---
 
@@ -10,7 +10,9 @@ If you have a usage or general question, you may ask it here or in our [Gitter C
 
 **Please check our [documentation](https://docs.rastervision.io/en/latest/index.html) first.**
 
-If you want help with an error, please use the bug report template instead and fill in all the details.
+If you have a usage question, please use the how-to issue template instead.
+
+If you want help with an error, please use the technical support issue template instead.
 
 Low-effort posts that are unclear, lack details, or are poorly formatted might be closed without a response.
 

--- a/.github/ISSUE_TEMPLATE/technical-support.md
+++ b/.github/ISSUE_TEMPLATE/technical-support.md
@@ -1,0 +1,41 @@
+---
+name: "\U0001F6E0 Technical Support"
+about: Running into an error but not sure if it's a bug? Use this template.
+---
+
+## ⚠ Error message with full stack trace
+
+```sh
+# The error message (with full stack trace, if applicable).
+```
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1.
+2.
+3.
+
+<!-- Please provide the command executed, source of the get_config() function, and any other context. -->
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Environment
+
+Running Raster Vision directly in Windows is not supported, and we recommend that you run it from within a Docker container.
+
+<!-- Please fill in the following. -->
+
+ - How you installed and are running Raster Vision (pip install on local vs. inside Docker image):
+ - Raster Vision version or commit:
+ - OS (e.g., Linux):
+ - Python version:
+ - CUDA/cuDNN version if running on GPU:
+ - Any other relevant information:
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
## Overview

This PR adds two new issue templates:
1. A technical support template for help with errors that are not necessarily bugs
2. A how-to template for usage questions

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A