### PR TITLE
Add GeoDataset.from_uris() for convenient initialization of GeoDatasets

### DIFF
--- a/rastervision_core/rastervision/core/data/__init__.py
+++ b/rastervision_core/rastervision/core/data/__init__.py
@@ -14,3 +14,4 @@ from rastervision.core.data.dataset import *
 from rastervision.core.data.dataset_config import *
 from rastervision.core.data.raster_transformer import *
 from rastervision.core.data.vector_transformer import *
+from rastervision.core.data.utils import *

--- a/rastervision_core/rastervision/core/data/scene_config.py
+++ b/rastervision_core/rastervision/core/data/scene_config.py
@@ -6,7 +6,7 @@ from rastervision.core.data.raster_source import RasterSourceConfig
 from rastervision.core.data.label_source import LabelSourceConfig
 from rastervision.core.data.label_store import LabelStoreConfig
 from rastervision.core.data.scene import Scene
-from rastervision.core.data.vector_source import GeoJSONVectorSource
+from rastervision.core.data.utils import get_polygons_from_uris
 
 
 def scene_config_upgrader(cfg_dict: dict, version: int) -> dict:
@@ -53,11 +53,8 @@ class SceneConfig(Config):
 
         aoi_polygons = []
         if self.aoi_uris is not None:
-            for uri in self.aoi_uris:
-                aoi_polygons += GeoJSONVectorSource(
-                    uri=uri,
-                    ignore_crs_field=True,
-                    crs_transformer=crs_transformer).get_geoms()
+            aoi_polygons += get_polygons_from_uris(self.aoi_uris,
+                                                   crs_transformer)
 
         return Scene(
             self.id,

--- a/rastervision_core/rastervision/core/data/utils/__init__.py
+++ b/rastervision_core/rastervision/core/data/utils/__init__.py
@@ -2,3 +2,4 @@
 
 from rastervision.core.data.utils.misc import *
 from rastervision.core.data.utils.geojson import *
+from rastervision.core.data.utils.factory import *

--- a/rastervision_core/rastervision/core/data/utils/factory.py
+++ b/rastervision_core/rastervision/core/data/utils/factory.py
@@ -1,0 +1,294 @@
+from typing import TYPE_CHECKING, List, Optional, Union
+from uuid import uuid4
+
+from rastervision.pipeline import rv_config
+from rastervision.core.data.utils import listify_uris, get_polygons_from_uris
+
+if TYPE_CHECKING:
+    from rastervision.core.data import ClassConfig, Scene
+
+
+def make_ss_scene(class_config: 'ClassConfig',
+                  image_uri: Union[str, List[str]],
+                  label_raster_uri: Optional[Union[str, List[str]]] = None,
+                  label_vector_uri: Optional[str] = None,
+                  aoi_uri: Union[str, List[str]] = [],
+                  label_vector_default_class_id: Optional[int] = None,
+                  image_raster_source_kw: dict = {},
+                  label_raster_source_kw: dict = {},
+                  label_vector_source_kw: dict = {}) -> 'Scene':
+    """Create a semantic segmentation scene from image and label URIs.
+
+    This is a convenience method. For more fine-grained control, it is
+    recommended to use the default constructor.
+
+    Args:
+        class_config (ClassConfig): The ClassConfig.
+        image_uri (Union[str, List[str]]): URI or list of URIs of GeoTIFFs to
+            use as the source of image data.
+        label_raster_uri (Optional[Union[str, List[str]]], optional): URI or
+            list of URIs of GeoTIFFs to use as the source of segmentation label
+            data. If the labels are in the form of GeoJSONs, use
+            label_vector_uri instead. Defaults to None.
+        label_vector_uri (Optional[str], optional):  URI of GeoJSON file to use
+            as the source of segmentation label data. If the labels are in the
+            form of GeoTIFFs, use label_raster_uri instead. Defaults to None.
+        aoi_uri (Union[str, List[str]], optional): URI or list of URIs of
+            GeoJSONs that specify the area-of-interest. If provided, the
+            dataset will only access data from this area. Defaults to [].
+        label_vector_default_class_id (Optional[int], optional): If using
+            label_vector_uri and all polygons in that file belong to the same
+            class and they do not contain a `class_id` property, then use this
+            argument to map all of the polgons to the appropriate class ID.
+            See docs for ClassInferenceTransformer for more details.
+            Defaults to None.
+        image_raster_source_kw (dict, optional): Additional arguments to pass
+            to the RasterioSource used for image data. See docs for
+            RasterioSource for more details. Defaults to {}.
+        label_raster_source_kw (dict, optional): Additional arguments to pass
+            to the RasterioSource used for label data, if label_raster_uri is
+            used. See docs for RasterioSource for more details. Defaults to {}.
+        label_vector_source_kw (dict, optional): Additional arguments to pass
+            to the GeoJSONVectorSource used for label data, if label_vector_uri
+            is used. See docs for GeoJSONVectorSource for more details.
+            Defaults to {}.
+
+    Raises:
+        ValueError: If both label_raster_uri and label_vector_uri are
+            specified.
+
+    Returns:
+        Scene: A semantic segmentation scene.
+    """
+    # use local imports to avoid circular import problems
+    from rastervision.core.data import (
+        GeoJSONVectorSource, RasterioSource, RasterizedSource, Scene,
+        SemanticSegmentationLabelSource, ClassInferenceTransformer)
+
+    if label_raster_uri is not None and label_vector_uri is not None:
+        raise ValueError('Specify either label_raster_uri or '
+                         'label_vector_uri or neither, but not both.')
+
+    class_config.ensure_null_class()
+
+    image_uri = listify_uris(image_uri)
+    raster_source = RasterioSource(uris=image_uri, **image_raster_source_kw)
+
+    crs_transformer = raster_source.get_crs_transformer()
+    extent = raster_source.get_extent()
+    null_class_id = class_config.get_null_class_id()
+
+    label_raster_source = None
+    if label_raster_uri is not None:
+        label_raster_uri = listify_uris(label_raster_uri)
+        label_raster_source = RasterioSource(
+            uris=label_raster_uri, **label_raster_source_kw)
+    elif label_vector_uri is not None:
+        if label_vector_default_class_id is not None:
+            # add a ClassInferenceTransformer to the VectorSource
+            class_inf_tf = ClassInferenceTransformer(
+                default_class_id=label_vector_default_class_id)
+            vector_tfs = label_vector_source_kw.get('vector_transformers', [])
+            label_vector_source_kw['vector_transformers'] = (
+                [class_inf_tf] + vector_tfs)
+        vector_source = GeoJSONVectorSource(
+            uri=label_vector_uri,
+            ignore_crs_field=True,
+            crs_transformer=crs_transformer,
+            **label_vector_source_kw)
+        label_raster_source = RasterizedSource(
+            vector_source=vector_source,
+            background_class_id=label_raster_source_kw.pop(
+                'background_class_id', null_class_id),
+            extent=extent,
+            **label_raster_source_kw)
+
+    label_source = None
+    if label_raster_source is not None:
+        label_source = SemanticSegmentationLabelSource(
+            raster_source=label_raster_source, null_class_id=null_class_id)
+
+    aoi_polygons = get_polygons_from_uris(aoi_uri, crs_transformer)
+    scene = Scene(
+        id=uuid4(),
+        raster_source=raster_source,
+        label_source=label_source,
+        aoi_polygons=aoi_polygons)
+
+    return scene
+
+
+def make_cc_scene(class_config: 'ClassConfig',
+                  image_uri: Union[str, List[str]],
+                  label_vector_uri: Optional[str] = None,
+                  aoi_uri: Union[str, List[str]] = [],
+                  label_vector_default_class_id: Optional[int] = None,
+                  image_raster_source_kw: dict = {},
+                  label_vector_source_kw: dict = {},
+                  label_source_kw: dict = {}) -> 'Scene':
+    """Create a chip classification scene from image and label URIs.
+
+    This is a convenience method. For more fine-grained control, it is
+    recommended to use the default constructor.
+
+    Args:
+        class_config (ClassConfig): The ClassConfig.
+        image_uri (Union[str, List[str]]): URI or list of URIs of GeoTIFFs to
+            use as the source of image data.
+        label_vector_uri (Optional[str], optional):  URI of GeoJSON file to use
+            as the source of segmentation label data. Defaults to None.
+        aoi_uri (Union[str, List[str]], optional): URI or list of URIs of
+            GeoJSONs that specify the area-of-interest. If provided, the
+            dataset will only access data from this area. Defaults to [].
+        label_vector_default_class_id (Optional[int], optional): If using
+            label_vector_uri and all polygons in that file belong to the same
+            class and they do not contain a `class_id` property, then use this
+            argument to map all of the polgons to the appropriate class ID.
+            See docs for ClassInferenceTransformer for more details.
+            Defaults to None.
+        image_raster_source_kw (dict, optional): Additional arguments to pass
+            to the RasterioSource used for image data. See docs for
+            RasterioSource for more details. Defaults to {}.
+        label_vector_source_kw (dict, optional): Additional arguments to pass
+            to the GeoJSONVectorSourceConfig used for label data, if 
+            label_vector_uri is used. See docs for GeoJSONVectorSourceConfig
+            for more details. Defaults to {}.
+        label_source_kw (dict, optional): Additional arguments to pass
+            to the ChipClassificationLabelSourceConfig used for label data, if
+            label_vector_uri is used. See docs for
+            ChipClassificationLabelSourceConfig for more details.
+            Defaults to {}.
+        **kwargs: All other keyword args are passed to the default constructor
+            for this class.
+
+    Returns:
+        Scene: A chip classification scene.
+    """
+    # use local imports to avoid circular import problems
+    from rastervision.core.data import (
+        RasterioSource, Scene, ClassInferenceTransformerConfig,
+        ChipClassificationLabelSourceConfig, GeoJSONVectorSourceConfig)
+
+    image_uri = listify_uris(image_uri)
+    raster_source = RasterioSource(image_uri, **image_raster_source_kw)
+
+    crs_transformer = raster_source.get_crs_transformer()
+    extent = raster_source.get_extent()
+
+    label_source = None
+    if label_vector_uri is not None:
+        if label_vector_default_class_id is not None:
+            # add a ClassInferenceTransformer to the VectorSource
+            class_inf_tf = ClassInferenceTransformerConfig(
+                default_class_id=label_vector_default_class_id)
+            vector_tfs = label_vector_source_kw.get('transformers', [])
+            label_vector_source_kw['transformers'] = (
+                [class_inf_tf] + vector_tfs)
+        geojson_cfg = GeoJSONVectorSourceConfig(
+            uri=label_vector_uri,
+            ignore_crs_field=True,
+            **label_vector_source_kw)
+        label_source_cfg = ChipClassificationLabelSourceConfig(
+            vector_source=geojson_cfg, **label_source_kw)
+        label_source = label_source_cfg.build(
+            class_config,
+            crs_transformer,
+            extent=extent,
+            tmp_dir=rv_config.get_tmp_dir())
+
+    aoi_polygons = get_polygons_from_uris(aoi_uri, crs_transformer)
+    scene = Scene(
+        id=uuid4(),
+        raster_source=raster_source,
+        label_source=label_source,
+        aoi_polygons=aoi_polygons)
+
+    return scene
+
+
+def make_od_scene(class_config: 'ClassConfig',
+                  image_uri: Union[str, List[str]],
+                  label_vector_uri: Optional[str] = None,
+                  aoi_uri: Union[str, List[str]] = [],
+                  label_vector_default_class_id: Optional[int] = None,
+                  image_raster_source_kw: dict = {},
+                  label_vector_source_kw: dict = {},
+                  label_source_kw: dict = {}) -> 'Scene':
+    """Create an object detection scene from image and label URIs.
+
+    This is a convenience method. For more fine-grained control, it is
+    recommended to use the default constructor.
+
+    Args:
+        class_config (ClassConfig): The ClassConfig.
+        image_uri (Union[str, List[str]]): URI or list of URIs of GeoTIFFs to
+            use as the source of image data.
+        label_vector_uri (Optional[str], optional):  URI of GeoJSON file to use
+            as the source of segmentation label data. Defaults to None.
+        aoi_uri (Union[str, List[str]], optional): URI or list of URIs of
+            GeoJSONs that specify the area-of-interest. If provided, the
+            dataset will only access data from this area. Defaults to [].
+        label_vector_default_class_id (Optional[int], optional): If using
+            label_vector_uri and all polygons in that file belong to the same
+            class and they do not contain a `class_id` property, then use this
+            argument to map all of the polgons to the appropriate class ID.
+            See docs for ClassInferenceTransformer for more details.
+            Defaults to None.
+        image_raster_source_kw (dict, optional): Additional arguments to pass
+            to the RasterioSource used for image data. See docs for
+            RasterioSource for more details. Defaults to {}.
+        label_vector_source_kw (dict, optional): Additional arguments to pass
+            to the GeoJSONVectorSourceConfig used for label data, if 
+            label_vector_uri is used. See docs for GeoJSONVectorSourceConfig
+            for more details. Defaults to {}.
+        label_source_kw (dict, optional): Additional arguments to pass
+            to the ChipClassificationLabelSourceConfig used for label data, if
+            label_vector_uri is used. See docs for
+            ChipClassificationLabelSourceConfig for more details.
+            Defaults to {}.
+        **kwargs: All other keyword args are passed to the default constructor
+            for this class.
+
+    Returns:
+        Scene: An object detection scene.
+    """
+    # use local imports to avoid circular import problems
+    from rastervision.core.data import (
+        RasterioSource, Scene, ClassInferenceTransformerConfig,
+        GeoJSONVectorSourceConfig, ObjectDetectionLabelSourceConfig)
+
+    image_uri = listify_uris(image_uri)
+    raster_source = RasterioSource(image_uri, **image_raster_source_kw)
+
+    crs_transformer = raster_source.get_crs_transformer()
+    extent = raster_source.get_extent()
+
+    label_source = None
+    if label_vector_uri is not None:
+        if label_vector_default_class_id is not None:
+            # add a ClassInferenceTransformer to the VectorSource
+            class_inf_tf = ClassInferenceTransformerConfig(
+                default_class_id=label_vector_default_class_id)
+            vector_tfs = label_vector_source_kw.get('transformers', [])
+            label_vector_source_kw['transformers'] = (
+                [class_inf_tf] + vector_tfs)
+        geojson_cfg = GeoJSONVectorSourceConfig(
+            uri=label_vector_uri,
+            ignore_crs_field=True,
+            **label_vector_source_kw)
+        label_source_cfg = ObjectDetectionLabelSourceConfig(
+            vector_source=geojson_cfg, **label_source_kw)
+        label_source = label_source_cfg.build(
+            class_config,
+            crs_transformer,
+            extent=extent,
+            tmp_dir=rv_config.get_tmp_dir())
+
+    aoi_polygons = get_polygons_from_uris(aoi_uri, crs_transformer)
+    scene = Scene(
+        id=uuid4(),
+        raster_source=raster_source,
+        label_source=label_source,
+        aoi_polygons=aoi_polygons)
+
+    return scene

--- a/rastervision_core/rastervision/core/data/utils/geojson.py
+++ b/rastervision_core/rastervision/core/data/utils/geojson.py
@@ -1,8 +1,10 @@
 from typing import (TYPE_CHECKING, Callable, Dict, Iterable, Iterator, List,
-                    Optional)
+                    Optional, Union)
 
 from shapely.geometry import shape, mapping
 from shapely.ops import transform
+
+from rastervision.core.data.utils.misc import listify_uris
 
 if TYPE_CHECKING:
     from rastervision.core.data.crs_transformer import CRSTransformer
@@ -234,3 +236,20 @@ def all_geoms_valid(geojson: dict):
     """Check if there are any invalid geometries in the GeoJSON."""
     geoms = geojson_to_geoms(geojson)
     return all(g.is_valid for g in geoms)
+
+
+def get_polygons_from_uris(
+        uris: Union[str, List[str]],
+        crs_transformer: 'CRSTransformer') -> List['BaseGeometry']:
+    """Load and return polygons (in pixel coords) from one or more URIs."""
+
+    # use local imports to avoid circular import problems
+    from rastervision.core.data import GeoJSONVectorSource
+
+    polygons = []
+    uris = listify_uris(uris)
+    for uri in uris:
+        source = GeoJSONVectorSource(
+            uri=uri, ignore_crs_field=True, crs_transformer=crs_transformer)
+        polygons += source.get_geoms()
+    return polygons

--- a/rastervision_core/rastervision/core/data/utils/misc.py
+++ b/rastervision_core/rastervision/core/data/utils/misc.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from PIL import ImageColor
@@ -54,3 +54,13 @@ def rgb_to_int_array(rgb_array):
 def all_equal(it: list):
     ''' Returns true if all elements are equal to each other '''
     return it.count(it[0]) == len(it)
+
+
+def listify_uris(uris: Union[str, List[str]]) -> List[str]:
+    if isinstance(uris, (list, tuple)):
+        pass
+    elif isinstance(uris, str):
+        uris = [uris]
+    else:
+        raise TypeError(f'Expected str or List[str], but got {type(uris)}.')
+    return uris

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/classification_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/classification_dataset.py
@@ -1,9 +1,13 @@
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable, List, Optional, Union
 import logging
 
 from rastervision.pytorch_learner.dataset import (
     ImageDataset, TransformType, SlidingWindowGeoDataset,
     RandomWindowGeoDataset, make_image_folder_dataset)
+from rastervision.core.data.utils import make_cc_scene
+
+if TYPE_CHECKING:
+    from rastervision.core.data import ClassConfig
 
 log = logging.getLogger(__name__)
 
@@ -16,7 +20,70 @@ class ClassificationImageDataset(ImageDataset):
             ds, *args, **kwargs, transform_type=TransformType.classification)
 
 
+def make_cc_geodataset(cls,
+                       class_config: 'ClassConfig',
+                       image_uri: Union[str, List[str]],
+                       label_vector_uri: Optional[str] = None,
+                       aoi_uri: Union[str, List[str]] = [],
+                       label_vector_default_class_id: Optional[int] = None,
+                       image_raster_source_kw: dict = {},
+                       label_vector_source_kw: dict = {},
+                       label_source_kw: dict = {},
+                       **kwargs):
+    """Create an instance of this class from image and label URIs.
+
+    This is a convenience method. For more fine-grained control, it is
+    recommended to use the default constructor.
+
+    Args:
+        class_config (ClassConfig): The ClassConfig.
+        image_uri (Union[str, List[str]]): URI or list of URIs of GeoTIFFs to
+            use as the source of image data.
+        label_vector_uri (Optional[str], optional):  URI of GeoJSON file to use
+            as the source of segmentation label data. Defaults to None.
+        aoi_uri (Union[str, List[str]], optional): URI or list of URIs of
+            GeoJSONs that specify the area-of-interest. If provided, the
+            dataset will only access data from this area. Defaults to [].
+        label_vector_default_class_id (Optional[int], optional): If using
+            label_vector_uri and all polygons in that file belong to the same
+            class and they do not contain a `class_id` property, then use this
+            argument to map all of the polgons to the appropriate class ID.
+            See docs for ClassInferenceTransformer for more details.
+            Defaults to None.
+        image_raster_source_kw (dict, optional): Additional arguments to pass
+            to the RasterioSource used for image data. See docs for
+            RasterioSource for more details. Defaults to {}.
+        label_vector_source_kw (dict, optional): Additional arguments to pass
+            to the GeoJSONVectorSourceConfig used for label data, if
+            label_vector_uri is used. See docs for GeoJSONVectorSourceConfig
+            for more details. Defaults to {}.
+        label_source_kw (dict, optional): Additional arguments to pass
+            to the ChipClassificationLabelSourceConfig used for label data, if
+            label_vector_uri is used. See docs for
+            ChipClassificationLabelSourceConfig for more details.
+            Defaults to {}.
+        **kwargs: All other keyword args are passed to the default constructor
+            for this class.
+
+    Returns:
+        An instance of this GeoDataset subclass.
+    """
+    scene = make_cc_scene(
+        class_config=class_config,
+        image_uri=image_uri,
+        label_vector_uri=label_vector_uri,
+        aoi_uri=aoi_uri,
+        label_vector_default_class_id=label_vector_default_class_id,
+        image_raster_source_kw=image_raster_source_kw,
+        label_vector_source_kw=label_vector_source_kw,
+        label_source_kw=label_source_kw)
+    ds = cls(scene, **kwargs)
+    return ds
+
+
 class ClassificationSlidingWindowGeoDataset(SlidingWindowGeoDataset):
+    from_uris = classmethod(make_cc_geodataset)
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args, **kwargs, transform_type=TransformType.classification)
@@ -28,6 +95,8 @@ class ClassificationSlidingWindowGeoDataset(SlidingWindowGeoDataset):
 
 
 class ClassificationRandomWindowGeoDataset(RandomWindowGeoDataset):
+    from_uris = classmethod(make_cc_geodataset)
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args, **kwargs, transform_type=TransformType.classification)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
@@ -126,6 +126,10 @@ class GeoDataset(AlbumentationsDataset):
     def __len__(self):
         raise NotImplementedError()
 
+    @classmethod
+    def from_uris(cls, *args, **kwargs):
+        raise NotImplementedError()
+
 
 T = TypeVar('T')
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, List, Dict
+from typing import TYPE_CHECKING, Optional, Tuple, List, Dict, Union
 from os.path import join
 from collections import defaultdict
 import logging
@@ -7,13 +7,16 @@ import albumentations as A
 import numpy as np
 from torch.utils.data import Dataset
 
-from rastervision.core.box import Box
 from rastervision.pipeline.file_system import file_to_json
-from rastervision.core.data.label import ObjectDetectionLabels
+from rastervision.core.box import Box
+from rastervision.core.data import ObjectDetectionLabels
 from rastervision.pytorch_learner.dataset import (
     TransformType, ImageDataset, SlidingWindowGeoDataset,
     RandomWindowGeoDataset, load_image)
+from rastervision.core.data.utils import make_od_scene
 
+if TYPE_CHECKING:
+    from rastervision.core.data import ClassConfig
 log = logging.getLogger(__name__)
 
 
@@ -59,13 +62,78 @@ class ObjectDetectionImageDataset(ImageDataset):
             ds, *args, **kwargs, transform_type=TransformType.object_detection)
 
 
+def make_od_geodataset(cls,
+                       class_config: 'ClassConfig',
+                       image_uri: Union[str, List[str]],
+                       label_vector_uri: Optional[str] = None,
+                       aoi_uri: Union[str, List[str]] = [],
+                       label_vector_default_class_id: Optional[int] = None,
+                       image_raster_source_kw: dict = {},
+                       label_vector_source_kw: dict = {},
+                       label_source_kw: dict = {},
+                       **kwargs):
+    """Create an instance of this class from image and label URIs.
+
+    This is a convenience method. For more fine-grained control, it is
+    recommended to use the default constructor.
+
+    Args:
+        class_config (ClassConfig): The ClassConfig.
+        image_uri (Union[str, List[str]]): URI or list of URIs of GeoTIFFs to
+            use as the source of image data.
+        label_vector_uri (Optional[str], optional):  URI of GeoJSON file to use
+            as the source of segmentation label data. Defaults to None.
+        aoi_uri (Union[str, List[str]], optional): URI or list of URIs of
+            GeoJSONs that specify the area-of-interest. If provided, the
+            dataset will only access data from this area. Defaults to [].
+        label_vector_default_class_id (Optional[int], optional): If using
+            label_vector_uri and all polygons in that file belong to the same
+            class and they do not contain a `class_id` property, then use this
+            argument to map all of the polgons to the appropriate class ID.
+            See docs for ClassInferenceTransformer for more details.
+            Defaults to None.
+        image_raster_source_kw (dict, optional): Additional arguments to pass
+            to the RasterioSource used for image data. See docs for
+            RasterioSource for more details. Defaults to {}.
+        label_vector_source_kw (dict, optional): Additional arguments to pass
+            to the GeoJSONVectorSourceConfig used for label data, if
+            label_vector_uri is used. See docs for GeoJSONVectorSourceConfig
+            for more details. Defaults to {}.
+        label_source_kw (dict, optional): Additional arguments to pass
+            to the ChipClassificationLabelSourceConfig used for label data, if
+            label_vector_uri is used. See docs for
+            ChipClassificationLabelSourceConfig for more details.
+            Defaults to {}.
+        **kwargs: All other keyword args are passed to the default constructor
+            for this class.
+
+    Returns:
+        An instance of this GeoDataset subclass.
+    """
+    scene = make_od_scene(
+        class_config=class_config,
+        image_uri=image_uri,
+        label_vector_uri=label_vector_uri,
+        aoi_uri=aoi_uri,
+        label_vector_default_class_id=label_vector_default_class_id,
+        image_raster_source_kw=image_raster_source_kw,
+        label_vector_source_kw=label_vector_source_kw,
+        label_source_kw=label_source_kw)
+    ds = cls(scene, **kwargs)
+    return ds
+
+
 class ObjectDetectionSlidingWindowGeoDataset(SlidingWindowGeoDataset):
+    from_uris = classmethod(make_od_geodataset)
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args, **kwargs, transform_type=TransformType.object_detection)
 
 
 class ObjectDetectionRandomWindowGeoDataset(RandomWindowGeoDataset):
+    from_uris = classmethod(make_od_geodataset)
+
     def __init__(self, *args, **kwargs):
         """Constructor.
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/semantic_segmentation_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/semantic_segmentation_dataset.py
@@ -1,6 +1,5 @@
-from typing import Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 from pathlib import Path
-
 import logging
 
 import numpy as np
@@ -9,6 +8,10 @@ from torch.utils.data import Dataset
 from rastervision.pytorch_learner.dataset import (
     ImageDataset, TransformType, SlidingWindowGeoDataset,
     RandomWindowGeoDataset, load_image, discover_images, ImageDatasetError)
+from rastervision.core.data.utils import make_ss_scene
+
+if TYPE_CHECKING:
+    from rastervision.core.data import ClassConfig
 
 log = logging.getLogger(__name__)
 
@@ -72,7 +75,80 @@ class SemanticSegmentationImageDataset(ImageDataset):
             transform_type=TransformType.semantic_segmentation)
 
 
+def make_ss_geodataset(
+        cls,
+        class_config: 'ClassConfig',
+        image_uri: Union[str, List[str]],
+        label_raster_uri: Optional[Union[str, List[str]]] = None,
+        label_vector_uri: Optional[str] = None,
+        aoi_uri: Union[str, List[str]] = [],
+        label_vector_default_class_id: Optional[int] = None,
+        image_raster_source_kw: dict = {},
+        label_raster_source_kw: dict = {},
+        label_vector_source_kw: dict = {},
+        **kwargs):
+    """Create an instance of this class from image and label URIs.
+
+    This is a convenience method. For more fine-grained control, it is
+    recommended to use the default constructor.
+
+    Args:
+        class_config (ClassConfig): The ClassConfig.
+        image_uri (Union[str, List[str]]): URI or list of URIs of GeoTIFFs to
+            use as the source of image data.
+        label_raster_uri (Optional[Union[str, List[str]]], optional): URI or
+            list of URIs of GeoTIFFs to use as the source of segmentation label
+            data. If the labels are in the form of GeoJSONs, use
+            label_vector_uri instead. Defaults to None.
+        label_vector_uri (Optional[str], optional):  URI of GeoJSON file to use
+            as the source of segmentation label data. If the labels are in the
+            form of GeoTIFFs, use label_raster_uri instead. Defaults to None.
+        aoi_uri (Union[str, List[str]], optional): URI or list of URIs of
+            GeoJSONs that specify the area-of-interest. If provided, the
+            dataset will only access data from this area. Defaults to [].
+        label_vector_default_class_id (Optional[int], optional): If using
+            label_vector_uri and all polygons in that file belong to the same
+            class and they do not contain a `class_id` property, then use this
+            argument to map all of the polgons to the appropriate class ID.
+            See docs for ClassInferenceTransformer for more details.
+            Defaults to None.
+        image_raster_source_kw (dict, optional): Additional arguments to pass
+            to the RasterioSource used for image data. See docs for
+            RasterioSource for more details. Defaults to {}.
+        label_raster_source_kw (dict, optional): Additional arguments to pass
+            to the RasterioSource used for label data, if label_raster_uri is
+            used. See docs for RasterioSource for more details. Defaults to {}.
+        label_vector_source_kw (dict, optional): Additional arguments to pass
+            to the GeoJSONVectorSource used for label data, if label_vector_uri
+            is used. See docs for GeoJSONVectorSource for more details.
+            Defaults to {}.
+        **kwargs: All other keyword args are passed to the default constructor
+            for this class.
+
+    Raises:
+        ValueError: If both label_raster_uri and label_vector_uri are
+            specified.
+
+    Returns:
+        An instance of this GeoDataset subclass.
+    """
+    scene = make_ss_scene(
+        class_config=class_config,
+        image_uri=image_uri,
+        label_raster_uri=label_raster_uri,
+        label_vector_uri=label_vector_uri,
+        aoi_uri=aoi_uri,
+        label_vector_default_class_id=label_vector_default_class_id,
+        image_raster_source_kw=image_raster_source_kw,
+        label_raster_source_kw=label_raster_source_kw,
+        label_vector_source_kw=label_vector_source_kw)
+    ds = cls(scene, **kwargs)
+    return ds
+
+
 class SemanticSegmentationSlidingWindowGeoDataset(SlidingWindowGeoDataset):
+    from_uris = classmethod(make_ss_geodataset)
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args,
@@ -81,6 +157,8 @@ class SemanticSegmentationSlidingWindowGeoDataset(SlidingWindowGeoDataset):
 
 
 class SemanticSegmentationRandomWindowGeoDataset(RandomWindowGeoDataset):
+    from_uris = classmethod(make_ss_geodataset)
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args,

--- a/tests/pytorch_learner/dataset/test_dataset.py
+++ b/tests/pytorch_learner/dataset/test_dataset.py
@@ -1,0 +1,137 @@
+from os.path import join
+import unittest
+
+import torch
+import numpy as np
+from shapely.geometry import Polygon, mapping
+
+from rastervision.pipeline import rv_config
+from rastervision.pipeline.file_system import json_to_file
+from rastervision.core.data import ClassConfig, RasterioCRSTransformer
+from rastervision.core.data.utils.geojson import (geometry_to_feature,
+                                                  features_to_geojson)
+from rastervision.pytorch_learner.dataset import (
+    SemanticSegmentationSlidingWindowGeoDataset,
+    ClassificationSlidingWindowGeoDataset,
+    ObjectDetectionSlidingWindowGeoDataset)
+
+from tests import data_file_path
+
+
+def make_overlapping_geojson(uri: str) -> str:
+    crs_tf = RasterioCRSTransformer.from_uri(uri)
+    xmin, ymin = crs_tf.pixel_to_map((0, 0))
+    xmax, ymax = crs_tf.pixel_to_map((10, 10))
+    polygon = Polygon.from_bounds(xmin, ymin, xmax, ymax)
+    geometry = mapping(polygon)
+    feature = geometry_to_feature(geometry, properties=dict(class_id=1))
+    geojson = features_to_geojson([feature])
+    return geojson
+
+
+class TestGeoDatasetFromURIs(unittest.TestCase):
+    def setUp(self) -> None:
+        self.image_uri = data_file_path('ones.tif')
+        self.tmp_dir = rv_config.get_tmp_dir()
+        geojson = make_overlapping_geojson(self.image_uri)
+        self.label_vector_uri = join(self.tmp_dir.name, 'geojson.json')
+        json_to_file(geojson, self.label_vector_uri)
+
+    def tearDown(self) -> None:
+        self.tmp_dir.cleanup()
+
+    def test_ss_from_uris(self):
+        class_config = ClassConfig(names=['bg', 'fg'], null_class='bg')
+        image_uri = self.image_uri
+        label_vector_uri = self.label_vector_uri
+
+        # no labels
+        ds = SemanticSegmentationSlidingWindowGeoDataset.from_uris(
+            class_config=class_config, image_uri=image_uri, size=10, stride=10)
+        x, y = ds[0]
+        torch.testing.assert_allclose(x * 255, torch.ones_like(x))
+        self.assertTrue(np.isnan(y.numpy()))
+
+        # raster labels
+        ds = SemanticSegmentationSlidingWindowGeoDataset.from_uris(
+            class_config=class_config,
+            image_uri=image_uri,
+            label_raster_uri=image_uri,
+            size=10,
+            stride=10)
+        x, y = ds[0]
+        torch.testing.assert_allclose(x * 255, torch.ones_like(x))
+        self.assertAlmostEqual(y.float().mean(), 1)
+
+        # rasterized labels
+        ds = SemanticSegmentationSlidingWindowGeoDataset.from_uris(
+            class_config=class_config,
+            image_uri=image_uri,
+            label_vector_uri=label_vector_uri,
+            size=10,
+            stride=10)
+        x, y = ds[0]
+        torch.testing.assert_allclose(x * 255, torch.ones_like(x))
+        torch.testing.assert_allclose(y, torch.ones_like(y))
+        x, y = ds[3]
+        torch.testing.assert_allclose(x * 255, torch.ones_like(x))
+        torch.testing.assert_allclose(y, torch.zeros_like(y))
+
+    def test_cc_from_uris(self):
+        class_config = ClassConfig(names=['bg', 'fg'], null_class='bg')
+        image_uri = self.image_uri
+        label_vector_uri = self.label_vector_uri
+
+        # no labels
+        ds = ClassificationSlidingWindowGeoDataset.from_uris(
+            class_config=class_config, image_uri=image_uri, size=10, stride=10)
+        x, y = ds[0]
+        torch.testing.assert_allclose(x * 255, torch.ones_like(x))
+        self.assertTrue(np.isnan(y.numpy()))
+
+        # vector labels
+        ds = ClassificationSlidingWindowGeoDataset.from_uris(
+            class_config=class_config,
+            image_uri=image_uri,
+            label_vector_uri=label_vector_uri,
+            label_source_kw=dict(background_class_id=0),
+            size=10,
+            stride=10)
+        x, y = ds[0]
+        torch.testing.assert_allclose(x * 255, torch.ones_like(x))
+        torch.testing.assert_allclose(y, torch.ones_like(y))
+        x, y = ds[3]
+        torch.testing.assert_allclose(x * 255, torch.ones_like(x))
+        torch.testing.assert_allclose(y, torch.zeros_like(y))
+
+    def test_od_from_uris(self):
+        class_config = ClassConfig(names=['bg', 'fg'], null_class='bg')
+        image_uri = self.image_uri
+        label_vector_uri = self.label_vector_uri
+
+        # no labels
+        ds = ObjectDetectionSlidingWindowGeoDataset.from_uris(
+            class_config=class_config, image_uri=image_uri, size=10, stride=10)
+        x, y = ds[0]
+        torch.testing.assert_allclose(x * 255, torch.ones_like(x))
+        self.assertTrue(np.isnan(y.numpy()))
+
+        # vector labels
+        ds = ObjectDetectionSlidingWindowGeoDataset.from_uris(
+            class_config=class_config,
+            image_uri=image_uri,
+            label_vector_uri=label_vector_uri,
+            size=20,
+            stride=20)
+        x, y = ds[0]
+        bboxes, class_ids, _ = y
+        np.testing.assert_allclose(bboxes, np.array([[0., 0., 10., 10.]]))
+        np.testing.assert_allclose(class_ids, np.array([1]))
+        x, y = ds[1]
+        bboxes, class_ids, _ = y
+        self.assertTupleEqual(bboxes.shape, (0, 4))
+        self.assertTupleEqual(class_ids.shape, (0, ))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Overview

This PR
- adds a `.from_uris()` class-method to the `GeoDataset` classes (for SS, CC, and OD, but not for Regression)
- these methods rely on new factory functions: `make_ss_scene()`, `make_cc_scene()`, and `make_od_scene()` that reside in `core/data/utils/factory.py`

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions
- See new unit tests.

Connects to #1395 