### PR TITLE
WIP: Build + publish ARM64 Docker image

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,11 +10,18 @@ jobs:
     strategy:
       matrix:
         image_type: [pytorch]
+        platform: [amd64, arm64]
     env:
       DOCKER_BUILDKIT: 1
       IMAGE_TYPE: ${{ matrix.image_type }}
+      PLATFORM: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64'
 
       - run: ./scripts/cibuild
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,11 @@ jobs:
     strategy:
       matrix:
         image_type: [pytorch]
+        platform: [amd64, arm64]
     env:
       DOCKER_BUILDKIT: 1
       IMAGE_TYPE: ${{ matrix.image_type }}
+      PLATFORM: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu${UBUNTU_VERSION}
 # ImportError: libGL.so.1: cannot open shared object file: No such file or directory
 # See https://stackoverflow.com/questions/55313610/importerror-libgl-so-1-cannot-open-shared-object-file-no-such-file-or-directo
 RUN apt-get update && \
-   apt-get install -y wget=1.* build-essential libgl1 && \
-   apt-get autoremove && apt-get autoclean && apt-get clean
+    apt-get install -y wget=1.* build-essential libgl1 && \
+    apt-get autoremove && apt-get autoclean && apt-get clean
 
 ARG PYTHON_VERSION=3.9
 ARG TARGETPLATFORM
@@ -21,9 +21,9 @@ RUN case ${TARGETPLATFORM} in \
 
 # Install Python and conda
 RUN wget -q -O ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(cat /root/linux_arch).sh && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
 ENV PATH /opt/conda/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
 RUN conda install -y python=${PYTHON_VERSION}
@@ -38,7 +38,7 @@ ENV GDAL_DATA=/opt/conda/lib/python${PYTHON_VERSION}/site-packages/rasterio/gdal
 # bash: /opt/conda/lib/libtinfo.so.6: no version information available (required by bash)
 # See https://askubuntu.com/questions/1354890/what-am-i-doing-wrong-in-conda
 RUN rm /opt/conda/lib/libtinfo.so.6 && \
-   ln -s /lib/$(cat /root/linux_arch)-linux-gnu/libtinfo.so.6 /opt/conda/lib/libtinfo.so.6
+    ln -s /lib/$(cat /root/linux_arch)-linux-gnu/libtinfo.so.6 /opt/conda/lib/libtinfo.so.6
 
 # needed for jupyter lab extensions
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \

--- a/docker/build
+++ b/docker/build
@@ -21,5 +21,13 @@ then
         exit
     fi
 
-    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --build-arg CUDA_VERSION="11.3.1" -t raster-vision-pytorch -f Dockerfile .
+    PLATFORM="amd64"
+    if [ "${1:-}" = "--arm64" ]
+    then
+        PLATFORM="arm64"
+    fi
+
+    DOCKER_BUILDKIT=1 docker build \
+        --platform linux/${PLATFORM} --build-arg CUDA_VERSION="11.3.1" \
+        -t raster-vision-pytorch-${PLATFORM} -f Dockerfile .
 fi

--- a/docker/ecr_publish
+++ b/docker/ecr_publish
@@ -21,7 +21,7 @@ then
         exit
     fi
 
-    IMAGE_NAME="raster-vision-pytorch:latest"
+    IMAGE_NAME="raster-vision-pytorch-amd64:latest"
     ACCOUNT_ID=$(aws sts get-caller-identity --output text --query 'Account')
     AWS_REGION="us-east-1"
 

--- a/docker/run
+++ b/docker/run
@@ -45,7 +45,7 @@ All arguments after above options are passed to 'docker run'.
 "
 }
 
-IMAGE="raster-vision-pytorch"
+IMAGE="raster-vision-pytorch-amd64"
 RASTER_VISION_DATA_DIR="${RASTER_VISION_DATA_DIR:-${REPO_ROOT}/data}"
 RASTER_VISION_NOTEBOOK_DIR="${RASTER_VISION_NOTEBOOK_DIR:-${REPO_ROOT}/notebooks}"
 
@@ -63,6 +63,10 @@ do
         ;;
         --aws)
         AWS="-e AWS_PROFILE=${AWS_PROFILE:-default} -v ${HOME}/.aws:/root/.aws:ro"
+        shift # past argument
+        ;;
+        --arm64)
+        IMAGE="raster-vision-pytorch-arm64"
         shift # past argument
         ;;
         --tensorboard)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -104,6 +104,10 @@ class Learner(ABC):
     If instantiated with training=False, the training apparatus (loss,
     optimizer, scheduler, logging, etc.) will not be set up and the model will
     be put into eval mode.
+
+    Note that various training and prediction methods have the side effect of
+    putting Learner.model into training or eval mode. No attempt is made to put the
+    model back into the mode it was previously in.
     """
 
     def __init__(self,

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -17,11 +17,18 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "${1:-}" == "--help" ]]; then
         usage
     else
-        docker build \
-            --platform linux/amd64 --build-arg CUDA_VERSION="11.3.1" \
-            -t "raster-vision-${IMAGE_TYPE}" \
-            -f Dockerfile .
-
-        ./scripts/test
+        if [[ "${PLATFORM}" == "arm64" ]]; then
+            docker build \
+                --platform linux/arm64 --build-arg CUDA_VERSION="11.3.1" \
+                -t "raster-vision-${IMAGE_TYPE}-arm64" \
+                -f Dockerfile .
+            ./scripts/test
+        else
+            docker build \
+                --platform linux/amd64 --build-arg CUDA_VERSION="11.3.1" \
+                -t "raster-vision-${IMAGE_TYPE}-amd64" \
+                -f Dockerfile .
+            ./scripts/test
+        fi
     fi
 fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -33,18 +33,18 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 
         if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
             # On master, use the current SHA and latest
-            docker tag "raster-vision-${IMAGE_TYPE}" \
-                "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${GITHUB_SHA}"
-            docker push "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${GITHUB_SHA}"
+            docker tag "raster-vision-${IMAGE_TYPE}-${PLATFORM}" \
+                "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${PLATFORM}-${GITHUB_SHA}"
+            docker push "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${PLATFORM}-${GITHUB_SHA}"
 
-            docker tag "raster-vision-${IMAGE_TYPE}" \
-                "quay.io/azavea/raster-vision:${IMAGE_TYPE}-latest"
-            docker push "quay.io/azavea/raster-vision:${IMAGE_TYPE}-latest"
+            docker tag "raster-vision-${IMAGE_TYPE}-${PLATFORM}" \
+                "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${PLATFORM}-latest"
+            docker push "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${PLATFORM}-latest"
         else
             # For everything else, use the branch or tag name
-            docker tag "raster-vision-${IMAGE_TYPE}" \
-                "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${GITHUB_REF##*/}"
-            docker push "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${GITHUB_REF##*/}"
+            docker tag "raster-vision-${IMAGE_TYPE}-${PLATFORM}" \
+                "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${PLATFORM}-${GITHUB_REF##*/}"
+            docker push "quay.io/azavea/raster-vision:${IMAGE_TYPE}-${PLATFORM}-${GITHUB_REF##*/}"
         fi
     fi
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -21,17 +21,17 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
             # Execute test suites
             docker run \
                 --rm -t \
-                "raster-vision-${IMAGE_TYPE}" \
+                "raster-vision-${IMAGE_TYPE}-${PLATFORM}" \
                 /opt/src/scripts/style_tests
             docker run \
                 -w "/opt/src" \
                 -v "$(pwd):/opt/src" \
                 --rm -t \
-                "raster-vision-${IMAGE_TYPE}" \
+                "raster-vision-${IMAGE_TYPE}-${PLATFORM}" \
                 /opt/src/scripts/unit_tests
             docker run \
                 --rm -t \
-                "raster-vision-${IMAGE_TYPE}" \
+                "raster-vision-${IMAGE_TYPE}-${PLATFORM}" \
                 /opt/src/scripts/integration_tests
 
             # Create new coverage reports
@@ -39,7 +39,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
                 -w "/opt/src" \
                 -v "$(pwd):/opt/src" \
                 --rm -t \
-                "raster-vision-${IMAGE_TYPE}" \
+                "raster-vision-${IMAGE_TYPE}-${PLATFORM}" \
                 coverage xml
         else
             # Local test suite runs against pytorch image by default


### PR DESCRIPTION
This PR adds the ability to build and use an ARM64 Docker image by passing the `--arm64` flag to `./docker/build` and then  `./docker/run`. It also changes the CI matrix so there are runs for `arm64` and `amd64` that build and publish the respective Docker images under the names `raster-vision:pytorch-arm64-<sha>` and `raster-vision:pytorch-amd64-<sha>`

This is being closed without merging because it isn't practical right now without having an arm64 runner. In the future when #1539 is completed we can resurrect this.

Closes #1481 
