### PR TITLE
Add option to build ARM64 Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
+ARG UBUNTU_VERSION=20.04
 ARG CUDA_VERSION
-FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu${UBUNTU_VERSION}
 
 # wget: needed below to install conda
 # build-essential: installs gcc which is needed to install some deps like rasterio
@@ -7,30 +8,37 @@ FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu20.04
 # ImportError: libGL.so.1: cannot open shared object file: No such file or directory
 # See https://stackoverflow.com/questions/55313610/importerror-libgl-so-1-cannot-open-shared-object-file-no-such-file-or-directo
 RUN apt-get update && \
-   apt-get install -y wget=1.* build-essential libgl1 && \
-   apt-get autoremove && apt-get autoclean && apt-get clean
+    apt-get install -y wget=1.* build-essential libgl1 && \
+    apt-get autoremove && apt-get autoclean && apt-get clean
+
+ARG PYTHON_VERSION=3.9
+ARG TARGETPLATFORM
+
+RUN case ${TARGETPLATFORM} in \
+         "linux/arm64")  LINUX_ARCH=aarch64  ;; \
+         *)              LINUX_ARCH=x86_64   ;; \
+    esac && echo ${LINUX_ARCH} > /root/linux_arch
 
 # Install Python and conda
-# Using Python 3.9 since that is the highest version supported by miniconda.
-RUN wget -q -O ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh
+RUN wget -q -O ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(cat /root/linux_arch).sh && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
 ENV PATH /opt/conda/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
-RUN conda install -y python=3.9
+RUN conda install -y python=${PYTHON_VERSION}
 RUN python -m pip install --upgrade pip
 
 # We need to install GDAL first to install Rasterio on non-AMD64 architectures.
 # The Rasterio wheels contain GDAL in them, but they are only built for AMD64 now.
 RUN conda install -y -c conda-forge gdal=3.5.2
-ENV GDAL_DATA=/opt/conda/lib/python3.9/site-packages/rasterio/gdal_data/
+ENV GDAL_DATA=/opt/conda/lib/python${PYTHON_VERSION}/site-packages/rasterio/gdal_data/
 
 # This is to prevent the following error when starting the container.
 # bash: /opt/conda/lib/libtinfo.so.6: no version information available (required by bash)
 # See https://askubuntu.com/questions/1354890/what-am-i-doing-wrong-in-conda
 RUN rm /opt/conda/lib/libtinfo.so.6 && \
-   ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 /opt/conda/lib/libtinfo.so.6
+    ln -s /lib/$(cat /root/linux_arch)-linux-gnu/libtinfo.so.6 /opt/conda/lib/libtinfo.so.6
 
 # needed for jupyter lab extensions
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
@@ -80,8 +88,9 @@ RUN pip install -r docs/requirements.txt
 
 # Install pandoc, needed for rendering notebooks
 # Get latest release link from here: https://github.com/jgm/pandoc/releases
-RUN wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb
-RUN dpkg -i pandoc-2.19.2-1-amd64.deb && rm pandoc-2.19.2-1-amd64.deb
+ARG TARGETARCH
+RUN wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-${TARGETARCH}.deb && \
+    dpkg -i pandoc-2.19.2-1-${TARGETARCH}.deb && rm pandoc-2.19.2-1-${TARGETARCH}.deb
 #########################
 
 # Fix CI problem by pinning pyopenssl version
@@ -118,5 +127,12 @@ COPY ./rastervision_core/ /opt/src/rastervision_core/
 COPY ./rastervision_pytorch_learner/ /opt/src/rastervision_pytorch_learner/
 COPY ./rastervision_pytorch_backend/ /opt/src/rastervision_pytorch_backend/
 COPY ./rastervision_gdal_vsi/ /opt/src/rastervision_gdal_vsi/
+
+# This gets rid of the following error when importing cv2 on arm64.
+# We cannot use the ENV directive since it cannot be used conditionally.
+# See https://github.com/opencv/opencv/issues/14884
+# ImportError: /lib/aarch64-linux-gnu/libGLdispatch.so.0: cannot allocate memory in static TLS block
+RUN if [${TARGETARCH} == "arm64"]; \
+    then echo "export LD_PRELOAD=/lib/$(cat /root/linux_arch)-linux-gnu/libGLdispatch.so.0:$LD_PRELOAD" >> /root/.bashrc; fi
 
 CMD ["bash"]

--- a/docker/build
+++ b/docker/build
@@ -10,6 +10,8 @@ function usage() {
     echo -n \
          "Usage: $(basename "$0")
 Build Docker images.
+
+--arm64 will build image for arm64 architecture
 "
 }
 
@@ -21,5 +23,15 @@ then
         exit
     fi
 
-    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --build-arg CUDA_VERSION="11.3.1" -t raster-vision-pytorch -f Dockerfile .
+    PLATFORM="amd64"
+    IMAGE_EXT=""
+    if [ "${1:-}" = "--arm64" ]
+    then
+        PLATFORM="arm64"
+        IMAGE_EXT="-arm64"
+    fi
+
+    DOCKER_BUILDKIT=1 docker build \
+        --platform linux/${PLATFORM} --build-arg CUDA_VERSION="11.3.1" \
+        -t raster-vision-pytorch${IMAGE_EXT} -f Dockerfile .
 fi

--- a/docker/ecr_publish
+++ b/docker/ecr_publish
@@ -21,7 +21,7 @@ then
         exit
     fi
 
-    IMAGE_NAME="raster-vision-pytorch:latest"
+    IMAGE_NAME="raster-vision-pytorch-amd64:latest"
     ACCOUNT_ID=$(aws sts get-caller-identity --output text --query 'Account')
     AWS_REGION="us-east-1"
 

--- a/docker/run
+++ b/docker/run
@@ -40,6 +40,7 @@ Options:
 --docs runs the docs server and forwards port 8000
 --debug forwards port 3000 for use with remote debugger
 --gpu use nvidia runtime
+--arm64 uses image built for arm64 architecture
 
 All arguments after above options are passed to 'docker run'.
 "
@@ -63,6 +64,10 @@ do
         ;;
         --aws)
         AWS="-e AWS_PROFILE=${AWS_PROFILE:-default} -v ${HOME}/.aws:/root/.aws:ro"
+        shift # past argument
+        ;;
+        --arm64)
+        IMAGE=${IMAGE}-arm64
         shift # past argument
         ;;
         --tensorboard)

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -31,6 +31,8 @@ After cloning the repo, you can build the Docker image using:
 
     > docker/build
 
+To build an image that can run natively on an ARM64 chip, pass the ``--arm64`` flag. This won't be necessary for most users, but if you have an ARM64 chip, like in a recent Macbook, this will speed things up greatly.
+
 Before running the container, set an environment variable to a local directory in which to store data.
 
 .. code-block:: console
@@ -50,6 +52,10 @@ This will mount the ``$RASTER_VISION_DATA_DIR`` local directory to to ``/opt/dat
     Users running under WSL2 in Windows will need to unset the ``NAME`` environment variable. For example, instead of
     ``docker/run``, you would run ``NAME='' docker/run``. By default, WSL2 sets a ``NAME`` variable that matches the network
     name of your computer. This environment variable collides with a variable in the ``docker/run`` script.
+
+.. warning::
+
+    If you have built an ARM64 image, you should pass the ``--arm64`` flag to ``docker/run``.
 
 This script also has options for forwarding AWS credentials, and running Jupyter notebooks which can be seen below.
 
@@ -75,6 +81,7 @@ This script also has options for forwarding AWS credentials, and running Jupyter
     --docs runs the docs server and forwards port 8000
     --debug forwards port 3000 for use with remote debugger
     --gpu use nvidia runtime
+    --arm64 uses image built for arm64 architecture
 
     All arguments after above options are passed to 'docker run'.
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -104,6 +104,10 @@ class Learner(ABC):
     If instantiated with training=False, the training apparatus (loss,
     optimizer, scheduler, logging, etc.) will not be set up and the model will
     be put into eval mode.
+
+    Note that various training and prediction methods have the side effect of
+    putting Learner.model into training or eval mode. No attempt is made to put the
+    model back into the mode it was previously in.
     """
 
     def __init__(self,


### PR DESCRIPTION
This PR adds the ability to build and use an ARM64 Docker image by passing the `--arm64` flag to `docker/build` and `docker/run`. Testing and publishing this image is left for future work (#1539) as it is difficult to setup an ARM64 runner at the moment.

This was tested by building the ARM64 image and running unit and integration tests and running a Jupyter notebook in it.

Closes https://github.com/azavea/raster-vision/issues/1481