### PR TITLE
Add error handling for empty DataLoader

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/visualizer/visualizer.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/visualizer/visualizer.py
@@ -153,8 +153,11 @@ class Visualizer(ABC):
         """
         collate_fn = self.get_collate_fn()
         dl = DataLoader(dataset, batch_sz, collate_fn=collate_fn, **kwargs)
-        for x, y in dl:
-            break
+        try:
+            x, y = next(iter(dl))
+        except StopIteration:
+            raise ValueError('dataset did not return a batch')
+
         return x, y
 
     def get_plot_nrows(self, **kwargs) -> int:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -1195,6 +1195,8 @@ class Learner(ABC):
                 if step_scheduler is not None:
                     step_scheduler.step()
                 num_samples += x.shape[0]
+        if len(outputs) == 0:
+            raise ValueError('Training dataset did not return any batches')
         metrics = self.train_end(outputs, num_samples)
         end = time.time()
         train_time = datetime.timedelta(seconds=end - start)

--- a/tests/pytorch_learner/dataset/visualizer/test_visualizer.py
+++ b/tests/pytorch_learner/dataset/visualizer/test_visualizer.py
@@ -1,0 +1,14 @@
+import unittest
+
+from rastervision.pytorch_learner.dataset.visualizer import SemanticSegmentationVisualizer
+
+
+class TestAoiSampler(unittest.TestCase):
+    def test_get_batch_from_empty_dataset(self):
+        viz = SemanticSegmentationVisualizer(
+            class_names=['background', 'building'],
+            class_colors=['lightgray', 'darkred'])
+        ds = []
+
+        with self.assertRaises(ValueError):
+            viz.get_batch(ds)


### PR DESCRIPTION
## Overview

This adds two small error checks for when the `DataLoader` returns an empty iterator. Without this, code crashes with hard-to-understand internal errors.

### Checklist

- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [X] Ran scripts/format_code and committed any changes
- [X] Documentation updated if needed
- [X] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

Learner:

* Create a dataset which is empty (for example, a random window sampler with an AOI that is impossible to hit)
* Run `train_epoch`
* `ValueError` should be thrown (previosly resulted in an `IndexError` when `outputs` was accessed)

Visualizer:

* Create a dataset which is empty (for example, a random window sampler with an AOI that is impossible to hit)
* Call `plot_batch`
* `ValueError` should be thrown (previously resulted in an `NameError` since `x` wasn't defined)
