### PR TITLE
Add comment about password for the ISPRS Potsdam dataset

### DIFF
--- a/docs/framework/examples.rst
+++ b/docs/framework/examples.rst
@@ -202,7 +202,7 @@ This `experiment <{{ repo_examples }}/semantic_segmentation/isprs_potsdam.py>`__
 
 Data:
 
-* The dataset can be `downloaded from here <https://www.isprs.org/education/benchmarks/UrbanSemLab/>`__. After downloading, unzip ``4_Ortho_RGBIR.zip`` and ``5_Labels_for_participants.zip`` into a directory, and then upload to S3 if desired.
+* The dataset can be `downloaded from here <https://www.isprs.org/education/benchmarks/UrbanSemLab/>`__. Access to files is password protected, but the password is provided on the same site. After downloading, unzip ``4_Ortho_RGBIR.zip`` and ``5_Labels_for_participants.zip`` into a directory, and then upload to S3 if desired.
 
 Arguments:
 


### PR DESCRIPTION
As mentioned by @AdeelH  [here](https://github.com/azavea/raster-vision/pull/1597#issuecomment-1344223354) I added a comment on where to find the password in the master branch

## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [x ] Documentation updated if needed
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
