### PR TITLE
Refactor to make it easier to programmatically make predictions on new scenes

### DIFF
--- a/rastervision_core/rastervision/core/backend/backend.py
+++ b/rastervision_core/rastervision/core/backend/backend.py
@@ -1,12 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import TYPE_CHECKING
 from contextlib import AbstractContextManager
 
-import numpy as np
-
-from rastervision.core.data_sample import DataSample
-from rastervision.core.box import Box
-from rastervision.core.data import Labels
+if TYPE_CHECKING:
+    from rastervision.core.data_sample import DataSample
+    from rastervision.core.data import Labels, Scene
 
 
 class SampleWriter(AbstractContextManager):
@@ -17,7 +15,7 @@ class SampleWriter(AbstractContextManager):
     """
 
     @abstractmethod
-    def write_sample(self, sample: DataSample):
+    def write_sample(self, sample: 'DataSample'):
         """Writes a single sample."""
         pass
 
@@ -49,12 +47,12 @@ class Backend(ABC):
         pass
 
     @abstractmethod
-    def predict(self, chips: np.ndarray, windows: List[Box]) -> Labels:
-        """Return predictions for a batch of chips using the model.
+    def predict_scene(self, scene: 'Scene', chip_sz: int,
+                      stride: int) -> 'Labels':
+        """Return predictions for an entire scene using the model.
 
         Args:
-            chips: input images of shape [height, width, channels]
-            windows: the windows corresponding to the chips in pixel coords
+            scene (Scene): Scene to run inference on.
 
         Return:
             Labels object containing predictions

--- a/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
+++ b/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
@@ -25,8 +25,8 @@ class ChipClassificationLabels(Labels):
         result.extend(other)
         return result
 
-    def __contains__(self, cell):
-        return cell.tuple_format() in self.cell_to_class_id
+    def __contains__(self, cell: Box):
+        return cell in self.cell_to_class_id
 
     def __setitem__(self, window: Box, scores: 'np.ndarray'):
         class_id = scores.argmax()
@@ -47,7 +47,10 @@ class ChipClassificationLabels(Labels):
                     result.set_cell(cell_box, class_id, scores)
         return result
 
-    def set_cell(self, cell, class_id, scores=None):
+    def set_cell(self,
+                 cell: Box,
+                 class_id: int,
+                 scores: Optional['np.ndarray'] = None):
         """Set cell and its class_id.
 
         Args:
@@ -57,41 +60,41 @@ class ChipClassificationLabels(Labels):
         """
         if scores is not None:
             scores = list(map(lambda x: float(x), list(scores)))
-        self.cell_to_class_id[cell.tuple_format()] = (class_id, scores)
+        self.cell_to_class_id[cell] = (class_id, scores)
 
-    def get_cell_class_id(self, cell):
+    def get_cell_class_id(self, cell: Box):
         """Return class_id for a cell.
 
         Args:
             cell: (Box)
         """
-        result = self.cell_to_class_id.get(cell.tuple_format())
+        result = self.cell_to_class_id.get(cell)
         if result:
             return result[0]
         else:
             return None
 
-    def get_cell_scores(self, cell):
+    def get_cell_scores(self, cell: Box):
         """Return scores for a cell.
 
         Args:
             cell: (Box)
         """
-        result = self.cell_to_class_id.get(cell.tuple_format())
+        result = self.cell_to_class_id.get(cell)
         if result:
             return result[1]
         else:
             return None
 
-    def get_cell_values(self, cell):
+    def get_cell_values(self, cell: Box):
         """Return a tuple of (class_id, scores) for a cell.
 
         Args:
             cell: (Box)
         """
-        return self.cell_to_class_id.get(cell.tuple_format())
+        return self.cell_to_class_id.get(cell)
 
-    def get_singleton_labels(self, cell):
+    def get_singleton_labels(self, cell: Box):
         """Return Labels object representing a single cell.
 
         Args:

--- a/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
+++ b/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
@@ -1,5 +1,9 @@
+from typing import TYPE_CHECKING, Optional
 from rastervision.core.box import Box
 from rastervision.core.data.label import Labels
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class ChipClassificationLabels(Labels):
@@ -23,6 +27,14 @@ class ChipClassificationLabels(Labels):
 
     def __contains__(self, cell):
         return cell.tuple_format() in self.cell_to_class_id
+
+    def __setitem__(self, window: Box, scores: 'np.ndarray'):
+        class_id = scores.argmax()
+        self.set_cell(window, class_id, scores=scores)
+
+    @classmethod
+    def make_empty(cls) -> 'ChipClassificationLabels':
+        return ChipClassificationLabels()
 
     def filter_by_aoi(self, aoi_polygons):
         result = ChipClassificationLabels()

--- a/rastervision_core/rastervision/core/data/label/labels.py
+++ b/rastervision_core/rastervision/core/data/label/labels.py
@@ -1,4 +1,8 @@
-from abc import (ABC, abstractmethod)
+from typing import TYPE_CHECKING, Any, Iterable
+from abc import (ABC, abstractclassmethod, abstractmethod)
+
+if TYPE_CHECKING:
+    from rastervision.core.box import Box
 
 
 class Labels(ABC):
@@ -28,3 +32,41 @@ class Labels(ABC):
     @abstractmethod
     def __eq__(self, other):
         pass
+
+    @abstractmethod
+    def __setitem__(self, key, value):
+        pass
+
+    @abstractclassmethod
+    def make_empty(cls) -> 'Labels':
+        """Instantiate an empty instance of this class.
+
+        Returns:
+            Labels: An object of the Label subclass on which this method is
+                called.
+        """
+        pass
+
+    @classmethod
+    def from_predictions(cls, windows: Iterable['Box'],
+                         predictions: Iterable[Any]) -> 'Labels':
+        """Instantiate from windows and their corresponding predictions.
+
+        This makes no assumptions about the type or format of the predictions.
+        Subclasses should implement the __setitem__ method to correctly handle
+        the predictions.
+
+        Args:
+            windows (Iterable[Box]): Boxes in pixel coords, specifying chips
+                in the raster.
+            predictions (Iterable[Any]): The model predictions for each chip
+                specified by the windows.
+
+        Returns:
+            Labels: An object of the Label subclass on which this method is
+                called.
+        """
+        labels = cls.make_empty()
+        for window, prediction in zip(windows, predictions):
+            labels[window] = prediction
+        return labels

--- a/rastervision_core/rastervision/core/data/label/labels.py
+++ b/rastervision_core/rastervision/core/data/label/labels.py
@@ -67,6 +67,8 @@ class Labels(ABC):
                 called.
         """
         labels = cls.make_empty()
-        for window, prediction in zip(windows, predictions):
+        # If predictions is tqdm-wrapped, it needs to be the first arg to zip()
+        # or the progress bar won't terminate with the correct count.
+        for prediction, window in zip(predictions, windows):
             labels[window] = prediction
         return labels

--- a/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
+++ b/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
@@ -381,6 +381,8 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
                 given predictions.
         """
         labels = cls.make_empty(extent, num_classes)
-        for window, prediction in zip(windows, predictions):
+        # If predictions is tqdm-wrapped, it needs to be the first arg to zip()
+        # or the progress bar won't terminate with the correct count.
+        for prediction, window in zip(predictions, windows):
             labels[window] = prediction
         return labels

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -93,7 +93,7 @@ class SemanticSegmentationLabelSource(ActivateMixin, LabelSource):
         Returns:
              SemanticSegmentationLabels
         """
-        labels = SemanticSegmentationLabels.build()
+        labels = SemanticSegmentationLabels.make_empty()
         window = window or self.raster_source.get_extent()
         raw_labels = self.raster_source.get_chip(window)
         label_arr = (np.squeeze(raw_labels) if self.class_transformer is None

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -353,7 +353,7 @@ class SemanticSegmentationLabelStore(LabelStore):
             'num_classes': len(self.class_config),
         }
         args.update(**kwargs)
-        labels = SemanticSegmentationLabels.build(**args)
+        labels = SemanticSegmentationLabels.make_empty(**args)
         return labels
 
     def _write_array(self, dataset: rio.DatasetReader, window: Box,

--- a/rastervision_core/rastervision/core/data/scene.py
+++ b/rastervision_core/rastervision/core/data/scene.py
@@ -44,7 +44,10 @@ class Scene(ActivateMixin):
 
     def __getitem__(self, window: Box) -> Tuple[Any, Any]:
         x = self.raster_source[window]
-        y = self.label_source[window]
+        if self.label_source is not None:
+            y = self.label_source[window]
+        else:
+            y = None
         return x, y
 
     def _subcomponents_to_activate(self) -> list:

--- a/rastervision_core/rastervision/core/data/scene.py
+++ b/rastervision_core/rastervision/core/data/scene.py
@@ -1,18 +1,21 @@
-from typing import Any, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from rastervision.core.data import ActivateMixin
 from rastervision.core.box import Box
+
+if TYPE_CHECKING:
+    from rastervision.core.data import (RasterSource, LabelSource, LabelStore)
 
 
 class Scene(ActivateMixin):
     """The raster data and labels associated with an area of interest."""
 
     def __init__(self,
-                 id,
-                 raster_source,
-                 ground_truth_label_source=None,
-                 prediction_label_store=None,
-                 aoi_polygons=None):
+                 id: str,
+                 raster_source: 'RasterSource',
+                 ground_truth_label_source: Optional['LabelSource'] = None,
+                 prediction_label_store: Optional['LabelStore'] = None,
+                 aoi_polygons: Optional[list] = None):
         """Construct a new Scene.
 
         Args:
@@ -32,11 +35,11 @@ class Scene(ActivateMixin):
             self.aoi_polygons = aoi_polygons
 
     @property
-    def label_source(self):
+    def label_source(self) -> 'LabelSource':
         return self.ground_truth_label_source
 
     @property
-    def label_store(self):
+    def label_store(self) -> 'LabelStore':
         return self.prediction_label_store
 
     def __getitem__(self, window: Box) -> Tuple[Any, Any]:
@@ -44,7 +47,7 @@ class Scene(ActivateMixin):
         y = self.label_source[window]
         return x, y
 
-    def _subcomponents_to_activate(self):
+    def _subcomponents_to_activate(self) -> list:
         return [
             self.raster_source, self.ground_truth_label_source,
             self.prediction_label_store

--- a/rastervision_core/rastervision/core/data/scene_config.py
+++ b/rastervision_core/rastervision/core/data/scene_config.py
@@ -49,7 +49,7 @@ class SceneConfig(Config):
 
         return self.__dict__.items()
 
-    def build(self, class_config, tmp_dir, use_transformers=True):
+    def build(self, class_config, tmp_dir, use_transformers=True) -> Scene:
         raster_source = self.raster_source.build(
             tmp_dir, use_transformers=use_transformers)
         crs_transformer = raster_source.get_crs_transformer()

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -1,21 +1,24 @@
+from typing import TYPE_CHECKING, List, Sequence
 import logging
-from typing import List, Sequence
 
 import numpy as np
 
 from rastervision.core.box import Box
-from rastervision.core.data import ClassConfig, Scene
 from rastervision.core.rv_pipeline.rv_pipeline import RVPipeline
 from rastervision.core.rv_pipeline.utils import (fill_no_data,
                                                  nodata_below_threshold)
 from rastervision.core.rv_pipeline.semantic_segmentation_config import (
     SemanticSegmentationWindowMethod, SemanticSegmentationChipOptions)
 
+if TYPE_CHECKING:
+    from rastervision.core.backend.backend import Backend
+    from rastervision.core.data import ClassConfig, Labels, Scene
+
 log = logging.getLogger(__name__)
 
 
-def get_train_windows(scene: Scene,
-                      class_config: ClassConfig,
+def get_train_windows(scene: 'Scene',
+                      class_config: 'ClassConfig',
                       chip_size: int,
                       chip_options: SemanticSegmentationChipOptions,
                       chip_nodata_threshold: float = 1.) -> List[Box]:
@@ -139,9 +142,9 @@ class SemanticSegmentation(RVPipeline):
 
         return labels
 
-    def get_predict_windows(self, extent: Box) -> List[Box]:
+    def predict_scene(self, scene: 'Scene', backend: 'Backend') -> 'Labels':
         chip_sz = self.config.predict_chip_sz
         stride = self.config.predict_options.stride
         if stride is None:
             stride = chip_sz
-        return extent.get_windows(chip_sz, stride)
+        return backend.predict_scene(scene, chip_sz=chip_sz, stride=stride)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING, Optional
 from os.path import join, splitext
 import tempfile
 
@@ -6,12 +7,14 @@ import numpy as np
 from rastervision.pipeline.file_system import (make_dir, upload_or_copy,
                                                zipdir)
 from rastervision.core.backend import Backend, SampleWriter
-from rastervision.core.data_sample import DataSample
-from rastervision.core.data import ClassConfig
-from rastervision.core.rv_pipeline import RVPipelineConfig
 from rastervision.core.utils.misc import save_img
-from rastervision.pytorch_learner.learner_config import LearnerConfig
 from rastervision.pytorch_learner.learner import Learner
+
+if TYPE_CHECKING:
+    from rastervision.core.data import ClassConfig, Scene
+    from rastervision.core.data_sample import DataSample
+    from rastervision.core.rv_pipeline import RVPipelineConfig
+    from rastervision.pytorch_learner.learner_config import LearnerConfig
 
 
 def write_chip(chip: np.ndarray, path: str) -> None:
@@ -34,7 +37,7 @@ def get_image_ext(chip: np.ndarray) -> str:
 
 
 class PyTorchLearnerSampleWriter(SampleWriter):
-    def __init__(self, output_uri: str, class_config: ClassConfig,
+    def __init__(self, output_uri: str, class_config: 'ClassConfig',
                  tmp_dir: str):
         """Constructor.
 
@@ -72,11 +75,11 @@ class PyTorchLearnerSampleWriter(SampleWriter):
         upload_or_copy(output_path, self.output_uri)
         self.tmp_dir_obj.cleanup()
 
-    def write_sample(self, sample: DataSample) -> None:
+    def write_sample(self, sample: 'DataSample') -> None:
         """Write a single sample to disk."""
         raise NotImplementedError()
 
-    def get_image_path(self, split_name: str, sample: DataSample) -> str:
+    def get_image_path(self, split_name: str, sample: 'DataSample') -> str:
         """Decide the save location of the image. Also, ensure that the target
         directory exists."""
         img_dir = join(self.sample_dir, split_name, 'img')
@@ -99,8 +102,8 @@ class PyTorchLearnerSampleWriter(SampleWriter):
 class PyTorchLearnerBackend(Backend):
     """Backend that uses the rastervision.pytorch_learner package to train models."""
 
-    def __init__(self, pipeline_cfg: RVPipelineConfig,
-                 learner_cfg: LearnerConfig, tmp_dir: str):
+    def __init__(self, pipeline_cfg: 'RVPipelineConfig',
+                 learner_cfg: 'LearnerConfig', tmp_dir: str):
         self.pipeline_cfg = pipeline_cfg
         self.learner_cfg = learner_cfg
         self.tmp_dir = tmp_dir
@@ -131,5 +134,8 @@ class PyTorchLearnerBackend(Backend):
     def get_sample_writer(self):
         raise NotImplementedError()
 
-    def predict_scene(self, scene):
+    def predict_scene(self,
+                      scene: 'Scene',
+                      chip_sz: int,
+                      stride: Optional[int] = None):
         raise NotImplementedError()

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
@@ -131,5 +131,5 @@ class PyTorchLearnerBackend(Backend):
     def get_sample_writer(self):
         raise NotImplementedError()
 
-    def predict(self, chips, windows):
+    def predict_scene(self, scene):
         raise NotImplementedError()

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
@@ -80,6 +80,7 @@ class PyTorchSemanticSegmentation(PyTorchLearnerBackend):
             ds,
             raw_out=raw_out,
             numpy_out=True,
+            predict_kw=dict(out_shape=(chip_sz, chip_sz)),
             progress_bar=True,
             progress_bar_kw=dict(desc=f'Making predictions on {scene.id}'))
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -47,12 +47,9 @@ class ClassificationImageDataConfig(ClassificationDataConfig, ImageDataConfig):
 @register_config('classification_geo_data')
 class ClassificationGeoDataConfig(ClassificationDataConfig, GeoDataConfig):
     def build_scenes(self, tmp_dir: str):
-        for s in self.scene_dataset.train_scenes:
-            s.label_source.lazy = True
-        for s in self.scene_dataset.validation_scenes:
-            s.label_source.lazy = True
-        for s in self.scene_dataset.test_scenes:
-            s.label_source.lazy = True
+        for s in self.scene_dataset.all_scenes:
+            if s.label_source is not None:
+                s.label_source.lazy = True
         return super().build_scenes(tmp_dir=tmp_dir)
 
     def scene_to_dataset(self,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/classification_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/classification_dataset.py
@@ -23,7 +23,8 @@ class ClassificationSlidingWindowGeoDataset(SlidingWindowGeoDataset):
 
     def init_windows(self):
         super().init_windows()
-        self.scene.label_source.populate_labels(cells=self.windows)
+        if self.scene.label_source is not None:
+            self.scene.label_source.populate_labels(cells=self.windows)
 
 
 class ClassificationRandomWindowGeoDataset(RandomWindowGeoDataset):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
@@ -60,7 +60,14 @@ class AlbumentationsDataset(Dataset):
         if self.to_pytorch:
             # (H, W, C) --> (C, H, W)
             x = torch.from_numpy(x).permute(2, 0, 1).float()
-            y = torch.from_numpy(y)
+            if y is not None:
+                y = torch.from_numpy(y)
+
+        if y is None:
+            # Ideally, y should be None to semantically convery the absence of
+            # any label, but PyTorch's defauult collate function doesn't handle
+            # None values.
+            y = torch.tensor(np.nan)
 
         return x, y
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -586,7 +586,7 @@ class Learner(ABC):
         """
         x = self.to_batch(x).float()
         x = self.to_device(x, self.device)
-        with torch.no_grad():
+        with torch.inference_mode():
             out = self.model(x)
             if not raw_out:
                 out = self.prob_to_pred(self.post_forward(out))
@@ -1032,7 +1032,7 @@ class Learner(ABC):
         self.model.eval()
         num_samples = 0
         outputs = []
-        with torch.no_grad():
+        with torch.inference_mode():
             with tqdm(dl, desc='Validating') as bar:
                 for batch_ind, (x, y) in enumerate(bar):
                     x = self.to_device(x, self.device)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -121,7 +121,7 @@ class Learner(ABC):
                  model_def_path: Optional[str] = None,
                  loss_def_path: Optional[str] = None,
                  training: bool = True):
-        """COnstructor.
+        """Constructor.
 
         Args:
             cfg (LearnerConfig): LearnerConfig.

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -778,7 +778,7 @@ class Learner(ABC):
                 x = self.to_device(x, self.device)
                 z = self.predict(x, raw_out=raw_out)
                 x = self.to_device(x, 'cpu')
-                y = self.to_device(y, 'cpu')
+                y = self.to_device(y, 'cpu') if y is not None else y
                 z = self.to_device(z, 'cpu')
                 if batched_output:
                     yield x, y, z
@@ -1118,7 +1118,7 @@ class Learner(ABC):
             x but with any Tensors in it on the device
         """
         if isinstance(x, list):
-            return [_x.to(device) for _x in x]
+            return [_x.to(device) if _x is not None else _x for _x in x]
         else:
             return x.to(device)
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -13,7 +13,6 @@ import numbers
 from tempfile import TemporaryDirectory
 
 import numpy as np
-import albumentations as A
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 
@@ -359,10 +358,6 @@ class Learner(ABC):
             save_dir=self.modules_dir,
             hubconf_dir=loss_def_path)
         return loss
-
-    def get_bbox_params(self) -> Optional[A.BboxParams]:
-        """Returns BboxParams used by albumentations for data augmentation."""
-        return None
 
     def get_collate_fn(self) -> Optional[callable]:
         """Returns a custom collate_fn to use in DataLoader.

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -14,7 +14,7 @@ import numbers
 from tempfile import TemporaryDirectory
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import matplotlib.pyplot as plt
 
 import torch

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
@@ -151,7 +151,7 @@ class RegressionLearner(Learner):
         super().eval_model(split)
 
         y, out = self.predict_dataloader(
-            self.get_dataloader(split), return_x=False, raw_out=False)
+            self.get_dataloader(split), return_format='yz', raw_out=False)
 
         max_scatter_points = self.cfg.data.plot_options.max_scatter_points
         if y.shape[0] > max_scatter_points:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -70,7 +70,7 @@ class SemanticSegmentationLearner(Learner):
             out = self.post_forward(out)
             out = out.softmax(dim=1)
 
-        # ensure output is the same shape as input
+        # ensure correct output shape
         if out.shape[-2:] != out_shape:
             out = F.interpolate(
                 out, size=out_shape, mode='bilinear', align_corners=False)

--- a/tests/core/data/label/test_semantic_segmentation_labels.py
+++ b/tests/core/data/label/test_semantic_segmentation_labels.py
@@ -11,18 +11,19 @@ from rastervision.core.data.label import (SemanticSegmentationLabels,
 class TestSemanticSegmentationLabels(unittest.TestCase):
     def test_build(self):
         self.assertIsInstance(
-            SemanticSegmentationLabels.build(smooth=False),
+            SemanticSegmentationLabels.make_empty(smooth=False),
             SemanticSegmentationDiscreteLabels)
 
         self.assertRaises(
-            ValueError, lambda: SemanticSegmentationLabels.build(smooth=True))
+            ValueError,
+            lambda: SemanticSegmentationLabels.make_empty(smooth=True))
 
         self.assertRaises(
-            ValueError, lambda: SemanticSegmentationLabels.build(
+            ValueError, lambda: SemanticSegmentationLabels.make_empty(
                 smooth=True, extent=Box(0, 0, 10, 10)))
 
         self.assertIsInstance(
-            SemanticSegmentationLabels.build(
+            SemanticSegmentationLabels.make_empty(
                 smooth=True, extent=Box(0, 0, 10, 10), num_classes=2),
             SemanticSegmentationSmoothLabels)
 

--- a/tests/pytorch_learner/test_classification_learner.py
+++ b/tests/pytorch_learner/test_classification_learner.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import logging
 
 import numpy as np
+import torch
 
 from rastervision.pipeline.file_system import json_to_file
 from rastervision.core.data import (
@@ -120,6 +121,14 @@ class TestClassificationLearner(unittest.TestCase):
             learner = backend.learner_cfg.build(tmp_dir, training=True)
             learner.plot_dataloaders()
             learner.plot_predictions(split='valid')
+
+            torch.save(learner.model.state_dict(),
+                       learner.last_model_weights_path)
+            learner.save_model_bundle()
+
+            pred_scene = dataset_cfg.validation_scenes[0].build(
+                class_config, tmp_dir)
+            _ = backend.predict_scene(pred_scene, chip_sz=100)
 
 
 if __name__ == '__main__':

--- a/tests/pytorch_learner/test_object_detection_learner.py
+++ b/tests/pytorch_learner/test_object_detection_learner.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import logging
 
 import numpy as np
+import torch
 
 from rastervision.core.data import (
     ClassConfig, DatasetConfig, RasterioSourceConfig, MultiRasterSourceConfig,
@@ -103,6 +104,14 @@ class TestObjectDetectionLearner(unittest.TestCase):
             learner = backend.learner_cfg.build(tmp_dir, training=True)
             learner.plot_dataloaders()
             learner.plot_predictions(split='valid')
+
+            torch.save(learner.model.state_dict(),
+                       learner.last_model_weights_path)
+            learner.save_model_bundle()
+
+            pred_scene = dataset_cfg.validation_scenes[0].build(
+                class_config, tmp_dir)
+            _ = backend.predict_scene(pred_scene, chip_sz=100)
 
 
 if __name__ == '__main__':

--- a/tests/pytorch_learner/test_semantic_segmentation_learner.py
+++ b/tests/pytorch_learner/test_semantic_segmentation_learner.py
@@ -78,6 +78,8 @@ class TestSemanticSegmentationLearner(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             class_config = ClassConfig(
                 names=[f'class_{i}' for i in range(num_classes)])
+            class_config.update()
+            class_config.ensure_null_class()
             dataset_cfg = DatasetConfig(
                 class_config=class_config,
                 train_scenes=[
@@ -126,7 +128,10 @@ class TestSemanticSegmentationLearner(unittest.TestCase):
             torch.save(learner.model.state_dict(),
                        learner.last_model_weights_path)
             learner.save_model_bundle()
-            backend.load_model()
+
+            pred_scene = dataset_cfg.validation_scenes[0].build(
+                class_config, tmp_dir)
+            _ = backend.predict_scene(pred_scene, chip_sz=100)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Overview

This PR makes it easier to make predictions on a new scene in a notebook.

Major changes:
- Add a `Learner.predict_dataset()` method.
- Refactor `PyTorchLearnerBackend` subclasses to make use of the above in their `predict_scene()` (previously `predict()`) method.
- Add a `Labels.from_predictions()` method to easily convert model predictions to `Labels`.
- Refactor `RVPipeline.predict_scene()` to simply call `Backend.predict_scene()` instead of reading and batching chips.

Minor changes:
- Allow GeoDataset to read from scene with no label source.
  - Returns `torch.tensor(nan)` for `y`.
- Fix pointless warnings produced by `tempfile.TemporaryDirectory()` in `RasterioSource` by replacing it with `tempfile.mkdtemp()`.
- Update unit tests.
- Minor code improvements.
  - Added more type hints
  - Moved imports to under `if TYPE_CHECKING` where possble

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

There is some code duplication across the `predict_scene()` methods in the backend learner classes, but I could not come up with an alternative that looked better.

## Testing Instructions

Try running this Colab notebook: https://colab.research.google.com/drive/1Pgoi56PwnU5ygCsKEOHexBIM5XxHhFvE?usp=sharing

In case the notebook keeps crashing when restarting the runtime, try the following:
- Clone the source branch of this PR
- Build the docker image (`docker/build`)
- Run a Jupyter Lab server inside the docker image (`docker/run --aws --gpu --jupyter-lab`)
- Navigate to the server URL
- Download the Colab notebook and open it in the local server or create a new local notebook and copy code from the Colab notebook
- Run the notebook

Connects to #1395 
