### PR TITLE
Misc object detection fixes and improvements

### DIFF
--- a/rastervision_core/rastervision/core/data/label/object_detection_labels.py
+++ b/rastervision_core/rastervision/core/data/label/object_detection_labels.py
@@ -61,6 +61,9 @@ class ObjectDetectionLabels(Labels):
         concatenated_labels = self + new_labels
         self.boxlist = concatenated_labels.boxlist
 
+    def __getitem__(self, window: Box) -> 'ObjectDetectionLabels':
+        return ObjectDetectionLabels.get_overlapping(self, window)
+
     def assert_equal(self, expected_labels: 'ObjectDetectionLabels'):
         np.testing.assert_array_equal(self.get_npboxes(),
                                       expected_labels.get_npboxes())

--- a/rastervision_core/rastervision/core/data/label/object_detection_labels.py
+++ b/rastervision_core/rastervision/core/data/label/object_detection_labels.py
@@ -235,16 +235,18 @@ class ObjectDetectionLabels(Labels):
     @staticmethod
     def get_overlapping(labels: 'ObjectDetectionLabels',
                         window: Box,
-                        ioa_thresh: float = 0.000001,
+                        ioa_thresh: float = 0.5,
                         clip: bool = False) -> 'ObjectDetectionLabels':
         """Return subset of labels that overlap with window.
 
         Args:
             labels: ObjectDetectionLabels
             window: Box
-            ioa_thresh: the minimum IOA for a box to be considered as
-                overlapping
-            clip: if True, clip label boxes to the window
+            ioa_thresh: The minimum intersection-over-area (IOA) for a box to
+                be considered as overlapping. For each box, IOA is defined as
+                the area of the intersection of the box with the window over
+                the area of the box.
+            clip: If True, clip label boxes to the window.
         """
         window_npbox = window.npbox_format()
         window_boxlist = BoxList(np.expand_dims(window_npbox, axis=0))
@@ -269,23 +271,26 @@ class ObjectDetectionLabels(Labels):
         return ObjectDetectionLabels.from_boxlist(new_boxlist)
 
     @staticmethod
-    def prune_duplicates(labels: 'ObjectDetectionLabels', score_thresh: float,
-                         merge_thresh: float) -> 'ObjectDetectionLabels':
-        """Remove duplicate boxes.
-
-        Runs non-maximum suppression to remove duplicate boxes that result from
-        sliding window prediction algorithm.
+    def prune_duplicates(
+            labels: 'ObjectDetectionLabels',
+            score_thresh: float,
+            merge_thresh: float,
+            max_output_size: Optional[int] = None) -> 'ObjectDetectionLabels':
+        """Remove duplicate boxes via non-maximum suppression.
 
         Args:
-            labels: ObjectDetectionLabels
-            score_thresh: the minimum allowed score of boxes
-            merge_thresh: the minimum IOA allowed when merging two boxes
-                together
+            labels: Labels whose boxes are to be pruned.
+            score_thresh: Prune boxes with score less than this threshold.
+            merge_thresh: Prune boxes with intersection-over-union (IOU)
+                greater than this threshold.
+            max_output_size (int): Maximum number of retained boxes.
+                If None, this is set to ``len(abels)``. Defaults to None.
 
         Returns:
-            ObjectDetectionLabels
+            ObjectDetectionLabels: Pruned labels.
         """
-        max_output_size = 1000000
+        if max_output_size is None:
+            max_output_size = len(labels)
         pruned_boxlist = non_max_suppression(
             labels.boxlist,
             max_output_size=max_output_size,

--- a/rastervision_core/rastervision/core/data/label/tfod_utils/np_box_list_ops.py
+++ b/rastervision_core/rastervision/core/data/label/tfod_utils/np_box_list_ops.py
@@ -15,6 +15,7 @@
 """Bounding Box List operations for Numpy BoxLists."""
 from typing import List, Optional, Tuple
 
+from tqdm.auto import trange
 import numpy as np
 
 from rastervision.core.data.label.tfod_utils.np_box_list import BoxList
@@ -196,7 +197,7 @@ def non_max_suppression(boxlist: BoxList,
     if iou_threshold < 0. or iou_threshold > 1.0:
         raise ValueError('IOU threshold must be in [0, 1]')
     if max_output_size < 0:
-        raise ValueError('max_output_size must be bigger than 0.')
+        raise ValueError('max_output_size must be >= 0.')
 
     boxlist = filter_scores_greater_than(boxlist, score_threshold)
     if boxlist.num_boxes() == 0:
@@ -218,7 +219,7 @@ def non_max_suppression(boxlist: BoxList,
     is_index_valid = np.full(num_boxes, 1, dtype=bool)
     selected_indices = []
     num_output = 0
-    for i in range(num_boxes):
+    for i in trange(num_boxes, desc='Pruning boxes', delay=5):
         if num_output < max_output_size:
             if is_index_valid[i]:
                 num_output += 1

--- a/rastervision_core/rastervision/core/data/label_source/object_detection_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/object_detection_label_source.py
@@ -26,7 +26,8 @@ class ObjectDetectionLabelSource(LabelSource):
             clip (bool, optional): Clip bounding boxes to window limits when
                 retrieving labels for a window. Defaults to False.
         """
-        geojson = vector_source.get_geojson()
+        self.vector_source = vector_source
+        geojson = self.vector_source.get_geojson()
         self.validate_geojson(geojson)
         self.labels = ObjectDetectionLabels.from_geojson(
             geojson, extent=extent)

--- a/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+import logging
 
 from rastervision.core.data.label import ObjectDetectionLabels
 from rastervision.core.data.label_store import LabelStore
@@ -8,6 +9,8 @@ from rastervision.pipeline.file_system import json_to_file
 
 if TYPE_CHECKING:
     from rastervision.core.data import ClassConfig, CRSTransformer
+
+log = logging.getLogger(__name__)
 
 
 class ObjectDetectionGeoJSONStore(LabelStore):
@@ -30,6 +33,7 @@ class ObjectDetectionGeoJSONStore(LabelStore):
 
     def save(self, labels: ObjectDetectionLabels) -> None:
         """Save labels to URI."""
+        log.info(f'Saving {len(labels)} boxes as GeoJSON.')
         boxes = labels.get_boxes()
         class_ids = [int(id) for id in labels.get_class_ids()]
         scores = labels.get_scores()

--- a/rastervision_core/rastervision/core/evaluation/classification_evaluation.py
+++ b/rastervision_core/rastervision/core/evaluation/classification_evaluation.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class ClassificationEvaluation(ABC):
-    """Base class for evaluating predictions for pipelines that have classes.
+    """Base class for representing prediction evaluations.
 
     Evaluations can be keyed, for instance, if evaluations happen per class.
 

--- a/rastervision_core/rastervision/core/evaluation/object_detection_evaluator.py
+++ b/rastervision_core/rastervision/core/evaluation/object_detection_evaluator.py
@@ -3,11 +3,7 @@ from rastervision.core.evaluation import (ClassificationEvaluator,
 
 
 class ObjectDetectionEvaluator(ClassificationEvaluator):
-    """Evaluates predictions for a set of scenes.
-    """
-
-    def __init__(self, class_config, output_uri):
-        super().__init__(class_config, output_uri)
+    """Evaluates predictions for a set of scenes."""
 
     def create_evaluation(self):
         return ObjectDetectionEvaluation(self.class_config)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
@@ -9,8 +9,7 @@ from rastervision.core.data import *
 from rastervision.core.analyzer import *
 from rastervision.pytorch_backend import *
 from rastervision.pytorch_learner import *
-from rastervision.pytorch_backend.examples.utils import (get_scene_info,
-                                                         save_image_crop)
+from rastervision.pytorch_backend.examples.utils import save_image_crop
 
 TRAIN_IDS = [
     '2_10', '2_11', '2_12', '2_14', '3_11', '3_13', '4_10', '5_10', '6_7',

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection.py
@@ -123,6 +123,7 @@ class PyTorchObjectDetection(PyTorchLearnerBackend):
                 ds,
                 raw_out=True,
                 numpy_out=True,
+                predict_kw=dict(out_shape=(chip_sz, chip_sz)),
                 progress_bar=True,
                 progress_bar_kw=dict(desc=f'Making predictions on {scene.id}'))
         )

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
@@ -186,8 +186,9 @@ class ObjectDetectionRandomWindowGeoDataset(RandomWindowGeoDataset):
                 threshold. Defaults to 0.2.
             **kwargs: See :meth:`.RandomWindowGeoDataset.__init__`.
         """
+        from rastervision.pytorch_learner import DEFAULT_BBOX_PARAMS
         self.bbox_params: Optional[A.BboxParams] = kwargs.pop(
-            'bbox_params', None)
+            'bbox_params', DEFAULT_BBOX_PARAMS)
         ioa_thresh: float = kwargs.pop('ioa_thresh', 0.9)
         clip: bool = kwargs.pop('clip', False)
         neg_ratio: Optional[float] = kwargs.pop('neg_ratio', None)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_utils.py
@@ -231,9 +231,13 @@ class BoxList():
         return self.ind_filter(good_inds)
 
     def scale(self, yscale: float, xscale: float) -> 'BoxList':
-        boxes = self.boxes * torch.tensor(
-            [[yscale, xscale, yscale, xscale]], device=self.boxes.device)
-        return BoxList(boxes, **self.extras)
+        """Scale box coords by the given scaling factors."""
+        dtype = self.boxes.dtype
+        boxes = self.boxes.float()
+        boxes[:, [0, 2]] *= xscale
+        boxes[:, [1, 3]] *= yscale
+        self.boxes = boxes.to(dtype=dtype)
+        return self
 
     def pin_memory(self) -> 'BoxList':
         self.boxes = self.boxes.pin_memory()

--- a/tests/core/data/label/test_object_detection_labels.py
+++ b/tests/core/data/label/test_object_detection_labels.py
@@ -9,7 +9,7 @@ from rastervision.core.data.label.object_detection_labels import (
 from rastervision.core.data.label.tfod_utils.np_box_list import BoxList
 
 
-class ObjectDetectionLabelsTest(unittest.TestCase):
+class TestObjectDetectionLabels(unittest.TestCase):
     def setUp(self):
         self.class_config = ClassConfig(names=['car', 'house'])
         self.npboxes = np.array([
@@ -103,7 +103,8 @@ class ObjectDetectionLabelsTest(unittest.TestCase):
 
     def test_get_overlapping(self):
         window = Box.make_square(0, 0, 2.01)
-        labels = ObjectDetectionLabels.get_overlapping(self.labels, window)
+        labels = ObjectDetectionLabels.get_overlapping(
+            self.labels, window, ioa_thresh=1e-6)
         labels.assert_equal(self.labels)
 
         window = Box.make_square(0, 0, 3)

--- a/tests/pytorch_learner/dataset/visualizer/test_visualizer.py
+++ b/tests/pytorch_learner/dataset/visualizer/test_visualizer.py
@@ -3,7 +3,7 @@ import unittest
 from rastervision.pytorch_learner.dataset.visualizer import SemanticSegmentationVisualizer
 
 
-class TestAoiSampler(unittest.TestCase):
+class TestVisualizer(unittest.TestCase):
     def test_get_batch_from_empty_dataset(self):
         viz = SemanticSegmentationVisualizer(
             class_names=['background', 'building'],

--- a/tests/pytorch_learner/test_object_detection_utils.py
+++ b/tests/pytorch_learner/test_object_detection_utils.py
@@ -153,6 +153,34 @@ class TestBoxList(unittest.TestCase):
         self.assertEqual(x.shape, (4, 3, 100, 100))
         self.assertTrue(all(b1 == b2 for b1, b2 in zip(boxlists, y)))
 
+    def test_scale(self):
+        boxes = torch.tensor([
+            [0, 0, 1, 1],
+            [0, 10, 10, 20],
+        ])
+        dtype = boxes.dtype
+
+        boxlist = BoxList(boxes.clone())
+        yscale, xscale = 1, 1
+        boxlist.scale(yscale, xscale)
+        torch.testing.assert_close(boxlist.boxes, boxes)
+
+        boxlist = BoxList(boxes.clone())
+        yscale, xscale = 5, 3
+        boxlist.scale(yscale, xscale)
+        x_expected = (boxes[:, [0, 2]] * xscale).to(dtype=dtype)
+        y_expected = (boxes[:, [1, 3]] * yscale).to(dtype=dtype)
+        torch.testing.assert_close(boxlist.boxes[:, [0, 2]], x_expected)
+        torch.testing.assert_close(boxlist.boxes[:, [1, 3]], y_expected)
+
+        boxlist = BoxList(boxes.clone())
+        yscale, xscale = 0.5, 0.3
+        boxlist.scale(yscale, xscale)
+        x_expected = (boxes[:, [0, 2]] * xscale).to(dtype=dtype)
+        y_expected = (boxes[:, [1, 3]] * yscale).to(dtype=dtype)
+        torch.testing.assert_close(boxlist.boxes[:, [0, 2]], x_expected)
+        torch.testing.assert_close(boxlist.boxes[:, [1, 3]], y_expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

This PR makes multiple small fixes and improvements to object detection-related code. The most notable change is that it is now possible to use an `img_sz` that is not equal to the `chip_sz` during prediction.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

See new unit tests.
