### PR TITLE
Fix problems with `Learner.from_model_bundle()` when using custom models and datasets

### DIFF
--- a/docs/usage/tutorials/pred_and_eval_ss.ipynb
+++ b/docs/usage/tutorials/pred_and_eval_ss.ipynb
@@ -81,6 +81,17 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "id": "3c42b89c-6699-4f6d-80a7-95d014727aaf",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "tags": []
+   },
+   "source": [
+    ".. note:: If you used a custom model instead of using :class:`~rastervision.pytorch_learner.learner_config.ModelConfig` while training, you will need to initialize that model again and pass it to :meth:`Learner.from_model_bundle`. See the :doc:`train` tutorial for an example."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "0701b1ac-01f7-40b6-8ac9-27f9e48dd9a4",
    "metadata": {},

--- a/docs/usage/tutorials/train.ipynb
+++ b/docs/usage/tutorials/train.ipynb
@@ -97,12 +97,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import albumentations as A\n",
+    "\n",
     "from rastervision.pytorch_learner import (\n",
     "    SemanticSegmentationRandomWindowGeoDataset,\n",
     "    SemanticSegmentationSlidingWindowGeoDataset,\n",
     "    SemanticSegmentationVisualizer)\n",
-    "\n",
-    "import albumentations as A\n",
     "\n",
     "viz = SemanticSegmentationVisualizer(\n",
     "    class_names=class_config.names, class_colors=class_config.colors)"
@@ -130,8 +130,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:53:52:rastervision.pipeline.file_system.utils: INFO - Using cached file /opt/data/tmp/cache/s3/spacenet-dataset/spacenet/SN7_buildings/train/L15-0331E-1257N_1327_3160_13/images/global_monthly_2018_01_mosaic_L15-0331E-1257N_1327_3160_13.tif.\n",
-      "2022-10-21 13:53:52:rastervision.pipeline.file_system.utils: INFO - Using cached file /opt/data/tmp/cache/s3/spacenet-dataset/spacenet/SN7_buildings/train/L15-0331E-1257N_1327_3160_13/labels/global_monthly_2018_01_mosaic_L15-0331E-1257N_1327_3160_13_Buildings.geojson.\n"
+      "2022-12-15 14:26:01:rastervision.pipeline.file_system.utils: INFO - Using cached file /opt/data/tmp/cache/s3/spacenet-dataset/spacenet/SN7_buildings/train/L15-0331E-1257N_1327_3160_13/images/global_monthly_2018_01_mosaic_L15-0331E-1257N_1327_3160_13.tif.\n",
+      "2022-12-15 14:26:01:rastervision.core.data.raster_source.rasterio_source: WARNING - Raster block size (2, 1024) is too non-square. This can slow down reading. Consider re-tiling using GDAL.\n",
+      "2022-12-15 14:26:01:rastervision.pipeline.file_system.utils: INFO - Using cached file /opt/data/tmp/cache/s3/spacenet-dataset/spacenet/SN7_buildings/train/L15-0331E-1257N_1327_3160_13/labels/global_monthly_2018_01_mosaic_L15-0331E-1257N_1327_3160_13_Buildings.geojson.\n"
      ]
     },
     {
@@ -228,14 +229,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:53:54:rastervision.pipeline.file_system.utils: INFO - Using cached file /opt/data/tmp/cache/s3/spacenet-dataset/spacenet/SN7_buildings/train/L15-0357E-1223N_1429_3296_13/images/global_monthly_2018_01_mosaic_L15-0357E-1223N_1429_3296_13.tif.\n",
-      "2022-10-21 13:53:54:rastervision.pipeline.file_system.utils: INFO - Using cached file /opt/data/tmp/cache/s3/spacenet-dataset/spacenet/SN7_buildings/train/L15-0357E-1223N_1429_3296_13/labels/global_monthly_2018_01_mosaic_L15-0357E-1223N_1429_3296_13_Buildings.geojson.\n"
+      "2022-12-15 14:26:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /opt/data/tmp/cache/s3/spacenet-dataset/spacenet/SN7_buildings/train/L15-0357E-1223N_1429_3296_13/images/global_monthly_2018_01_mosaic_L15-0357E-1223N_1429_3296_13.tif.\n",
+      "2022-12-15 14:26:05:rastervision.core.data.raster_source.rasterio_source: WARNING - Raster block size (2, 1024) is too non-square. This can slow down reading. Consider re-tiling using GDAL.\n",
+      "2022-12-15 14:26:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /opt/data/tmp/cache/s3/spacenet-dataset/spacenet/SN7_buildings/train/L15-0357E-1223N_1429_3296_13/labels/global_monthly_2018_01_mosaic_L15-0357E-1223N_1429_3296_13_Buildings.geojson.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "121"
+       "100"
       ]
      },
      "execution_count": 6,
@@ -315,7 +317,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Using cache found in /root/.cache/torch/hub/AdeelH_pytorch-fpn_master\n"
+      "Using cache found in /root/.cache/torch/hub/AdeelH_pytorch-fpn_0.3\n"
      ]
     }
    ],
@@ -323,7 +325,7 @@
     "import torch\n",
     "\n",
     "model = torch.hub.load(\n",
-    "    'AdeelH/pytorch-fpn',\n",
+    "    'AdeelH/pytorch-fpn:0.3',\n",
     "    'make_fpn_resnet',\n",
     "    name='resnet18',\n",
     "    fpn_type='panoptic',\n",
@@ -367,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "bdd7be9c-6058-484a-a71a-4cbeeb28bcf4",
    "metadata": {},
    "outputs": [],
@@ -395,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "459c2be9-6116-4291-a3c4-7cb87a504839",
    "metadata": {},
    "outputs": [],
@@ -423,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "483fc2c6-9cc3-45ef-81d6-f1739006312d",
    "metadata": {},
    "outputs": [],
@@ -458,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "29abd7fe-7413-4a40-821d-6ccea14e3558",
    "metadata": {},
    "outputs": [],
@@ -470,12 +472,13 @@
     "    output_dir='./train-demo/',\n",
     "    model=model,\n",
     "    train_ds=train_ds,\n",
-    "    valid_ds=val_ds)"
+    "    valid_ds=val_ds,\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "c6c6673d-a3a2-4810-b8c9-29d94dd0257d",
    "metadata": {},
    "outputs": [
@@ -483,8 +486,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:54:04:rastervision.pytorch_learner.learner: INFO - train_ds: 400 items\n",
-      "2022-10-21 13:54:04:rastervision.pytorch_learner.learner: INFO - valid_ds: 121 items\n"
+      "2022-12-15 14:26:26:rastervision.pytorch_learner.learner: INFO - train_ds: 400 items\n",
+      "2022-12-15 14:26:26:rastervision.pytorch_learner.learner: INFO - valid_ds: 100 items\n"
      ]
     }
    ],
@@ -518,7 +521,9 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "87c19038-65dd-454f-9a88-3ae7be517e65",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%load_ext tensorboard"
@@ -536,7 +541,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3c09f9df-d76b-4dea-8845-2e41c2ad9496",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%tensorboard --bind_all --logdir \"./train-demo/tb-logs\" --reload_interval 10 "
@@ -545,7 +552,9 @@
   {
    "cell_type": "markdown",
    "id": "3e91845e-3043-43a2-8c5e-491b2c0a0992",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "![A screenshot of the Tensorboard dashboard.](../../img/tensorboard.png \"A screenshot of the Tensorboard dashboard.\")\n"
    ]
@@ -564,38 +573,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "5032aecd-7592-42b9-a597-4793038b7e7a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:54:07:rastervision.pytorch_learner.learner: INFO - epoch: 0\n"
+      "2022-12-15 14:26:42:rastervision.pytorch_learner.learner: INFO - epoch: 0\n"
      ]
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.04071664810180664,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Training",
-       "rate": null,
-       "total": 50,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d8c7fd376d944cf7bb54b67032c430ca",
+       "model_id": "f1bab2d74a0644c4aa5c632988f01e27",
        "version_major": 2,
        "version_minor": 0
       },
@@ -608,30 +602,13 @@
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.03299593925476074,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Validating",
-       "rate": null,
-       "total": 16,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1916a148e36a4e00b69b5788e60327c1",
+       "model_id": "f7891cb7dbab406a86243de67370a50d",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Validating:   0%|          | 0/16 [00:00<?, ?it/s]"
+       "Validating:   0%|          | 0/13 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -641,45 +618,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:54:31:rastervision.pytorch_learner.learner: INFO - metrics:\n",
-      "{'avg_f1': 0.9063443541526794,\n",
-      " 'avg_precision': 0.9242058992385864,\n",
-      " 'avg_recall': 0.8891600370407104,\n",
-      " 'background_f1': 0.9402472376823425,\n",
-      " 'background_precision': 0.963484525680542,\n",
-      " 'background_recall': 0.9181045889854431,\n",
-      " 'building_f1': 0.23569801449775696,\n",
-      " 'building_precision': 0.1801292449235916,\n",
-      " 'building_recall': 0.34084731340408325,\n",
+      "2022-12-15 14:26:57:rastervision.pytorch_learner.learner: INFO - metrics:\n",
+      "{'avg_f1': 0.9074727892875671,\n",
+      " 'avg_precision': 0.9226699471473694,\n",
+      " 'avg_recall': 0.8927680850028992,\n",
+      " 'background_f1': 0.9416702389717102,\n",
+      " 'background_precision': 0.9641342163085938,\n",
+      " 'background_recall': 0.9202292561531067,\n",
+      " 'building_f1': 0.3365422785282135,\n",
+      " 'building_precision': 0.2660379707813263,\n",
+      " 'building_recall': 0.45789051055908203,\n",
       " 'epoch': 0,\n",
-      " 'train_loss': 0.04628021240234375,\n",
-      " 'train_time': '0:00:15.237473',\n",
-      " 'val_loss': 0.06725204735994339,\n",
-      " 'valid_time': '0:00:08.886707'}\n",
-      "2022-10-21 13:54:31:rastervision.pytorch_learner.learner: INFO - epoch: 1\n"
+      " 'train_loss': 0.06389201164245606,\n",
+      " 'train_time': '0:00:10.922799',\n",
+      " 'val_loss': 0.06789381802082062,\n",
+      " 'valid_time': '0:00:03.880362'}\n",
+      "2022-12-15 14:26:57:rastervision.pytorch_learner.learner: INFO - epoch: 1\n"
      ]
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.030795812606811523,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Training",
-       "rate": null,
-       "total": 50,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "86e86d4f090945b9a429d5c98a56c241",
+       "model_id": "0eae30fc0e134970b1ed84b2cefc95a1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -692,30 +652,13 @@
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.030585527420043945,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Validating",
-       "rate": null,
-       "total": 16,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8d1047fc6fe44c0195c86ccd6cfb1388",
+       "model_id": "1fa12ea20e814081b5dcbbe6e1310dd9",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Validating:   0%|          | 0/16 [00:00<?, ?it/s]"
+       "Validating:   0%|          | 0/13 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -725,45 +668,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:54:55:rastervision.pytorch_learner.learner: INFO - metrics:\n",
-      "{'avg_f1': 0.8758389949798584,\n",
-      " 'avg_precision': 0.9373558759689331,\n",
-      " 'avg_recall': 0.8218992948532104,\n",
-      " 'background_f1': 0.898644208908081,\n",
-      " 'background_precision': 0.9779720902442932,\n",
-      " 'background_recall': 0.8312200903892517,\n",
-      " 'building_f1': 0.26652103662490845,\n",
-      " 'building_precision': 0.16794010996818542,\n",
-      " 'building_recall': 0.6453303098678589,\n",
+      "2022-12-15 14:27:12:rastervision.pytorch_learner.learner: INFO - metrics:\n",
+      "{'avg_f1': 0.9250732064247131,\n",
+      " 'avg_precision': 0.916088879108429,\n",
+      " 'avg_recall': 0.9342355132102966,\n",
+      " 'background_f1': 0.9656270146369934,\n",
+      " 'background_precision': 0.9497168064117432,\n",
+      " 'background_recall': 0.9820793271064758,\n",
+      " 'building_f1': 0.2418244332075119,\n",
+      " 'building_precision': 0.3835538327693939,\n",
+      " 'building_recall': 0.17657652497291565,\n",
       " 'epoch': 1,\n",
-      " 'train_loss': 0.02682020902633667,\n",
-      " 'train_time': '0:00:15.355702',\n",
-      " 'val_loss': 0.06331045925617218,\n",
-      " 'valid_time': '0:00:08.924265'}\n",
-      "2022-10-21 13:54:56:rastervision.pytorch_learner.learner: INFO - epoch: 2\n"
+      " 'train_loss': 0.032022590637207034,\n",
+      " 'train_time': '0:00:10.916714',\n",
+      " 'val_loss': 0.12407467514276505,\n",
+      " 'valid_time': '0:00:04.199710'}\n",
+      "2022-12-15 14:27:13:rastervision.pytorch_learner.learner: INFO - epoch: 2\n"
      ]
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.033206939697265625,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Training",
-       "rate": null,
-       "total": 50,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "56f0e1954ccc401e968f77d9f4f5c800",
+       "model_id": "f0d8611a4e16439bb3620ccae5b734d8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -776,30 +702,13 @@
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.03395509719848633,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Validating",
-       "rate": null,
-       "total": 16,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9dbb593a50fc42ba94e9651ee304e575",
+       "model_id": "a595c018bdc14bc39514a5e0d96ff8c3",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Validating:   0%|          | 0/16 [00:00<?, ?it/s]"
+       "Validating:   0%|          | 0/13 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -809,21 +718,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:55:21:rastervision.pytorch_learner.learner: INFO - metrics:\n",
-      "{'avg_f1': 0.887840986251831,\n",
-      " 'avg_precision': 0.9439790844917297,\n",
-      " 'avg_recall': 0.8380051851272583,\n",
-      " 'background_f1': 0.9082092046737671,\n",
-      " 'background_precision': 0.9833714962005615,\n",
-      " 'background_recall': 0.8437208533287048,\n",
-      " 'building_f1': 0.31117182970046997,\n",
-      " 'building_precision': 0.19774767756462097,\n",
-      " 'building_recall': 0.729731023311615,\n",
+      "2022-12-15 14:27:28:rastervision.pytorch_learner.learner: INFO - metrics:\n",
+      "{'avg_f1': 0.8449840545654297,\n",
+      " 'avg_precision': 0.9309152960777283,\n",
+      " 'avg_recall': 0.7735764980316162,\n",
+      " 'background_f1': 0.8657280802726746,\n",
+      " 'background_precision': 0.9788642525672913,\n",
+      " 'background_recall': 0.7760347723960876,\n",
+      " 'building_f1': 0.27820268273353577,\n",
+      " 'building_precision': 0.1715911626815796,\n",
+      " 'building_recall': 0.7346470952033997,\n",
       " 'epoch': 2,\n",
-      " 'train_loss': 0.028932266235351563,\n",
-      " 'train_time': '0:00:16.125036',\n",
-      " 'val_loss': 0.052588216960430145,\n",
-      " 'valid_time': '0:00:09.313433'}\n"
+      " 'train_loss': 0.03501858711242676,\n",
+      " 'train_time': '0:00:11.307989',\n",
+      " 'val_loss': 0.05712978541851044,\n",
+      " 'valid_time': '0:00:04.134225'}\n"
      ]
     }
    ],
@@ -841,38 +750,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "30ca36b6-37da-4772-b557-b8bd5b9af272",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:55:23:rastervision.pytorch_learner.learner: INFO - epoch: 3\n"
+      "2022-12-15 14:27:28:rastervision.pytorch_learner.learner: INFO - Resuming training from epoch 3\n",
+      "2022-12-15 14:27:28:rastervision.pytorch_learner.learner: INFO - epoch: 3\n"
      ]
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.04657793045043945,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Training",
-       "rate": null,
-       "total": 50,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3275f5ed596649c7bf0bbadc42d0a4d5",
+       "model_id": "3a6169bd439a4b5685ee3deac4744869",
        "version_major": 2,
        "version_minor": 0
       },
@@ -885,30 +780,13 @@
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.029911279678344727,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Validating",
-       "rate": null,
-       "total": 16,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1b25ae6e6cd744dcb4faf12641d541b2",
+       "model_id": "fc59d58d92cb4f6ca7ac2cfe4e2c803d",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Validating:   0%|          | 0/16 [00:00<?, ?it/s]"
+       "Validating:   0%|          | 0/13 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -918,45 +796,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:55:48:rastervision.pytorch_learner.learner: INFO - metrics:\n",
-      "{'avg_f1': 0.8662914633750916,\n",
-      " 'avg_precision': 0.9477248191833496,\n",
-      " 'avg_recall': 0.7977450489997864,\n",
-      " 'background_f1': 0.8820752501487732,\n",
-      " 'background_precision': 0.9884632229804993,\n",
-      " 'background_recall': 0.7963629961013794,\n",
-      " 'building_f1': 0.2900361716747284,\n",
-      " 'building_precision': 0.17599470913410187,\n",
-      " 'building_recall': 0.8239251375198364,\n",
+      "2022-12-15 14:27:44:rastervision.pytorch_learner.learner: INFO - metrics:\n",
+      "{'avg_f1': 0.8460741639137268,\n",
+      " 'avg_precision': 0.9367697834968567,\n",
+      " 'avg_recall': 0.7713902592658997,\n",
+      " 'background_f1': 0.8635478019714355,\n",
+      " 'background_precision': 0.984494686126709,\n",
+      " 'background_recall': 0.7690666317939758,\n",
+      " 'building_f1': 0.29575374722480774,\n",
+      " 'building_precision': 0.18099400401115417,\n",
+      " 'building_recall': 0.8081868290901184,\n",
       " 'epoch': 3,\n",
-      " 'train_loss': 0.02868288040161133,\n",
-      " 'train_time': '0:00:16.083816',\n",
-      " 'val_loss': 0.05553163215517998,\n",
-      " 'valid_time': '0:00:09.339830'}\n",
-      "2022-10-21 13:55:49:rastervision.pytorch_learner.learner: INFO - epoch: 4\n"
+      " 'train_loss': 0.03204505920410156,\n",
+      " 'train_time': '0:00:11.553398',\n",
+      " 'val_loss': 0.05406069755554199,\n",
+      " 'valid_time': '0:00:04.054214'}\n",
+      "2022-12-15 14:27:44:rastervision.pytorch_learner.learner: INFO - epoch: 4\n"
      ]
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.04182314872741699,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Training",
-       "rate": null,
-       "total": 50,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f351e3e6a88d494e9aa7faad74d0ef64",
+       "model_id": "94a8b27b49af419fa735262e26ef43c5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -969,30 +830,13 @@
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.03390097618103027,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Validating",
-       "rate": null,
-       "total": 16,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e7c9d2b9b32e40cab556e0de9c13f642",
+       "model_id": "7c55a8e2d5074c8dbadd1a2bed9312c0",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Validating:   0%|          | 0/16 [00:00<?, ?it/s]"
+       "Validating:   0%|          | 0/13 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -1002,45 +846,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:56:14:rastervision.pytorch_learner.learner: INFO - metrics:\n",
-      "{'avg_f1': 0.9257288575172424,\n",
-      " 'avg_precision': 0.9331725239753723,\n",
-      " 'avg_recall': 0.918402910232544,\n",
-      " 'background_f1': 0.9565563201904297,\n",
-      " 'background_precision': 0.9676290154457092,\n",
-      " 'background_recall': 0.9457340836524963,\n",
-      " 'building_f1': 0.3299404978752136,\n",
-      " 'building_precision': 0.28044360876083374,\n",
-      " 'building_recall': 0.4006538987159729,\n",
+      "2022-12-15 14:28:00:rastervision.pytorch_learner.learner: INFO - metrics:\n",
+      "{'avg_f1': 0.832942545413971,\n",
+      " 'avg_precision': 0.9333340525627136,\n",
+      " 'avg_recall': 0.7520503401756287,\n",
+      " 'background_f1': 0.8505723476409912,\n",
+      " 'background_precision': 0.9818631410598755,\n",
+      " 'background_recall': 0.7502516508102417,\n",
+      " 'building_f1': 0.272173136472702,\n",
+      " 'building_precision': 0.16482366621494293,\n",
+      " 'building_recall': 0.7805342674255371,\n",
       " 'epoch': 4,\n",
-      " 'train_loss': 0.029659500122070314,\n",
-      " 'train_time': '0:00:15.839903',\n",
-      " 'val_loss': 0.056976836174726486,\n",
-      " 'valid_time': '0:00:09.132699'}\n",
-      "2022-10-21 13:56:15:rastervision.pytorch_learner.learner: INFO - epoch: 5\n"
+      " 'train_loss': 0.030616183280944825,\n",
+      " 'train_time': '0:00:11.438546',\n",
+      " 'val_loss': 0.058418720960617065,\n",
+      " 'valid_time': '0:00:04.163509'}\n",
+      "2022-12-15 14:28:00:rastervision.pytorch_learner.learner: INFO - epoch: 5\n"
      ]
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.03530478477478027,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Training",
-       "rate": null,
-       "total": 50,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f5a226d160884444ba35377c091b67a6",
+       "model_id": "7176559d8186457fb2314035afbbb516",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1053,30 +880,13 @@
     },
     {
      "data": {
-      "application/json": {
-       "ascii": false,
-       "bar_format": null,
-       "colour": null,
-       "elapsed": 0.03031182289123535,
-       "initial": 0,
-       "n": 0,
-       "ncols": null,
-       "nrows": 30,
-       "postfix": null,
-       "prefix": "Validating",
-       "rate": null,
-       "total": 16,
-       "unit": "it",
-       "unit_divisor": 1000,
-       "unit_scale": false
-      },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d925a6a292f64e3f9739ae9dd678ff7e",
+       "model_id": "dd9b3ba92ddd4997a2a79b9198438d7d",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Validating:   0%|          | 0/16 [00:00<?, ?it/s]"
+       "Validating:   0%|          | 0/13 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -1086,21 +896,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 13:56:39:rastervision.pytorch_learner.learner: INFO - metrics:\n",
-      "{'avg_f1': 0.9225586652755737,\n",
-      " 'avg_precision': 0.9400836825370789,\n",
-      " 'avg_recall': 0.9056751132011414,\n",
-      " 'background_f1': 0.9490233063697815,\n",
-      " 'background_precision': 0.9750348925590515,\n",
-      " 'background_recall': 0.9243635535240173,\n",
-      " 'building_f1': 0.3696795403957367,\n",
-      " 'building_precision': 0.27798280119895935,\n",
-      " 'building_recall': 0.5516492128372192,\n",
+      "2022-12-15 14:28:16:rastervision.pytorch_learner.learner: INFO - metrics:\n",
+      "{'avg_f1': 0.8777509331703186,\n",
+      " 'avg_precision': 0.930891215801239,\n",
+      " 'avg_recall': 0.8303500413894653,\n",
+      " 'background_f1': 0.9030481576919556,\n",
+      " 'background_precision': 0.9763485193252563,\n",
+      " 'background_recall': 0.8399853110313416,\n",
+      " 'building_f1': 0.32184305787086487,\n",
+      " 'building_precision': 0.2110251784324646,\n",
+      " 'building_recall': 0.6777646541595459,\n",
       " 'epoch': 5,\n",
-      " 'train_loss': 0.02884626865386963,\n",
-      " 'train_time': '0:00:15.232563',\n",
-      " 'val_loss': 0.058977968990802765,\n",
-      " 'valid_time': '0:00:08.873377'}\n"
+      " 'train_loss': 0.028649821281433105,\n",
+      " 'train_time': '0:00:11.639080',\n",
+      " 'val_loss': 0.053958915174007416,\n",
+      " 'valid_time': '0:00:04.503397'}\n"
      ]
     }
    ],
@@ -1124,7 +934,13 @@
    "cell_type": "code",
    "execution_count": 19,
    "id": "900246ef-24c4-48fd-b6db-0783e9f3986f",
-   "metadata": {},
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -1159,7 +975,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "d3a2bd4c-1582-44ae-bb14-ef476162928d",
+   "id": "625a57de-e68b-4ed8-9458-8155b045fa32",
    "metadata": {
     "raw_mimetype": "text/restructuredtext",
     "tags": []
@@ -1170,17 +986,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "070e8f60-10e4-4ec8-b295-22c54cdbeb78",
+   "metadata": {},
+   "source": [
+    "Note the warning about `ModelConfig`. This is relevant when loading from from the bundle as we will see [below](#Using-model-bundles)."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "9b2bd337-7fb1-466c-9ecd-d513488bee6e",
+   "execution_count": 16,
+   "id": "0fa4b02c-8e7c-496b-82b8-ebefe82fc8d3",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-10-21 14:00:53:rastervision.pytorch_learner.learner: INFO - Creating bundle.\n",
-      "2022-10-21 14:00:53:rastervision.pytorch_learner.learner: INFO - Saving bundle to ./train-demo/model-bundle.zip.\n"
+      "2022-12-15 14:28:17:rastervision.pytorch_learner.learner: WARNING - Model was not configured via ModelConfig, and therefore, will not be reconstructable form the model-bundle. You will need to initialize the model yourself and pass it to from_model_bundle().\n",
+      "2022-12-15 14:28:17:rastervision.pytorch_learner.learner: INFO - Creating bundle.\n",
+      "2022-12-15 14:28:18:rastervision.pytorch_learner.learner: INFO - Saving bundle to ./train-demo/model-bundle.zip.\n"
      ]
     }
    ],
@@ -1191,9 +1016,19 @@
   {
    "cell_type": "markdown",
    "id": "4593b043-c586-4f7b-a58f-dac131f5cf8c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Examine learner output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "476e72fb-de7c-4c6a-9cf8-e544149a4f7a",
+   "metadata": {},
+   "source": [
+    "The trained model weights are saved at `./train-demo/last-model.pth` as well as inside the model-bundle."
    ]
   },
   {
@@ -1222,6 +1057,238 @@
    "source": [
     "!apt-get install tree > \"/dev/null\"\n",
     "!tree \"./train-demo/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01700834-7006-4dc7-a1e0-f8544b8a7f76",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "tags": []
+   },
+   "source": [
+    "## Using model-bundles"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "df8a0f4e-52cd-4c6e-8481-7c0863e4e275",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "tags": []
+   },
+   "source": [
+    "For predictions -- :meth:`Learner.from_model_bundle`\n",
+    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68041fa3-8c5a-456e-a28a-63989c960b88",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "tags": []
+   },
+   "source": [
+    "We can use the model-bundle to re-construct our `Learner` and then use it to make predictions."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "a0982ed5-bf5f-494a-a56e-bceca657ec1d",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "tags": []
+   },
+   "source": [
+    ".. note:: Since we used a custom model instead of using :class:`ModelConfig`, the model-bundle does not know how to construct the model; therefore, we need to pass in the model again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "142cf300-aecf-48b4-bf98-ea2b09e9aa57",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-12-15 14:28:21:rastervision.pytorch_learner.learner: INFO - Loading learner from bundle ./train-demo/model-bundle.zip.\n",
+      "2022-12-15 14:28:21:rastervision.pytorch_learner.learner: INFO - Unzipping model-bundle to /opt/data/tmp/tmp_9hxtbek/model-bundle\n",
+      "2022-12-15 14:28:21:rastervision.pytorch_learner.learner: INFO - Loading model weights from: /opt/data/tmp/tmp_9hxtbek/model-bundle/model.pth\n"
+     ]
+    }
+   ],
+   "source": [
+    "from rastervision.pytorch_learner import SemanticSegmentationLearner\n",
+    "\n",
+    "learner = SemanticSegmentationLearner.from_model_bundle(\n",
+    "    model_bundle_uri='./train-demo/model-bundle.zip',\n",
+    "    output_dir='./train-demo/',\n",
+    "    model=model,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5516180e-ba48-4993-b9a0-2d18d3b4d6a0",
+   "metadata": {},
+   "source": [
+    "For next steps, see the [\"Prediction and Evaluation\" tutorial](./pred_and_eval_ss.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "a848a93e-6181-4422-abf2-f09bafa973de",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "tags": []
+   },
+   "source": [
+    "For fine-tuning -- :meth:`Learner.from_model_bundle`\n",
+    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6c7157b-1f31-469d-8bb6-9cafa7f3edf6",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "tags": []
+   },
+   "source": [
+    "We can also re-construct the `Learner` in order to continue training, perhaps on a different dataset. To do this, we pass in `train_ds` and `val_ds` and set `training=True`"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "98feac57-f906-47a2-8076-b7aa84b5823d",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "tags": []
+   },
+   "source": [
+    ".. note:: Since we used a custom model instead of using :class:`ModelConfig`, the model-bundle does not know how to construct the model; therefore, we need to pass in the model again."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "9b74be39-35e3-4b9c-af0a-06d7f07f9421",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "tags": []
+   },
+   "source": [
+    ".. note:: Optimizers and schedulers are (currently) not stored in model-bundles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "5e9ba02c-d9ce-48dd-9b8c-61885a4e5314",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-12-15 14:28:22:rastervision.pytorch_learner.learner: INFO - Loading learner from bundle ./train-demo/model-bundle.zip.\n",
+      "2022-12-15 14:28:22:rastervision.pytorch_learner.learner: INFO - Unzipping model-bundle to /opt/data/tmp/tmpcx15mo9q/model-bundle\n",
+      "2022-12-15 14:28:22:rastervision.pytorch_learner.learner: INFO - Loading model weights from: /opt/data/tmp/tmpcx15mo9q/model-bundle/model.pth\n",
+      "2022-12-15 14:28:22:rastervision.pytorch_learner.learner: INFO - Loading checkpoint from ./train-demo/last-model.pth\n"
+     ]
+    }
+   ],
+   "source": [
+    "from rastervision.pytorch_learner import SemanticSegmentationLearner\n",
+    "\n",
+    "learner = SemanticSegmentationLearner.from_model_bundle(\n",
+    "    model_bundle_uri='./train-demo/model-bundle.zip',\n",
+    "    output_dir='./train-demo/',\n",
+    "    model=model,\n",
+    "    train_ds=train_ds,\n",
+    "    valid_ds=val_ds,\n",
+    "    training=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "890b4d7e-6eb7-4a54-8446-0bf943be7239",
+   "metadata": {},
+   "source": [
+    "Continue training:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "b35da2ac-847d-47aa-a79f-21929bdadca0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-12-15 14:28:23:rastervision.pytorch_learner.learner: INFO - Resuming training from epoch 6\n",
+      "2022-12-15 14:28:23:rastervision.pytorch_learner.learner: INFO - epoch: 6\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5079638e88eb406cb12e649517a066fd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Training:   0%|          | 0/50 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "809da298801a4edfa7553a962ee95968",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Validating:   0%|          | 0/13 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-12-15 14:28:39:rastervision.pytorch_learner.learner: INFO - metrics:\n",
+      "{'avg_f1': 0.812635600566864,\n",
+      " 'avg_precision': 0.9350194334983826,\n",
+      " 'avg_recall': 0.7185811996459961,\n",
+      " 'background_f1': 0.8263904452323914,\n",
+      " 'background_precision': 0.9844221472740173,\n",
+      " 'background_recall': 0.7120786905288696,\n",
+      " 'building_f1': 0.2574964761734009,\n",
+      " 'building_precision': 0.15267422795295715,\n",
+      " 'building_recall': 0.8215558528900146,\n",
+      " 'epoch': 6,\n",
+      " 'train_loss': 0.04115571975708008,\n",
+      " 'train_time': '0:00:11.777954',\n",
+      " 'val_loss': 0.05978838726878166,\n",
+      " 'valid_time': '0:00:04.738656'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "learner.train(epochs=1)"
    ]
   }
  ],

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -1020,6 +1020,13 @@ class Learner(ABC):
         from rastervision.pytorch_learner.learner_pipeline_config import (
             LearnerPipelineConfig)
 
+        if self.cfg.model is None:
+            log.warning(
+                'Model was not configured via ModelConfig, and therefore, '
+                'will not be reconstructable form the model-bundle. You will '
+                'need to initialize the model yourself and pass it to '
+                'from_model_bundle().')
+
         log.info('Creating bundle.')
         model_bundle_dir = join(self.tmp_dir, 'model-bundle')
         make_dir(model_bundle_dir, force_empty=True)


### PR DESCRIPTION
## Overview

This PR fixes a problem (reported [here](https://github.com/azavea/raster-vision/discussions/1585#discussioncomment-4409121)) that prevented loading a `Learner` from a model-bundle when the `Learner` was originally trained using a user-specified model (as opposed to a model derived from a `ModelConfig`).

It also updates the [training](https://raster-vision--1605.org.readthedocs.build/en/1605/usage/tutorials/train.html) and [prediction](https://raster-vision--1605.org.readthedocs.build/en/1605/usage/tutorials/pred_and_eval_ss.html) tutorials to talk about this use-case.

### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes
Will run all examples again before release.
