### PR TITLE
Bug fix: do not zero out null class pixels

### DIFF
--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -5,8 +5,7 @@ import numpy as np
 
 from rastervision.core.box import Box
 from rastervision.core.rv_pipeline.rv_pipeline import RVPipeline
-from rastervision.core.rv_pipeline.utils import (fill_no_data,
-                                                 nodata_below_threshold)
+from rastervision.core.rv_pipeline.utils import nodata_below_threshold
 from rastervision.core.rv_pipeline.semantic_segmentation_config import (
     SemanticSegmentationWindowMethod)
 
@@ -131,14 +130,6 @@ class SemanticSegmentation(RVPipeline):
 
     def get_train_labels(self, window, scene):
         return scene.label_source.get_labels(window=window)
-
-    def post_process_sample(self, sample):
-        # Use null label for each pixel with NODATA.
-        img = sample.chip
-        label_arr = sample.labels.get_label_arr(sample.window)
-        null_class_id = self.config.dataset.class_config.null_class_id
-        sample.chip = fill_no_data(img, label_arr, null_class_id)
-        return sample
 
     def post_process_batch(self, windows, chips, labels):
         # Fill in null class for any NODATA pixels.

--- a/rastervision_core/rastervision/core/rv_pipeline/utils.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/utils.py
@@ -10,12 +10,3 @@ def nodata_below_threshold(chip: np.ndarray,
         chip = chip.sum(axis=-1)
     nodata_prop = (chip == 0).mean()
     return nodata_prop < threshold
-
-
-def fill_no_data(img: np.ndarray, label_arr: np.ndarray,
-                 null_class_id: int) -> None:
-    """ If chip has null labels, fill in those pixels with nodata. """
-    mask = label_arr == null_class_id
-    if np.any(mask):
-        img[mask, :] = 0
-    return img

--- a/rastervision_core/rastervision/core/rv_pipeline/utils.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/utils.py
@@ -1,12 +1,24 @@
-# from typing import
 import numpy as np
 
 
 def nodata_below_threshold(chip: np.ndarray,
                            threshold: float,
                            nodata_val: int = 0) -> bool:
-    """ Check if proportion of nodata pixels is below the threshold. """
+    """Check if proportion of nodata pixels is below the threshold.
+
+    Args:
+        chip (np.ndarray): Raster as (H, W) or (H, W, C) numpy array.
+        threshold (float): Threshold to check the fraction of NODATA pixels
+            against.
+        nodata_val (int, optional): Value that represents NODATA pixels.
+            Defaults to 0.
+
+    Returns:
+        bool: Whether the fraction of NODATA pixels is below the given
+            threshold.
+    """
     if len(chip.shape) == 3:
+        # (H, W, C) --> (H, W)
         chip = chip.sum(axis=-1)
-    nodata_prop = (chip == 0).mean()
+    nodata_prop = (chip == nodata_val).mean()
     return nodata_prop < threshold

--- a/tests/core/rv_pipeline/test_utils.py
+++ b/tests/core/rv_pipeline/test_utils.py
@@ -2,20 +2,10 @@ import unittest
 
 import numpy as np
 
-from rastervision.core.rv_pipeline.utils import (fill_no_data,
-                                                 nodata_below_threshold)
+from rastervision.core.rv_pipeline.utils import nodata_below_threshold
 
 
 class TestUtils(unittest.TestCase):
-    def test_fill_no_data(self):
-        chip = np.ones((256, 256, 3), dtype=np.uint8)
-        label = np.zeros((256, 256), dtype=np.uint8)
-        label[:, 128:] = 2
-
-        chip_filled = fill_no_data(chip, label, null_class_id=2)
-        self.assertEqual(chip_filled[:, 128:].sum(), 0)
-        self.assertEqual(chip_filled[:, :128].sum(), chip[:, :128].sum())
-
     def test_nodata_below_threshold(self):
         chip = np.ones((256, 256, 3), dtype=np.uint8)
         # different proportions of nodata


### PR DESCRIPTION
## Overview

This PR removes the unintuitive and unnecessary behavior of filling in zeros for null class pixels while creating training chips for semantic segmentation.

This behavior is also clearly incompatible with the use of the background class as the null class.

See discussion in #1549.

### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This also makes the chip sampling behavior more similar to `GeoDataset` behavior, and thus, connects to #1496.
