### PR TITLE
Fix #991 and #1452

### DIFF
--- a/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
@@ -2,7 +2,7 @@ import sys
 from os.path import dirname, join
 from subprocess import Popen
 
-from rastervision.pipeline.file_system import str_to_file
+from rastervision.pipeline.file_system import str_to_file, download_if_needed
 from rastervision.pipeline.runner.runner import Runner
 from rastervision.pipeline.utils import terminate_at_exit
 
@@ -68,7 +68,8 @@ class LocalRunner(Runner):
 
         makefile_path = join(dirname(cfg_json_uri), 'Makefile')
         str_to_file(makefile, makefile_path)
-        process = Popen(['make', '-j', '-f', makefile_path])
+        makefile_path_local = download_if_needed(makefile_path)
+        process = Popen(['make', '-j', '-f', makefile_path_local])
         terminate_at_exit(process)
         exitcode = process.wait()
         if exitcode != 0:


### PR DESCRIPTION
## Overview

This PR fixes an issue with the `LocalRunner` reported in #991 and #1452 by ensuring that the path passed to `make` is local.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness


Fixes #991
Fixes #1452
