### PR TITLE
Improve docstrings for most commonly used classes and configs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,7 @@ nbsphinx_prolog = r"""
 
             os.environ['GDAL_DATA'] = check_output('pip show rasterio | grep Location | awk \'{print $NF"/rasterio/gdal_data/"}\'', shell=True).decode().strip()
             os.environ['AWS_NO_SIGN_REQUEST'] = 'YES'
-        
+
         See this `Colab notebook <https://colab.research.google.com/drive/1qUl_6McbLJr9KjrhHnx_SWbSYkLPL2uW>`__ for an example.
 
 """ # noqa

--- a/docs/framework/pipelines.rst
+++ b/docs/framework/pipelines.rst
@@ -131,7 +131,7 @@ The following table shows the corresponding ``Configs`` for various commonly use
         - :class:`~data.raster_source.multi_raster_source_config.MultiRasterSourceConfig`
         - :class:`~data.raster_source.rasterized_source_config.RasterizedSourceConfig`
 
-     -  
+     -
    * -  :class:`~data.raster_transformer.raster_transformer.RasterTransformer`
 
         - :class:`~data.raster_transformer.cast_transformer.CastTransformer`
@@ -150,7 +150,7 @@ The following table shows the corresponding ``Configs`` for various commonly use
         - :class:`~data.raster_transformer.rgb_class_transformer_config.RGBClassTransformerConfig`
         - :class:`~data.raster_transformer.stats_transformer_config.StatsTransformerConfig`
 
-     -  
+     -
    * -  :class:`~data.vector_source.vector_source.VectorSource`
 
         - :class:`~data.vector_source.geojson_vector_source.GeoJSONVectorSource`
@@ -159,7 +159,7 @@ The following table shows the corresponding ``Configs`` for various commonly use
 
         - :class:`~data.vector_source.geojson_vector_source_config.GeoJSONVectorSourceConfig`
 
-     -  
+     -
    * -  :class:`~data.vector_transformer.vector_transformer.VectorTransformer`
 
         - :class:`~data.vector_transformer.buffer_transformer.BufferTransformer`
@@ -172,7 +172,7 @@ The following table shows the corresponding ``Configs`` for various commonly use
         - :class:`~data.vector_transformer.class_inference_transformer_config.ClassInferenceTransformerConfig`
         - :class:`~data.vector_transformer.shift_transformer_config.ShiftTransformerConfig`
 
-     -  
+     -
    * -  :class:`~data.label_source.label_source.LabelSource`
 
         - :class:`~data.label_source.chip_classification_label_source.ChipClassificationLabelSource`
@@ -185,7 +185,7 @@ The following table shows the corresponding ``Configs`` for various commonly use
         - :class:`~data.label_source.semantic_segmentation_label_source_config.SemanticSegmentationLabelSourceConfig`
         - :class:`~data.label_source.object_detection_label_source_config.ObjectDetectionLabelSourceConfig`
 
-     -  
+     -
    * -  :class:`~data.label_store.label_store.LabelStore`
 
         - :class:`~data.label_store.chip_classification_geojson_store.ChipClassificationGeoJSONStore`

--- a/docs/framework/quickstart.rst
+++ b/docs/framework/quickstart.rst
@@ -38,9 +38,9 @@ The Data
 .. raw:: html
 
     <div style="position: relative; padding-bottom: 56.25%; overflow: hidden; max-width: 100%;">
-        <iframe 
-            src="../_static/tiny-spacenet-map.html" 
-            frameborder="0" 
+        <iframe
+            src="../_static/tiny-spacenet-map.html"
+            frameborder="0"
             allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
         </iframe>
     </div>

--- a/docs/framework/quickstart.rst
+++ b/docs/framework/quickstart.rst
@@ -48,7 +48,7 @@ The Data
 Configuring a semantic segmentation pipeline
 ----------------------------------------------
 
-Create a Python file in the ``${RV_QUICKSTART_CODE_DIR}`` named ``tiny_spacenet.py``. Inside, you're going to write a function called ``get_config`` that returns a ``SemanticSegmentationConfig`` object. This object's type is a subclass of ``PipelineConfig``, and configures a semantic segmentation pipeline which (optionally) analyzes the imagery, (optionally) creates training chips, trains a model, makes predictions on validation scenes, evaluates the predictions, and saves a model bundle.
+Create a Python file in the ``${RV_QUICKSTART_CODE_DIR}`` named ``tiny_spacenet.py``. Inside, you're going to write a function called ``get_config`` that returns a :class:`~rastervision.core.rv_pipeline.semantic_segmentation_config.SemanticSegmentationConfig` object. This object's type is a subclass of :class:`~rastervision.pipeline.pipeline_config.PipelineConfig`, and configures a semantic segmentation pipeline which (optionally) analyzes the imagery, (optionally) creates training chips, trains a model, makes predictions on validation scenes, evaluates the predictions, and saves a model bundle.
 
 .. literalinclude:: /../rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
     :language: python

--- a/rastervision_core/rastervision/core/analyzer/analyzer_config.py
+++ b/rastervision_core/rastervision/core/analyzer/analyzer_config.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
 
 @register_config('analyzer')
 class AnalyzerConfig(Config):
+    """Configure an :class:`.Analyzer`."""
+
     def build(self, scene_group: Optional[Tuple[str, Iterable[str]]] = None
               ) -> 'Analyzer':
         pass

--- a/rastervision_core/rastervision/core/analyzer/stats_analyzer.py
+++ b/rastervision_core/rastervision/core/analyzer/stats_analyzer.py
@@ -6,7 +6,7 @@ from rastervision.core.data import Scene
 
 
 class StatsAnalyzer(Analyzer):
-    """Computes RasterStats against the entire scene set."""
+    """Compute imagery statistics of scenes."""
 
     def __init__(self,
                  stats_uri: Optional[str] = None,

--- a/rastervision_core/rastervision/core/analyzer/stats_analyzer_config.py
+++ b/rastervision_core/rastervision/core/analyzer/stats_analyzer_config.py
@@ -10,7 +10,11 @@ if TYPE_CHECKING:
 
 @register_config('stats_analyzer')
 class StatsAnalyzerConfig(AnalyzerConfig):
-    """Config for an Analyzer that computes imagery statistics of scenes."""
+    """Configure a :class:`.StatsAnalyzer`.
+
+    A :class:`.StatsAnalyzer` computes imagery statistics of scenes which can
+    be used to normalize chips read from them.
+    """
 
     output_uri: Optional[str] = Field(
         None,

--- a/rastervision_core/rastervision/core/backend/backend_config.py
+++ b/rastervision_core/rastervision/core/backend/backend_config.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 @register_config('backend')
 class BackendConfig(Config):
-    """Configuration for Backend."""
+    """Configure a :class:`.Backend`."""
 
     def build(self, pipeline: 'RVPipeline', tmp_dir: str) -> 'Backend':
         raise NotImplementedError()

--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -19,7 +19,7 @@ class BoxSizeError(ValueError):
 
 
 class Box():
-    """A multi-purpose box (ie. rectangle)."""
+    """A multi-purpose box (ie. rectangle) representation ."""
 
     def __init__(self, ymin, xmin, ymax, xmax):
         """Construct a bounding box.

--- a/rastervision_core/rastervision/core/data/class_config.py
+++ b/rastervision_core/rastervision/core/data/class_config.py
@@ -10,7 +10,8 @@ DEFAULT_NULL_CLASS_COLOR = 'black'
 
 @register_config('class_config')
 class ClassConfig(Config):
-    """Configures the class names that are being predicted."""
+    """Configure class information for a machine learning task."""
+
     names: List[str] = Field(
         ...,
         description='Names of classes. The i-th class in this list will have '

--- a/rastervision_core/rastervision/core/data/crs_transformer/crs_transformer.py
+++ b/rastervision_core/rastervision/core/data/crs_transformer/crs_transformer.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class CRSTransformer(ABC):
     """Transforms map points in some CRS into pixel coordinates.
 
-    Each transformer is associated with a particular RasterSource.
+    Each transformer is associated with a particular :class:`.RasterSource`.
     """
 
     def __init__(self,

--- a/rastervision_core/rastervision/core/data/dataset_config.py
+++ b/rastervision_core/rastervision/core/data/dataset_config.py
@@ -19,7 +19,7 @@ def dataset_config_upgrader(cfg_dict: dict, version: int) -> dict:
 
 @register_config('dataset', upgrader=dataset_config_upgrader)
 class DatasetConfig(Config):
-    """Config for a Dataset comprising the scenes for train, valid, and test splits."""
+    """Configure train, validation, and test splits for a dataset."""
     class_config: ClassConfig
     train_scenes: List[SceneConfig]
     validation_scenes: List[SceneConfig]

--- a/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source_config.py
@@ -20,10 +20,10 @@ def cc_label_source_config_upgrader(cfg_dict: dict, version: int) -> dict:
     'chip_classification_label_source',
     upgrader=cc_label_source_config_upgrader)
 class ChipClassificationLabelSourceConfig(LabelSourceConfig):
-    """Config for a source of labels for chip classification.
+    """Configure a :class:`.ChipClassificationLabelSource`.
 
-    This can be provided explicitly as a grid of cells, or a grid of cells can be
-    inferred from arbitrary polygons.
+    This can be provided explicitly as a grid of cells, or a grid of cells can
+    be inferred from arbitrary polygons.
     """
     vector_source: Optional[VectorSourceConfig] = None
     ioa_thresh: float = Field(

--- a/rastervision_core/rastervision/core/data/label_source/label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/label_source_config.py
@@ -3,6 +3,8 @@ from rastervision.pipeline.config import Config, register_config
 
 @register_config('label_source')
 class LabelSourceConfig(Config):
+    """Configure a :class:`.LabelSource`."""
+
     def build(self, class_config, crs_transformer, extent, tmp_dir):
         raise NotImplementedError()
 

--- a/rastervision_core/rastervision/core/data/label_source/object_detection_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/object_detection_label_source_config.py
@@ -8,7 +8,8 @@ from rastervision.pipeline.config import register_config, validator
 
 @register_config('object_detection_label_source')
 class ObjectDetectionLabelSourceConfig(LabelSourceConfig):
-    """Config for a read-only label source for object detection."""
+    """Configure an :class:`.ObjectDetectionLabelSource`."""
+
     vector_source: VectorSourceConfig
 
     @validator('vector_source')

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
@@ -21,7 +21,8 @@ def ss_label_source_config_upgrader(cfg_dict: dict, version: int) -> dict:
     'semantic_segmentation_label_source',
     upgrader=ss_label_source_config_upgrader)
 class SemanticSegmentationLabelSourceConfig(LabelSourceConfig):
-    """Config for a read-only label source for semantic segmentation."""
+    """Configure a :class:`.SemanticSegmentationLabelSource`."""
+
     raster_source: Union[RasterSourceConfig, RasterizedSourceConfig] = Field(
         ..., description='The labels in the form of rasters.')
 

--- a/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store_config.py
@@ -8,7 +8,7 @@ from rastervision.pipeline.config import register_config, Field
 
 @register_config('chip_classification_geojson_store')
 class ChipClassificationGeoJSONStoreConfig(LabelStoreConfig):
-    """Config for storage for chip classification predictions."""
+    """Configure a :class:`.ChipClassificationGeoJSONStore`."""
 
     uri: Optional[str] = Field(
         None,

--- a/rastervision_core/rastervision/core/data/label_store/label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/label_store.py
@@ -2,8 +2,7 @@ from abc import ABC, abstractmethod
 
 
 class LabelStore(ABC):
-    """This defines how to store prediction labels are stored for a scene.
-    """
+    """This defines how to store prediction labels for a scene."""
 
     @abstractmethod
     def save(self, labels):

--- a/rastervision_core/rastervision/core/data/label_store/label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/label_store_config.py
@@ -3,6 +3,8 @@ from rastervision.pipeline.config import Config, register_config
 
 @register_config('label_store')
 class LabelStoreConfig(Config):
+    """Configure a :class:`.LabelStore`."""
+
     def build(self, class_config, crs_transformer, extent, tmp_dir):
         pass
 

--- a/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store_config.py
@@ -8,7 +8,7 @@ from rastervision.pipeline.config import register_config, Field
 
 @register_config('object_detection_geojson_store')
 class ObjectDetectionGeoJSONStoreConfig(LabelStoreConfig):
-    """Config for storage for object detection predictions."""
+    """Configure an :class:`.ObjectDetectionGeoJSONStore`."""
 
     uri: Optional[str] = Field(
         None,

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -28,8 +28,8 @@ log = logging.getLogger(__name__)
 class SemanticSegmentationLabelStore(LabelStore):
     """Storage for semantic segmentation predictions.
 
-    Stores class raster as GeoTIFF, and can optionally vectorizes predictions and stores
-    them in GeoJSON files.
+    Can store predicted class ID raster and class scores raster as GeoTIFFs,
+    and can optionally vectorize predictions and store them as GeoJSON files.
     """
 
     def __init__(

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
@@ -91,7 +91,7 @@ class BuildingVectorOutputConfig(VectorOutputConfig):
 
 @register_config('semantic_segmentation_label_store')
 class SemanticSegmentationLabelStoreConfig(LabelStoreConfig):
-    """Config for storage for semantic segmentation predictions.
+    """Configure a :class:`.SemanticSegmentationLabelStore`.
 
     Stores class raster as GeoTIFF, and can optionally vectorizes predictions and stores
     them in GeoJSON files.

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -18,6 +18,8 @@ def multi_rs_config_upgrader(cfg_dict: dict, version: int) -> dict:
 
 @register_config('multi_raster_source', upgrader=multi_rs_config_upgrader)
 class MultiRasterSourceConfig(RasterSourceConfig):
+    """Configure a :class:`.MultiRasterSource`."""
+
     raster_sources: conlist(
         RasterSourceConfig, min_items=1) = Field(
             ..., description='List of RasterSourceConfig to combine.')

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -20,6 +20,8 @@ def rs_config_upgrader(cfg_dict: dict, version: int) -> dict:
 
 @register_config('raster_source', upgrader=rs_config_upgrader)
 class RasterSourceConfig(Config):
+    """Configure a :class:`.RasterSource`."""
+
     channel_order: Optional[List[int]] = Field(
         None,
         description=

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -164,7 +164,7 @@ class RasterioSource(RasterSource):
 
     This RasterSource can read any file that can be opened by
     `Rasterio/GDAL <https://www.gdal.org/formats_list.html>`_.
-    
+
     If there are multiple image files that cover a single scene, you can pass
     the corresponding list of URIs, and read them as if it were a single
     stitched-together image.

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
@@ -22,6 +22,8 @@ def rasterio_source_config_upgrader(cfg_dict: dict, version: int) -> dict:
 
 @register_config('rasterio_source', upgrader=rasterio_source_config_upgrader)
 class RasterioSourceConfig(RasterSourceConfig):
+    """Configure a :class:`.RasterioSource`."""
+
     uris: Union[str, List[str]] = Field(
         ...,
         description='One or more image URIs that comprise the imagery for a '

--- a/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
@@ -16,7 +16,7 @@ class RasterizerConfig(Config):
         False,
         description='If True, all pixels touched by geometries will be burned '
         'in. If false, only pixels whose center is within the polygon or that '
-        'are selected by Bresenham’s line algorithm will be burned in. '
+        'are selected by Bresenham\'s line algorithm will be burned in. '
         '(See rasterio.features.rasterize for more details).')
 
 

--- a/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
@@ -8,6 +8,8 @@ from rastervision.pipeline.config import (register_config, Config, Field,
 
 @register_config('rasterizer')
 class RasterizerConfig(Config):
+    """Configure rasterization params for a :class:`.RasterizedSource`."""
+
     background_class_id: int = Field(
         ...,
         description='The class_id to use for any background pixels, i.e. '
@@ -22,6 +24,8 @@ class RasterizerConfig(Config):
 
 @register_config('rasterized_source')
 class RasterizedSourceConfig(Config):
+    """Configure a :class:`.RasterizedSource`."""
+
     vector_source: VectorSourceConfig
     rasterizer_config: RasterizerConfig
 

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 class CastTransformer(RasterTransformer):
-    """ Casts chips to the specified dtype. """
+    """Casts chips to the specified dtype."""
 
     def __init__(self, to_dtype: str):
         """Constructor.

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer_config.py
@@ -7,6 +7,8 @@ from rastervision.core.data.raster_transformer.cast_transformer import (  # noqa
 
 @register_config('cast_transformer')
 class CastTransformerConfig(RasterTransformerConfig):
+    """Configure a :class:`.CastTransformer`."""
+
     to_dtype: str = Field(
         ...,
         description='dtype to cast raster to. Must be a valid Numpy dtype '

--- a/rastervision_core/rastervision/core/data/raster_transformer/min_max_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/min_max_transformer_config.py
@@ -5,7 +5,7 @@ from rastervision.core.data.raster_transformer import (RasterTransformerConfig,
 
 @register_config('min_max_transformer')
 class MinMaxTransformerConfig(RasterTransformerConfig):
-    """Transforms chips by scaling values in each channel to span 0-255."""
+    """Configure a :class:`.MinMaxTransformer`."""
 
     def build(self):
         return MinMaxTransformer()

--- a/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer.py
@@ -5,8 +5,7 @@ from rastervision.core.data.raster_transformer.raster_transformer \
 
 
 class NanTransformer(RasterTransformer):
-    """Removes NaN values from float raster
-    """
+    """Removes NaN values from float raster."""
 
     def __init__(self, to_value: float = 0.0):
         """Construct a new NanTransformer.

--- a/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer_config.py
@@ -9,6 +9,8 @@ from rastervision.core.data.raster_transformer.nan_transformer import (  # noqa
 
 @register_config('nan_transformer')
 class NanTransformerConfig(RasterTransformerConfig):
+    """Configure a :class:`.NanTransformer`."""
+
     to_value: Optional[float] = Field(
         0.0, description=('Turn all NaN values into this value.'))
 

--- a/rastervision_core/rastervision/core/data/raster_transformer/raster_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/raster_transformer_config.py
@@ -3,6 +3,8 @@ from rastervision.pipeline.config import Config, register_config
 
 @register_config('raster_transformer')
 class RasterTransformerConfig(Config):
+    """Configure a :class:`.RasterTransformer`."""
+
     def update(self, pipeline=None, scene=None):
         pass
 

--- a/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer.py
@@ -6,8 +6,7 @@ if TYPE_CHECKING:
 
 
 class ReclassTransformer(RasterTransformer):
-    """Reclassifies label raster
-    """
+    """Maps class IDs in a label raster to other values."""
 
     def __init__(self, mapping: Dict[int, int]):
         """Construct a new ReclassTransformer.

--- a/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer_config.py
@@ -7,6 +7,8 @@ from rastervision.core.data.raster_transformer import (RasterTransformerConfig,
 
 @register_config('reclass_transformer')
 class ReclassTransformerConfig(RasterTransformerConfig):
+    """Configure a :class:`.ReclassTransformer`."""
+
     mapping: Dict[int, int] = Field(
         ..., description=('The reclassification mapping.'))
 

--- a/rastervision_core/rastervision/core/data/raster_transformer/rgb_class_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/rgb_class_transformer_config.py
@@ -6,6 +6,8 @@ from rastervision.core.data.raster_transformer import (RasterTransformerConfig,
 
 @register_config('rgb_class_transformer')
 class RGBClassTransformerConfig(RasterTransformerConfig):
+    """Configure a :class:`.RGBClassTransformer`."""
+
     class_config: ClassConfig = Field(
         ...,
         description=('The class config defining the mapping between '

--- a/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
@@ -12,10 +12,11 @@ class StatsTransformer(RasterTransformer):
     """Transforms non-uint8 to uint8 values using channel statistics.
 
     This works as follows:
+
     - Convert pixel values to z-scores using channel means and standard
-    deviations.
+      deviations.
     - Clip z-scores to the specified number of standard deviations (default 3)
-    on each side.
+      on each side.
     - Scale values to 0-255 and cast to uint8.
 
     This transformation is not applied to NODATA pixels (assumed to be pixels

--- a/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer_config.py
@@ -24,6 +24,8 @@ def stats_transformer_config_upgrader(cfg_dict: dict, version: int) -> dict:
 @register_config(
     'stats_transformer', upgrader=stats_transformer_config_upgrader)
 class StatsTransformerConfig(RasterTransformerConfig):
+    """Configure a :class:`.StatsTransformer`."""
+
     stats_uri: Optional[str] = Field(
         None,
         description='The URI of the output of the StatsAnalyzer. '

--- a/rastervision_core/rastervision/core/data/scene.py
+++ b/rastervision_core/rastervision/core/data/scene.py
@@ -34,7 +34,7 @@ class Scene:
 
     @property
     def extent(self) -> 'Box':
-        """Extent of the associated RasterSource."""
+        """Extent of the associated :class:`.RasterSource`."""
         return self.raster_source.extent
 
     def __getitem__(self, key: Any) -> Tuple[Any, Any]:

--- a/rastervision_core/rastervision/core/data/scene_config.py
+++ b/rastervision_core/rastervision/core/data/scene_config.py
@@ -26,7 +26,9 @@ def scene_config_upgrader(cfg_dict: dict, version: int) -> dict:
 
 @register_config('scene', upgrader=scene_config_upgrader)
 class SceneConfig(Config):
-    """Config for Scene which comprises raster data and labels for an AOI."""
+    """Configure a :class:`.Scene` comprising raster data & labels for an AOI.
+    """
+
     id: str
     raster_source: RasterSourceConfig
     label_source: Optional[LabelSourceConfig] = None

--- a/rastervision_core/rastervision/core/data/utils/geojson.py
+++ b/rastervision_core/rastervision/core/data/utils/geojson.py
@@ -254,7 +254,7 @@ def simplify_polygons(geojson: dict) -> dict:
     1.  *Sometimes* break up a polygon with "bowties" into multiple polygons.
         (See https://github.com/shapely/shapely/issues/599.)
     2.  *Sometimes* "simplify" polygons. See shapely documentation for
-        :function:``buffer``.
+        :meth:`.BaseGeometry.buffer`.
 
     Args:
         geojson (dict): A GeoJSON-like mapping of a FeatureCollection.

--- a/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
+++ b/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
@@ -8,11 +8,27 @@ if TYPE_CHECKING:
 
 
 class GeoJSONVectorSource(VectorSource):
+    """A :class:`.VectorSource` for reading GeoJSON files."""
+
     def __init__(self,
                  uri: str,
                  crs_transformer: 'CRSTransformer',
                  vector_transformers: List['VectorTransformer'] = [],
                  ignore_crs_field: bool = False):
+        """Constructor.
+
+        Args:
+            uri (str): URI of the GeoJSON file.
+            crs_transformer: A ``CRSTransformer`` to convert
+                between map and pixel coords. Normally this is obtained from a
+                :class:`.RasterSource`.
+            vector_transformers: ``VectorTransformers`` for transforming
+                geometries. Defaults to ``[]``.
+            ignore_crs_field (bool): Ignore the CRS specified in the file and
+                assume WGS84 (EPSG:4326) coords. Only WGS84 is supported
+                currently. If False, and the file contains a CRS, will throw an
+                exception on read. Defaults to False.
+        """
         self.uri = uri
         self.ignore_crs_field = ignore_crs_field
         super().__init__(
@@ -22,7 +38,7 @@ class GeoJSONVectorSource(VectorSource):
         # download first so that it gets cached
         geojson = file_to_json(download_if_needed(self.uri))
         if not self.ignore_crs_field and 'crs' in geojson:
-            raise Exception(
+            raise NotImplementedError(
                 f'The GeoJSON file at {self.uri} contains a CRS field which '
                 'is not allowed by the current GeoJSON standard or by '
                 'Raster Vision. All coordinates are expected to be in '

--- a/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source_config.py
+++ b/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source_config.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 
 @register_config('geojson_vector_source')
 class GeoJSONVectorSourceConfig(VectorSourceConfig):
+    """Configure a :class:`.GeoJSONVectorSource`."""
+
     uri: str = Field(..., description='The URI of a GeoJSON file.')
     ignore_crs_field: bool = False
 

--- a/rastervision_core/rastervision/core/data/vector_source/vector_source.py
+++ b/rastervision_core/rastervision/core/data/vector_source/vector_source.py
@@ -23,6 +23,15 @@ class VectorSource(ABC):
     def __init__(self,
                  crs_transformer: 'CRSTransformer',
                  vector_transformers: List['VectorTransformer'] = []):
+        """Constructor.
+
+        Args:
+            crs_transformer: A ``CRSTransformer`` to convert
+                between map and pixel coords. Normally this is obtained from a
+                :class:`.RasterSource`.
+            vector_transformers: ``VectorTransformers`` for transforming
+                geometries. Defaults to ``[]``.
+        """
         self.crs_transformer = crs_transformer
         self.vector_transformers = vector_transformers
         self._geojson = None
@@ -32,6 +41,7 @@ class VectorSource(ABC):
         """Return transformed GeoJSON.
 
         This makes the following transformations to the raw geojson:
+
         - converts to pixels coords (by default)
         - removes empty features
         - splits apart multi-geoms and geom collections into single geometries
@@ -77,6 +87,7 @@ class VectorSource(ABC):
         pass
 
     def get_dataframe(self, to_map_coords: bool = False) -> gpd.GeoDataFrame:
+        """Return geometries as a :class:`~geopandas.GeoDataFrame`."""
         geojson = self.get_geojson(to_map_coords=to_map_coords)
         df = gpd.GeoDataFrame.from_features(geojson)
         if len(df) == 0 and 'geometry' not in df.columns:
@@ -85,6 +96,7 @@ class VectorSource(ABC):
 
     @property
     def extent(self) -> Box:
+        """Envelope of union of all geoms."""
         if self._extent is None:
             envelope = unary_union(self.get_geoms()).envelope
             self._extent = Box.from_shapely(envelope).to_int()

--- a/rastervision_core/rastervision/core/data/vector_source/vector_source_config.py
+++ b/rastervision_core/rastervision/core/data/vector_source/vector_source_config.py
@@ -44,6 +44,8 @@ def vector_source_config_upgrader(cfg_dict: dict, version: int) -> dict:
 
 @register_config('vector_source', upgrader=vector_source_config_upgrader)
 class VectorSourceConfig(Config):
+    """Configure a :class:`.VectorSource`."""
+
     transformers: List[VectorTransformerConfig] = Field(
         [], description='List of VectorTransformers.')
 

--- a/rastervision_core/rastervision/core/data/vector_transformer/buffer_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/vector_transformer/buffer_transformer_config.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 @register_config('buffer_transformer')
 class BufferTransformerConfig(VectorTransformerConfig):
-    """Configure the conversion of non-polygon geometries into polygons.
+    """Configure a :class:`.BufferTransformer`.
 
     This is useful, for example, for buffering lines representing roads so that
     their width roughly matches the width of roads in the imagery.

--- a/rastervision_core/rastervision/core/data/vector_transformer/class_inference_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/vector_transformer/class_inference_transformer_config.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 @register_config('class_inference_transformer')
 class ClassInferenceTransformerConfig(VectorTransformerConfig):
+    """Configure a :class:`.ClassInferenceTransformer`."""
+
     default_class_id: Optional[int] = Field(
         None,
         description='The default class_id to use if class cannot be inferred '

--- a/rastervision_core/rastervision/core/data/vector_transformer/shift_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/vector_transformer/shift_transformer_config.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 @register_config('shift_transformer')
 class ShiftTransformerConfig(VectorTransformerConfig):
-    """Shift geometries by some distance specified in meters."""
+    """Configure a :class:`.ShiftTransformer`."""
 
     x_shift: float = Field(
         0.0,

--- a/rastervision_core/rastervision/core/data/vector_transformer/vector_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/vector_transformer/vector_transformer_config.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
 
 @register_config('vector_transformer')
 class VectorTransformerConfig(Config):
+    """Configure a :class:`.VectorTransformer`."""
+
     def update(self,
                pipeline: Optional['RVPipelineConfig'] = None,
                scene: Optional['SceneConfig'] = None) -> None:

--- a/rastervision_core/rastervision/core/evaluation/chip_classification_evaluator_config.py
+++ b/rastervision_core/rastervision/core/evaluation/chip_classification_evaluator_config.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
 
 @register_config('chip_classification_evaluator')
 class ChipClassificationEvaluatorConfig(ClassificationEvaluatorConfig):
+    """Configure a :class:`.ChipClassificationEvaluator`."""
+
     def build(self,
               class_config: 'ClassConfig',
               scene_group: Optional[Tuple[str, Iterable[str]]] = None

--- a/rastervision_core/rastervision/core/evaluation/classification_evaluator_config.py
+++ b/rastervision_core/rastervision/core/evaluation/classification_evaluator_config.py
@@ -4,4 +4,6 @@ from rastervision.core.evaluation.evaluator_config import EvaluatorConfig
 
 @register_config('classification_evaluator')
 class ClassificationEvaluatorConfig(EvaluatorConfig):
+    """Configure a :class:`.ClassificationEvaluator`."""
+
     pass

--- a/rastervision_core/rastervision/core/evaluation/evaluator_config.py
+++ b/rastervision_core/rastervision/core/evaluation/evaluator_config.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
 
 @register_config('evaluator')
 class EvaluatorConfig(Config):
+    """Configure an :class:`.Evaluator`."""
+
     output_uri: Optional[str] = Field(
         None,
         description='URI of directory where evaluator output will be saved. '

--- a/rastervision_core/rastervision/core/evaluation/object_detection_evaluator_config.py
+++ b/rastervision_core/rastervision/core/evaluation/object_detection_evaluator_config.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 @register_config('object_detection_evaluator')
 class ObjectDetectionEvaluatorConfig(ClassificationEvaluatorConfig):
+    """Configure an :class:`.ObjectDetectionEvaluator`."""
+
     def build(self,
               class_config: 'ClassConfig',
               scene_group: Optional[Tuple[str, Iterable[str]]] = None

--- a/rastervision_core/rastervision/core/evaluation/semantic_segmentation_evaluator_config.py
+++ b/rastervision_core/rastervision/core/evaluation/semantic_segmentation_evaluator_config.py
@@ -23,6 +23,8 @@ def ss_evaluator_config_upgrader(cfg_dict: dict, version: int) -> dict:
 @register_config(
     'semantic_segmentation_evaluator', upgrader=ss_evaluator_config_upgrader)
 class SemanticSegmentationEvaluatorConfig(ClassificationEvaluatorConfig):
+    """Configure a :class:`.SemanticSegmentationEvaluator`."""
+
     def build(self,
               class_config: 'ClassConfig',
               scene_group: Optional[Tuple[str, Iterable[str]]] = None

--- a/rastervision_core/rastervision/core/rv_pipeline/chip_classification_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/chip_classification_config.py
@@ -7,6 +7,8 @@ from rastervision.core.evaluation import ChipClassificationEvaluatorConfig
 
 @register_config('chip_classification')
 class ChipClassificationConfig(RVPipelineConfig):
+    """Configure a :class:`.ChipClassification` pipeline."""
+
     def build(self, tmp_dir):
         from rastervision.core.rv_pipeline.chip_classification import ChipClassification
         return ChipClassification(self, tmp_dir)

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection_config.py
@@ -59,6 +59,8 @@ class ObjectDetectionPredictOptions(PredictOptions):
 
 @register_config('object_detection')
 class ObjectDetectionConfig(RVPipelineConfig):
+    """Configure an :class:`.ObjectDetection` pipeline."""
+
     chip_options: ObjectDetectionChipOptions = ObjectDetectionChipOptions()
     predict_options: ObjectDetectionPredictOptions = ObjectDetectionPredictOptions(
     )

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
@@ -23,7 +23,8 @@ class PredictOptions(Config):
 
 @register_config('rv_pipeline')
 class RVPipelineConfig(PipelineConfig):
-    """Config for RVPipeline."""
+    """Configure an :class:`.RVPipeline`."""
+
     dataset: DatasetConfig = Field(
         ...,
         description=

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
@@ -104,6 +104,8 @@ class SemanticSegmentationPredictOptions(PredictOptions):
 
 @register_config('semantic_segmentation', upgrader=ss_config_upgrader)
 class SemanticSegmentationConfig(RVPipelineConfig):
+    """Configure a :class:`.SemanticSegmentation` pipeline."""
+
     chip_options: SemanticSegmentationChipOptions = \
         SemanticSegmentationChipOptions()
     predict_options: SemanticSegmentationPredictOptions = \

--- a/rastervision_pipeline/rastervision/pipeline/pipeline_config.py
+++ b/rastervision_pipeline/rastervision/pipeline/pipeline_config.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 @register_config('pipeline')
 class PipelineConfig(Config):
-    """Base class for configuring Pipelines.
+    """Base class for configuring :class:`Pipelines <.Pipeline>`.
 
     This should be subclassed to configure new Pipelines.
     """

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
@@ -41,6 +41,8 @@ def clf_learner_backend_config_upgrader(cfg_dict, version):
     'pytorch_chip_classification_backend',
     upgrader=clf_learner_backend_config_upgrader)
 class PyTorchChipClassificationConfig(PyTorchLearnerBackendConfig):
+    """Configure a :class:`.PyTorchChipClassification` backend."""
+
     model: ClassificationModelConfig
 
     def get_learner_config(self, pipeline):

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -13,6 +13,8 @@ log = logging.getLogger(__name__)
 
 @register_config('pytorch_learner_backend')
 class PyTorchLearnerBackendConfig(BackendConfig):
+    """Configure a :class:`.PyTorchLearnerBackend`."""
+
     model: ModelConfig
     solver: SolverConfig
     data: DataConfig

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -41,6 +41,8 @@ def objdet_learner_backend_config_upgrader(cfg_dict, version):
     'pytorch_object_detection_backend',
     upgrader=objdet_learner_backend_config_upgrader)
 class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
+    """Configure a :class:`.PyTorchObjectDetection` backend."""
+
     model: ObjectDetectionModelConfig
 
     def get_learner_config(self, pipeline):

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -41,6 +41,8 @@ def ss_learner_backend_config_upgrader(cfg_dict, version):
     'pytorch_semantic_segmentation_backend',
     upgrader=ss_learner_backend_config_upgrader)
 class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
+    """Configure a :class:`.PyTorchSemanticSegmentation` backend."""
+
     model: SemanticSegmentationModelConfig
 
     def get_learner_config(self, pipeline):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -35,6 +35,8 @@ class ClassificationDataConfig(Config):
 
 @register_config('classification_image_data')
 class ClassificationImageDataConfig(ClassificationDataConfig, ImageDataConfig):
+    """Configure :class:`ClassificationImageDatasets <.ClassificationImageDataset>`."""
+
     data_format: ClassificationDataFormat = ClassificationDataFormat.image_folder
 
     def dir_to_dataset(self, data_dir: str, transform: A.BasicTransform
@@ -46,6 +48,11 @@ class ClassificationImageDataConfig(ClassificationDataConfig, ImageDataConfig):
 
 @register_config('classification_geo_data')
 class ClassificationGeoDataConfig(ClassificationDataConfig, GeoDataConfig):
+    """Configure classification :class:`GeoDatasets <.GeoDataset>`.
+
+    See :mod:`rastervision.pytorch_learner.dataset.classification_dataset`.
+    """
+
     def build_scenes(self, tmp_dir: str):
         for s in self.scene_dataset.all_scenes:
             if s.label_source is not None:
@@ -89,6 +96,8 @@ class ClassificationGeoDataConfig(ClassificationDataConfig, GeoDataConfig):
 
 @register_config('classification_model')
 class ClassificationModelConfig(ModelConfig):
+    """Configure a classification model."""
+
     def build_default_model(self, num_classes: int,
                             in_channels: int) -> nn.Module:
         from torchvision import models
@@ -125,6 +134,8 @@ class ClassificationModelConfig(ModelConfig):
 
 @register_config('classification_learner')
 class ClassificationLearnerConfig(LearnerConfig):
+    """Configure a :class:`.ClassificationLearner`."""
+
     data: Union[ClassificationImageDataConfig, ClassificationGeoDataConfig]
     model: Optional[ClassificationModelConfig]
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/classification_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/classification_dataset.py
@@ -24,14 +24,12 @@ class ClassificationImageDataset(ImageDataset):
                  *args, **kwargs):
         """Constructor.
 
-        .. currentmodule:: rastervision.pytorch_learner.dataset.dataset
-
         Args:
             data_dir (str): Root directory containing class dirs.
             class_names (Optional[Iterable[str]]): Class names. Should match
                 class dir names.
-            *args: See :meth:`ImageDataset.__init__`.
-            **kwargs: See :meth:`ImageDataset.__init__`.
+            *args: See :meth:`.ImageDataset.__init__`.
+            **kwargs: See :meth:`.ImageDataset.__init__`.
         """
         ds = make_image_folder_dataset(data_dir, classes=class_names)
         super().__init__(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
@@ -68,23 +68,19 @@ class CocoDataset(Dataset):
 class ObjectDetectionImageDataset(ImageDataset):
     """Read Object Detection data in the COCO format.
 
-    .. currentmodule:: rastervision.pytorch_learner.dataset.object_detection_dataset
-
-    Uses :class:`CocoDataset` to read the data.
+    Uses :class:`.CocoDataset` to read the data.
     """
 
     def __init__(self, img_dir: str, annotation_uri: str, *args, **kwargs):
         """Constructor.
-
-        .. currentmodule:: rastervision.pytorch_learner.dataset.dataset
 
         Args:
             img_dir (str): Directory containing the images. Image filenames
                 must match the image IDs in the annotations file.
             annotation_uri (str): URI to a JSON file containing annotations in
                 the COCO format.
-            *args: See :meth:`ImageDataset.__init__`.
-            **kwargs: See :meth:`ImageDataset.__init__`.
+            *args: See :meth:`.ImageDataset.__init__`.
+            **kwargs: See :meth:`.ImageDataset.__init__`.
         """
         ds = CocoDataset(img_dir, annotation_uri)
         super().__init__(
@@ -167,10 +163,8 @@ class ObjectDetectionRandomWindowGeoDataset(RandomWindowGeoDataset):
     def __init__(self, *args, **kwargs):
         """Constructor.
 
-        .. currentmodule:: rastervision.pytorch_learner.dataset.dataset
-
         Args:
-            *args: See :meth:`RandomWindowGeoDataset.__init__`.
+            *args: See :meth:`.RandomWindowGeoDataset.__init__`.
 
         Keyword Args:
             bbox_params (Optional[A.BboxParams], optional): Optional
@@ -190,7 +184,7 @@ class ObjectDetectionRandomWindowGeoDataset(RandomWindowGeoDataset):
             neg_ioa_thresh (float, optional): A window will be considered
                 negative if its max IoA with any bounding box is less than this
                 threshold. Defaults to 0.2.
-            **kwargs: See :meth:`RandomWindowGeoDataset.__init__`.
+            **kwargs: See :meth:`.RandomWindowGeoDataset.__init__`.
         """
         self.bbox_params: Optional[A.BboxParams] = kwargs.pop(
             'bbox_params', None)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/semantic_segmentation_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/semantic_segmentation_dataset.py
@@ -64,21 +64,17 @@ class SemanticSegmentationDataReader(Dataset):
 class SemanticSegmentationImageDataset(ImageDataset):
     """Reads semantic segmentatioin images and labels from files.
 
-    .. currentmodule:: rastervision.pytorch_learner.dataset.semantic_segmentation_dataset
-
-    Uses :class:`SemanticSegmentationDataReader` to read the data.
+    Uses :class:`.SemanticSegmentationDataReader` to read the data.
     """
 
     def __init__(self, img_dir: str, label_dir: str, *args, **kwargs):
         """Constructor.
 
-        .. currentmodule:: rastervision.pytorch_learner.dataset.dataset
-
         Args:
             img_dir (str): Directory containing images.
             label_dir (str): Directory containing segmentation masks.
-            *args: See :meth:`ImageDataset.__init__`.
-            **kwargs: See :meth:`ImageDataset.__init__`.
+            *args: See :meth:`.ImageDataset.__init__`.
+            **kwargs: See :meth:`.ImageDataset.__init__`.
         """
 
         ds = SemanticSegmentationDataReader(img_dir, label_dir)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -929,8 +929,6 @@ class Learner(ABC):
             This is the bundle saved in ``train/model-bundle.zip`` and not
             ``bundle/model-bundle.zip``.
 
-        .. currentmodule:: rastervision.pytorch_learner.learner
-
         Args:
             model_bundle_uri (str): URI of the model bundle.
             tmp_dir (Optional[str], optional): Optional temporary directory.
@@ -944,7 +942,7 @@ class Learner(ABC):
                 model will be put into eval mode. If True, the training
                 apparatus will be set up and the model will be put into
                 training mode. Defaults to True.
-            **kwargs: See :meth:`Learner.__init__`.
+            **kwargs: See :meth:`.Learner.__init__`.
 
         Raises:
             FileNotFoundError: If using custom Albumentations transforms and

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -1057,6 +1057,11 @@ class GeoDataWindowMethod(Enum):
 
 @register_config('geo_data_window')
 class GeoDataWindowConfig(Config):
+    """Configure a :class:`.GeoDataset`.
+
+    See :mod:`rastervision.pytorch_learner.dataset.dataset`.
+    """
+
     method: GeoDataWindowMethod = Field(
         GeoDataWindowMethod.sliding, description='')
     size: Union[PosInt, Tuple[PosInt, PosInt]] = Field(
@@ -1142,6 +1147,11 @@ class GeoDataWindowConfig(Config):
 
 @register_config('geo_data')
 class GeoDataConfig(DataConfig):
+    """Configure :class:`GeoDatasets <.GeoDataset>`.
+
+    See :mod:`rastervision.pytorch_learner.dataset.dataset`.
+    """
+
     scene_dataset: Optional['SceneDatasetConfig'] = Field(None, description='')
     window_opts: Union[GeoDataWindowConfig, Dict[str,
                                                  GeoDataWindowConfig]] = Field(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_pipeline_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_pipeline_config.py
@@ -5,6 +5,8 @@ from rastervision.pytorch_learner import LearnerConfig
 
 @register_config('learner_pipeline')
 class LearnerPipelineConfig(PipelineConfig):
+    """Configure a :class:`.LearnerPipeline`."""
+
     learner: LearnerConfig
 
     def update(self):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -47,6 +47,8 @@ class ObjectDetectionDataConfig(Config):
 @register_config('object_detection_image_data')
 class ObjectDetectionImageDataConfig(ObjectDetectionDataConfig,
                                      ImageDataConfig):
+    """Configure :class:`ObjectDetectionImageDatasets <.ObjectDetectionImageDataset>`."""
+
     data_format: ObjectDetectionDataFormat = ObjectDetectionDataFormat.coco
 
     def dir_to_dataset(self, data_dir: str, transform: A.BasicTransform
@@ -60,6 +62,10 @@ class ObjectDetectionImageDataConfig(ObjectDetectionDataConfig,
 
 @register_config('object_detection_geo_data_window')
 class ObjectDetectionGeoDataWindowConfig(GeoDataWindowConfig):
+    """Configure an object detection :class:`.GeoDataset`.
+
+    See :mod:`rastervision.pytorch_learner.dataset.object_detection_dataset`.
+    """
     ioa_thresh: float = Field(
         0.8,
         description='When a box is partially outside of a training chip, it '
@@ -87,6 +93,11 @@ class ObjectDetectionGeoDataWindowConfig(GeoDataWindowConfig):
 
 @register_config('object_detection_geo_data')
 class ObjectDetectionGeoDataConfig(ObjectDetectionDataConfig, GeoDataConfig):
+    """Configure object detection :class:`GeoDatasets <.GeoDataset>`.
+
+    See :mod:`rastervision.pytorch_learner.dataset.object_detection_dataset`.
+    """
+
     def scene_to_dataset(
             self,
             scene: Scene,
@@ -131,6 +142,8 @@ class ObjectDetectionGeoDataConfig(ObjectDetectionDataConfig, GeoDataConfig):
 
 @register_config('object_detection_model')
 class ObjectDetectionModelConfig(ModelConfig):
+    """Configure an object detection model."""
+
     backbone: Backbone = Field(
         Backbone.resnet50,
         description=
@@ -203,6 +216,8 @@ class ObjectDetectionModelConfig(ModelConfig):
 
 @register_config('object_detection_learner')
 class ObjectDetectionLearnerConfig(LearnerConfig):
+    """Configure an :class:`.ObjectDetectionLearner`."""
+
     data: Union[ObjectDetectionImageDataConfig, ObjectDetectionGeoDataConfig]
     model: Optional[ObjectDetectionModelConfig]
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner_config.py
@@ -48,6 +48,8 @@ class RegressionDataConfig(Config):
 
 @register_config('regression_image_data')
 class RegressionImageDataConfig(RegressionDataConfig, ImageDataConfig):
+    """Configure :class:`RegressionImageDatasets <.RegressionImageDataset>`."""
+
     data_format: RegressionDataFormat = RegressionDataFormat.csv
     plot_options: Optional[RegressionPlotOptions] = Field(
         RegressionPlotOptions(), description='Options to control plotting.')
@@ -61,6 +63,11 @@ class RegressionImageDataConfig(RegressionDataConfig, ImageDataConfig):
 
 @register_config('regression_geo_data')
 class RegressionGeoDataConfig(RegressionDataConfig, GeoDataConfig):
+    """Configure regression :class:`GeoDatasets <.GeoDataset>`.
+
+    See :mod:`rastervision.pytorch_learner.dataset.regression_dataset`.
+    """
+
     plot_options: Optional[RegressionPlotOptions] = Field(
         RegressionPlotOptions(), description='Options to control plotting.')
 
@@ -126,6 +133,8 @@ class RegressionModel(nn.Module):
 
 @register_config('regression_model')
 class RegressionModelConfig(ModelConfig):
+    """Configure a regression model."""
+
     output_multiplier: List[float] = None
 
     def update(self, learner=None):
@@ -185,6 +194,8 @@ class RegressionModelConfig(ModelConfig):
 
 @register_config('regression_learner')
 class RegressionLearnerConfig(LearnerConfig):
+    """Configure a :class:`.RegressionLearner`."""
+
     model: Optional[RegressionModelConfig]
     data: Union[RegressionImageDataConfig, RegressionGeoDataConfig]
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
@@ -61,14 +61,11 @@ class SemanticSegmentationDataConfig(Config):
     'semantic_segmentation_image_data', upgrader=ss_image_data_config_upgrader)
 class SemanticSegmentationImageDataConfig(SemanticSegmentationDataConfig,
                                           ImageDataConfig):
-    """Configure reading of a semnatic segmentation image dataset.
+    """Configure :class:`SemanticSegmentationImageDatasets <.SemanticSegmentationImageDataset>`.
 
-    .. currentmodule:: rastervision.pytorch_learner.dataset.semantic_segmentation_dataset
+    This assumes the following file structure:
 
-    This is used to instantiate a :class:`SemanticSegmentationImageDataset`
-    and assumes the following file structure:
-
-    .. code-block:: txt
+    .. code-block:: text
 
         <data_dir>/
             img/
@@ -82,7 +79,7 @@ class SemanticSegmentationImageDataConfig(SemanticSegmentationDataConfig,
                 ...
                 <img N>.<extension>
 
-    """
+    """ # noqa
     data_format: SemanticSegmentationDataFormat = (
         SemanticSegmentationDataFormat.default)
 
@@ -104,6 +101,12 @@ class SemanticSegmentationImageDataConfig(SemanticSegmentationDataConfig,
 @register_config('semantic_segmentation_geo_data')
 class SemanticSegmentationGeoDataConfig(SemanticSegmentationDataConfig,
                                         GeoDataConfig):
+    """Configure semantic segmentation :class:`GeoDatasets <.GeoDataset>`.
+
+    See
+    :mod:`rastervision.pytorch_learner.dataset.semantic_segmentation_dataset`.
+    """
+
     def update(self, *args, **kwargs):
         SemanticSegmentationDataConfig.update(self)
         GeoDataConfig.update(self, *args, **kwargs)
@@ -144,6 +147,8 @@ class SemanticSegmentationGeoDataConfig(SemanticSegmentationDataConfig,
 
 @register_config('semantic_segmentation_model')
 class SemanticSegmentationModelConfig(ModelConfig):
+    """Configure a semantic segmentation model."""
+
     backbone: Backbone = Field(
         Backbone.resnet50,
         description=(
@@ -193,6 +198,8 @@ class SemanticSegmentationModelConfig(ModelConfig):
 
 @register_config('semantic_segmentation_learner')
 class SemanticSegmentationLearnerConfig(LearnerConfig):
+    """Configure a :class:`.SemanticSegmentationLearner`."""
+
     data: Union[SemanticSegmentationImageDataConfig,
                 SemanticSegmentationGeoDataConfig]
     model: Optional[SemanticSegmentationModelConfig]


### PR DESCRIPTION
## Overview

This PR improves the docstrings for the most commonly used classes and configs. Most config docstrings now have a link to their corresponding non-config class.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

While working on this PR, I learned that 
```reST
:some_domain:`~full.path.to.SomeObject`
```
can be shortened to 
```reST
:some_domain:`.SomeObject`
```

This made adding cross-reference to docstrings a lot cleaner.

## Testing Instructions

Check if the build docs look fine.

Part of #1505 