### PR TITLE
Fix #1555

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -45,4 +45,4 @@ python:
 search:
   ranking:
     # down-rank source code pages
-    '*/_modules/*': -10
+    _modules/*: -10

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,8 +107,6 @@ extensions = [
     'sphinx_gallery.load_style',
     # add a copy button to code blocks
     'sphinx_copybutton',
-    # search-as-you-type
-    'sphinx_search.extension',
 ]
 
 #########################

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,6 @@ myst-parser==0.18.1
 autodoc-pydantic==1.8.0
 nbsphinx==0.8.9
 sphinx-copybutton==0.5.*
-readthedocs-sphinx-search==0.1.*
 
 # update when this is resolved: https://github.com/spatialaudio/nbsphinx/issues/655
 sphinx-gallery>=0.10,<0.11


### PR DESCRIPTION
## Overview

This PR fixes #1555 by removing the `readthedocs-sphinx-search` sphinx extension. It also attempts to fix the pattern for matching source code pages in `.readthedocs.yml` as the previous one did not seem to work.

### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes #1555 
