### PR TITLE
Speed up `RGBClassTransformer` by an order of magnitude

### DIFF
--- a/rastervision_core/rastervision/core/data/utils/misc.py
+++ b/rastervision_core/rastervision/core/data/utils/misc.py
@@ -66,7 +66,7 @@ def normalize_color(
                     f'but found {type(color)}.')
 
 
-def rgb_to_int_array(rgb_array):
+def rgb_to_int_array(rgb_array: np.ndarray) -> np.ndarray:
     r = np.array(rgb_array[:, :, 0], dtype=np.uint32) * (1 << 16)
     g = np.array(rgb_array[:, :, 1], dtype=np.uint32) * (1 << 8)
     b = np.array(rgb_array[:, :, 2], dtype=np.uint32) * (1 << 0)


### PR DESCRIPTION
## Overview

This PR significantly speeds up `RGBClassTransformer` by replacing `np.vectorize` with `ReclassTransformer`.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions
```python
from rastervision.core.data import ClassConfig, RGBClassTransformer

from tqdm.auto import tqdm
import rasterio as rio
import numpy as np

class_config = ClassConfig(
    names=['Car', 'Building', 'Low Vegetation', 'Tree', 'Impervious', 'Clutter'], 
    colors=['#ffff00', '#0000ff', '#00ffff', '#00ff00', '#ffffff', '#ff0000'])
rgb_tf = RGBClassTransformer(class_config)
```
```python
%%time

with rio.open('<path to ISPRS Potsdam data>/5_Labels_for_participants/top_potsdam_4_11_label.tif') as ds:
    block_windows = [w for _, w in ds.block_windows(1)]
    with tqdm(block_windows) as bar:
        tiles = [rgb_tf.transform(ds.read(window=w).transpose(1, 2, 0)) for w in bar]
```

### Before
```
CPU times: user 23.5 s, sys: 467 ms, total: 24 s
Wall time: 23.7 s
```

### After
```
CPU times: user 1.94 s, sys: 101 ms, total: 2.04 s
Wall time: 2.02 s
```

### Bonus: after re-tiling
```sh
gdal_translate -co TILED=YES -co BLOCKXSIZE=512 -co BLOCKYSIZE=512 \
    "<path>/5_Labels_for_participants/top_potsdam_4_11_label.tif" \
    "<path>/5_Labels_for_participants/top_potsdam_4_11_label_tiled.tif"
```
```
CPU times: user 619 ms, sys: 68.2 ms, total: 687 ms
Wall time: 674 ms
```