### PR TITLE
Only set default stride if stride value is missing in `GeoDataWindowConfig`

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -1124,7 +1124,10 @@ class GeoDataWindowConfig(Config):
         method = values.get('method')
         size = values.get('size')
         if method == GeoDataWindowMethod.sliding:
-            values['stride'] = size
+            has_stride = values.get('stride') is not None
+
+            if not has_stride:
+                values['stride'] = size
         elif method == GeoDataWindowMethod.random:
             size_lims = values.get('size_lims')
             h_lims = values.get('h_lims')

--- a/tests/pytorch_learner/test_learner_config.py
+++ b/tests/pytorch_learner/test_learner_config.py
@@ -1,0 +1,15 @@
+import unittest
+
+from rastervision.pytorch_learner import (GeoDataWindowConfig,
+                                          GeoDataWindowMethod)
+
+
+class TestGeoDataWindowConfig(unittest.TestCase):
+    def test_default_stride(self):
+        cfg = GeoDataWindowConfig(method=GeoDataWindowMethod.sliding, size=256)
+        self.assertEqual(cfg.stride, 256)
+
+    def test_set_stride(self):
+        cfg = GeoDataWindowConfig(
+            method=GeoDataWindowMethod.sliding, size=256, stride=15)
+        self.assertEqual(cfg.stride, 15)


### PR DESCRIPTION
## Overview

Yet another tiny fix for what I believe is a bug: when passing `stride` to `GeoDataWindowConfig`, it is currently always overwritten with the default value (`size`).

With this PR, the default is only set if `stride` has not been explicitly set, much like the logic for `size_lims` in the same class.

### Checklist

- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [X] Ran scripts/format_code and committed any changes
- [X] Documentation updated if needed
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* Added a unit test for both the default (no explicit `stride` parameter, value should fallback to `size`) and when `stride` is set, so running unit tests should be enough to verify that this works
* Creating a dataset with a non-default stride and check that the correct number of windows are created
