### PR TITLE
Fix a bug introduced in #1413

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -320,7 +320,7 @@ class Learner(ABC):
         self.model = self.build_model(model_def_path=model_def_path)
 
         self.model.to(self.device)
-        self.load_init_weights()
+        self.load_init_weights(model_weights_path=model_weights_path)
 
     def build_model(self, model_def_path: Optional[str] = None) -> nn.Module:
         """Build a PyTorch model."""


### PR DESCRIPTION
## Overview

This PR fixes a bug introduced in #1413 that cause the weight from the model bundle to not be loaded.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This was not caught by the integration tests because they expect the `init_weights` to be the same as the trained weights.

## Testing Instructions
```sh
rastervision predict \
    "s3://azavea-research-public-data/raster-vision/examples/model-zoo-0.13/isprs-potsdam-ss/model-bundle.zip" \
    "s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_8_RGBIR.tif" \
    "./pred_ss_potsdam/" \
    --channel-order 3 0 1
```

The above should produce random predictions when run without this fix and good predictions when run with this fix.