### PR TITLE
Fix problems with readthedocs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,13 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  # ubuntu-20.04 is the minimum available option
+  os: ubuntu-20.04
+  tools:
+    python: "3.7"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -19,7 +26,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 from pallets_sphinx_themes import ProjectLink, get_version
 
 # -*- coding: utf-8 -*-
@@ -27,7 +29,7 @@ author = 'Azavea'
 # The short X.Y version
 version = '0.13'
 # The full version, including alpha/beta/rc tags
-release = '0.13.0'
+release = '0.13.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/rastervision_aws_batch/requirements.txt
+++ b/rastervision_aws_batch/requirements.txt
@@ -1,3 +1,3 @@
+rastervision_pipeline==0.13.1
 boto3>=1.9.201
-rastervision_pipeline==0.13
 awscli==1.19.*

--- a/rastervision_aws_batch/setup.py
+++ b/rastervision_aws_batch/setup.py
@@ -10,7 +10,7 @@ with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
 install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
 
 name = 'rastervision_aws_batch'
-version = '0.13'
+version = '0.13.1'
 description = 'A rastervision plugin that adds an AWS Batch pipeline runner'
 
 setup(

--- a/rastervision_aws_s3/requirements.txt
+++ b/rastervision_aws_s3/requirements.txt
@@ -1,4 +1,4 @@
+rastervision_pipeline==0.13.1
 boto3>=1.9.201
-rastervision_pipeline==0.13
 awscli==1.19.*
 tqdm==4.64.0

--- a/rastervision_aws_s3/setup.py
+++ b/rastervision_aws_s3/setup.py
@@ -10,7 +10,7 @@ with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
 install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
 
 name = 'rastervision_aws_s3'
-version = '0.13'
+version = '0.13.1'
 description = 'A rastervision plugin that adds an AWS S3 file system'
 
 setup(

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -1,4 +1,4 @@
-rastervision_pipeline==0.13.*
+rastervision_pipeline==0.13.1
 numpy<1.22
 shapely==1.6.*
 pillow==8.4.*

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -13,4 +13,4 @@ joblib>=0.11
 threadpoolctl>=2.0.0
 opencv-python==4.1.*
 opencv-python-headless<4.3
-tqdm==4.63.1
+tqdm==4.64.0

--- a/rastervision_core/setup.py
+++ b/rastervision_core/setup.py
@@ -10,7 +10,7 @@ with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
 install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
 
 name = 'rastervision_core'
-version = '0.13'
+version = '0.13.1'
 description = 'A rastervision plugin that adds geospatial machine learning pipelines'
 
 setup(

--- a/rastervision_gdal_vsi/requirements.txt
+++ b/rastervision_gdal_vsi/requirements.txt
@@ -1,2 +1,2 @@
-rastervision_pipeline==0.13
+rastervision_pipeline==0.13.1
 gdal==3.0.4

--- a/rastervision_gdal_vsi/setup.py
+++ b/rastervision_gdal_vsi/setup.py
@@ -10,7 +10,7 @@ with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
 install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
 
 name = 'rastervision_gdal_vsi'
-version = '0.13'
+version = '0.13.1'
 description = 'A rastervision plugin that adds a GDAL VSI file system'
 
 setup(

--- a/rastervision_pipeline/rastervision/pipeline/version.py
+++ b/rastervision_pipeline/rastervision/pipeline/version.py
@@ -1,2 +1,2 @@
 """Library verison"""
-__version__ = '0.13.0'
+__version__ = '0.13.1'

--- a/rastervision_pipeline/setup.py
+++ b/rastervision_pipeline/setup.py
@@ -10,7 +10,7 @@ with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
 install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
 
 name = 'rastervision_pipeline'
-version = '0.13'
+version = '0.13.1'
 description = 'The main rastervision package for configuring, defining, and running pipelines'
 
 setup(

--- a/rastervision_pytorch_backend/requirements.txt
+++ b/rastervision_pytorch_backend/requirements.txt
@@ -1,4 +1,4 @@
-rastervision_pipeline==0.13
-rastervision_core==0.13.*
-rastervision_pytorch_learner==0.13
-rastervision_aws_s3==0.13.*
+rastervision_pipeline==0.13.1
+rastervision_core==0.13.1
+rastervision_pytorch_learner==0.13.1
+rastervision_aws_s3==0.13.1

--- a/rastervision_pytorch_backend/setup.py
+++ b/rastervision_pytorch_backend/setup.py
@@ -10,7 +10,7 @@ with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
 install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
 
 name = 'rastervision_pytorch_backend'
-version = '0.13'
+version = '0.13.1'
 description = 'A rastervision plugin that adds PyTorch backends for rastervision.core pipelines'
 
 setup(

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -1,5 +1,5 @@
-rastervision_pipeline==0.13.*
-rastervision_core==0.13.*
+rastervision_pipeline==0.13.1
+rastervision_core==0.13.1
 numpy<1.22
 pillow==8.4.*
 torch==1.11.*

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -14,4 +14,4 @@ triangle==20200424
 opencv-python==4.1.*
 opencv-python-headless<4.3
 matplotlib==3.5.*
-tqdm==4.63.1
+tqdm==4.64.0

--- a/rastervision_pytorch_learner/setup.py
+++ b/rastervision_pytorch_learner/setup.py
@@ -10,7 +10,7 @@ with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
 install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
 
 name = 'rastervision_pytorch_learner'
-version = '0.13'
+version = '0.13.1'
 description = 'A rastervision plugin that adds PyTorch training pipelines'
 
 setup(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-rastervision_pipeline==0.13
-rastervision_aws_s3==0.13
-rastervision_aws_batch==0.13
-rastervision_core==0.13
-rastervision_pytorch_learner==0.13
+rastervision_pipeline==0.13.1
+rastervision_aws_s3==0.13.1
+rastervision_aws_batch==0.13.1
+rastervision_core==0.13.1
+rastervision_pytorch_learner==0.13.1
 rastervision_pytorch_backend==0.13.1
-rastervision_gdal_vsi==0.13
+rastervision_gdal_vsi==0.13.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import (setup, find_namespace_packages)
 from imp import load_source
 
 here = op.abspath(op.dirname(__file__))
-__version__ = '0.13'
+__version__ = '0.13.1'
 
 # get the dependencies and installs
 with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:


### PR DESCRIPTION
## Overview

This PR
- updates `.readthedocs.yml` to conform to the latest standard
- updates `.readthedocs.yml` to install RV plugins from source instead of from pypi
- changes version strings to 0.13.1 everywhere in RV
- makes version numbers for each dependency consistent across all RV plugins

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

See also the discussion here: https://github.com/azavea/raster-vision/pull/1146

## Testing Instructions

- Check if the CI doc build succeeds.
