### PR TITLE
Fix docker build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu${UBUNTU_VERSION}
 # ImportError: libGL.so.1: cannot open shared object file: No such file or directory
 # See https://stackoverflow.com/questions/55313610/importerror-libgl-so-1-cannot-open-shared-object-file-no-such-file-or-directo
 RUN apt-get update && \
-    apt-get install -y wget=1.* build-essential libgl1 && \
+    apt-get install -y wget=1.* build-essential libgl1 curl && \
     apt-get autoremove && apt-get autoclean && apt-get clean
 
 ARG PYTHON_VERSION=3.9
@@ -18,6 +18,10 @@ RUN case ${TARGETPLATFORM} in \
          "linux/arm64")  LINUX_ARCH=aarch64  ;; \
          *)              LINUX_ARCH=x86_64   ;; \
     esac && echo ${LINUX_ARCH} > /root/linux_arch
+
+# needed for jupyter lab extensions
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt-get install -y nodejs
 
 # Install Python and conda
 RUN wget -q -O ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(cat /root/linux_arch).sh && \
@@ -39,10 +43,6 @@ ENV GDAL_DATA=/opt/conda/lib/python${PYTHON_VERSION}/site-packages/rasterio/gdal
 # See https://askubuntu.com/questions/1354890/what-am-i-doing-wrong-in-conda
 RUN rm /opt/conda/lib/libtinfo.so.6 && \
     ln -s /lib/$(cat /root/linux_arch)-linux-gnu/libtinfo.so.6 /opt/conda/lib/libtinfo.so.6
-
-# needed for jupyter lab extensions
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
-    apt-get install -y nodejs
 
 WORKDIR /opt/src/
 


### PR DESCRIPTION
## Overview

This PR fixes two errors that have recently started appearing when building the docker image:
1. A miniconda installation error discussed here: https://github.com/ContinuumIO/anaconda-issues/issues/13110
2. An error in the NodeJS installation step. This required explicitly installing `curl` and moving this build step above the conda installation step.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

`docker/build` should run to completion without errors.
