### PR TITLE
Bug fix: ensure default bbox_params are passed to ObjectDetectionRandomWindowGeoDataset

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -87,12 +87,13 @@ class ObjectDetectionGeoDataWindowConfig(GeoDataWindowConfig):
 
 @register_config('object_detection_geo_data')
 class ObjectDetectionGeoDataConfig(ObjectDetectionDataConfig, GeoDataConfig):
-    def scene_to_dataset(self,
-                         scene: Scene,
-                         transform: Optional[A.BasicTransform] = None,
-                         bbox_params: Optional[A.BboxParams] = None
-                         ) -> Union[ObjectDetectionSlidingWindowGeoDataset,
-                                    ObjectDetectionRandomWindowGeoDataset]:
+    def scene_to_dataset(
+            self,
+            scene: Scene,
+            transform: Optional[A.BasicTransform] = None,
+            bbox_params: Optional[A.BboxParams] = DEFAULT_BBOX_PARAMS
+    ) -> Union[ObjectDetectionSlidingWindowGeoDataset,
+               ObjectDetectionRandomWindowGeoDataset]:
         if isinstance(self.window_opts, dict):
             opts = self.window_opts[scene.id]
         else:


### PR DESCRIPTION
## Overview

See the following Gitter discussion for details: https://gitter.im/azavea/raster-vision?at=62b3bf233bbb3848898ed004

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A
