### PR TITLE
Fix #1517

### DIFF
--- a/rastervision_core/rastervision/core/rv_pipeline/__init__.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     SemanticSegmentationPredictOptions.__name__,
     SemanticSegmentationWindowMethod.__name__,
     ObjectDetection.__name__,
+    ObjectDetectionConfig.__name__,
     ObjectDetectionChipOptions.__name__,
     ObjectDetectionChipOptions.__name__,
     ObjectDetectionPredictOptions.__name__,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification.py
@@ -65,7 +65,7 @@ class PyTorchChipClassification(PyTorchLearnerBackend):
         # Important to use self.learner.cfg.data instead of
         # self.learner_cfg.data because of the updates
         # Learner.from_model_bundle() makes to the custom transforms.
-        base_tf, _ = self.learner_cfg.data.get_data_transforms()
+        base_tf, _ = self.learner.cfg.data.get_data_transforms()
         ds = ClassificationSlidingWindowGeoDataset(
             scene, size=chip_sz, stride=stride, transform=base_tf)
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
@@ -114,7 +114,7 @@ class PyTorchObjectDetection(PyTorchLearnerBackend):
         # Important to use self.learner.cfg.data instead of
         # self.learner_cfg.data because of the updates
         # Learner.from_model_bundle() makes to the custom transforms.
-        base_tf, _ = self.learner_cfg.data.get_data_transforms()
+        base_tf, _ = self.learner.cfg.data.get_data_transforms()
         ds = ObjectDetectionSlidingWindowGeoDataset(
             scene, size=chip_sz, stride=stride, transform=base_tf)
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable, Iterator, Optional
+from typing import TYPE_CHECKING, Dict, Iterator, Optional
 from os.path import join, basename
 import uuid
 
@@ -10,9 +10,9 @@ from rastervision.pytorch_learner.dataset import (
     ObjectDetectionSlidingWindowGeoDataset)
 
 if TYPE_CHECKING:
+    import numpy as np
     from rastervision.core.data import Scene
     from rastervision.core.data_sample import DataSample
-    from rastervision.pytorch_learner.object_detection_utils import BoxList
 
 
 class PyTorchObjectDetectionSampleWriter(PyTorchLearnerSampleWriter):
@@ -118,7 +118,7 @@ class PyTorchObjectDetection(PyTorchLearnerBackend):
         ds = ObjectDetectionSlidingWindowGeoDataset(
             scene, size=chip_sz, stride=stride, transform=base_tf)
 
-        predictions: Iterator[Iterable[BoxList]] = (
+        predictions: Iterator[Dict[str, 'np.ndarray']] = (
             self.learner.predict_dataset(
                 ds,
                 raw_out=True,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
@@ -51,6 +51,7 @@ __all__ = [
     ObjectDetectionDataConfig.__name__,
     ObjectDetectionGeoDataConfig.__name__,
     ObjectDetectionImageDataConfig.__name__,
+    ObjectDetectionGeoDataWindowConfig.__name__,
     RegressionDataConfig.__name__,
     RegressionGeoDataConfig.__name__,
     RegressionImageDataConfig.__name__,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -315,8 +315,11 @@ class Learner(ABC):
         """Setup self.model.
 
         Args:
-            model_def_path (str, optional): Model definition path. Will be
-            available when loading from a bundle. Defaults to None.
+            model_weights_path (Optional[str], optional): Path to model
+                weights. Will be available when loading from a bundle.
+                Defaults to None.
+            model_def_path (Optional[str], optional): Path to model definition.
+                Will be available when loading from a bundle. Defaults to None.
         """
         if self.model is not None:
             self.model.to(self.device)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
@@ -54,7 +54,7 @@ class ObjectDetectionLearner(Learner):
                 model, ignored_output_inds=[0, num_classes + 1])
 
         self.model.to(self.device)
-        self.load_init_weights()
+        self.load_init_weights(model_weights_path)
 
     def build_metric_names(self):
         metric_names = [


### PR DESCRIPTION
## Overview

This is the same fix as #1441. That PR overlooked applying it to the `ObjectDetectionLearner`.

### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

See note in #1441.

## Testing Instructions

```sh
rastervision predict \
    "s3://raster-vision-lf-dev/examples/10-27-2022a/output/cowc-potsdam-od/bundle/model-bundle.zip" \
    "s3://raster-vision-raw-data/isprs-potsdam/4_Ortho_RGBIR/top_potsdam_2_13_RGBIR.tif" \
    "./preds.json"
```

Fixes #1517
