### PR TITLE
Make image name handling in `docker/ecr_publish` consistent with `docker/build`

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -8,9 +8,11 @@ fi
 
 function usage() {
     echo -n \
-         "Usage: $(basename "$0")
+         "Usage: $(basename "$0") [<options>]
+
 Build Docker images.
 
+Options:
 --arm64 will build image for arm64 architecture
 "
 }

--- a/docker/ecr_publish
+++ b/docker/ecr_publish
@@ -10,6 +10,8 @@ function usage() {
     echo -n \
          "Usage: $(basename "$0")
 Publishes raster-vision-pytorch image to ECR. Expects RV_ECR_IMAGE env var to be set to <ecr_repo_name>:<tag_name>
+
+--arm64 will publish the ARM64 image
 "
 }
 
@@ -21,6 +23,10 @@ then
         exit
     fi
     IMAGE_NAME="raster-vision-pytorch:latest"
+    if [ "${1:-}" = "--arm64" ]
+    then
+        IMAGE_NAME="raster-vision-pytorch-arm64:latest"
+    fi
     ACCOUNT_ID=$(aws sts get-caller-identity --output text --query 'Account')
     AWS_REGION="us-east-1"
 

--- a/docker/ecr_publish
+++ b/docker/ecr_publish
@@ -8,9 +8,13 @@ fi
 
 function usage() {
     echo -n \
-         "Usage: $(basename "$0")
-Publishes raster-vision-pytorch image to ECR. Expects RV_ECR_IMAGE env var to be set to <ecr_repo_name>:<tag_name>
+         "Usage: $(basename "$0") [<options>]
 
+Publishes raster-vision-pytorch image to ECR.
+
+Expects the RV_ECR_IMAGE env var to be set to <ecr_repo_name>:<tag_name>
+
+Options:
 --arm64 will publish the ARM64 image
 "
 }

--- a/docker/ecr_publish
+++ b/docker/ecr_publish
@@ -20,8 +20,7 @@ then
         usage
         exit
     fi
-
-    IMAGE_NAME="raster-vision-pytorch-amd64:latest"
+    IMAGE_NAME="raster-vision-pytorch:latest"
     ACCOUNT_ID=$(aws sts get-caller-identity --output text --query 'Account')
     AWS_REGION="us-east-1"
 

--- a/docker/run
+++ b/docker/run
@@ -22,7 +22,7 @@ fi
 
 function usage() {
     echo -n \
-         "Usage: $(basename "$0") <options> <command>
+         "Usage: $(basename "$0") [<options>] [<additional docker run args>]
 
 Run a console in a Raster Vision Docker image locally.
 By default, the raster-vision-pytorch image is used in the CPU runtime.


### PR DESCRIPTION
## Overview

This PR fixes a discrepancy between the image name being used by the `build` and `ecr_publish` scripts for AMD64 builds. It also adds an `--arm64` option to `ecr_publish` and slightly improves the formatting of script help texts.

### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

- `docker/ecr_publish`
- `docker/ecr_publish --arm64`
- `docker/ecr_publish --help`
