### PR TITLE
Updating cloudformation template to allow use of on-demand GPU instances

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -323,6 +323,31 @@ Resources:
         Tags:
           Name: !Join ["", [!Ref Prefix, "RasterVisionGpuComputeEnvironment"]]
           ComputeEnvironment: Raster Vision
+  
+  EC2GpuComputeEnvironment:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      ComputeEnvironmentName:
+        !Join ["", [!Ref Prefix, "RasterVisionGpuComputeEnvironment"]]
+      Type: Managed
+      State: ENABLED
+      ServiceRole: !Ref BatchServiceIAMRole
+      ComputeResources:
+        Type: EC2
+        Ec2KeyPair: !Ref KeyName
+        MinvCpus: !Ref MinimumVCPUs
+        DesiredvCpus: !Ref DesiredVCPUs
+        MaxvCpus: !Ref MaximumVCPUs
+        InstanceRole: !Ref BatchInstanceProfile
+        InstanceTypes: !Ref GpuInstanceTypes
+        SecurityGroupIds:
+          - !Ref ContainerInstanceSecurityGroup
+        Subnets: !Ref SubnetIds
+        LaunchTemplate:
+          LaunchTemplateId: !Ref GpuLaunchTemplate
+        Tags:
+          Name: !Join ["", [!Ref Prefix, "RasterVisionEC2GpuComputeEnvironment"]]
+          ComputeEnvironment: Raster Vision
 
   CpuLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
@@ -371,6 +396,8 @@ Resources:
       ComputeEnvironmentOrder:
         - ComputeEnvironment: !Ref GpuComputeEnvironment
           Order: 1
+        - ComputeEnvironment: !Ref EC2GpuComputeEnvironment
+          Order: 2
 
   CpuJobQueue:
     Type: AWS::Batch::JobQueue


### PR DESCRIPTION
## Overview

Sometime spot GPU instances are not available. In that case, it should be able to use on-demand instances to create GPU compute resources.

### Checklist

- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

None

## Testing Instructions

* Use this cloudformation template to create new stack.

Closes #1469 
