### PR TITLE
Allow discarding edges of predicted chips in SS, add `Labels.save()` convenience method and refactor `SemanticSegmentationDiscreteLabels`

### DIFF
--- a/docs/tutorials/reading_labels.ipynb
+++ b/docs/tutorials/reading_labels.ipynb
@@ -454,7 +454,7 @@
                 "from rastervision.core.data import SemanticSegmentationLabelSource\n",
                 "\n",
                 "label_source = SemanticSegmentationLabelSource(\n",
-                "    label_raster_source, null_class_id=class_config.null_class_id)"
+                "    label_raster_source, class_config)"
             ]
         },
         {

--- a/rastervision_core/rastervision/core/data/label/__init__.py
+++ b/rastervision_core/rastervision/core/data/label/__init__.py
@@ -4,6 +4,7 @@ from rastervision.core.data.label.labels import *
 from rastervision.core.data.label.chip_classification_labels import *
 from rastervision.core.data.label.semantic_segmentation_labels import *
 from rastervision.core.data.label.object_detection_labels import *
+from rastervision.core.data.label.utils import *
 
 __all__ = [
     Labels.__name__,

--- a/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
+++ b/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
@@ -1,10 +1,14 @@
-from typing import (Any, Dict, Iterable, List, Optional, Sequence, Tuple)
+from typing import (TYPE_CHECKING, Any, Dict, Iterable, List, Optional,
+                    Sequence, Tuple)
 from dataclasses import dataclass
 
 import numpy as np
 
 from rastervision.core.box import Box
 from rastervision.core.data.label import Labels
+
+if TYPE_CHECKING:
+    from shapely.geometry import Polygon
 
 
 @dataclass
@@ -66,7 +70,7 @@ class ChipClassificationLabels(Labels):
     def make_empty(cls) -> 'ChipClassificationLabels':
         return ChipClassificationLabels()
 
-    def filter_by_aoi(self, aoi_polygons):
+    def filter_by_aoi(self, aoi_polygons: Iterable['Polygon']):
         result = ChipClassificationLabels()
         for cell in self.cell_to_label:
             cell_box = Box(*cell)

--- a/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
+++ b/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
@@ -8,6 +8,7 @@ from rastervision.core.box import Box
 from rastervision.core.data.label import Labels
 
 if TYPE_CHECKING:
+    from rastervision.core.data import (ClassConfig, CRSTransformer)
     from shapely.geometry import Polygon
 
 
@@ -153,3 +154,21 @@ class ChipClassificationLabels(Labels):
         """
         for cell in labels.get_cells():
             self.set_cell(cell, *labels[cell])
+
+    def save(self, uri: str, class_config: 'ClassConfig',
+             crs_transformer: 'CRSTransformer') -> None:
+        """Save labels as a GeoJSON file.
+
+        Args:
+            uri (str): URI of the output file.
+            class_config (ClassConfig): ClassConfig to map class IDs to names.
+            crs_transformer (CRSTransformer): CRSTransformer to convert from
+                pixel-coords to map-coords before saving.
+        """
+        from rastervision.core.data import ChipClassificationGeoJSONStore
+
+        label_store = ChipClassificationGeoJSONStore(
+            uri=uri,
+            class_config=class_config,
+            crs_transformer=crs_transformer)
+        label_store.save(self)

--- a/rastervision_core/rastervision/core/data/label/labels.py
+++ b/rastervision_core/rastervision/core/data/label/labels.py
@@ -72,3 +72,8 @@ class Labels(ABC):
         for prediction, window in zip(predictions, windows):
             labels[window] = prediction
         return labels
+
+    @abstractmethod
+    def save(self, uri: str) -> None:
+        """Save to file."""
+        pass

--- a/rastervision_core/rastervision/core/data/label/object_detection_labels.py
+++ b/rastervision_core/rastervision/core/data/label/object_detection_labels.py
@@ -10,6 +10,7 @@ from rastervision.core.data.label.tfod_utils.np_box_list_ops import (
     non_max_suppression)
 
 if TYPE_CHECKING:
+    from rastervision.core.data import (ClassConfig, CRSTransformer)
     from shapely.geometry import Polygon
 
 
@@ -288,3 +289,21 @@ class ObjectDetectionLabels(Labels):
             iou_threshold=merge_thresh,
             score_threshold=score_thresh)
         return ObjectDetectionLabels.from_boxlist(pruned_boxlist)
+
+    def save(self, uri: str, class_config: 'ClassConfig',
+             crs_transformer: 'CRSTransformer') -> None:
+        """Save labels as a GeoJSON file.
+
+        Args:
+            uri (str): URI of the output file.
+            class_config (ClassConfig): ClassConfig to map class IDs to names.
+            crs_transformer (CRSTransformer): CRSTransformer to convert from
+                pixel-coords to map-coords before saving.
+        """
+        from rastervision.core.data import ObjectDetectionGeoJSONStore
+
+        label_store = ObjectDetectionGeoJSONStore(
+            uri=uri,
+            class_config=class_config,
+            crs_transformer=crs_transformer)
+        label_store.save(self)

--- a/rastervision_core/rastervision/core/data/label/object_detection_labels.py
+++ b/rastervision_core/rastervision/core/data/label/object_detection_labels.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 import numpy as np
 from shapely.geometry import shape
 
@@ -9,6 +9,9 @@ from rastervision.core.data.label.tfod_utils.np_box_list_ops import (
     prune_non_overlapping_boxes, clip_to_window, concatenate,
     non_max_suppression)
 
+if TYPE_CHECKING:
+    from shapely.geometry import Polygon
+
 
 class ObjectDetectionLabels(Labels):
     """A set of boxes and associated class_ids and scores.
@@ -16,7 +19,10 @@ class ObjectDetectionLabels(Labels):
     Implemented using the Tensorflow Object Detection API's BoxList class.
     """
 
-    def __init__(self, npboxes, class_ids, scores=None):
+    def __init__(self,
+                 npboxes: np.array,
+                 class_ids: np.array,
+                 scores: np.array = None):
         """Construct a set of object detection labels.
 
         Args:
@@ -36,10 +42,11 @@ class ObjectDetectionLabels(Labels):
             scores = np.ones(class_ids.shape)
         self.boxlist.add_field('scores', scores)
 
-    def __add__(self, other):
+    def __add__(self,
+                other: 'ObjectDetectionLabels') -> 'ObjectDetectionLabels':
         return ObjectDetectionLabels.concatenate(self, other)
 
-    def __eq__(self, other):
+    def __eq__(self, other: 'ObjectDetectionLabels') -> bool:
         return (isinstance(other, ObjectDetectionLabels)
                 and self.to_dict() == other.to_dict())
 
@@ -53,7 +60,7 @@ class ObjectDetectionLabels(Labels):
         concatenated_labels = self + new_labels
         self.boxlist = concatenated_labels.boxlist
 
-    def assert_equal(self, expected_labels):
+    def assert_equal(self, expected_labels: 'ObjectDetectionLabels'):
         np.testing.assert_array_equal(self.get_npboxes(),
                                       expected_labels.get_npboxes())
         np.testing.assert_array_equal(self.get_class_ids(),
@@ -61,7 +68,7 @@ class ObjectDetectionLabels(Labels):
         np.testing.assert_array_equal(self.get_scores(),
                                       expected_labels.get_scores())
 
-    def filter_by_aoi(self, aoi_polygons):
+    def filter_by_aoi(self, aoi_polygons: Iterable['Polygon']):
         boxes = self.get_boxes()
         class_ids = self.get_class_ids()
         scores = self.get_scores()
@@ -92,7 +99,7 @@ class ObjectDetectionLabels(Labels):
         return cls(npboxes, class_ids, scores)
 
     @staticmethod
-    def from_boxlist(boxlist):
+    def from_boxlist(boxlist: BoxList):
         """Make ObjectDetectionLabels from BoxList object."""
         scores = (boxlist.get_field('scores')
                   if boxlist.has_field('scores') else None)
@@ -100,7 +107,8 @@ class ObjectDetectionLabels(Labels):
             boxlist.get(), boxlist.get_field('classes'), scores=scores)
 
     @staticmethod
-    def from_geojson(geojson, extent=None):
+    def from_geojson(geojson: dict,
+                     extent: Optional[Box] = None) -> 'ObjectDetectionLabels':
         """Convert GeoJSON to ObjectDetectionLabels object.
 
         If extent is provided, filter out the boxes that lie "more than a little
@@ -140,31 +148,31 @@ class ObjectDetectionLabels(Labels):
                 labels, extent, ioa_thresh=0.8, clip=True)
         return labels
 
-    def get_boxes(self):
+    def get_boxes(self) -> List[Box]:
         """Return list of Boxes."""
         return [Box.from_npbox(npbox) for npbox in self.boxlist.get()]
 
-    def get_npboxes(self):
+    def get_npboxes(self) -> np.ndarray:
         return self.boxlist.get()
 
-    def get_scores(self):
+    def get_scores(self) -> np.ndarray:
         if self.boxlist.has_field('scores'):
             return self.boxlist.get_field('scores')
         return None
 
-    def get_class_ids(self):
+    def get_class_ids(self) -> np.ndarray:
         return self.boxlist.get_field('classes')
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.boxlist.get().shape[0]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.boxlist.get())
 
-    def to_boxlist(self):
+    def to_boxlist(self) -> BoxList:
         return self.boxlist
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """Returns a dict version of these labels.
 
         The Dict has a Box as a key, and a tuple of (class_id, score)
@@ -179,7 +187,7 @@ class ObjectDetectionLabels(Labels):
         return d
 
     @staticmethod
-    def local_to_global(npboxes, window):
+    def local_to_global(npboxes: np.ndarray, window: Box):
         """Convert from local to global coordinates.
 
         The local coordinates are row/col within the window frame of reference.
@@ -190,7 +198,7 @@ class ObjectDetectionLabels(Labels):
         return npboxes + np.array([[ymin, xmin, ymin, xmin]])
 
     @staticmethod
-    def global_to_local(npboxes, window):
+    def global_to_local(npboxes: np.ndarray, window: Box):
         """Convert from global to local coordinates.
 
         The global coordinates are row/col within the extent of a RasterSource.
@@ -201,7 +209,7 @@ class ObjectDetectionLabels(Labels):
         return npboxes - np.array([[ymin, xmin, ymin, xmin]])
 
     @staticmethod
-    def local_to_normalized(npboxes, window):
+    def local_to_normalized(npboxes: np.ndarray, window: Box):
         """Convert from local to normalized coordinates.
 
         The local coordinates are row/col within the window frame of reference.
@@ -211,7 +219,7 @@ class ObjectDetectionLabels(Labels):
         return npboxes / np.array([[height, width, height, width]])
 
     @staticmethod
-    def normalized_to_local(npboxes, window):
+    def normalized_to_local(npboxes: np.ndarray, window: Box):
         """Convert from normalized to local coordinates.
 
         Normalized coordinates range from 0 to 1 on each (height/width) axis.
@@ -221,7 +229,10 @@ class ObjectDetectionLabels(Labels):
         return npboxes * np.array([[height, width, height, width]])
 
     @staticmethod
-    def get_overlapping(labels, window, ioa_thresh=0.000001, clip=False):
+    def get_overlapping(labels: 'ObjectDetectionLabels',
+                        window: Box,
+                        ioa_thresh: float = 0.000001,
+                        clip: bool = False) -> 'ObjectDetectionLabels':
         """Return subset of labels that overlap with window.
 
         Args:
@@ -241,7 +252,9 @@ class ObjectDetectionLabels(Labels):
         return ObjectDetectionLabels.from_boxlist(boxlist)
 
     @staticmethod
-    def concatenate(labels1, labels2):
+    def concatenate(
+            labels1: 'ObjectDetectionLabels',
+            labels2: 'ObjectDetectionLabels') -> 'ObjectDetectionLabels':
         """Return concatenation of labels.
 
         Args:
@@ -252,7 +265,8 @@ class ObjectDetectionLabels(Labels):
         return ObjectDetectionLabels.from_boxlist(new_boxlist)
 
     @staticmethod
-    def prune_duplicates(labels, score_thresh, merge_thresh):
+    def prune_duplicates(labels: 'ObjectDetectionLabels', score_thresh: float,
+                         merge_thresh: float) -> 'ObjectDetectionLabels':
         """Remove duplicate boxes.
 
         Runs non-maximum suppression to remove duplicate boxes that result from

--- a/rastervision_core/rastervision/core/data/label/utils.py
+++ b/rastervision_core/rastervision/core/data/label/utils.py
@@ -1,0 +1,27 @@
+from typing import (TYPE_CHECKING, Iterable, Iterator, List, Tuple)
+if TYPE_CHECKING:
+    import numpy as np
+    from rastervision.core.box import Box
+
+
+def discard_prediction_edges(
+        windows: Iterable['Box'], predictions: Iterable['np.ndarray'],
+        crop_sz: int) -> Tuple[List['Box'], Iterator['np.ndarray']]:
+    """Discard the edges of predicted chips.
+
+    Args:
+        windows (Iterable[Box]): The windows corresponding to the chips.
+        predictions (Iterable[np.ndarray]): The predicted chips.
+        crop_sz (int): Number of pixel rows/cols to discard.
+
+    Returns:
+        Tuple[Iterator[Box], Iterator[np.ndarray]]: Cropped windows and chips.
+    """
+    windows_cropped = [w.center_crop(crop_sz, crop_sz) for w in windows]
+    array_slices = [
+        wc.to_offsets(w).to_slices() for w, wc in zip(windows, windows_cropped)
+    ]
+    predictions_cropped = (p[..., yslice, xslice]
+                           for p, (xslice,
+                                   yslice) in zip(predictions, array_slices))
+    return windows_cropped, predictions_cropped

--- a/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source.py
@@ -114,7 +114,7 @@ def read_labels(labels_df: gpd.GeoDataFrame,
         extent_polygon = extent.to_shapely()
         labels_df = labels_df[labels_df.intersects(extent_polygon)]
         boxes = np.array([
-            Box.from_shapely(c).to_int().to_extent_coords(extent)
+            Box.from_shapely(c).to_int().shift_origin(extent)
             for c in labels_df.geometry
         ])
     else:
@@ -194,7 +194,7 @@ class ChipClassificationLabelSource(LabelSource):
                 raise ValueError('cell_sz is not set.')
             cells = self.extent.get_windows(cfg.cell_sz, cfg.cell_sz)
         else:
-            cells = [cell.to_extent_coords(self.extent) for cell in cells]
+            cells = [cell.shift_origin(self.extent) for cell in cells]
 
         known_cells = [c for c in cells if c in self.labels]
         unknown_cells = [c for c in cells if c not in self.labels]
@@ -217,7 +217,7 @@ class ChipClassificationLabelSource(LabelSource):
                    window: Optional[Box] = None) -> ChipClassificationLabels:
         if window is None:
             return self.labels
-        window = window.to_extent_coords(self.extent)
+        window = window.shift_origin(self.extent)
         return self.labels.get_singleton_labels(window)
 
     def __getitem__(self, key: Any) -> int:

--- a/rastervision_core/rastervision/core/data/label_source/object_detection_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/object_detection_label_source.py
@@ -50,7 +50,7 @@ class ObjectDetectionLabelSource(LabelSource):
         """
         if window is None:
             return self.labels
-        window = window.to_extent_coords(self.extent)
+        window = window.shift_origin(self.extent)
         return ObjectDetectionLabels.get_overlapping(
             self.labels, window, ioa_thresh=ioa_thresh, clip=clip)
 

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -66,17 +66,22 @@ class SemanticSegmentationLabelSource(LabelSource):
         """Get labels for a window.
 
         Args:
-             window: Either None or a window given as a Box object. Uses full extent of
-                scene if window is not provided.
+            window (Optional[Box], optional): Window to get labels for. If
+            None, returns labels covering the full extent of the scene.
+
         Returns:
-             SemanticSegmentationLabels
+            SemanticSegmentationLabels: The labels.
         """
         if window is None:
             window = self.extent
 
-        labels = SemanticSegmentationLabels.make_empty()
         label_arr = self.get_label_arr(window)
+        labels = SemanticSegmentationLabels.make_empty(
+            extent=self.extent,
+            num_classes=len(self.class_config),
+            smooth=False)
         labels[window] = label_arr
+
         return labels
 
     def get_label_arr(self, window: Optional[Box] = None) -> np.ndarray:
@@ -91,7 +96,7 @@ class SemanticSegmentationLabelSource(LabelSource):
             None, returns a label array covering the full extent of the scene.
 
         Returns:
-            (np.ndarray): Label array.
+            np.ndarray: Label array.
         """
         if window is None:
             window = self.extent

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -72,8 +72,6 @@ class SemanticSegmentationLabelSource(LabelSource):
         """
         if window is None:
             window = self.extent
-        else:
-            window = window.to_extent_coords(self.extent)
 
         labels = SemanticSegmentationLabels.make_empty()
         label_arr = self.get_label_arr(window)
@@ -91,8 +89,6 @@ class SemanticSegmentationLabelSource(LabelSource):
         """
         if window is None:
             window = self.extent
-        else:
-            window = window.to_extent_coords(self.extent)
 
         label_arr = self.raster_source.get_chip(window)
         label_arr = np.squeeze(label_arr)

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -3,6 +3,7 @@ from typing import (Any, List, Optional)
 import numpy as np
 
 from rastervision.core.box import Box
+from rastervision.core.data import ClassConfig
 from rastervision.core.data.label import SemanticSegmentationLabels
 from rastervision.core.data.label_source.label_source import LabelSource
 from rastervision.core.data.raster_source import RasterSource
@@ -24,7 +25,7 @@ def fill_edge(label_arr: np.ndarray, window: Box, extent: Box,
 class SemanticSegmentationLabelSource(LabelSource):
     """A read-only label source for semantic segmentation."""
 
-    def __init__(self, raster_source: RasterSource, null_class_id: int):
+    def __init__(self, raster_source: RasterSource, class_config: ClassConfig):
         """Constructor.
 
         Args:
@@ -35,7 +36,7 @@ class SemanticSegmentationLabelSource(LabelSource):
                 retrieved using class_config.null_class_id.
         """
         self.raster_source = raster_source
-        self.null_class_id = null_class_id
+        self.class_config = class_config
 
     def enough_target_pixels(self, window: Box, target_count_threshold: int,
                              target_classes: List[int]) -> bool:
@@ -81,19 +82,25 @@ class SemanticSegmentationLabelSource(LabelSource):
     def get_label_arr(self, window: Optional[Box] = None) -> np.ndarray:
         """Get labels for a window.
 
+        The returned array will be the same size as the input window. If window
+        overflows the extent, the overflowing region will be filled with the ID
+        of the null class as defined by the class_config.
+
         Args:
-             window: Either None or a window given as a Box object. Uses full
-                extent of scene if window is not provided.
+            window (Optional[Box], optional): Window to get labels for. If
+            None, returns a label array covering the full extent of the scene.
+
         Returns:
-             np.ndarray
+            (np.ndarray): Label array.
         """
         if window is None:
             window = self.extent
 
         label_arr = self.raster_source.get_chip(window)
-        label_arr = np.squeeze(label_arr)
+        if label_arr.ndim == 3:
+            label_arr = np.squeeze(label_arr, axis=2)
         label_arr = fill_edge(label_arr, window, self.extent,
-                              self.null_class_id)
+                              self.class_config.null_class_id)
         return label_arr
 
     @property

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -40,8 +40,7 @@ class SemanticSegmentationLabelSource(LabelSource):
 
     def enough_target_pixels(self, window: Box, target_count_threshold: int,
                              target_classes: List[int]) -> bool:
-        """Given a window, answer whether the window contains enough pixels in
-        the target classes.
+        """Check if window contains enough pixels of the given target classes.
 
         Args:
              window: The larger window from-which the sub-window will
@@ -57,7 +56,7 @@ class SemanticSegmentationLabelSource(LabelSource):
 
         target_count = 0
         for class_id in target_classes:
-            target_count = target_count + (label_arr == class_id).sum()
+            target_count += (label_arr == class_id).sum()
 
         return target_count >= target_count_threshold
 

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
@@ -31,4 +31,4 @@ class SemanticSegmentationLabelSourceConfig(LabelSourceConfig):
                                           extent)
         else:
             rs = self.raster_source.build(tmp_dir)
-        return SemanticSegmentationLabelSource(rs, class_config.null_class_id)
+        return SemanticSegmentationLabelSource(rs, class_config)

--- a/rastervision_core/rastervision/core/data/label_store/__init__.py
+++ b/rastervision_core/rastervision/core/data/label_store/__init__.py
@@ -8,6 +8,7 @@ from rastervision.core.data.label_store.semantic_segmentation_label_store import
 from rastervision.core.data.label_store.semantic_segmentation_label_store_config import *
 from rastervision.core.data.label_store.object_detection_geojson_store import *
 from rastervision.core.data.label_store.object_detection_geojson_store_config import *
+from rastervision.core.data.label_store.utils import *
 
 __all__ = [
     LabelStore.__name__,

--- a/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from rastervision.pipeline.file_system import json_to_file
 from rastervision.core.data.label import ChipClassificationLabels
 from rastervision.core.data.label_store import LabelStore
@@ -6,11 +8,15 @@ from rastervision.core.data.label_source import (
     ChipClassificationLabelSourceConfig)
 from rastervision.core.data.vector_source import (GeoJSONVectorSourceConfig)
 
+if TYPE_CHECKING:
+    from rastervision.core.data import ClassConfig, CRSTransformer
+
 
 class ChipClassificationGeoJSONStore(LabelStore):
     """Storage for chip classification predictions."""
 
-    def __init__(self, uri, class_config, crs_transformer):
+    def __init__(self, uri: str, class_config: 'ClassConfig',
+                 crs_transformer: 'CRSTransformer'):
         """Constructor.
 
         Args:
@@ -23,7 +29,7 @@ class ChipClassificationGeoJSONStore(LabelStore):
         self.class_config = class_config
         self.crs_transformer = crs_transformer
 
-    def save(self, labels):
+    def save(self, labels: ChipClassificationLabels) -> None:
         """Save labels to URI if writable.
 
         Note that if the grid is inferred from polygons, only the grid will be
@@ -40,11 +46,11 @@ class ChipClassificationGeoJSONStore(LabelStore):
             scores=scores)
         json_to_file(geojson, self.uri)
 
-    def get_labels(self):
+    def get_labels(self) -> ChipClassificationLabels:
         vs = GeoJSONVectorSourceConfig(uri=self.uri)
         ls = ChipClassificationLabelSourceConfig(vector_source=vs).build(
             self.class_config, self.crs_transformer)
         return ls.get_labels()
 
-    def empty_labels(self):
+    def empty_labels(self) -> ChipClassificationLabels:
         return ChipClassificationLabels()

--- a/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
@@ -1,14 +1,20 @@
+from typing import TYPE_CHECKING
+
 from rastervision.core.data.label import ObjectDetectionLabels
 from rastervision.core.data.label_store import LabelStore
 from rastervision.core.data.label_store.utils import boxes_to_geojson
 from rastervision.core.data.vector_source import GeoJSONVectorSourceConfig
 from rastervision.pipeline.file_system import json_to_file
 
+if TYPE_CHECKING:
+    from rastervision.core.data import ClassConfig, CRSTransformer
+
 
 class ObjectDetectionGeoJSONStore(LabelStore):
     """Storage for object detection predictions."""
 
-    def __init__(self, uri, class_config, crs_transformer):
+    def __init__(self, uri: str, class_config: 'ClassConfig',
+                 crs_transformer: 'CRSTransformer'):
         """Constructor.
 
         Args:
@@ -22,11 +28,11 @@ class ObjectDetectionGeoJSONStore(LabelStore):
         self.crs_transformer = crs_transformer
         self.class_config = class_config
 
-    def save(self, labels):
+    def save(self, labels: ObjectDetectionLabels) -> None:
         """Save labels to URI."""
         boxes = labels.get_boxes()
-        class_ids = labels.get_class_ids().tolist()
-        scores = labels.get_scores().tolist()
+        class_ids = [int(id) for id in labels.get_class_ids()]
+        scores = labels.get_scores()
         geojson = boxes_to_geojson(
             boxes,
             class_ids,
@@ -35,10 +41,10 @@ class ObjectDetectionGeoJSONStore(LabelStore):
             scores=scores)
         json_to_file(geojson, self.uri)
 
-    def get_labels(self):
+    def get_labels(self) -> ObjectDetectionLabels:
         vector_source = GeoJSONVectorSourceConfig(uri=self.uri).build(
             self.class_config, self.crs_transformer)
         return ObjectDetectionLabels.from_geojson(vector_source.get_geojson())
 
-    def empty_labels(self):
+    def empty_labels(self) -> ObjectDetectionLabels:
         return ObjectDetectionLabels.make_empty()

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -1,25 +1,26 @@
 from typing import TYPE_CHECKING, Optional, Sequence, Tuple
 from os.path import join
 import logging
-from tqdm.auto import tqdm
 
 import numpy as np
 import rasterio as rio
+from tqdm.auto import tqdm
 
 from rastervision.pipeline import rv_config
 from rastervision.pipeline.file_system import (
     get_local_path, json_to_file, make_dir, sync_to_dir, file_exists)
 from rastervision.core.box import Box
 from rastervision.core.data import (CRSTransformer, ClassConfig)
-from rastervision.core.data.label import SemanticSegmentationLabels
+from rastervision.core.data.label import (SemanticSegmentationLabels,
+                                          SemanticSegmentationSmoothLabels)
 from rastervision.core.data.label_store import LabelStore
+from rastervision.core.data.label_source import SemanticSegmentationLabelSource
 from rastervision.core.data.raster_transformer import RGBClassTransformer
-from rastervision.core.data.raster_source import RasterioSourceConfig
+from rastervision.core.data.raster_source import RasterioSource
 
 if TYPE_CHECKING:
     from rastervision.core.data import (VectorOutputConfig,
-                                        SemanticSegmentationDiscreteLabels,
-                                        SemanticSegmentationSmoothLabels)
+                                        SemanticSegmentationDiscreteLabels)
 
 log = logging.getLogger(__name__)
 
@@ -36,9 +37,9 @@ class SemanticSegmentationLabelStore(LabelStore):
             uri: str,
             extent: Box,
             crs_transformer: CRSTransformer,
+            class_config: ClassConfig,
             tmp_dir: Optional[str] = None,
             vector_outputs: Optional[Sequence['VectorOutputConfig']] = None,
-            class_config: ClassConfig = None,
             save_as_rgb: bool = False,
             smooth_output: bool = False,
             smooth_as_uint8: bool = False,
@@ -91,24 +92,29 @@ class SemanticSegmentationLabelStore(LabelStore):
         if save_as_rgb:
             self.class_transformer = RGBClassTransformer(class_config)
 
-        self.label_raster_source = None
-        self.score_raster_source = None
+        self.label_source = None
+        self.score_source = None
 
         if file_exists(self.label_uri):
-            cfg = RasterioSourceConfig(uris=[self.label_uri])
-            self.label_raster_source = cfg.build(tmp_dir)
+            if self.class_transformer is not None:
+                tfs = [self.class_transformer]
+            else:
+                tfs = []
+            label_raster_source = RasterioSource(
+                self.label_uri, raster_transformers=tfs)
+            self.label_source = SemanticSegmentationLabelSource(
+                label_raster_source, class_config)
 
         if self.smooth_output:
             if file_exists(self.score_uri):
-                cfg = RasterioSourceConfig(uris=[self.score_uri])
-                raster_source = cfg.build(tmp_dir)
+                raster_source = RasterioSource(self.score_uri)
                 extents_equal = raster_source.extent == self.extent
                 bands_equal = raster_source.num_channels == len(class_config)
                 self_dtype = np.uint8 if self.smooth_as_uint8 else np.float32
                 dtypes_equal = raster_source.dtype == self_dtype
 
                 if extents_equal and bands_equal and dtypes_equal:
-                    self.score_raster_source = raster_source
+                    self.score_source = raster_source
                 else:
                     raise FileExistsError(f'{self.score_uri} already exists '
                                           'and is incompatible.')
@@ -128,56 +134,52 @@ class SemanticSegmentationLabelStore(LabelStore):
         """Get all labels.
 
         Returns:
-            SemanticSegmentationLabels
+            SemanticSegmentationDiscreteLabels
         """
-        if self.label_raster_source is None:
+        if self.label_source is None:
             raise FileNotFoundError(
                 f'Raster source at {self.label_uri} does not exist.')
 
-        extent = self.label_raster_source.extent
-        raw_labels = self.label_raster_source.get_chip(extent)
-        if self.class_transformer is None:
-            label_arr = np.squeeze(raw_labels)
-        else:
-            label_arr = self.class_transformer.rgb_to_class(raw_labels)
-
-        labels = self.empty_labels(smooth=False)
-        labels[extent] = label_arr
-        return labels
+        return self.label_source.get_labels()
 
     def get_scores(self) -> 'SemanticSegmentationSmoothLabels':
         """Get all scores.
 
         Returns:
-            SemanticSegmentationLabels
+            SemanticSegmentationSmoothLabels
         """
-        if self.score_raster_source is None:
+        if self.score_source is None:
             raise Exception(
                 f'Raster source at {self.score_uri} does not exist '
                 'or is not consistent with the current params.')
 
-        extent = self.score_raster_source.extent
-        score_arr = self.score_raster_source.get_chip(extent)
-        # (H, W, C) --> (C, H, W)
-        score_arr = score_arr.transpose(2, 0, 1)
+        log.info('Loading scores...')
+
+        extent = self.score_source.extent
         try:
             hits_arr = np.load(self.hits_uri)
         except FileNotFoundError:
             log.warn(f'Pixel hits array not found at {self.hits_uri}.'
-                     'Setting all pixels to 1.')
-            hits_arr = np.ones(score_arr.shape[-2:], dtype=np.uint8)
+                     'Setting all pixels hits to 1.')
+            hits_arr = np.ones(extent.size, dtype=np.uint8)
 
+        score_arr = self.score_source.get_chip(extent)
+        # (H, W, C) --> (C, H, W)
+        score_arr = score_arr.transpose(2, 0, 1)
         # convert to float
         if score_arr.dtype == np.uint8:
             score_arr = score_arr.astype(np.float16)
             score_arr /= 255
 
-        labels: 'SemanticSegmentationSmoothLabels' = self.empty_labels()
+        labels = self.empty_labels()
+        assert isinstance(labels, SemanticSegmentationSmoothLabels)
         labels.pixel_scores = score_arr * hits_arr
         labels.pixel_hits = hits_arr
         return labels
 
-    def save(self, labels: SemanticSegmentationLabels) -> None:
+    def save(self,
+             labels: SemanticSegmentationLabels,
+             profile: Optional[dict] = None) -> None:
         """Save labels to disk.
 
         More info on rasterio IO:
@@ -190,19 +192,20 @@ class SemanticSegmentationLabelStore(LabelStore):
         local_root = get_local_path(self.root_uri, self.tmp_dir)
         make_dir(local_root)
 
-        height, width = self.extent.ymax, self.extent.xmax
-        out_profile = {
-            'driver': 'GTiff',
-            'height': height,
-            'width': width,
-            'transform': self.crs_transformer.transform,
-            'crs': self.crs_transformer.image_crs,
-            'blockxsize': min(self.rasterio_block_size, width),
-            'blockysize': min(self.rasterio_block_size, height)
-        }
+        height, width = self.extent.size
+        out_profile = dict(
+            driver='GTiff',
+            height=height,
+            width=width,
+            transform=self.crs_transformer.transform,
+            crs=self.crs_transformer.image_crs,
+            blockxsize=min(self.rasterio_block_size, width),
+            blockysize=min(self.rasterio_block_size, height))
+        if profile is not None:
+            out_profile.update(profile)
 
         # if old scores exist, combine them with the new ones
-        if self.score_raster_source:
+        if self.score_source is not None:
             log.info('Old scores found. Merging with current scores.')
             old_labels = self.get_scores()
             labels += old_labels
@@ -212,37 +215,24 @@ class SemanticSegmentationLabelStore(LabelStore):
 
         if self.smooth_output:
             self.write_smooth_raster_output(
-                out_profile,
-                get_local_path(self.score_uri, self.tmp_dir),
-                get_local_path(self.hits_uri, self.tmp_dir),
-                labels,
-                chip_sz=self.rasterio_block_size)
+                out_profile, get_local_path(self.score_uri, self.tmp_dir),
+                get_local_path(self.hits_uri, self.tmp_dir), labels)
 
         if self.vector_outputs:
             self.write_vector_outputs(labels)
 
         sync_to_dir(local_root, self.root_uri)
 
-    def write_smooth_raster_output(self,
-                                   out_profile: dict,
-                                   scores_path: str,
-                                   hits_path: str,
-                                   labels: SemanticSegmentationLabels,
-                                   chip_sz: Optional[int] = None) -> None:
+    def write_smooth_raster_output(
+            self, out_profile: dict, scores_path: str, hits_path: str,
+            labels: SemanticSegmentationSmoothLabels) -> None:
+        num_bands = labels.num_classes
         dtype = np.uint8 if self.smooth_as_uint8 else np.float32
+        out_profile.update(dict(count=num_bands, dtype=dtype))
 
-        out_profile.update({
-            'count': labels.num_classes,
-            'dtype': dtype,
-        })
-        if chip_sz is None:
-            windows = [self.extent]
-        else:
-            windows = labels.get_windows()
-
-        log.info('Writing smooth labels to disk.')
-        with rio.open(scores_path, 'w', **out_profile) as dataset:
-            with tqdm(windows, desc='Writing windows to GeoTiff') as bar:
+        with rio.open(scores_path, 'w', **out_profile) as ds:
+            windows = [Box.from_rasterio(w) for _, w in ds.block_windows(1)]
+            with tqdm(windows, desc='Saving pixel scores') as bar:
                 for window in bar:
                     window, _ = self._clip_to_extent(self.extent, window)
                     score_arr = labels.get_score_arr(window)
@@ -250,62 +240,32 @@ class SemanticSegmentationLabelStore(LabelStore):
                         score_arr = self._scores_to_uint8(score_arr)
                     else:
                         score_arr = score_arr.astype(dtype)
-                    self._write_array(dataset, window, score_arr)
+                    self._write_array(ds, window, score_arr)
+
         # save pixel hits too
         np.save(hits_path, labels.pixel_hits)
 
     def write_discrete_raster_output(
             self, out_profile: dict, path: str,
             labels: SemanticSegmentationLabels) -> None:
-
         num_bands = 1 if self.class_transformer is None else 3
         dtype = np.uint8
-        out_profile.update({'count': num_bands, 'dtype': dtype})
+        out_profile.update(dict(count=num_bands, dtype=dtype))
 
-        windows = labels.get_windows()
-
-        log.info('Writing labels to disk.')
-        with rio.open(path, 'w', **out_profile) as dataset:
-            with tqdm(windows, desc='Writing windows to GeoTiff') as bar:
+        null_class_id = self.class_config.null_class_id
+        with rio.open(path, 'w', **out_profile) as ds:
+            windows = [Box.from_rasterio(w) for _, w in ds.block_windows(1)]
+            with tqdm(windows, desc='Saving pixel labels') as bar:
                 for window in bar:
-                    label_arr = labels.get_label_arr(window).astype(dtype)
+                    label_arr = labels.get_label_arr(
+                        window, null_class_id).astype(dtype)
                     window, label_arr = self._clip_to_extent(
                         self.extent, window, label_arr)
                     if self.class_transformer is not None:
                         label_arr = self.class_transformer.class_to_rgb(
                             label_arr)
                         label_arr = label_arr.transpose(2, 0, 1)
-                    self._write_array(dataset, window, label_arr)
-
-    def _labels_to_full_label_arr(
-            self, labels: SemanticSegmentationLabels) -> np.ndarray:
-        """Get an array of labels covering the full extent."""
-        try:
-            label_arr = labels.get_label_arr(self.extent)
-            return label_arr
-        except KeyError:
-            pass
-
-        # we will construct the array from individual windows
-        windows = labels.get_windows()
-
-        # value for pixels not convered by any windows
-        try:
-            default_class_id = self.class_config.null_class_id
-        except ValueError:
-            # Set it to a high value so that it doesn't match any class's id.
-            # assumption: num_classes < 256
-            default_class_id = 255
-
-        label_arr = np.full(
-            self.extent.size, fill_value=default_class_id, dtype=np.uint8)
-
-        for w in windows:
-            ymin, xmin, ymax, xmax = w
-            arr = labels.get_label_arr(w)
-            w, arr = self._clip_to_extent(self.extent, w, arr)
-            label_arr[ymin:ymax, xmin:xmax] = arr
-        return label_arr
+                    self._write_array(ds, window, label_arr)
 
     def write_vector_outputs(self, labels: SemanticSegmentationLabels) -> None:
         """Write vectorized outputs for all configs in self.vector_outputs."""
@@ -315,7 +275,9 @@ class SemanticSegmentationLabelStore(LabelStore):
 
         log.info('Writing vector output to disk.')
 
-        label_arr = self._labels_to_full_label_arr(labels)
+        label_arr = labels.get_label_arr(self.extent,
+                                         self.class_config.null_class_id)
+
         with tqdm(self.vector_outputs, desc='Vectorizing predictions') as bar:
             for i, vo in enumerate(bar):
                 bar.set_postfix(
@@ -352,11 +314,10 @@ class SemanticSegmentationLabelStore(LabelStore):
 
     def empty_labels(self, **kwargs) -> SemanticSegmentationLabels:
         """Returns an empty SemanticSegmentationLabels object."""
-        args = {
-            'smooth': self.smooth_output,
-            'extent': self.extent,
-            'num_classes': len(self.class_config),
-        }
+        args = dict(
+            extent=self.extent,
+            num_classes=len(self.class_config),
+            smooth=self.smooth_output)
         args.update(**kwargs)
         labels = SemanticSegmentationLabels.make_empty(**args)
         return labels
@@ -366,12 +327,12 @@ class SemanticSegmentationLabelStore(LabelStore):
         """Write array out to a rasterio dataset. Array must be of shape
         (C, H, W).
         """
-        window = window.rasterio_format()
+        rio_window = window.rasterio_format()
         if len(arr.shape) == 2:
-            dataset.write_band(1, arr, window=window)
+            dataset.write_band(1, arr, window=rio_window)
         else:
             for i, band in enumerate(arr, start=1):
-                dataset.write_band(i, band, window=window)
+                dataset.write_band(i, band, window=rio_window)
 
     def _clip_to_extent(self,
                         extent: Box,

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
@@ -127,12 +127,12 @@ class SemanticSegmentationLabelStoreConfig(LabelStoreConfig):
         class_config.ensure_null_class()
 
         label_store = SemanticSegmentationLabelStore(
-            self.uri,
-            extent,
-            crs_transformer,
-            tmp_dir,
-            vector_outputs=self.vector_output,
+            uri=self.uri,
+            extent=extent,
+            crs_transformer=crs_transformer,
             class_config=class_config,
+            tmp_dir=tmp_dir,
+            vector_outputs=self.vector_output,
             save_as_rgb=self.rgb,
             smooth_output=self.smooth_output,
             smooth_as_uint8=self.smooth_as_uint8,

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -262,7 +262,7 @@ class RasterioSource(RasterSource):
                   window: Box,
                   bands: Optional[Sequence[int]] = None,
                   out_shape: Optional[Tuple[int, ...]] = None) -> np.ndarray:
-        window = window.to_extent_coords(self.extent)
+        window = window.shift_origin(self.extent)
         chip = load_window(
             self.image_dataset,
             bands=bands,

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -166,6 +166,8 @@ class RasterioSource(RasterSource):
         """
         self.uris = listify_uris(uris)
         self.allow_streaming = allow_streaming
+        self._num_channels = None
+        self._dtype = None
 
         self.tmp_dir = tmp_dir
         if self.tmp_dir is None:
@@ -175,9 +177,22 @@ class RasterioSource(RasterSource):
         self.imagery_path = self.download_data(
             self.tmp_dir, stream=self.allow_streaming)
         self.image_dataset = rasterio.open(self.imagery_path)
+
+        block_shapes = set(self.image_dataset.block_shapes)
+        if len(block_shapes) > 1:
+            log.warn('Raster bands have non-identical block shapes: '
+                     f'{block_shapes}. This can slow down reading. '
+                     'Consider re-tiling using GDAL.')
+
+        for h, w in block_shapes:
+            # the choice of 4 here is arbitrary
+            if max(h, w) / min(h, w) > 4:
+                log.warn(f'Raster block size {(h, w)} is too non-square. '
+                         'This can slow down reading. '
+                         'Consider re-tiling using GDAL.')
+
         self._crs_transformer = RasterioCRSTransformer.from_dataset(
             self.image_dataset)
-        self._dtype = None
 
         num_channels_raw = self.image_dataset.count
         if channel_order is None:
@@ -185,13 +200,11 @@ class RasterioSource(RasterSource):
         self.bands_to_read = np.array(channel_order, dtype=int) + 1
 
         # number of output channels
-        self._num_channels = None
         if len(raster_transformers) == 0:
             self._num_channels = len(self.bands_to_read)
 
         mask_flags = self.image_dataset.mask_flag_enums
-        self.is_masked = any(
-            [m for m in mask_flags if m != MaskFlags.all_valid])
+        self.is_masked = any(m for m in mask_flags if m != MaskFlags.all_valid)
 
         if extent is None:
             height = self.image_dataset.height

--- a/rastervision_core/rastervision/core/data/utils/factory.py
+++ b/rastervision_core/rastervision/core/data/utils/factory.py
@@ -105,7 +105,7 @@ def make_ss_scene(class_config: 'ClassConfig',
     label_source = None
     if label_raster_source is not None:
         label_source = SemanticSegmentationLabelSource(
-            raster_source=label_raster_source, null_class_id=null_class_id)
+            raster_source=label_raster_source, class_config=class_config)
 
     aoi_polygons = get_polygons_from_uris(aoi_uri, crs_transformer)
     scene = Scene(

--- a/rastervision_core/rastervision/core/data/utils/geojson.py
+++ b/rastervision_core/rastervision/core/data/utils/geojson.py
@@ -103,11 +103,23 @@ def geojson_to_geoms(geojson: dict) -> Iterator['BaseGeometry']:
     return geoms
 
 
-def geoms_to_geojson(geoms: Iterable['BaseGeometry']) -> dict:
+def geoms_to_geojson(geoms: Iterable['BaseGeometry'],
+                     properties: Optional[Iterable[dict]] = None) -> dict:
     """Serialize shapely geometries to GeoJSON."""
-    geometries = [mapping(g) for g in geoms]
-    geojson = geometries_to_geojson(geometries)
+    if properties is None:
+        features = [geom_to_feature(g) for g in geoms]
+    else:
+        features = [geom_to_feature(g, p) for g, p in zip(geoms, properties)]
+    geojson = features_to_geojson(features)
     return geojson
+
+
+def geom_to_feature(geom: 'BaseGeometry',
+                    properties: Optional[dict] = None) -> dict:
+    """Serialize a single shapely geomety to a GeoJSON Feature."""
+    geomety = mapping(geom)
+    feature = geometry_to_feature(geomety, properties=properties)
+    return feature
 
 
 def filter_features(func: Callable,

--- a/rastervision_core/rastervision/core/evaluation/evaluator_config.py
+++ b/rastervision_core/rastervision/core/evaluation/evaluator_config.py
@@ -5,6 +5,7 @@ from rastervision.pipeline.config import register_config, Config, Field
 
 if TYPE_CHECKING:
     from rastervision.core.data import ClassConfig
+    from rastervision.core.evaluation import Evaluator
     from rastervision.core.rv_pipeline import RVPipelineConfig
 
 
@@ -20,7 +21,7 @@ class EvaluatorConfig(Config):
     def build(self,
               class_config: 'ClassConfig',
               scene_group: Optional[Tuple[str, Iterable[str]]] = None
-              ) -> 'EvaluatorConfig':
+              ) -> 'Evaluator':
         pass
 
     def get_output_uri(self, scene_group_name: Optional[str] = None) -> str:

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -8,12 +8,18 @@ from rastervision.core.rv_pipeline.rv_pipeline import RVPipeline
 from rastervision.core.rv_pipeline.utils import (fill_no_data,
                                                  nodata_below_threshold)
 from rastervision.core.rv_pipeline.semantic_segmentation_config import (
-    SemanticSegmentationWindowMethod, SemanticSegmentationChipOptions)
+    SemanticSegmentationWindowMethod)
 
 if TYPE_CHECKING:
     from rastervision.core.backend.backend import Backend
-    from rastervision.core.data import (ClassConfig, Labels, Scene,
-                                        SemanticSegmentationLabelSource)
+    from rastervision.core.data import (
+        ClassConfig,
+        Labels,
+        Scene,
+        SemanticSegmentationLabelSource,
+    )
+    from rastervision.core.rv_pipeline.semantic_segmentation_config import (
+        SemanticSegmentationConfig, SemanticSegmentationChipOptions)
 
 log = logging.getLogger(__name__)
 
@@ -21,7 +27,7 @@ log = logging.getLogger(__name__)
 def get_train_windows(scene: 'Scene',
                       class_config: 'ClassConfig',
                       chip_size: int,
-                      chip_options: SemanticSegmentationChipOptions,
+                      chip_options: 'SemanticSegmentationChipOptions',
                       chip_nodata_threshold: float = 1.) -> List[Box]:
     """Get training windows covering a scene.
 
@@ -144,8 +150,22 @@ class SemanticSegmentation(RVPipeline):
         return labels
 
     def predict_scene(self, scene: 'Scene', backend: 'Backend') -> 'Labels':
-        chip_sz = self.config.predict_chip_sz
-        stride = self.config.predict_options.stride
+        cfg: 'SemanticSegmentationConfig' = self.config
+        chip_sz = cfg.predict_chip_sz
+        stride = cfg.predict_options.stride
+        crop_sz = cfg.predict_options.crop_sz
+
         if stride is None:
             stride = chip_sz
-        return backend.predict_scene(scene, chip_sz=chip_sz, stride=stride)
+
+        if crop_sz == 'auto':
+            overlap_sz = chip_sz - stride
+            if overlap_sz % 2 == 1:
+                log.warn(
+                    'Using crop_sz="auto" but overlap size (chip_sz minus '
+                    'stride) is odd. This means that one pixel row/col will '
+                    'still overlap after cropping.')
+            crop_sz = overlap_sz // 2
+
+        return backend.predict_scene(
+            scene, chip_sz=chip_sz, stride=stride, crop_sz=crop_sz)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
@@ -78,8 +78,13 @@ class PyTorchSemanticSegmentation(PyTorchLearnerBackend):
         # self.learner_cfg.data because of the updates
         # Learner.from_model_bundle() makes to the custom transforms.
         base_tf, _ = self.learner.cfg.data.get_data_transforms()
+        pad_direction = 'end' if crop_sz is None else 'both'
         ds = SemanticSegmentationSlidingWindowGeoDataset(
-            scene, size=chip_sz, stride=stride, transform=base_tf)
+            scene,
+            size=chip_sz,
+            stride=stride,
+            pad_direction=pad_direction,
+            transform=base_tf)
 
         predictions: Iterator[np.ndarray] = self.learner.predict_dataset(
             ds,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -68,6 +68,7 @@ class ClassificationGeoDataConfig(ClassificationDataConfig, GeoDataConfig):
                 size=opts.size,
                 stride=opts.stride,
                 padding=opts.padding,
+                pad_direction=opts.pad_direction,
                 transform=transform)
         elif opts.method == GeoDataWindowMethod.random:
             ds = ClassificationRandomWindowGeoDataset(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -6,6 +6,7 @@ import logging
 
 from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, List,
                     Optional, Sequence, Tuple, Union)
+from typing_extensions import Literal
 from pydantic import (PositiveFloat, PositiveInt as PosInt, constr, confloat,
                       conint)
 from pydantic.utils import sequence_like
@@ -1072,6 +1073,11 @@ class GeoDataWindowConfig(Config):
         None,
         description='How many pixels are windows allowed to overflow '
         'the edges of the raster source.')
+    pad_direction: Literal['both', 'start', 'end'] = Field(
+        'end',
+        description='If "end", only pad ymax and xmax (bottom and right). '
+        'If "start", only pad ymin and xmin (top and left). If "both", '
+        'pad all sides. Has no effect if paddiong is zero. Defaults to "end".')
     size_lims: Optional[Tuple[PosInt, PosInt]] = Field(
         None,
         description='[min, max) interval from which window sizes will be '

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -105,6 +105,7 @@ class ObjectDetectionGeoDataConfig(ObjectDetectionDataConfig, GeoDataConfig):
                 size=opts.size,
                 stride=opts.stride,
                 padding=opts.padding,
+                pad_direction=opts.pad_direction,
                 transform=transform)
         elif opts.method == GeoDataWindowMethod.random:
             ds = ObjectDetectionRandomWindowGeoDataset(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner_config.py
@@ -80,6 +80,7 @@ class RegressionGeoDataConfig(RegressionDataConfig, GeoDataConfig):
                 size=opts.size,
                 stride=opts.stride,
                 padding=opts.padding,
+                pad_direction=opts.pad_direction,
                 transform=transform)
         elif opts.method == GeoDataWindowMethod.random:
             ds = RegressionRandomWindowGeoDataset(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
@@ -96,6 +96,7 @@ class SemanticSegmentationGeoDataConfig(SemanticSegmentationDataConfig,
                 size=opts.size,
                 stride=opts.stride,
                 padding=opts.padding,
+                pad_direction=opts.pad_direction,
                 transform=transform)
         elif opts.method == GeoDataWindowMethod.random:
             ds = SemanticSegmentationRandomWindowGeoDataset(

--- a/tests/core/data/label/test_semantic_segmentation_labels.py
+++ b/tests/core/data/label/test_semantic_segmentation_labels.py
@@ -303,21 +303,21 @@ class TestSemanticSegmentationSmoothLabels(unittest.TestCase):
 
         # normal window
         box_in = (120, 150, 170, 200)
-        box_out_expected = (20, 50, 70, 100)
+        box_out_expected = Box(20, 50, 70, 100)
         box_out_actual = labels._to_local_coords(box_in)
-        self.assertTupleEqual(box_out_actual, box_out_expected)
+        self.assertEqual(box_out_actual, box_out_expected)
 
         # window completely outside the extent
         box_in = (0, 0, 100, 100)
-        box_out_expected = (0, 0, 0, 0)
+        box_out_expected = Box(0, 0, 0, 0)
         box_out_actual = labels._to_local_coords(box_in)
-        self.assertTupleEqual(box_out_actual, box_out_expected)
+        self.assertEqual(box_out_actual, box_out_expected)
 
         # window completely outside the extent
         box_in = (200, 200, 300, 300)
-        box_out_expected = (100, 100, 100, 100)
+        box_out_expected = Box(100, 100, 100, 100)
         box_out_actual = labels._to_local_coords(box_in)
-        self.assertTupleEqual(box_out_actual, box_out_expected)
+        self.assertEqual(box_out_actual, box_out_expected)
 
     def test_save(self):
         class_config = ClassConfig(names=['bg', 'fg'], null_class='bg')

--- a/tests/core/data/label/test_semantic_segmentation_labels.py
+++ b/tests/core/data/label/test_semantic_segmentation_labels.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 
 from rastervision.core.box import Box
+from rastervision.core.data import ClassConfig
 from rastervision.core.data.label import (SemanticSegmentationLabels,
                                           SemanticSegmentationDiscreteLabels,
                                           SemanticSegmentationSmoothLabels)
@@ -10,48 +11,126 @@ from rastervision.core.data.label import (SemanticSegmentationLabels,
 
 class TestSemanticSegmentationLabels(unittest.TestCase):
     def test_build(self):
+        extent = Box(0, 0, 10, 10)
+        num_classes = 2
+
+        # smooth=False
+        msg = ('smooth=False should return a '
+               'SemanticSegmentationDiscreteLabels instance')
+        labels = SemanticSegmentationLabels.make_empty(
+            extent=extent, num_classes=num_classes, smooth=False)
         self.assertIsInstance(
-            SemanticSegmentationLabels.make_empty(smooth=False),
-            SemanticSegmentationDiscreteLabels)
+            labels, SemanticSegmentationDiscreteLabels, msg=msg)
 
-        self.assertRaises(
-            ValueError,
-            lambda: SemanticSegmentationLabels.make_empty(smooth=True))
-
-        self.assertRaises(
-            ValueError, lambda: SemanticSegmentationLabels.make_empty(
-                smooth=True, extent=Box(0, 0, 10, 10)))
-
+        # smooth=True
+        msg = ('smooth=True should return a '
+               'SemanticSegmentationSmoothLabels instance')
+        labels = SemanticSegmentationLabels.make_empty(
+            extent=extent, num_classes=num_classes, smooth=True)
         self.assertIsInstance(
-            SemanticSegmentationLabels.make_empty(
-                smooth=True, extent=Box(0, 0, 10, 10), num_classes=2),
-            SemanticSegmentationSmoothLabels)
+            labels, SemanticSegmentationSmoothLabels, msg=msg)
 
 
 class TestSemanticSegmentationDiscreteLabels(unittest.TestCase):
     def setUp(self):
+        self.class_config = ClassConfig(names=['bg', 'fg'], null_class='bg')
+        num_classes = len(self.class_config)
+        extent = Box(0, 0, 20, 20)
         self.windows = [Box.make_square(0, 0, 10), Box.make_square(0, 10, 10)]
-        self.label_arr0 = np.random.choice([0, 1], (10, 10))
-        self.label_arr1 = np.random.choice([0, 1], (10, 10))
-        self.labels = SemanticSegmentationDiscreteLabels()
+        self.label_arr0 = np.random.randint(0, num_classes, size=(10, 10))
+        self.label_arr1 = np.random.randint(0, num_classes, size=(10, 10))
+        self.labels = SemanticSegmentationDiscreteLabels(
+            extent=extent, num_classes=num_classes)
         self.labels[self.windows[0]] = self.label_arr0
         self.labels[self.windows[1]] = self.label_arr1
 
-    def test_get(self):
+    def test_get_label_arr(self):
         np.testing.assert_array_equal(
             self.labels.get_label_arr(self.windows[0]), self.label_arr0)
 
+    def test_get_label_arr_empty(self):
+        extent = Box(0, 0, 3, 3)
+        labels = SemanticSegmentationDiscreteLabels(extent, 2)
+        label_arr = labels.get_label_arr(extent)
+        np.testing.assert_array_equal(label_arr, np.full((3, 3), -1))
+
+        window = Box(0, 0, 2, 2)
+        labels[window] = np.ones((2, 2))
+        label_arr = labels.get_label_arr(extent)
+        exp_label_arr = np.array([
+            [1, 1, -1],
+            [1, 1, -1],
+            [-1, -1, -1],
+        ])
+        np.testing.assert_array_equal(label_arr, exp_label_arr)
+
     def test_get_with_aoi(self):
-        null_class_id = 2
+        null_class_id = self.class_config.null_class_id
 
         aoi_polygons = [Box.make_square(5, 15, 2).to_shapely()]
-        exp_label_arr = np.full(self.label_arr1.shape, null_class_id)
+        exp_label_arr = np.full_like(self.label_arr1, fill_value=null_class_id)
         exp_label_arr[5:7, 5:7] = self.label_arr1[5:7, 5:7]
 
         labels = self.labels.filter_by_aoi(aoi_polygons, null_class_id)
         label_arr = labels.get_label_arr(self.windows[1])
         np.testing.assert_array_equal(label_arr, exp_label_arr)
-        self.assertEqual(1, len(labels.window_to_label_arr))
+
+    def test_make_empty(self):
+        extent = Box(0, 0, 10, 10)
+        num_classes = 3
+        labels = SemanticSegmentationDiscreteLabels.make_empty(
+            extent=extent, num_classes=num_classes)
+        self.assertEqual(labels.extent, extent)
+        self.assertEqual(labels.num_classes, num_classes)
+        self.assertEqual(labels.dtype, np.uint8)
+        self.assertEqual(labels.pixel_counts.shape,
+                         (num_classes, *extent.size))
+
+    def test_setitem(self):
+        extent = Box(0, 0, 3, 3)
+        labels = SemanticSegmentationDiscreteLabels(extent, 2)
+
+        labels[extent] = np.eye(3)
+        labels[extent] = np.eye(3)
+        labels[extent] = np.random.randint(0, 2, size=(3, 3))
+        label_arr = labels.get_label_arr(extent)
+        np.testing.assert_array_equal(label_arr, np.eye(3))
+
+    def test_delitem(self):
+        extent = Box(0, 0, 3, 3)
+        labels = SemanticSegmentationDiscreteLabels(extent, 2)
+        labels[extent] = np.eye(3)
+        del labels[extent]
+        label_arr = labels.get_label_arr(extent)
+        np.testing.assert_array_equal(label_arr, np.full((3, 3), -1))
+
+    def test_eq(self):
+        extent = Box(0, 0, 3, 3)
+        labels1 = SemanticSegmentationDiscreteLabels(extent, 2)
+        labels1[extent] = np.eye(3)
+        labels2 = SemanticSegmentationDiscreteLabels(extent, 2)
+        labels2[extent] = np.eye(3)
+        labels3 = SemanticSegmentationDiscreteLabels(extent, 2)
+        labels3[extent] = np.zeros((3, 3))
+        self.assertEqual(labels1, labels2)
+        self.assertNotEqual(labels1, labels3)
+        self.assertNotEqual(labels2, labels3)
+
+    def test_get_score_arr(self):
+        extent = Box(0, 0, 3, 3)
+        labels = SemanticSegmentationDiscreteLabels(extent, 2)
+
+        labels[extent] = np.zeros((3, 3))
+        labels[extent] = np.ones((3, 3))
+        scores = labels.get_score_arr(extent)
+        np.testing.assert_array_equal(scores[0], np.full((3, 3), 0.5))
+        np.testing.assert_array_equal(scores[1], np.full((3, 3), 0.5))
+
+        labels[extent] = np.ones((3, 3))
+        labels[extent] = np.ones((3, 3))
+        scores = labels.get_score_arr(extent)
+        np.testing.assert_array_equal(scores[0], np.full((3, 3), 0.25))
+        np.testing.assert_array_equal(scores[1], np.full((3, 3), 0.75))
 
 
 def make_random_scores(num_classes, h, w):
@@ -59,26 +138,22 @@ def make_random_scores(num_classes, h, w):
     # softmax
     arr = np.exp(arr, out=arr)
     arr /= arr.sum(axis=0)
-    return arr
+    return arr.astype(np.float16)
 
 
 class TestSemanticSegmentationSmoothLabels(unittest.TestCase):
     def setUp(self):
-        self.windows = [
-            Box.make_square(0, 0, 10),
-            Box.make_square(0, 5, 10),
-            Box.make_square(0, 10, 10)
-        ]
+        self.extent = Box(0, 0, 10, 20)
         self.num_classes = 3
+        self.windows = [
+            Box(0, 0, 10, 10),
+            Box(0, 5, 10, 15),
+            Box(0, 10, 10, 20)
+        ]
         self.scores_left = make_random_scores(self.num_classes, 10, 10)
         self.scores_mid = make_random_scores(self.num_classes, 10, 10)
         self.scores_right = make_random_scores(self.num_classes, 10, 10)
 
-        self.scores_left = self.scores_left.astype(np.float16)
-        self.scores_mid = self.scores_mid.astype(np.float16)
-        self.scores_right = self.scores_right.astype(np.float16)
-
-        self.extent = Box(0, 0, 10, 20)
         self.labels = SemanticSegmentationSmoothLabels(
             extent=self.extent, num_classes=self.num_classes)
         self.labels[self.windows[0]] = self.scores_left
@@ -108,9 +183,21 @@ class TestSemanticSegmentationSmoothLabels(unittest.TestCase):
 
     def test_get_label_arr(self):
         avg_scores = self.expected_scores / self.expected_hits
-        labels = np.argmax(avg_scores, axis=0)
-        np.testing.assert_array_equal(labels,
-                                      self.labels.get_label_arr(self.extent))
+        exp_label_arr = np.argmax(avg_scores, axis=0)
+        label_arr = self.labels.get_label_arr(self.extent)
+        np.testing.assert_array_equal(label_arr, exp_label_arr)
+
+    def test_get_label_arr_empty(self):
+        extent = Box(0, 0, 3, 3)
+        labels = SemanticSegmentationSmoothLabels(extent, 2)
+        label_arr = labels.get_label_arr(extent)
+        np.testing.assert_array_equal(label_arr, np.full((3, 3), -1))
+
+        window = Box(0, 0, 2, 2)
+        labels[window] = np.random.randint(0, 2, size=(2, 2))
+        label_arr = labels.get_label_arr(extent)
+        np.testing.assert_array_equal(label_arr[:, 2], np.array([-1, -1, -1]))
+        np.testing.assert_array_equal(label_arr[2, :], np.array([-1, -1, -1]))
 
     def test_pixel_hits(self):
         np.testing.assert_array_equal(self.expected_hits,
@@ -126,7 +213,7 @@ class TestSemanticSegmentationSmoothLabels(unittest.TestCase):
     def test_get_with_aoi(self):
         null_class_id = 2
 
-        aoi = Box.make_square(5, 15, 2)
+        aoi = Box(5, 15, 7, 17)
         aoi_polygons = [aoi.to_shapely()]
         exp_label_arr = self.labels.get_label_arr(self.windows[2])
         exp_label_arr[:] = null_class_id

--- a/tests/core/data/label_source/test_semantic_segmentation_label_source.py
+++ b/tests/core/data/label_source/test_semantic_segmentation_label_source.py
@@ -16,58 +16,57 @@ class TestSemanticSegmentationLabelSource(unittest.TestCase):
     def test_enough_target_pixels_true(self):
         data = np.zeros((10, 10, 1), dtype=np.uint8)
         data[4:, 4:, :] = 1
-        null_class_id = 2
+        class_config = ClassConfig(names=['bg', 'fg', 'null'])
         raster_source = MockRasterSource([0], 1)
         raster_source.set_raster(data)
         label_source = SemanticSegmentationLabelSource(raster_source,
-                                                       null_class_id)
+                                                       class_config)
         extent = Box(0, 0, 10, 10)
         self.assertTrue(label_source.enough_target_pixels(extent, 30, [1]))
 
     def test_enough_target_pixels_false(self):
         data = np.zeros((10, 10, 1), dtype=np.uint8)
         data[7:, 7:, :] = 1
-        null_class_id = 2
+        class_config = ClassConfig(names=['bg', 'fg', 'null'])
         raster_source = MockRasterSource([0], 1)
         raster_source.set_raster(data)
         label_source = SemanticSegmentationLabelSource(raster_source,
-                                                       null_class_id)
+                                                       class_config)
         extent = Box(0, 0, 10, 10)
         self.assertFalse(label_source.enough_target_pixels(extent, 30, [1]))
 
     def test_get_labels(self):
         data = np.zeros((10, 10, 1), dtype=np.uint8)
         data[7:, 7:, 0] = 1
-        null_class_id = 2
+        class_config = ClassConfig(names=['bg', 'fg', 'null'])
         raster_source = MockRasterSource([0], 1)
         raster_source.set_raster(data)
         label_source = SemanticSegmentationLabelSource(raster_source,
-                                                       null_class_id)
+                                                       class_config)
         window = Box.make_square(7, 7, 3)
         labels = label_source.get_labels(window=window)
         label_arr = labels.get_label_arr(window)
         expected_label_arr = np.ones((3, 3))
         np.testing.assert_array_equal(label_arr, expected_label_arr)
 
-    def test_get_labels_off_edge(self):
+    def test_get_label_arr_off_edge(self):
         data = np.zeros((10, 10, 1), dtype=np.uint8)
         data[7:, 7:, 0] = 1
-        null_class_id = 2
+        class_config = ClassConfig(names=['bg', 'fg', 'null'])
         raster_source = MockRasterSource([0], 1)
         raster_source.set_raster(data)
         label_source = SemanticSegmentationLabelSource(raster_source,
-                                                       null_class_id)
+                                                       class_config)
         window = Box.make_square(7, 7, 6)
-        labels = label_source.get_labels(window=window)
-        label_arr = labels.get_label_arr(window)
-        expected_label_arr = np.full((6, 6), 2)
+        label_arr = label_source.get_label_arr(window)
+        expected_label_arr = np.full((6, 6), class_config.null_class_id)
         expected_label_arr[0:3, 0:3] = 1
         np.testing.assert_array_equal(label_arr, expected_label_arr)
 
     def test_get_labels_rgb(self):
         data = np.zeros((10, 10, 3), dtype=np.uint8)
         data[7:, 7:, :] = [1, 1, 1]
-        null_class_id = 2
+        class_config = ClassConfig(names=['bg', 'fg', 'null'])
         rgb_class_config = ClassConfig(names=['a'], colors=['#010101'])
         rgb_class_config.ensure_null_class()
         raster_source = MockRasterSource(
@@ -78,7 +77,7 @@ class TestSemanticSegmentationLabelSource(unittest.TestCase):
             ])
         raster_source.set_raster(data)
         label_source = SemanticSegmentationLabelSource(raster_source,
-                                                       null_class_id)
+                                                       class_config)
         window = Box.make_square(7, 7, 3)
         labels = label_source.get_labels(window=window)
         label_arr = labels.get_label_arr(window)

--- a/tests/core/data/label_store/test_utils.py
+++ b/tests/core/data/label_store/test_utils.py
@@ -1,0 +1,66 @@
+import unittest
+
+from rastervision.core.box import Box
+from rastervision.core.data import ClassConfig, IdentityCRSTransformer
+from rastervision.core.data.utils import geojson_to_geoms
+from rastervision.core.data.label_store.utils import boxes_to_geojson
+
+
+class TestUtils(unittest.TestCase):
+    def test_boxes_to_geojson_without_scores(self):
+        class_config = ClassConfig(names=['bg', 'fg'], null_class='bg')
+        crs_transformer = IdentityCRSTransformer()
+        boxes_in = [Box(0, 0, 100, 100), Box(0, 0, 200, 200)]
+        class_ids_in = [0, 1]
+        class_names_in = ['bg', 'fg']
+        scores_in = None
+        geojson = boxes_to_geojson(
+            boxes=boxes_in,
+            class_ids=class_ids_in,
+            crs_transformer=crs_transformer,
+            class_config=class_config,
+            scores=scores_in)
+
+        properties_out = [f['properties'] for f in geojson['features']]
+        class_ids_out = [p.get('class_id') for p in properties_out]
+        class_names_out = [p.get('class_name') for p in properties_out]
+        scores_out_single = [p.get('score') for p in properties_out]
+        scores_out_mult = [p.get('scores') for p in properties_out]
+        self.assertListEqual(class_ids_out, class_ids_in)
+        self.assertListEqual(class_names_out, class_names_in)
+        self.assertListEqual(scores_out_single, [None, None])
+        self.assertListEqual(scores_out_mult, [None, None])
+        boxes_out = [Box.from_shapely(g) for g in geojson_to_geoms(geojson)]
+        for box_in, box_out in zip(boxes_in, boxes_out):
+            self.assertEqual(box_in, box_out)
+
+    def test_boxes_to_geojson_with_scores(self):
+        class_config = ClassConfig(names=['bg', 'fg'], null_class='bg')
+        crs_transformer = IdentityCRSTransformer()
+        boxes_in = [Box(0, 0, 100, 100), Box(0, 0, 200, 200)]
+        class_ids_in = [0, 1]
+        class_names_in = ['bg', 'fg']
+        scores_in = [0.9, [0.2, 0.8]]
+        geojson = boxes_to_geojson(
+            boxes=boxes_in,
+            class_ids=class_ids_in,
+            crs_transformer=crs_transformer,
+            class_config=class_config,
+            scores=scores_in)
+
+        properties_out = [f['properties'] for f in geojson['features']]
+        class_ids_out = [p.get('class_id') for p in properties_out]
+        class_names_out = [p.get('class_name') for p in properties_out]
+        scores_out_single = [p.get('score') for p in properties_out]
+        scores_out_mult = [p.get('scores') for p in properties_out]
+        self.assertListEqual(class_ids_out, class_ids_in)
+        self.assertListEqual(class_names_out, class_names_in)
+        self.assertListEqual(scores_out_single, [0.9, None])
+        self.assertListEqual(scores_out_mult, [None, [0.2, 0.8]])
+        boxes_out = [Box.from_shapely(g) for g in geojson_to_geoms(geojson)]
+        for box_in, box_out in zip(boxes_in, boxes_out):
+            self.assertEqual(box_in, box_out)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/evaluation/test_semantic_segmentation_evaluation.py
+++ b/tests/core/evaluation/test_semantic_segmentation_evaluation.py
@@ -13,7 +13,6 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         class_config = ClassConfig(names=['one', 'two'])
         class_config.update()
         class_config.ensure_null_class()
-        null_class_id = class_config.null_class_id
 
         gt_array = np.zeros((4, 4, 1), dtype=np.uint8)
         gt_array[2, 2, 0] = 1
@@ -21,14 +20,14 @@ class TestSemanticSegmentationEvaluation(unittest.TestCase):
         gt_raster = MockRasterSource([0], 1)
         gt_raster.set_raster(gt_array)
         gt_label_source = SemanticSegmentationLabelSource(
-            gt_raster, null_class_id)
+            gt_raster, class_config)
 
         p_array = np.zeros((4, 4, 1), dtype=np.uint8)
         p_array[1, 1, 0] = 1
         p_raster = MockRasterSource([0], 1)
         p_raster.set_raster(p_array)
         p_label_source = SemanticSegmentationLabelSource(
-            p_raster, null_class_id)
+            p_raster, class_config)
 
         eval = SemanticSegmentationEvaluation(class_config)
         eval.compute(gt_label_source.get_labels(), p_label_source.get_labels())

--- a/tests/core/evaluation/test_semantic_segmentation_evaluator.py
+++ b/tests/core/evaluation/test_semantic_segmentation_evaluator.py
@@ -29,7 +29,6 @@ class TestSemanticSegmentationEvaluator(unittest.TestCase):
         self.class_config = ClassConfig(names=['one', 'two'])
         self.class_config.update()
         self.class_config.ensure_null_class()
-        self.null_class_id = self.class_config.null_class_id
 
     def tearDown(self):
         self.tmp_dir.cleanup()
@@ -44,13 +43,13 @@ class TestSemanticSegmentationEvaluator(unittest.TestCase):
         gt_rs = MockRasterSource(channel_order=[0], num_channels_raw=1)
         gt_arr = np.full((10, 10, 1), class_id)
         gt_rs.set_raster(gt_arr)
-        gt_ls = SemanticSegmentationLabelSource(gt_rs, self.null_class_id)
+        gt_ls = SemanticSegmentationLabelSource(gt_rs, self.class_config)
 
         pred_rs = MockRasterSource(channel_order=[0], num_channels_raw=1)
         pred_arr = np.zeros((10, 10, 1))
         pred_arr[5:10, :, :] = 1
         pred_rs.set_raster(pred_arr)
-        pred_ls = SemanticSegmentationLabelSource(pred_rs, self.null_class_id)
+        pred_ls = SemanticSegmentationLabelSource(pred_rs, self.class_config)
 
         return Scene(scene_id, rs, gt_ls, pred_ls)
 
@@ -90,7 +89,7 @@ class TestSemanticSegmentationEvaluator(unittest.TestCase):
                 ]),
             rasterizer_config=RasterizerConfig(background_class_id=1))
         gt_rs = config.build(self.class_config, crs_transformer, extent)
-        gt_ls = SemanticSegmentationLabelSource(gt_rs, self.null_class_id)
+        gt_ls = SemanticSegmentationLabelSource(gt_rs, self.class_config)
 
         config = RasterizedSourceConfig(
             vector_source=GeoJSONVectorSourceConfig(
@@ -100,7 +99,7 @@ class TestSemanticSegmentationEvaluator(unittest.TestCase):
                 ]),
             rasterizer_config=RasterizerConfig(background_class_id=1))
         pred_rs = config.build(self.class_config, crs_transformer, extent)
-        pred_ls = SemanticSegmentationLabelSource(pred_rs, self.null_class_id)
+        pred_ls = SemanticSegmentationLabelSource(pred_rs, self.class_config)
         pred_ls.vector_outputs = [
             PolygonVectorOutputConfig(
                 uri=pred_uri, denoise=0, class_id=class_id)

--- a/tests/core/test_box.py
+++ b/tests/core/test_box.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 from shapely.geometry import box as ShapelyBox
 
-from rastervision.core.box import Box, BoxSizeError
+from rastervision.core.box import Box, BoxSizeError, RioWindow
 
 np.random.seed(1)
 
@@ -155,6 +155,19 @@ class TestBox(unittest.TestCase):
         self.assertEqual(
             (rio_w.col_off, rio_w.row_off, rio_w.width, rio_w.height),
             (x, y, w, h))
+
+    def test_from_rasterio(self):
+        rio_w = RioWindow.from_slices((10, 20), (1, 2))
+        box = Box.from_rasterio(rio_w)
+        self.assertEqual(box, Box(10, 1, 20, 2))
+
+    def test_intersects(self):
+        box = Box(0, 0, 10, 10)
+        self.assertTrue(box.intersects(Box(0, 5, 10, 15)))
+        self.assertTrue(box.intersects(Box(-5, 0, 5, 10)))
+        self.assertFalse(box.intersects(Box(20, 20, 30, 30)))
+        self.assertFalse(box.intersects(Box(0, 10, 10, 20)))
+        self.assertFalse(box.intersects(Box(10, 0, 20, 10)))
 
     def test_translate(self):
         box = Box(*np.random.randint(100, size=4))

--- a/tests/core/test_box.py
+++ b/tests/core/test_box.py
@@ -227,40 +227,130 @@ class TestBox(unittest.TestCase):
         self.assertIsNot(copy_box, self.box)
         self.assertEqual(copy_box, self.box)
 
+    def test_pad(self):
+        box_in = Box(10, 10, 20, 20)
+        box_out = box_in.pad(ymin=20, xmin=20, ymax=20, xmax=20)
+        self.assertEqual(box_out, Box(-10, -10, 40, 40))
+
+        box_in = Box(10, 10, 20, 20)
+        box_out = box_in.pad(ymin=20, xmin=0, ymax=0, xmax=20)
+        self.assertEqual(box_out, Box(-10, 10, 20, 40))
+
     def test_get_windows(self):
-        extent = Box(0, 0, 100, 100)
-        windows = list(extent.get_windows(10, 10))
-        self.assertEqual(len(windows), 100)
+        box = Box(0, 0, 10, 10)
+        self.assertRaises(ValueError, lambda: box.get_windows(-1, 1))
+        self.assertRaises(ValueError, lambda: box.get_windows(1, -1))
+        self.assertRaises(ValueError, lambda: box.get_windows(0, 1))
+        self.assertRaises(ValueError, lambda: box.get_windows(1, 0))
+        self.assertRaises(ValueError,
+                          lambda: box.get_windows(1, 1, padding=-1))
 
         extent = Box(0, 0, 100, 100)
-        windows = list(extent.get_windows(10, 5))
-        self.assertEqual(len(windows), 400)
+        windows = extent.get_windows(size=10, stride=10)
+        self.assertEqual(len(windows), 10 * 10)
+
+        extent = Box(0, 0, 100, 100)
+        windows = extent.get_windows(size=10, stride=5)
+        self.assertEqual(len(windows), 20 * 20)
 
         extent = Box(0, 0, 20, 20)
-        windows = set(
-            [window.tuple_format() for window in extent.get_windows(10, 10)])
-        expected_windows = [
+        windows = set(extent.get_windows(size=10, stride=10))
+        expected_windows = set([
             Box.make_square(0, 0, 10),
-            Box.make_square(10, 0, 10),
             Box.make_square(0, 10, 10),
+            Box.make_square(10, 0, 10),
             Box.make_square(10, 10, 10)
-        ]
-        expected_windows = set(
-            [window.tuple_format() for window in expected_windows])
+        ])
         self.assertSetEqual(windows, expected_windows)
 
         extent = Box(10, 10, 20, 20)
-        windows = set(
-            [window.tuple_format() for window in extent.get_windows(6, 6)])
-        expected_windows = [
+        windows = set(extent.get_windows(size=6, stride=6))
+        expected_windows = set([
             Box.make_square(10, 10, 6),
             Box.make_square(10, 16, 6),
             Box.make_square(16, 10, 6),
             Box.make_square(16, 16, 6)
-        ]
-        expected_windows = set(
-            [window.tuple_format() for window in expected_windows])
+        ])
         self.assertSetEqual(windows, expected_windows)
+
+        extent = Box(0, 0, 10, 10)
+        args = dict(size=5, stride=3, padding=1, pad_direction='end')
+        windows = set(extent.get_windows(**args))
+        expected_windows = set([
+            Box(0, 0, 5, 5),
+            Box(0, 3, 5, 8),
+            Box(0, 6, 5, 11),
+            Box(3, 0, 8, 5),
+            Box(3, 3, 8, 8),
+            Box(3, 6, 8, 11),
+            Box(6, 0, 11, 5),
+            Box(6, 3, 11, 8),
+            Box(6, 6, 11, 11),
+        ])
+        arg_str = ', '.join(f'{k}={v!r}' for k, v in args.items())
+        msg = f'{extent!r}.get_windows({arg_str})'
+        self.assertSetEqual(windows, expected_windows, msg=msg)
+
+        extent = Box(0, 0, 10, 10)
+        args = dict(size=5, stride=3, padding=1, pad_direction='start')
+        windows = set(extent.get_windows(**args))
+        expected_windows = set([
+            Box(-1, -1, 4, 4),
+            Box(-1, 2, 4, 7),
+            Box(-1, 5, 4, 10),
+            Box(2, -1, 7, 4),
+            Box(2, 2, 7, 7),
+            Box(2, 5, 7, 10),
+            Box(5, -1, 10, 4),
+            Box(5, 2, 10, 7),
+            Box(5, 5, 10, 10),
+        ])
+        arg_str = ', '.join(f'{k}={v!r}' for k, v in args.items())
+        msg = f'{extent!r}.get_windows({arg_str})'
+        self.assertSetEqual(windows, expected_windows, msg=msg)
+
+        extent = Box(0, 0, 10, 10)
+        args = dict(size=5, stride=3, padding=1, pad_direction='both')
+        windows = set(extent.get_windows(**args))
+        expected_windows = set([
+            Box(-1, -1, 4, 4),
+            Box(-1, 2, 4, 7),
+            Box(-1, 5, 4, 10),
+            Box(2, -1, 7, 4),
+            Box(2, 2, 7, 7),
+            Box(2, 5, 7, 10),
+            Box(5, -1, 10, 4),
+            Box(5, 2, 10, 7),
+            Box(5, 5, 10, 10),
+        ])
+        arg_str = ', '.join(f'{k}={v!r}' for k, v in args.items())
+        msg = f'{extent!r}.get_windows({arg_str})'
+        self.assertSetEqual(windows, expected_windows, msg=msg)
+
+        extent = Box(0, 0, 10, 10)
+        args = dict(size=5, stride=3, padding=2, pad_direction='both')
+        windows = set(extent.get_windows(**args))
+        expected_windows = set([
+            Box(-2, -2, 3, 3),
+            Box(-2, 1, 3, 6),
+            Box(-2, 4, 3, 9),
+            Box(-2, 7, 3, 12),
+            Box(1, -2, 6, 3),
+            Box(1, 1, 6, 6),
+            Box(1, 4, 6, 9),
+            Box(1, 7, 6, 12),
+            Box(4, -2, 9, 3),
+            Box(4, 1, 9, 6),
+            Box(4, 4, 9, 9),
+            Box(4, 7, 9, 12),
+            Box(7, -2, 12, 3),
+            Box(7, 1, 12, 6),
+            Box(7, 4, 12, 9),
+            Box(7, 7, 12, 12),
+        ])
+        arg_str = ', '.join(f'{k}={v!r}' for k, v in args.items())
+        msg = f'{extent!r}.get_windows({arg_str})'
+        self.assertSetEqual(windows, expected_windows, msg=msg)
 
     def test_unpacking(self):
         box = Box(1, 2, 3, 4)

--- a/tests/core/test_box.py
+++ b/tests/core/test_box.py
@@ -176,13 +176,15 @@ class TestBox(unittest.TestCase):
             box.translate(dy, dx),
             Box(box.ymin + dy, box.xmin + dx, box.ymax + dy, box.xmax + dx))
 
-    def test_to_extent_coords(self):
-        box = Box(0, 0, 10, 10)
+    def test_shift_origin(self):
         extent = Box(5, 5, 8, 8)
-        self.assertEqual(
-            box.to_extent_coords(extent),
-            Box(box.ymin + extent.ymin, box.xmin + extent.xmin,
-                box.ymax + extent.ymin, box.xmax + extent.xmin))
+        box = Box(0, 0, 10, 10)
+        self.assertEqual(box.shift_origin(extent), Box(5, 5, 15, 15))
+
+    def test_to_offsets(self):
+        outer = Box(10, 10, 20, 20)
+        inner = Box(15, 15, 18, 18)
+        self.assertEqual(inner.to_offsets(outer), Box(5, 5, 8, 8))
 
     def test_to_shapely(self):
         bounds = self.box.to_shapely().bounds
@@ -195,13 +197,17 @@ class TestBox(unittest.TestCase):
         self.assertEqual(output_square, square)
         self.assertEqual(output_square.width, output_square.height)
 
-    def test_make_eroded(self):
+    def test_erode(self):
         max_extent = Box.make_square(0, 0, 10)
         box = Box(1, 1, 3, 4)
         buffer_size = erosion_size = 1
-        eroded_box = box.buffer(buffer_size, max_extent) \
-                        .make_eroded(erosion_size)
+        eroded_box = box.buffer(buffer_size, max_extent).erode(erosion_size)
         self.assertEqual(eroded_box, box)
+
+    def test_center_crop(self):
+        box_in = Box(0, 0, 10, 10)
+        box_out = box_in.center_crop(2, 4)
+        self.assertEqual(box_out, Box(2, 4, 8, 6))
 
     def test_buffer(self):
         buffer_size = 1

--- a/tests/pytorch_learner/dataset/test_dataset.py
+++ b/tests/pytorch_learner/dataset/test_dataset.py
@@ -47,7 +47,11 @@ class TestGeoDatasetFromURIs(unittest.TestCase):
 
         # no labels
         ds = SemanticSegmentationSlidingWindowGeoDataset.from_uris(
-            class_config=class_config, image_uri=image_uri, size=10, stride=10)
+            class_config=class_config,
+            image_uri=image_uri,
+            size=10,
+            stride=10,
+            padding=0)
         x, y = ds[0]
         torch.testing.assert_allclose(x * 255, torch.ones_like(x))
         self.assertTrue(np.isnan(y.numpy()))
@@ -58,7 +62,8 @@ class TestGeoDatasetFromURIs(unittest.TestCase):
             image_uri=image_uri,
             label_raster_uri=image_uri,
             size=10,
-            stride=10)
+            stride=10,
+            padding=0)
         x, y = ds[0]
         torch.testing.assert_allclose(x * 255, torch.ones_like(x))
         self.assertAlmostEqual(y.float().mean(), 1)
@@ -69,7 +74,8 @@ class TestGeoDatasetFromURIs(unittest.TestCase):
             image_uri=image_uri,
             label_vector_uri=label_vector_uri,
             size=10,
-            stride=10)
+            stride=10,
+            padding=0)
         x, y = ds[0]
         torch.testing.assert_allclose(x * 255, torch.ones_like(x))
         torch.testing.assert_allclose(y, torch.ones_like(y))
@@ -84,7 +90,11 @@ class TestGeoDatasetFromURIs(unittest.TestCase):
 
         # no labels
         ds = ClassificationSlidingWindowGeoDataset.from_uris(
-            class_config=class_config, image_uri=image_uri, size=10, stride=10)
+            class_config=class_config,
+            image_uri=image_uri,
+            size=10,
+            stride=10,
+            padding=0)
         x, y = ds[0]
         torch.testing.assert_allclose(x * 255, torch.ones_like(x))
         self.assertTrue(np.isnan(y.numpy()))
@@ -96,7 +106,8 @@ class TestGeoDatasetFromURIs(unittest.TestCase):
             label_vector_uri=label_vector_uri,
             label_source_kw=dict(background_class_id=0),
             size=10,
-            stride=10)
+            stride=10,
+            padding=0)
         x, y = ds[0]
         torch.testing.assert_allclose(x * 255, torch.ones_like(x))
         torch.testing.assert_allclose(y, torch.ones_like(y))
@@ -111,7 +122,11 @@ class TestGeoDatasetFromURIs(unittest.TestCase):
 
         # no labels
         ds = ObjectDetectionSlidingWindowGeoDataset.from_uris(
-            class_config=class_config, image_uri=image_uri, size=10, stride=10)
+            class_config=class_config,
+            image_uri=image_uri,
+            size=10,
+            stride=10,
+            padding=0)
         x, y = ds[0]
         torch.testing.assert_allclose(x * 255, torch.ones_like(x))
         self.assertTrue(np.isnan(y.numpy()))
@@ -122,7 +137,8 @@ class TestGeoDatasetFromURIs(unittest.TestCase):
             image_uri=image_uri,
             label_vector_uri=label_vector_uri,
             size=20,
-            stride=20)
+            stride=20,
+            padding=0)
         x, y = ds[0]
         bboxes = y.get_field('boxes')
         class_ids = y.get_field('class_ids')

--- a/tests/pytorch_learner/test_data_config.py
+++ b/tests/pytorch_learner/test_data_config.py
@@ -416,7 +416,8 @@ class TestGeoDataConfig(unittest.TestCase):
             test_scenes=[make_scene(nchannels, nclasses) for _ in range(0)])
         data_cfg = SemanticSegmentationGeoDataConfig(
             scene_dataset=dataset_cfg,
-            window_opts=GeoDataWindowConfig(size=chip_sz, stride=chip_sz),
+            window_opts=GeoDataWindowConfig(
+                size=chip_sz, stride=chip_sz, padding=0),
             class_names=class_config.names,
             class_colors=class_config.colors,
             img_sz=img_sz,


### PR DESCRIPTION
## Overview

This PR
- Allow cropping edges of predicted chips in SS to reduce boundary artifacts.
  - See `SemanticSegmentationLabels.from_predictions()` and `SemanticSegmentationPredictOptions`.
  - This can be used in conjunction with existing merging functionality for even better results (see images below).
- Adds a `Labels.save()` convenience method, obviating the need to separately instantiate a `LableStore`.
- Re-implements `SemanticSegmentationDiscreteLabels` such that it stores data in an array instead of a dict. This makes it more similar to `SemanticSegmentationSmoothLabels`.
    - This array stores the counts for how many times each pixel has been classified as each class, which allows merging overlapping chips in a principled way.
    - This makes it more memory efficient if using `stride` < `chip_sz`.
    - It also makes `SemanticSegmentationEvaluation` less brittle since the gt and pred labels no longer need to have the same dict keys.

Minor changes:
- `RasterioSource` now throws warnings during initialization about sub-optimal raster tiling.
- Removed wasteful calls to `SemanticSegmentationLabelSource.enough_target_pixles()` with target pixels set to _all_ class IDs.
- Other minor refactoring and type hint improvements.
- Add/update unit tests.

**Cropping demo**
`s3://raster-vision-ahassan/rvtest/pr_1486/predict/`

![ss_pred_crop_building](https://user-images.githubusercontent.com/13014700/194561610-ad3624d6-82c0-41e2-994e-7cf64a072157.png)
![ss_pred_crop_trees](https://user-images.githubusercontent.com/13014700/194561618-22bc05f1-46ae-4b48-ac8a-a126cd028de3.png)


### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions
- See new/updated unit tests.
- Examine cropping results:
  ```py
  rs_no_overlap = RasterioSource('s3://raster-vision-ahassan/rvtest/pr_1486/predict/no_crop_2/2_12/scores.tif')
  rs_no_crop = RasterioSource('s3://raster-vision-ahassan/rvtest/pr_1486/predict/no_crop/2_12/scores.tif')
  rs_crop = RasterioSource('s3://raster-vision-ahassan/rvtest/pr_1486/predict/crop_auto/2_12/scores.tif')
  rs_crop_merge = RasterioSource('s3://raster-vision-ahassan/rvtest/pr_1486/predict/overlap_100_crop_25/2_12/scores.tif')
  ```
