### PR TITLE
Fix a bug in `DataConfig` validation and refactor `ClassConfig`

### DIFF
--- a/rastervision_core/rastervision/core/data/class_config.py
+++ b/rastervision_core/rastervision/core/data/class_config.py
@@ -1,15 +1,21 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 from rastervision.pipeline.config import (Config, register_config, ConfigError,
-                                          Field)
+                                          Field, validator)
 from rastervision.core.data.utils import color_to_triple
+
+DEFAULT_NULL_CLASS_NAME = 'null'
+DEFAULT_NULL_CLASS_COLOR = 'black'
 
 
 @register_config('class_config')
 class ClassConfig(Config):
     """Configures the class names that are being predicted."""
-    names: List[str] = Field(..., description='Names of classes.')
-    colors: Optional[List[Union[List, str]]] = Field(
+    names: List[str] = Field(
+        ...,
+        description='Names of classes. The i-th class in this list will have '
+        'class ID = i.')
+    colors: Optional[List[Union[str, Tuple]]] = Field(
         None,
         description=
         ('Colors used to visualize classes. Can be color strings accepted by '
@@ -17,44 +23,96 @@ class ClassConfig(Config):
          'for each class.'))
     null_class: Optional[str] = Field(
         None,
-        description=
-        ('Optional name of class in `names` to use as the null class. This is used in '
-         'semantic segmentation to represent the label for imagery pixels that are '
-         'NODATA or that are missing a label. If None, and this Config is part of a '
-         'SemanticSegmentationConfig, a null class will be added automatically.'
-         ))
+        description='Optional name of class in `names` to use as the null '
+        'class. This is used in semantic segmentation to represent the label '
+        'for imagery pixels that are NODATA or that are missing a label. '
+        f'If None and the class names include "{DEFAULT_NULL_CLASS_NAME}", '
+        'it will automatically be used as the null class. If None, and this '
+        'Config is part of a SemanticSegmentationConfig, a null class will be '
+        'added automatically.')
 
-    def get_class_id(self, name):
+    @validator('colors', always=True)
+    def validate_colors(cls, v: Optional[List[Union[str, Tuple]]],
+                        values: dict) -> Optional[List[Union[str, Tuple]]]:
+        """Compare length w/ names. Also auto-generate if not specified."""
+        class_names = values['names']
+        class_colors = v
+        if class_colors is None:
+            class_colors = [color_to_triple() for _ in class_names]
+        elif len(class_names) != len(class_colors):
+            raise ConfigError(f'len(class_names) ({len(class_names)}) != '
+                              f'len(class_colors) ({len(class_colors)})\n'
+                              f'class_names: {class_names}\n'
+                              f'class_colors: {class_colors}')
+        return class_colors
+
+    @validator('null_class', always=True)
+    def validate_null_class(cls, v: Optional[str],
+                            values: dict) -> Optional[str]:
+        """Check if in names. If 'null' in names, use it as null class."""
+        names = values['names']
+        if v is None:
+            if DEFAULT_NULL_CLASS_NAME in names:
+                v = DEFAULT_NULL_CLASS_NAME
+        else:
+            if v not in names:
+                raise ConfigError(
+                    f'The null_class, "{v}", must be in list of class names.')
+
+            # edge case
+            default_null_class_in_names = (DEFAULT_NULL_CLASS_NAME in names)
+            null_class_neq_default = (v != DEFAULT_NULL_CLASS_NAME)
+            if default_null_class_in_names and null_class_neq_default:
+                raise ConfigError(
+                    f'"{DEFAULT_NULL_CLASS_NAME}" is in names but the '
+                    f'specified null_class is something else ("{v}").')
+        return v
+
+    def get_class_id(self, name: str) -> int:
         return self.names.index(name)
 
-    def get_name(self, id):
+    def get_name(self, id: int) -> str:
         return self.names[id]
 
-    def get_null_class_id(self):
+    def get_null_class_id(self) -> int:
         if self.null_class is None:
             raise ValueError('null_class is not set')
         return self.get_class_id(self.null_class)
 
-    def get_color_to_class_id(self):
+    def get_color_to_class_id(self) -> dict:
         return dict([(self.colors[i], i) for i in range(len(self.colors))])
 
-    def ensure_null_class(self):
-        """Add a null class if one isn't set."""
-        if self.null_class is None:
-            self.null_class = 'null'
-            if self.null_class not in self.names:
-                self.names.append('null')
-                self.colors.append('black')
+    def ensure_null_class(self) -> None:
+        """Add a null class if one isn't set. This method is idempotent."""
+        if self.null_class is not None:
+            return
 
-    def update(self, pipeline=None):
-        if not self.colors:
-            self.colors = [color_to_triple() for _ in self.names]
+        null_class_name = DEFAULT_NULL_CLASS_NAME
+        null_class_color = DEFAULT_NULL_CLASS_COLOR
 
-    def validate_config(self):
-        if self.null_class is not None and self.null_class not in self.names:
-            raise ConfigError(
-                'The null_class: {} must be in list of class names.'.format(
-                    self.null_class))
+        # This might seeem redundant given the null class validator above, but
+        # is actually important. Sometimes there can be multiple ClassConfig
+        # instances that reference the same list objects for names and colors
+        # (not clear why this happens). This means that
+        # each ensure_null_class() call will add to names and colors in each
+        # copy of ClassConfig but only set its own null_class, which makes this
+        # method() non-idempotent.
+        if null_class_name in self.names:
+            self.null_class = null_class_name
+            return
 
-    def __len__(self):
+        # use random color if default color is already taken
+        null_class_color_triple = color_to_triple(null_class_color)
+        all_color_triples = [
+            color_to_triple(c) if isinstance(c, str) else c
+            for c in self.colors
+        ]
+        if null_class_color_triple in all_color_triples:
+            null_class_color = color_to_triple()
+
+        self.names.append(null_class_name)
+        self.colors.append(null_class_color)
+        self.null_class = null_class_name
+
+    def __len__(self) -> int:
         return len(self.names)

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
@@ -92,8 +92,8 @@ class SemanticSegmentationConfig(RVPipelineConfig):
         return SemanticSegmentation(self, tmp_dir)
 
     def update(self):
-        super().update()
         self.dataset.class_config.ensure_null_class()
+        super().update()
 
     def validate_config(self):
         super().validate_config()

--- a/rastervision_pipeline/rastervision/pipeline/config.py
+++ b/rastervision_pipeline/rastervision/pipeline/config.py
@@ -55,7 +55,7 @@ class Config(BaseModel):
                 summary += '\n'
         return summary
 
-    def update(self):
+    def update(self, *args, **kwargs):
         """Update any fields before validation.
 
         Subclasses should override this to provide complex default behavior, for

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -585,9 +585,12 @@ class DataConfig(Config):
         class_names = values.get('class_names')
         class_colors = values.get('class_colors')
         if class_colors is not None:
-            if len(class_colors) != len(class_names):
-                raise ConfigError('len(class_colors) != len(class_names)')
-        else:
+            if len(class_names) != len(class_colors):
+                raise ConfigError(f'len(class_names) ({len(class_names)}) != '
+                                  f'len(class_colors) ({len(class_colors)})\n'
+                                  f'class_names: {class_names}\n'
+                                  f'class_colors: {class_colors}')
+        elif len(class_names) > 0:
             values['class_colors'] = [color_to_triple() for _ in class_names]
         return values
 

--- a/tests/core/data/test_class_config.py
+++ b/tests/core/data/test_class_config.py
@@ -1,0 +1,93 @@
+from typing import Callable
+import unittest
+
+from rastervision.core.data.class_config import (
+    ClassConfig, DEFAULT_NULL_CLASS_NAME, DEFAULT_NULL_CLASS_COLOR)
+from rastervision.pipeline.config import ValidationError
+
+
+class TestClassConfig(unittest.TestCase):
+    def assertNoError(self, fn: Callable, msg: str = ''):
+        try:
+            fn()
+        except Exception:
+            self.fail(msg)
+
+    def test_len_validation(self):
+        args = dict(names=['a', 'b'], colors=['red', 'green'])
+        self.assertNoError(lambda: ClassConfig(**args))
+
+        args = dict(names=['a', 'b'], colors=['red'])
+        self.assertRaises(ValidationError, lambda: ClassConfig(**args))
+
+    def test_auto_colors_initialization(self):
+        args = dict(names=['a', 'b'])
+        self.assertNoError(lambda: ClassConfig(**args))
+
+        cfg = ClassConfig(**args)
+        self.assertEqual(len(cfg.names), len(cfg.colors))
+
+    def test_null_class_validation(self):
+        args = dict(names=['a', 'b'], null_class='a')
+        self.assertNoError(lambda: ClassConfig(**args))
+
+        args = dict(names=['a', 'b'], null_class='c')
+        self.assertRaises(ValidationError, lambda: ClassConfig(**args))
+
+        cfg = ClassConfig(
+            names=['a', 'b', DEFAULT_NULL_CLASS_NAME], null_class=None)
+        self.assertEqual(cfg.null_class, DEFAULT_NULL_CLASS_NAME)
+
+        args = dict(names=['a', 'b', DEFAULT_NULL_CLASS_NAME], null_class='a')
+        self.assertRaises(ValidationError, lambda: ClassConfig(**args))
+
+    def test_ensure_null_class(self):
+        cfg = ClassConfig(names=['a', 'b'])
+        cfg.ensure_null_class()
+        self.assertEqual(len(cfg.names), 3)
+        self.assertEqual(len(cfg.colors), 3)
+        self.assertEqual(cfg.names[-1], DEFAULT_NULL_CLASS_NAME)
+        self.assertEqual(cfg.colors[-1], DEFAULT_NULL_CLASS_COLOR)
+
+        # test idempotence
+        cfg.ensure_null_class()
+        cfg.ensure_null_class()
+        cfg.ensure_null_class()
+        self.assertEqual(len(cfg.names), 3)
+        self.assertEqual(len(cfg.colors), 3)
+        self.assertEqual(cfg.names[-1], DEFAULT_NULL_CLASS_NAME)
+        self.assertEqual(cfg.colors[-1], DEFAULT_NULL_CLASS_COLOR)
+
+        cfg = ClassConfig(names=['a', 'b'], null_class='a')
+        cfg.ensure_null_class()
+        self.assertEqual(len(cfg.names), 2)
+        self.assertEqual(len(cfg.colors), 2)
+
+        cfg = ClassConfig(
+            names=['a', 'b'], colors=['red', DEFAULT_NULL_CLASS_COLOR])
+        cfg.ensure_null_class()
+        self.assertEqual(len(cfg.names), 3)
+        self.assertEqual(len(cfg.colors), 3)
+        self.assertEqual(cfg.names[-1], DEFAULT_NULL_CLASS_NAME)
+        self.assertNotEqual(cfg.colors[-1], DEFAULT_NULL_CLASS_COLOR)
+
+    def test_getters(self):
+        cfg = ClassConfig(names=['a', 'b'], colors=['r', 'k'], null_class='a')
+        self.assertEqual(cfg.get_class_id('a'), 0)
+        self.assertEqual(cfg.get_class_id('b'), 1)
+        self.assertRaises(ValueError, lambda: cfg.get_class_id('c'))
+
+        self.assertEqual(cfg.get_name(0), 'a')
+        self.assertEqual(cfg.get_name(1), 'b')
+        self.assertRaises(IndexError, lambda: cfg.get_name(2))
+
+        self.assertEqual(cfg.get_null_class_id(), 0)
+
+        color_to_class_id = cfg.get_color_to_class_id()
+        self.assertEqual(len(color_to_class_id), 2)
+        self.assertEqual(color_to_class_id['r'], 0)
+        self.assertEqual(color_to_class_id['k'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

This PR
- Fixes an error in `DataConfig` (`"len(class_colors) != len(class_names) (type=value_error.config)"`) reported [here](https://github.com/azavea/raster-vision/issues/1427) and [here](https://gitter.im/azavea/raster-vision?at=62d0e33b9a314a3ec48b1cdf)
- Refactors `ClassConfig`
  - to use pydantic validators (no longer need to call `.update()` or `.validate_config()`)
  - to allow implicitly specifying a null class by passing "null" in names
- Adds unit tests for `ClassConfig`

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

- Check if semantic segmentation examples run without errors.
- See new unit tests.

Closes #1427 