### PR TITLE
Fix #1430

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -71,14 +71,14 @@ class ObjectDetectionGeoDataWindowConfig(GeoDataWindowConfig):
         False,
         description='Clip bounding boxes to window limits when retrieving '
         'labels for a window.')
-    neg_ratio: float = Field(
-        1.0,
+    neg_ratio: Optional[float] = Field(
+        None,
         description='The ratio of negative chips (those containing no '
         'bounding boxes) to positive chips. This can be useful if the '
         'statistics of the background is different in positive chips. For '
         'example, in car detection, the positive chips will always contain '
         'roads, but no examples of rooftops since cars tend to not be near '
-        'rooftops. Defaults to 1.0.')
+        'rooftops. Defaults to None.')
     neg_ioa_thresh: float = Field(
         0.2,
         description='A window will be considered negative if its max IoA with '

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-flake8==4.0.*
+flake8==5.0.*
 moto==3.1.5
 coverage==5.5
 codecov==2.1.12


### PR DESCRIPTION
Also make it None by default.

## Overview

This PR 
- makes `ObjectDetectionGeoDataWindowConfig.neg_ratio` optional
- makes `ObjectDetectionGeoDataWindowConfig.neg_ratio` `None` by default
- Bumps `flake8` to `5.0.*` to fix a CI error

### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness


Closes #1430 
