### PR TITLE
[BACKPORT] Only set default stride if stride value is missing in `GeoDataWindowConfig`

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -1124,7 +1124,10 @@ class GeoDataWindowConfig(Config):
         method = values.get('method')
         size = values.get('size')
         if method == GeoDataWindowMethod.sliding:
-            values['stride'] = size
+            has_stride = values.get('stride') is not None
+
+            if not has_stride:
+                values['stride'] = size
         elif method == GeoDataWindowMethod.random:
             size_lims = values.get('size_lims')
             h_lims = values.get('h_lims')

--- a/tests/pytorch_learner/test_learner_config.py
+++ b/tests/pytorch_learner/test_learner_config.py
@@ -1,0 +1,15 @@
+import unittest
+
+from rastervision.pytorch_learner import (GeoDataWindowConfig,
+                                          GeoDataWindowMethod)
+
+
+class TestGeoDataWindowConfig(unittest.TestCase):
+    def test_default_stride(self):
+        cfg = GeoDataWindowConfig(method=GeoDataWindowMethod.sliding, size=256)
+        self.assertEqual(cfg.stride, 256)
+
+    def test_set_stride(self):
+        cfg = GeoDataWindowConfig(
+            method=GeoDataWindowMethod.sliding, size=256, stride=15)
+        self.assertEqual(cfg.stride, 15)


### PR DESCRIPTION
#1674 