### PR TITLE
Set tutorial path as default jupyter path

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -62,7 +62,7 @@ function find_free_port_in_range() {
 
 IMAGE="raster-vision-pytorch"
 RASTER_VISION_DATA_DIR="${RASTER_VISION_DATA_DIR:-${REPO_ROOT}/data}"
-RASTER_VISION_NOTEBOOK_DIR="${RASTER_VISION_NOTEBOOK_DIR:-${REPO_ROOT}/notebooks}"
+RASTER_VISION_NOTEBOOK_DIR="${RASTER_VISION_NOTEBOOK_DIR:-${REPO_ROOT}/docs/usage/tutorials}"
 
 # Parse options using scheme in
 # https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash


### PR DESCRIPTION
## Overview

This PR is to update Jupyter default path to where tutorials notebooks are located. This PR is an idea as describe [here](https://github.com/azavea/raster-vision/discussions/1593#discussioncomment-4336560).

### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

```sh
docker/run --jupyter
```
