### PR TITLE
Bug fix: do not set `cfg.model.pretrained=False` in `Learner.from_model_bundle()`

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -1005,14 +1005,10 @@ class Learner(ABC):
             # config has been altered, so re-validate
             cfg = build_config(cfg.dict())
 
-        if cfg.model is not None:
-            # we have trained weights, so avoid wasteful download
-            cfg.model.pretrained = False
-        else:
-            if kwargs.get('model') is None:
-                raise ValueError(
-                    'Model definition is not saved in the model-bundle. '
-                    'Please specify the model explicitly.')
+        if cfg.model is None and kwargs.get('model') is None:
+            raise ValueError(
+                'Model definition is not saved in the model-bundle. '
+                'Please specify the model explicitly.')
 
         if cls == Learner:
             if len(kwargs) > 0:


### PR DESCRIPTION
 Overview

This PR fixes a bug reported in #1625.

### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

Run the COWC Potsdam example with `-a multiband True`.
