### PR TITLE
Allow caching downloads

### DIFF
--- a/rastervision_core/rastervision/core/predictor.py
+++ b/rastervision_core/rastervision/core/predictor.py
@@ -1,20 +1,19 @@
 from typing import TYPE_CHECKING, List, Optional
 from os.path import join
-import zipfile
 import logging
 
 from rastervision.pipeline import rv_config
 from rastervision.pipeline.config import (build_config, upgrade_config)
 from rastervision.pipeline.file_system.utils import (download_if_needed,
-                                                     make_dir, file_to_json)
+                                                     file_to_json, unzip)
 from rastervision.core.data import (
     ChannelOrderError, SemanticSegmentationLabelStoreConfig,
     PolygonVectorOutputConfig, StatsTransformerConfig)
 from rastervision.core.analyzer import StatsAnalyzerConfig
 
 if TYPE_CHECKING:
-    from rastervision.core.rv_pipeline import RVPipelineConfig  # noqa
-    from rastervision.core.data import SceneConfig  # noqa
+    from rastervision.core.rv_pipeline import RVPipelineConfig
+    from rastervision.core.data import SceneConfig
 
 log = logging.getLogger(__name__)
 
@@ -45,11 +44,9 @@ class Predictor():
         self.update_stats = update_stats
         self.model_loaded = False
 
-        bundle_path = download_if_needed(model_bundle_uri, tmp_dir)
+        bundle_path = download_if_needed(model_bundle_uri)
         bundle_dir = join(tmp_dir, 'bundle')
-        make_dir(bundle_dir)
-        with zipfile.ZipFile(bundle_path, 'r') as bundle_zip:
-            bundle_zip.extractall(path=bundle_dir)
+        unzip(bundle_path, bundle_dir)
 
         config_path = join(bundle_dir, 'pipeline-config.json')
         config_dict = file_to_json(config_path)

--- a/rastervision_pipeline/rastervision/pipeline/file_system/utils.py
+++ b/rastervision_pipeline/rastervision/pipeline/file_system/utils.py
@@ -1,7 +1,6 @@
 import os
 from os.path import join
 import shutil
-import gzip
 from threading import Timer
 import time
 import logging
@@ -287,44 +286,6 @@ def str_to_file(content_str: str, uri: str, fs: Optional[FileSystem] = None):
     if not fs:
         fs = FileSystem.get_file_system(uri, 'r')
     return fs.write_str(uri, content_str)
-
-
-def get_cached_file(cache_dir: str, uri: str) -> str:
-    """Download a file and unzip it using a cache.
-
-    This downloads a file if it isn't already in the cache, and unzips
-    the file using gunzip if it hasn't already been unzipped (and the uri
-    has a .gz suffix).
-
-    Args:
-        cache_dir: dir to use for cache directory
-        uri: URI of a file that can be opened by a supported RV file system
-
-    Returns:
-        path of the (downloaded and unzipped) cached file
-    """
-    # Only download if it isn't in the cache.
-    path = get_local_path(uri, cache_dir)
-    if not os.path.isfile(path):
-        path = download_if_needed(uri, cache_dir)
-
-    # Unzip if .gz file
-    if path.endswith('.gz'):
-        # If local URI, then make ungz_path in temp cache, so it isn't unzipped
-        # alongside the original file.
-        if os.path.isfile(uri):
-            ungz_path = os.path.join(cache_dir, path)[:-3]
-        else:
-            ungz_path = path[:-3]
-
-        # Check to see if it is already unzipped before unzipping.
-        if not os.path.isfile(ungz_path):
-            with gzip.open(path, 'rb') as f_in:
-                with open(ungz_path, 'wb') as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-        path = ungz_path
-
-    return path
 
 
 def file_to_json(uri: str) -> dict:

--- a/rastervision_pipeline/rastervision/pipeline/rv_config.py
+++ b/rastervision_pipeline/rastervision/pipeline/rv_config.py
@@ -120,6 +120,12 @@ class RVConfig:
             log.debug('Temporary directory root is: {}'.format(
                 self.tmp_dir_root))
 
+    def get_cache_dir(self) -> TemporaryDirectory:
+        """Return the cache directory."""
+        cache_dir = os.path.join(self.tmp_dir_root, 'cache')
+        os.makedirs(cache_dir, exist_ok=True)
+        return cache_dir
+
     def set_everett_config(self,
                            profile: str = None,
                            rv_home: str = None,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
@@ -166,20 +166,18 @@ def read_stac(uri: str, unzip_dir: Optional[str] = None) -> List[dict]:
     uri_path = Path(uri)
     is_zip = uri_path.suffix.lower() == '.zip'
 
-    with TemporaryDirectory() as tmp_dir:
-        catalog_path = download_if_needed(uri, tmp_dir)
-        if not is_zip:
-            return parse_stac(catalog_path)
-        if unzip_dir is None:
-            raise ValueError(
-                f'uri ("{uri}") is a zip file, but no unzip_dir provided.')
-        zip_path = catalog_path
-        unzip(zip_path, target_dir=unzip_dir)
-        catalog_paths = list(Path(unzip_dir).glob('**/catalog.json'))
-        if len(catalog_paths) == 0:
-            raise FileNotFoundError(f'Unable to find "catalog.json" in {uri}.')
-        elif len(catalog_paths) > 1:
-            raise Exception(f'More than one "catalog.json" found in '
-                            f'{uri}.')
-        catalog_path = str(catalog_paths[0])
+    catalog_path = download_if_needed(uri)
+    if not is_zip:
         return parse_stac(catalog_path)
+    if unzip_dir is None:
+        raise ValueError(
+            f'uri ("{uri}") is a zip file, but no unzip_dir provided.')
+    zip_path = catalog_path
+    unzip(zip_path, target_dir=unzip_dir)
+    catalog_paths = list(Path(unzip_dir).glob('**/catalog.json'))
+    if len(catalog_paths) == 0:
+        raise FileNotFoundError(f'Unable to find "catalog.json" in {uri}.')
+    elif len(catalog_paths) > 1:
+        raise Exception(f'More than one "catalog.json" found in ' f'{uri}.')
+    catalog_path = str(catalog_paths[0])
+    return parse_stac(catalog_path)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
@@ -3,13 +3,13 @@ import csv
 from io import StringIO
 import os
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import rasterio
 from shapely.strtree import STRtree
 from shapely.geometry import shape, mapping
 from shapely.ops import transform
 
+from rastervision.pipeline import rv_config
 from rastervision.core import Box
 from rastervision.core.data import (RasterioCRSTransformer,
                                     GeoJSONVectorSourceConfig)
@@ -42,7 +42,7 @@ def crop_image(image_uri, window, crop_uri):
     rasterio_window = window.rasterio_format()
     im = im_dataset.read(window=rasterio_window)
 
-    with TemporaryDirectory() as tmp_dir:
+    with rv_config.get_tmp_dir() as tmp_dir:
         crop_path = get_local_path(crop_uri, tmp_dir)
         make_dir(crop_path, use_dirname=True)
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
-from tempfile import TemporaryDirectory
 import logging
 
+from rastervision.pipeline import rv_config
 from rastervision.pipeline.config import (register_config, Field)
 from rastervision.core.backend import BackendConfig
 from rastervision.core.rv_pipeline import RVPipelineConfig
@@ -75,7 +75,7 @@ class PyTorchLearnerBackendConfig(BackendConfig):
             'DataConfig.img_channels or RasterSourceConfig.channel_order. '
             'Building first scene to figure it out. This might take some '
             'time. To avoid this, specify one of the above.')
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             scene = all_scenes[0].build(
                 pipeline_cfg.dataset.class_config,
                 tmp_dir,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -965,7 +965,7 @@ class Learner(ABC):
                           cfg: Optional['LearnerConfig'] = None,
                           training: bool = False):
         """Create a Learner from a model bundle."""
-        model_bundle_path = download_if_needed(model_bundle_uri, tmp_dir)
+        model_bundle_path = download_if_needed(model_bundle_uri)
         model_bundle_dir = join(tmp_dir, 'model-bundle')
         unzip(model_bundle_path, model_bundle_dir)
 
@@ -1109,7 +1109,7 @@ class Learner(ABC):
 
     def load_weights(self, uri: str, **kwargs) -> None:
         """Load model weights from a file."""
-        weights_path = download_if_needed(uri, self.tmp_dir)
+        weights_path = download_if_needed(uri)
         self.model.load_state_dict(
             torch.load(weights_path, map_location=self.device), **kwargs)
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -11,7 +11,6 @@ import shutil
 import logging
 from subprocess import Popen
 import numbers
-from tempfile import TemporaryDirectory
 
 import numpy as np
 from tqdm.auto import tqdm
@@ -23,6 +22,7 @@ import torch.nn as nn
 from torch.utils.tensorboard import SummaryWriter
 from torch.utils.data import DataLoader
 
+from rastervision.pipeline import rv_config
 from rastervision.pipeline.file_system import (
     sync_to_dir, json_to_file, file_to_json, make_dir, zipdir,
     download_if_needed, download_or_copy, sync_from_dir, get_local_path, unzip,
@@ -174,7 +174,7 @@ class Learner(ABC):
                 'cfg.model can only be None if a custom model is specified.')
 
         if tmp_dir is None:
-            self._tmp_dir = TemporaryDirectory()
+            self._tmp_dir = rv_config.get_tmp_dir()
             tmp_dir = self._tmp_dir.name
         self.tmp_dir = tmp_dir
         self.device = 'cuda' if torch.cuda.is_available() else 'cpu'

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -986,7 +986,7 @@ class ImageDataConfig(DataConfig):
 
         unzip_dir = join(unzip_dir, 'data', str(uuid.uuid4()))
         for i, zip_uri in enumerate(zip_uris):
-            zip_path = download_if_needed(zip_uri, unzip_dir)
+            zip_path = download_if_needed(zip_uri)
             data_dir = join(unzip_dir, str(i))
             data_dirs.append(data_dir)
             unzip(zip_path, data_dir)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_utils.py
@@ -2,7 +2,6 @@ from typing import (Any, Callable, Optional, Sequence, Tuple, Iterable, List,
                     Dict, Union)
 from collections import defaultdict
 from os.path import join
-import tempfile
 from operator import iand
 from functools import reduce
 
@@ -16,6 +15,7 @@ from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
 import numpy as np
 
+from rastervision.pipeline import rv_config
 from rastervision.pipeline.file_system import json_to_file
 
 
@@ -90,7 +90,7 @@ def compute_coco_eval(outputs, targets, num_class_ids):
             {'boxes': <tensor with shape (n, 4)>,
              'class_ids': <tensor with shape (n,)>}
     """
-    with tempfile.TemporaryDirectory() as tmp_dir:
+    with rv_config.get_tmp_dir() as tmp_dir:
         preds = get_coco_preds(outputs)
         # ap is undefined when there are no predicted boxes
         if len(preds) == 0:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/torch_hub.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/torch_hub.py
@@ -1,4 +1,3 @@
-from tempfile import TemporaryDirectory
 from typing import Any, Optional
 from pathlib import Path
 from os.path import join, isdir, realpath
@@ -7,6 +6,7 @@ from glob import glob
 
 import torch.hub
 
+from rastervision.pipeline import rv_config
 from rastervision.pipeline.file_system import (download_if_needed, unzip)
 
 
@@ -119,7 +119,7 @@ def torch_hub_load_uri(uri: str, hubconf_dir: str, entrypoint: str, *args,
     if is_zip:
         # unzip
         zip_path = download_if_needed(uri)
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             unzip_dir = join(tmp_dir, uri_path.stem)
             _remove_dir(unzip_dir)
             unzip(zip_path, target_dir=unzip_dir)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
@@ -1,5 +1,4 @@
 from typing import Dict, Sequence, Tuple, Optional, Union, List, Iterable
-from tempfile import TemporaryDirectory
 from os.path import basename, join
 import logging
 
@@ -12,6 +11,7 @@ import albumentations as A
 from albumentations.core.transforms_interface import ImageOnlyTransform
 import cv2
 
+from rastervision.pipeline import rv_config
 from rastervision.pipeline.config import ConfigError
 
 log = logging.getLogger(__name__)
@@ -160,7 +160,7 @@ def deserialize_albumentation_transform(tf_dict: dict) -> A.BasicTransform:
     if lambda_transforms_path is not None:
         from rastervision.pipeline.file_system import download_if_needed
 
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             filename = basename(lambda_transforms_path)
             # download the transforms definition file into tmp_dir
             lambda_transforms_path = download_if_needed(

--- a/tests/pipeline/test_file_system.py
+++ b/tests/pipeline/test_file_system.py
@@ -195,7 +195,11 @@ class TestDownloadIfNeeded(unittest.TestCase):
 
         str_to_file(self.content_str, self.local_path)
         upload_or_copy(self.local_path, self.local_path)
+        # with download_dir
         local_path = download_if_needed(self.local_path, self.tmp_dir.name)
+        self.assertEqual(local_path, self.local_path)
+        # without download_dir
+        local_path = download_if_needed(self.local_path)
         self.assertEqual(local_path, self.local_path)
 
     def test_download_if_needed_s3(self):
@@ -204,7 +208,12 @@ class TestDownloadIfNeeded(unittest.TestCase):
 
         str_to_file(self.content_str, self.local_path)
         upload_or_copy(self.local_path, self.s3_path)
+        # with download_dir
         local_path = download_if_needed(self.s3_path, self.tmp_dir.name)
+        content_str = file_to_str(local_path)
+        self.assertEqual(self.content_str, content_str)
+        # without download_dir
+        local_path = download_if_needed(self.s3_path)
         content_str = file_to_str(local_path)
         self.assertEqual(self.content_str, content_str)
 

--- a/tests/pipeline/test_file_system.py
+++ b/tests/pipeline/test_file_system.py
@@ -1,8 +1,6 @@
 import os
 import unittest
-from unittest.mock import patch
 import datetime
-import gzip
 
 import boto3
 from moto import mock_s3
@@ -10,7 +8,7 @@ from moto import mock_s3
 from rastervision.pipeline.file_system import (
     file_to_str, str_to_file, download_if_needed, upload_or_copy, make_dir,
     get_local_path, file_exists, sync_from_dir, sync_to_dir, list_paths,
-    get_cached_file, NotReadableError, NotWritableError, FileSystem)
+    NotReadableError, NotWritableError, FileSystem)
 from rastervision.pipeline import rv_config
 
 LOREM = """ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -454,64 +452,6 @@ class TestHttpMisc(unittest.TestCase):
         fs = FileSystem.get_file_system(uri, 'r')
         self.assertRaises(NotWritableError,
                           lambda: fs.write_bytes(uri, bytes([0x00, 0x01])))
-
-
-@mock_s3
-class TestGetCachedFile(unittest.TestCase):
-    def setUp(self):
-        # Setup mock S3 bucket.
-        self.s3 = boto3.client('s3')
-        self.bucket_name = 'mock_bucket'
-        self.s3.create_bucket(Bucket=self.bucket_name)
-
-        self.content_str = 'hello'
-        self.file_name = 'hello.txt'
-        self.tmp_dir = rv_config.get_tmp_dir()
-        self.cache_dir = os.path.join(self.tmp_dir.name, 'cache')
-
-    def tearDown(self):
-        self.tmp_dir.cleanup()
-
-    def test_local(self):
-        local_path = os.path.join(self.tmp_dir.name, self.file_name)
-        str_to_file(self.content_str, local_path)
-
-        path = get_cached_file(self.cache_dir, local_path)
-        self.assertTrue(os.path.isfile(path))
-
-    def test_local_zip(self):
-        local_path = os.path.join(self.tmp_dir.name, self.file_name)
-        local_gz_path = local_path + '.gz'
-        with gzip.open(local_gz_path, 'wb') as f:
-            f.write(bytes(self.content_str, encoding='utf-8'))
-
-        with patch('gzip.open', side_effect=gzip.open) as patched_gzip_open:
-            path = get_cached_file(self.cache_dir, local_gz_path)
-            self.assertTrue(os.path.isfile(path))
-            self.assertNotEqual(path, local_gz_path)
-            with open(path, 'r') as f:
-                self.assertEqual(f.read(), self.content_str)
-
-            # Check that calling it again doesn't invoke the gzip.open method again.
-            path = get_cached_file(self.cache_dir, local_gz_path)
-            self.assertTrue(os.path.isfile(path))
-            self.assertNotEqual(path, local_gz_path)
-            with open(path, 'r') as f:
-                self.assertEqual(f.read(), self.content_str)
-            self.assertEqual(patched_gzip_open.call_count, 1)
-
-    def test_remote(self):
-        with patch(
-                'rastervision.pipeline.file_system.utils.download_if_needed',
-                side_effect=download_if_needed) as patched_download:
-            s3_path = 's3://{}/{}'.format(self.bucket_name, self.file_name)
-            str_to_file(self.content_str, s3_path)
-            path = get_cached_file(self.cache_dir, s3_path)
-            self.assertTrue(os.path.isfile(path))
-
-            # Check that calling it again doesn't invoke the download method again.
-            self.assertTrue(os.path.isfile(path))
-            self.assertEqual(patched_download.call_count, 1)
 
 
 if __name__ == '__main__':

--- a/tests/pytorch_backend/test_pytorch_learner_backend.py
+++ b/tests/pytorch_backend/test_pytorch_learner_backend.py
@@ -1,10 +1,10 @@
 import unittest
 from os.path import join
-from tempfile import TemporaryDirectory
 
 import numpy as np
 from PIL import Image
 
+from rastervision.pipeline import rv_config
 from rastervision.pytorch_backend.pytorch_learner_backend import (
     get_image_ext, write_chip)
 
@@ -23,7 +23,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(get_image_ext(chip), 'npy')
 
     def test_write_chip(self):
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             chip = np.random.randint(0, 256, size=(100, 100, 3))
             path = join(tmp_dir, 'test.png')
             write_chip(chip, path)

--- a/tests/pytorch_learner/dataset/utils/test_utils.py
+++ b/tests/pytorch_learner/dataset/utils/test_utils.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 
 import numpy as np
 
+from rastervision.pipeline import rv_config
 from rastervision.pytorch_learner.dataset import (
     discover_images, load_image, make_image_folder_dataset, DatasetFolder)
 from rastervision.pytorch_backend.pytorch_learner_backend import write_chip
@@ -12,7 +13,7 @@ from rastervision.pytorch_backend.pytorch_learner_backend import write_chip
 
 class TestUtils(unittest.TestCase):
     def test_discover_images(self):
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             chip = np.random.randint(
                 0, 256, size=(100, 100, 3), dtype=np.uint8)
             path_1 = join(tmp_dir, 'test.png')
@@ -32,7 +33,7 @@ class TestUtils(unittest.TestCase):
             self.assertIn(Path(path_2), paths)
 
     def test_load_image(self):
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             chip = np.random.randint(0, 256, size=(100, 100), dtype=np.uint8)
             path = join(tmp_dir, '1.png')
             write_chip(chip, path)
@@ -52,7 +53,7 @@ class TestUtils(unittest.TestCase):
             np.testing.assert_array_equal(load_image(path), chip)
 
     def test_make_image_folder_dataset(self):
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             with TemporaryDirectory(dir=tmp_dir) as dir_a, TemporaryDirectory(
                     dir=tmp_dir) as dir_b:
                 chip = np.random.randint(

--- a/tests/pytorch_learner/test_classification_learner.py
+++ b/tests/pytorch_learner/test_classification_learner.py
@@ -1,13 +1,13 @@
 from typing import Any, Callable
 import unittest
 from os.path import join
-from tempfile import TemporaryDirectory
 from uuid import uuid4
 import logging
 
 import numpy as np
 import torch
 
+from rastervision.pipeline import rv_config
 from rastervision.pipeline.file_system import json_to_file
 from rastervision.core.data import (
     ClassConfig, DatasetConfig, RasterioSourceConfig, MultiRasterSourceConfig,
@@ -87,7 +87,7 @@ class TestClassificationLearner(unittest.TestCase):
         produce plots."""
         logging.disable(logging.CRITICAL)
 
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             class_config = ClassConfig(
                 names=[f'class_{i}' for i in range(num_classes)])
             dataset_cfg = DatasetConfig(

--- a/tests/pytorch_learner/test_data_config.py
+++ b/tests/pytorch_learner/test_data_config.py
@@ -1,6 +1,7 @@
 from typing import Callable
 import unittest
 
+from rastervision.pipeline import rv_config
 from rastervision.pytorch_learner import (
     DataConfig, ImageDataConfig, SemanticSegmentationDataConfig,
     SemanticSegmentationImageDataConfig, SemanticSegmentationGeoDataConfig,
@@ -170,7 +171,6 @@ class TestImageDataConfig(unittest.TestCase):
         self.assertNoError(lambda: ImageDataConfig(**args))
 
     def test_build_cc(self):
-        from tempfile import TemporaryDirectory
         import os
         from os.path import join
         import numpy as np
@@ -184,7 +184,7 @@ class TestImageDataConfig(unittest.TestCase):
         img_sz = 200
         nchannels = 3
         nchips = 5
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             # prepare data
             data_dir = join(tmp_dir, 'data')
             for split in ['train', 'valid']:
@@ -245,7 +245,6 @@ class TestImageDataConfig(unittest.TestCase):
             del test_ds
 
     def test_build_ss(self):
-        from tempfile import TemporaryDirectory
         import os
         from os.path import join
         import numpy as np
@@ -258,7 +257,7 @@ class TestImageDataConfig(unittest.TestCase):
         img_sz = 200
         nchannels = 3
         nchips = 5
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             # prepare data
             data_dir = join(tmp_dir, 'data')
             for split in ['train', 'valid']:
@@ -352,7 +351,6 @@ class TestGeoDataConfig(unittest.TestCase):
         self.assertRaises(ValidationError, lambda: GeoDataWindowConfig(**args))
 
     def test_build_ss(self):
-        from tempfile import TemporaryDirectory
         from uuid import uuid4
         import numpy as np
         from rastervision.core.data import (
@@ -416,7 +414,7 @@ class TestGeoDataConfig(unittest.TestCase):
             class_colors=class_config.colors,
             img_sz=img_sz,
             num_workers=0)
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             train_ds, val_ds, test_ds = data_cfg.build(tmp_dir)
             self.assertEqual(len(train_ds), 4 * (600 // chip_sz)**2)
             self.assertEqual(len(val_ds), 2 * (600 // chip_sz)**2)

--- a/tests/pytorch_learner/test_model_config.py
+++ b/tests/pytorch_learner/test_model_config.py
@@ -1,10 +1,10 @@
 from typing import Callable
 import unittest
-from tempfile import TemporaryDirectory
 
 import torch
 from torch import nn
 
+from rastervision.pipeline import rv_config
 from rastervision.pytorch_learner import (
     Backbone, ExternalModuleConfig, SemanticSegmentationModelConfig,
     ClassificationModelConfig, ObjectDetectionModelConfig)
@@ -33,7 +33,7 @@ class TestExternalModuleConfig(unittest.TestCase):
                           lambda: ExternalModuleConfig(**args))
 
     def test_build(self):
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             cfg = ExternalModuleConfig(
                 github_repo='AdeelH/pytorch-multi-class-focal-loss:1.1',
                 entrypoint='focal_loss',

--- a/tests/pytorch_learner/test_object_detection_learner.py
+++ b/tests/pytorch_learner/test_object_detection_learner.py
@@ -1,12 +1,12 @@
 from typing import Any, Callable
 import unittest
-from tempfile import TemporaryDirectory
 from uuid import uuid4
 import logging
 
 import numpy as np
 import torch
 
+from rastervision.pipeline import rv_config
 from rastervision.core.data import (
     ClassConfig, DatasetConfig, RasterioSourceConfig, MultiRasterSourceConfig,
     SubRasterSourceConfig, ReclassTransformerConfig, SceneConfig,
@@ -69,7 +69,7 @@ class TestObjectDetectionLearner(unittest.TestCase):
         produce plots."""
         logging.disable(logging.CRITICAL)
 
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             class_config = ClassConfig(
                 names=[f'class_{i}' for i in range(num_classes)])
             dataset_cfg = DatasetConfig(

--- a/tests/pytorch_learner/test_regression_learner.py
+++ b/tests/pytorch_learner/test_regression_learner.py
@@ -1,13 +1,13 @@
 from typing import Any, Callable
 import unittest
 from os.path import join
-from tempfile import TemporaryDirectory
 from uuid import uuid4
 import logging
 
 import numpy as np
 import torch
 
+from rastervision.pipeline import rv_config
 from rastervision.core.data import (
     ClassConfig, DatasetConfig, RasterioSourceConfig, MultiRasterSourceConfig,
     SubRasterSourceConfig, ReclassTransformerConfig, SceneConfig,
@@ -70,7 +70,7 @@ class TestClassificationLearner(unittest.TestCase):
         produce plots."""
         logging.disable(logging.CRITICAL)
 
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             class_config = ClassConfig(
                 names=[f'class_{i}' for i in range(num_classes)])
             dataset_cfg = DatasetConfig(

--- a/tests/pytorch_learner/test_semantic_segmentation_learner.py
+++ b/tests/pytorch_learner/test_semantic_segmentation_learner.py
@@ -1,12 +1,12 @@
 from typing import Any, Callable
 import unittest
-from tempfile import TemporaryDirectory
 from uuid import uuid4
 import logging
 
 import numpy as np
 import torch
 
+from rastervision.pipeline import rv_config
 from rastervision.core.data import (
     ClassConfig, DatasetConfig, RasterioSourceConfig, MultiRasterSourceConfig,
     SubRasterSourceConfig, ReclassTransformerConfig, SceneConfig,
@@ -75,7 +75,7 @@ class TestSemanticSegmentationLearner(unittest.TestCase):
         produce plots."""
         logging.disable(logging.CRITICAL)
 
-        with TemporaryDirectory() as tmp_dir:
+        with rv_config.get_tmp_dir() as tmp_dir:
             class_config = ClassConfig(
                 names=[f'class_{i}' for i in range(num_classes)])
             class_config.update()

--- a/tests/pytorch_learner/utils/test_torch_hub.py
+++ b/tests/pytorch_learner/utils/test_torch_hub.py
@@ -78,7 +78,6 @@ class TestTorchHubUtils(unittest.TestCase):
             loss = torch_hub_load_github(
                 repo='AdeelH/pytorch-multi-class-focal-loss:1.1',
                 hubconf_dir=hubconf_dir,
-                tmp_dir=tmp_dir,
                 entrypoint='focal_loss',
                 alpha=[.75, .25],
                 gamma=2)
@@ -102,7 +101,6 @@ class TestTorchHubUtils(unittest.TestCase):
             loss = torch_hub_load_uri(
                 uri=hubconf_dir,
                 hubconf_dir=hubconf_dir,
-                tmp_dir=tmp_dir,
                 entrypoint='focal_loss',
                 alpha=[.75, .25],
                 gamma=2)
@@ -118,7 +116,6 @@ class TestTorchHubUtils(unittest.TestCase):
                 uri=
                 'https://github.com/AdeelH/pytorch-multi-class-focal-loss/archive/refs/tags/1.1.zip',  # noqa
                 hubconf_dir=hubconf_dir,
-                tmp_dir=tmp_dir,
                 entrypoint='focal_loss',
                 alpha=[.75, .25],
                 gamma=2)


### PR DESCRIPTION
## Overview

This PR makes it so that `download_if_needed()` downloads files to `{rv_config.tmp_dir_root}/cache` by default if a `download_dir` is not specified.

This allows caching of downloads by omitting `download_dir` where it is a temporary directory and we might need to download the same file multiple times.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

- Open the logs for the CI build for this PR and search (using the search bar) for "Using cached". Or see screenshots below:
![image](https://user-images.githubusercontent.com/13014700/182821700-ce48f40d-d86c-4496-b26a-5da6c541858e.png)
![image](https://user-images.githubusercontent.com/13014700/182821949-09964ee7-8688-420b-b79c-d467696b4e76.png)

- Run a predict command using a remote image (example below) and check whether it downloads only once.
```sh
rastervision predict \
    "s3://azavea-research-public-data/raster-vision/examples/model-zoo-0.13/isprs-potsdam-ss/model-bundle.zip" \
    "s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_8_RGBIR.tif" \
    "./pred_ss_potsdam/" \
    --channel-order 3 0 1
```

Closes #1449 
