### PR TITLE
Fix #1052

### DIFF
--- a/cookiecutter_template/{{cookiecutter.project_name}}/rastervision_{{cookiecutter.project_name}}/rastervision/{{cookiecutter.project_name}}/__init__.py
+++ b/cookiecutter_template/{{cookiecutter.project_name}}/rastervision_{{cookiecutter.project_name}}/rastervision/{{cookiecutter.project_name}}/__init__.py
@@ -1,6 +1,9 @@
 # flake8: noqa
-import rastervision.pipeline
-import rastervision.{{cookiecutter.project_name}}.test_pipeline_config
+
 
 def register_plugin(registry):
     pass
+
+
+import rastervision.pipeline
+import rastervision.{{cookiecutter.project_name}}.test_pipeline_config

--- a/rastervision_aws_batch/rastervision/aws_batch/__init__.py
+++ b/rastervision_aws_batch/rastervision/aws_batch/__init__.py
@@ -1,10 +1,9 @@
 # flake8: noqa
 
-import rastervision.pipeline
-from rastervision.aws_batch.aws_batch_runner import *
-
 
 def register_plugin(registry):
+    from rastervision.aws_batch.aws_batch_runner import (AWS_BATCH,
+                                                         AWSBatchRunner)
     registry.set_plugin_version('rastervision.aws_batch', 0)
     registry.set_plugin_aliases('rastervision.aws_batch',
                                 ['rastervision2.aws_batch'])
@@ -13,3 +12,7 @@ def register_plugin(registry):
         'gpu_job_queue', 'gpu_job_def', 'cpu_job_queue', 'cpu_job_def',
         'attempts'
     ])
+
+
+import rastervision.pipeline
+from rastervision.aws_batch.aws_batch_runner import *

--- a/rastervision_aws_s3/rastervision/aws_s3/__init__.py
+++ b/rastervision_aws_s3/rastervision/aws_s3/__init__.py
@@ -1,8 +1,5 @@
 # flake8: noqa
 
-import rastervision.pipeline
-from rastervision.aws_s3.s3_file_system import (AWS_S3, S3FileSystem)
-
 
 def register_plugin(registry):
     registry.set_plugin_version('rastervision.aws_s3', 0)
@@ -10,3 +7,7 @@ def register_plugin(registry):
                                 ['rastervision2.aws_s3'])
     registry.add_file_system(S3FileSystem)
     registry.add_rv_config_schema(AWS_S3, ['requester_pays'])
+
+
+import rastervision.pipeline
+from rastervision.aws_s3.s3_file_system import (AWS_S3, S3FileSystem)

--- a/rastervision_core/rastervision/core/__init__.py
+++ b/rastervision_core/rastervision/core/__init__.py
@@ -1,5 +1,13 @@
 # flake8: noqa
 
+
+def register_plugin(registry):
+    registry.set_plugin_version('rastervision.core', 3)
+    registry.set_plugin_aliases('rastervision.core', ['rastervision2.core'])
+    from rastervision.core.cli import predict
+    registry.add_plugin_command(predict)
+
+
 import rastervision.pipeline
 from rastervision.core.box import *
 from rastervision.core.data_sample import *
@@ -13,10 +21,3 @@ import rastervision.core.backend
 import rastervision.core.data
 import rastervision.core.rv_pipeline
 import rastervision.core.evaluation
-
-
-def register_plugin(registry):
-    registry.set_plugin_version('rastervision.core', 3)
-    registry.set_plugin_aliases('rastervision.core', ['rastervision2.core'])
-    from rastervision.core.cli import predict
-    registry.add_plugin_command(predict)

--- a/rastervision_core/rastervision/core/data/raster_source/__init__.py
+++ b/rastervision_core/rastervision/core/data/raster_source/__init__.py
@@ -1,5 +1,4 @@
 # flake8: noqa
-
 from rastervision.core.data.raster_source.raster_source import *
 from rastervision.core.data.raster_source.raster_source_config import *
 from rastervision.core.data.raster_source.rasterio_source import *
@@ -8,7 +7,3 @@ from rastervision.core.data.raster_source.rasterized_source import *
 from rastervision.core.data.raster_source.rasterized_source_config import *
 from rastervision.core.data.raster_source.multi_raster_source import *
 from rastervision.core.data.raster_source.multi_raster_source_config import *
-
-
-def register_plugin(registry):
-    registry.set_plugin_version('rastervision.core', 1)

--- a/rastervision_gdal_vsi/rastervision/gdal_vsi/__init__.py
+++ b/rastervision_gdal_vsi/rastervision/gdal_vsi/__init__.py
@@ -1,11 +1,12 @@
 # flake8: noqa
 
-import rastervision.pipeline
-from rastervision.gdal_vsi.vsi_file_system import VsiFileSystem
-
 
 def register_plugin(registry):
     registry.set_plugin_version('rastervision.gdal_vsi', 0)
     registry.set_plugin_aliases('rastervision.gdal_vsi',
                                 ['rastervision2.gdal_vsi'])
     registry.add_file_system(VsiFileSystem)
+
+
+import rastervision.pipeline
+from rastervision.gdal_vsi.vsi_file_system import VsiFileSystem

--- a/rastervision_pipeline/rastervision/pipeline/registry.py
+++ b/rastervision_pipeline/rastervision/pipeline/registry.py
@@ -234,7 +234,7 @@ class Registry():
         return discovered_plugins
 
     def load_plugins(self,
-                     plugins_names: Optional[Iterable[str]] = None) -> None:
+                     plugin_names: Optional[Iterable[str]] = None) -> None:
         """Load plugins and register their resources.
 
         Import each Python module within the rastervision namespace package
@@ -242,14 +242,11 @@ class Registry():
         """
         import importlib
 
-        if plugins_names is None:
-            plugins_names = self.discover_plugins()
+        if plugin_names is None:
+            plugin_names = self.discover_plugins()
 
-        loaded_plugins = {
-            name: importlib.import_module(name)
-            for name in plugins_names
-        }
-        for name, module in loaded_plugins.items():
+        for name in plugin_names:
+            module = importlib.import_module(name)
             register_plugin = getattr(module, 'register_plugin', None)
             if register_plugin:
                 register_plugin(self)

--- a/rastervision_pipeline/rastervision/pipeline_example_plugin1/__init__.py
+++ b/rastervision_pipeline/rastervision/pipeline_example_plugin1/__init__.py
@@ -1,5 +1,12 @@
 # flake8: noqa
 
+
+def register_plugin(registry):
+    # Can be used to manually update the registry. Useful
+    # for adding new FileSystems and Runners.
+    pass
+
+
 # Must import pipeline package first.
 import rastervision.pipeline
 
@@ -7,9 +14,3 @@ import rastervision.pipeline
 # get called.
 import rastervision.pipeline_example_plugin1.sample_pipeline
 import rastervision.pipeline_example_plugin1.sample_pipeline2
-
-
-def register_plugin(registry):
-    # Can be used to manually update the registry. Useful
-    # for adding new FileSystems and Runners.
-    pass

--- a/rastervision_pipeline/rastervision/pipeline_example_plugin2/__init__.py
+++ b/rastervision_pipeline/rastervision/pipeline_example_plugin2/__init__.py
@@ -1,14 +1,15 @@
 # flake8: noqa
 
+
+def register_plugin(registry):
+    # Can be used to manually update the registry. Useful
+    # for adding new FileSystems and Runners.
+    pass
+
+
 # Must import pipeline package first.
 import rastervision.pipeline
 
 # Then import any modules that add Configs so that the register_config decorators
 # get called.
 import rastervision.pipeline_example_plugin2.deluxe_message_maker
-
-
-def register_plugin(registry):
-    # Can be used to manually update the registry. Useful
-    # for adding new FileSystems and Runners.
-    pass

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/__init__.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/__init__.py
@@ -1,5 +1,12 @@
 # flake8: noqa
 
+
+def register_plugin(registry):
+    registry.set_plugin_version('rastervision.pytorch_backend', 1)
+    registry.set_plugin_aliases('rastervision.pytorch_backend',
+                                ['rastervision2.pytorch_backend'])
+
+
 import rastervision.pipeline
 from rastervision.pytorch_backend.pytorch_chip_classification_config import *
 from rastervision.pytorch_backend.pytorch_chip_classification import *
@@ -7,9 +14,3 @@ from rastervision.pytorch_backend.pytorch_semantic_segmentation_config import *
 from rastervision.pytorch_backend.pytorch_semantic_segmentation import *
 from rastervision.pytorch_backend.pytorch_object_detection_config import *
 from rastervision.pytorch_backend.pytorch_object_detection import *
-
-
-def register_plugin(registry):
-    registry.set_plugin_version('rastervision.pytorch_backend', 1)
-    registry.set_plugin_aliases('rastervision.pytorch_backend',
-                                ['rastervision2.pytorch_backend'])

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
@@ -1,5 +1,12 @@
 # flake8: noqa
 
+
+def register_plugin(registry):
+    registry.set_plugin_version('rastervision.pytorch_learner', 4)
+    registry.set_plugin_aliases('rastervision.pytorch_learner',
+                                ['rastervision2.pytorch_learner'])
+
+
 import rastervision.pipeline
 from rastervision.pytorch_learner.learner_config import *
 from rastervision.pytorch_learner.learner import *
@@ -14,9 +21,3 @@ from rastervision.pytorch_learner.semantic_segmentation_learner import *
 from rastervision.pytorch_learner.object_detection_learner_config import *
 from rastervision.pytorch_learner.object_detection_learner import *
 from rastervision.pytorch_learner.dataset import *
-
-
-def register_plugin(registry):
-    registry.set_plugin_version('rastervision.pytorch_learner', 4)
-    registry.set_plugin_aliases('rastervision.pytorch_learner',
-                                ['rastervision2.pytorch_learner'])

--- a/scripts/format_code
+++ b/scripts/format_code
@@ -30,5 +30,13 @@ else
     find . -name '*.py' -print0 | xargs -0 $UNIFY
 
     echo "Running yapf..."
-    yapf -ipr "$SRC_DIR" -e "*.git*" -e "*build*" -e "*cookiecutter_template*" -e "*tfod_utils*" -e "**/conf.py" -e "**/setup.py" -e "*.history*"
+    yapf -ipr "$SRC_DIR" \
+        -e "*.git*" \
+        -e "*build*" \
+        -e "*cookiecutter_template*" \
+        -e "*tfod_utils*" \
+        -e "**/conf.py" \
+        -e "**/setup.py" \
+        -e "*.history*" \
+        -e "data/*"
 fi

--- a/scripts/style_tests
+++ b/scripts/style_tests
@@ -24,12 +24,22 @@ if [ "${1:-}" = "--help" ]; then
 else
     echo "Checking that code is consistent with flake8..."
 
-    flake8 "$SRC_DIR" --exclude ".git,build,docs,*tfod_utils*,cookiecutter_template,.history"
+    flake8 "$SRC_DIR" \
+        --exclude ".git,build,docs,cookiecutter_template,*tfod_utils*,.history,data"
 
     # Exit code of 1 if yapf has a non-empty diff
     # (ie. scripts/format_code needs to be run)
     echo "Checking that code is consistent with yapf..."
-    if !(yapf -dpr -e "*.git*" -e "*build*" -e "*cookiecutter_template*" -e "*tfod_utils*" -e "**/conf.py" -e "**/setup.py" -e "*.history*" "$SRC_DIR" > /dev/null); then
+    if !(yapf -dpr \
+        -e "*.git*" \
+        -e "*build*" \
+        -e "*cookiecutter_template*" \
+        -e "*tfod_utils*" \
+        -e "**/conf.py" \
+        -e "**/setup.py" \
+        -e "*.history*" \
+        -e "data/*" \
+        "$SRC_DIR" > /dev/null); then
         echo "Code has not been formatted by yapf. Need to run ./scripts/format_code."
         exit 1
     fi

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,11 +1,5 @@
 import os
 
-# It is important for some tests that this import runs before unittest imports
-# any other tests so that the registry is set up correctly.
-# To ensure this file gets executed first, unit tests should be run using:
-# python -m unittest discover -t /opt/src tests -vf
-import rastervision.pipeline  # noqa
-
 
 def data_file_path(rel_path):
     data_dir = os.path.join(os.path.dirname(__file__), 'data_files')


### PR DESCRIPTION
## Overview

This PR fixes the bug reported and discussed in #1052.

In short, the bug causes `rastervision.core` to not be registered in the [`Registry`](https://github.com/azavea/raster-vision/blob/master/rastervision_pipeline/rastervision/pipeline/registry.py).

A different manifestation of this error has been seen and fixed before. Specifically, in [this commit](https://github.com/azavea/raster-vision/commit/10e9cf1cf3b83f0d728446ac754bb203f047eb91) which describes it like so:
<blockquote>
This is meant to fix a problem that occurred when running a unit test [...]. Specifically, when [...] `upgrade_config(config_dict)` [was called], it would throw a `KeyError` for "rastervision.core" due to "rastervision.core" being absent from the registry.

This was traced down to be due to the following workflow:
- `unittest discover` runs all discovered test files in alphabetical order
- the first file happens to be `tests/core/data/crs_transformer/test_rasterio_crs_transformer.py`
- the line `from rastervision.core.data.crs_transformer import RasterioCRSTransformer` in this file is run
- this causes core's `__init__.py`'s `import rastervision.pipeline` line to be run
- this causes the registry to be initialized
- the registry attempts to find all the plugins and load their `register_plugin()` functions
- (not 100% certain about this part but it seems like) when the registry tries to import core, it results in a circular import. At this point, core is already in `sys.modules` but has not been fully executed yet. Which means its `register_plugin()` hasn't been defined yet! Some context: https://stackoverflow.com/a/744403/5908685 .
- the registry fails to find core's `register_plugin()` and therefore fails to register it
</blockquote>

To summarize, when a Raster Vision plugin calls `import rastervision.pipeline` in its `__init__.py` before defining a `register_plugin()` function, that plugin will fail to get registered.

This PR fixes this problem by simply moving the `register_plugin()` definition to the top in each plugin's top-level `__init__.py`.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

Create a python file with the following contents (or run in a Python/IPython shell):
```python
from rastervision.core.predictor import Predictor

model_bundle_path = 's3://azavea-research-public-data/raster-vision/examples/model-zoo-0.13/isprs-potsdam-ss/model-bundle.zip'
tmp_dir = '/opt/tmp'
predictor = Predictor(model_bundle_path, tmp_dir)
```

This should fail without the changes in this PR and succeed with them.

Fixes #1052
