### PR TITLE
Update example plugin `__init__.py` files to include `registry.set_plugin_version()` calls

### DIFF
--- a/docs/framework/architecture.rst
+++ b/docs/framework/architecture.rst
@@ -65,6 +65,7 @@ Finally, in order to package this code as a plugin, and make it usable within th
 .. literalinclude:: /../rastervision_pipeline/rastervision/pipeline_example_plugin1/__init__.py
     :language: python
     :caption: rastervision.pipeline_example_plugin1.__init__
+    :lines: 3-
 
 We can invoke the Raster Vision CLI to run the pipeline using:
 

--- a/rastervision_pipeline/rastervision/pipeline_example_plugin1/__init__.py
+++ b/rastervision_pipeline/rastervision/pipeline_example_plugin1/__init__.py
@@ -2,9 +2,16 @@
 
 
 def register_plugin(registry):
-    # Can be used to manually update the registry. Useful
-    # for adding new FileSystems and Runners.
-    pass
+    """Each plugin must register itself and FileSystems, Runners it defines.
+    
+    The version number helps ensure backward compatibility of configs across
+    versions. If you change the fields of a config but want it to remain
+    backward-compatible you can increment the version below and define a
+    config-upgrader function that makes the old version of the config dict
+    compatible with the new version. This upgrader function should be passed to
+    the :func:`.register_config` decorator of the config in question.
+    """
+    registry.set_plugin_version('rastervision.pipeline_example_plugin1', 0)
 
 
 # Must import pipeline package first.

--- a/rastervision_pipeline/rastervision/pipeline_example_plugin2/__init__.py
+++ b/rastervision_pipeline/rastervision/pipeline_example_plugin2/__init__.py
@@ -2,9 +2,16 @@
 
 
 def register_plugin(registry):
-    # Can be used to manually update the registry. Useful
-    # for adding new FileSystems and Runners.
-    pass
+    """Each plugin must register itself and FileSystems, Runners it defines.
+    
+    The version number helps ensure backward compatibility of configs across
+    versions. If you change the fields of a config but want it to remain
+    backward-compatible you can increment the version below and define a
+    config-upgrader function that makes the old version of the config dict
+    compatible with the new version. This upgrader function should be passed to
+    the :func:`.register_config` decorator of the config in question.
+    """
+    registry.set_plugin_version('rastervision.pipeline_example_plugin2', 0)
 
 
 # Must import pipeline package first.


### PR DESCRIPTION
## Overview

All plugins are required to register themselves in the `Registry` by calling `registry.set_plugin_version()`. However, currently the example plugins and docs do not make this clear. This PR fixes this oversight.

This was brought up in #1652.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

See docs build: https://raster-vision--1665.org.readthedocs.build/en/1665/framework/architecture.html#id4
