### PR TITLE
Allow `GeoJSONVectorSource` to accept multiple URIs

### DIFF
--- a/docs/usage/tutorials/scenes_and_aois.ipynb
+++ b/docs/usage/tutorials/scenes_and_aois.ipynb
@@ -133,7 +133,7 @@
     "    default_class_id=class_config.get_class_id('building'))\n",
     "\n",
     "vector_source = GeoJSONVectorSource(\n",
-    "    uri=label_uri,\n",
+    "    label_uri,\n",
     "    ignore_crs_field=True,\n",
     "    crs_transformer=raster_source.crs_transformer,\n",
     "    vector_transformers=[class_inf_tf])\n",

--- a/integration_tests/chip_classification/config.py
+++ b/integration_tests/chip_classification/config.py
@@ -28,7 +28,7 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
         id = basename(img_path)
         label_source = ChipClassificationLabelSourceConfig(
             vector_source=GeoJSONVectorSourceConfig(
-                uri=label_path, ignore_crs_field=True),
+                uris=label_path, ignore_crs_field=True),
             ioa_thresh=0.5,
             use_intersection_over_cell=False,
             pick_min_class_id=True,

--- a/integration_tests/object_detection/config.py
+++ b/integration_tests/object_detection/config.py
@@ -28,7 +28,7 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
         raster_source = RasterioSourceConfig(
             channel_order=[0, 1, 2], uris=[img_path])
         label_source = ObjectDetectionLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=label_path))
+            vector_source=GeoJSONVectorSourceConfig(uris=label_path))
         return SceneConfig(
             id=scene_id,
             raster_source=raster_source,

--- a/rastervision_core/rastervision/core/__init__.py
+++ b/rastervision_core/rastervision/core/__init__.py
@@ -2,7 +2,7 @@
 
 
 def register_plugin(registry):
-    registry.set_plugin_version('rastervision.core', 7)
+    registry.set_plugin_version('rastervision.core', 8)
     from rastervision.core.cli import predict
     registry.add_plugin_command(predict)
 

--- a/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
@@ -47,7 +47,7 @@ class ChipClassificationGeoJSONStore(LabelStore):
         json_to_file(geojson, self.uri)
 
     def get_labels(self) -> ChipClassificationLabels:
-        vs = GeoJSONVectorSourceConfig(uri=self.uri)
+        vs = GeoJSONVectorSourceConfig(uris=self.uri)
         ls = ChipClassificationLabelSourceConfig(vector_source=vs).build(
             self.class_config, self.crs_transformer)
         return ls.get_labels()

--- a/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
@@ -46,7 +46,7 @@ class ObjectDetectionGeoJSONStore(LabelStore):
         json_to_file(geojson, self.uri)
 
     def get_labels(self) -> ObjectDetectionLabels:
-        vector_source = GeoJSONVectorSourceConfig(uri=self.uri).build(
+        vector_source = GeoJSONVectorSourceConfig(uris=self.uri).build(
             self.class_config, self.crs_transformer)
         return ObjectDetectionLabels.from_geojson(vector_source.get_geojson())
 

--- a/rastervision_core/rastervision/core/data/utils/factory.py
+++ b/rastervision_core/rastervision/core/data/utils/factory.py
@@ -98,7 +98,7 @@ def make_ss_scene(image_uri: Union[str, List[str]],
             label_vector_source_kw['vector_transformers'] = (
                 [class_inf_tf] + vector_tfs)
         vector_source = GeoJSONVectorSource(
-            uri=label_vector_uri,
+            uris=label_vector_uri,
             ignore_crs_field=True,
             crs_transformer=crs_transformer,
             **label_vector_source_kw)
@@ -196,7 +196,7 @@ def make_cc_scene(image_uri: Union[str, List[str]],
             label_vector_source_kw['transformers'] = (
                 [class_inf_tf] + vector_tfs)
         geojson_cfg = GeoJSONVectorSourceConfig(
-            uri=label_vector_uri,
+            uris=label_vector_uri,
             ignore_crs_field=True,
             **label_vector_source_kw)
         # use config to ensure required transformers are auto added
@@ -287,7 +287,7 @@ def make_od_scene(image_uri: Union[str, List[str]],
             label_vector_source_kw['transformers'] = (
                 [class_inf_tf] + vector_tfs)
         geojson_cfg = GeoJSONVectorSourceConfig(
-            uri=label_vector_uri,
+            uris=label_vector_uri,
             ignore_crs_field=True,
             **label_vector_source_kw)
         # use config to ensure required transformers are auto added

--- a/rastervision_core/rastervision/core/data/utils/geojson.py
+++ b/rastervision_core/rastervision/core/data/utils/geojson.py
@@ -5,8 +5,6 @@ from copy import deepcopy
 from shapely.geometry import shape, mapping
 from tqdm.auto import tqdm
 
-from rastervision.core.data.utils.misc import listify_uris
-
 if TYPE_CHECKING:
     from rastervision.core.data.crs_transformer import CRSTransformer
     from shapely.geometry.base import BaseGeometry
@@ -339,12 +337,9 @@ def get_polygons_from_uris(
     # use local imports to avoid circular import problems
     from rastervision.core.data import GeoJSONVectorSource
 
-    polygons = []
-    uris = listify_uris(uris)
-    for uri in uris:
-        source = GeoJSONVectorSource(
-            uri=uri, ignore_crs_field=True, crs_transformer=crs_transformer)
-        polygons += source.get_geoms()
+    source = GeoJSONVectorSource(
+        uris=uris, ignore_crs_field=True, crs_transformer=crs_transformer)
+    polygons = source.get_geoms()
     return polygons
 
 

--- a/rastervision_core/rastervision/core/data/utils/geojson.py
+++ b/rastervision_core/rastervision/core/data/utils/geojson.py
@@ -346,3 +346,10 @@ def get_polygons_from_uris(
             uri=uri, ignore_crs_field=True, crs_transformer=crs_transformer)
         polygons += source.get_geoms()
     return polygons
+
+
+def merge_geojsons(geojsons: Iterable[dict]) -> dict:
+    """Merge features from all given GeoJSONs into one GeoJSON."""
+    features = sum([g.get('features', []) for g in geojsons], [])
+    geojson_merged = features_to_geojson(features)
+    return geojson_merged

--- a/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
+++ b/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Union
 
-from rastervision.core.data.vector_source.vector_source import VectorSource
 from rastervision.pipeline.file_system import download_if_needed, file_to_json
+from rastervision.core.data.vector_source.vector_source import VectorSource
+from rastervision.core.data.utils import listify_uris, merge_geojsons
 
 if TYPE_CHECKING:
     from rastervision.core.data import CRSTransformer, VectorTransformer
@@ -11,14 +12,14 @@ class GeoJSONVectorSource(VectorSource):
     """A :class:`.VectorSource` for reading GeoJSON files."""
 
     def __init__(self,
-                 uri: str,
+                 uris: Union[str, List[str]],
                  crs_transformer: 'CRSTransformer',
                  vector_transformers: List['VectorTransformer'] = [],
                  ignore_crs_field: bool = False):
         """Constructor.
 
         Args:
-            uri (str): URI of the GeoJSON file.
+            uris (Union[str, List[str]]): URI(s) of the GeoJSON file(s).
             crs_transformer: A ``CRSTransformer`` to convert
                 between map and pixel coords. Normally this is obtained from a
                 :class:`.RasterSource`.
@@ -29,22 +30,26 @@ class GeoJSONVectorSource(VectorSource):
                 currently. If False, and the file contains a CRS, will throw an
                 exception on read. Defaults to False.
         """
-        self.uri = uri
+        self.uris = listify_uris(uris)
         self.ignore_crs_field = ignore_crs_field
         super().__init__(
             crs_transformer, vector_transformers=vector_transformers)
 
-    def _get_geojson(self):
+    def _get_geojson(self) -> dict:
+        geojsons = [self._get_geojson_single(uri) for uri in self.uris]
+        geojson = merge_geojsons(geojsons)
+        return geojson
+
+    def _get_geojson_single(self, uri: str) -> dict:
         # download first so that it gets cached
-        geojson = file_to_json(download_if_needed(self.uri))
+        geojson = file_to_json(download_if_needed(uri))
         if not self.ignore_crs_field and 'crs' in geojson:
             raise NotImplementedError(
-                f'The GeoJSON file at {self.uri} contains a CRS field which '
+                f'The GeoJSON file at {uri} contains a CRS field which '
                 'is not allowed by the current GeoJSON standard or by '
                 'Raster Vision. All coordinates are expected to be in '
                 'EPSG:4326 CRS. If the file uses EPSG:4326 (ie. lat/lng on '
                 'the WGS84 reference ellipsoid) and you would like to ignore '
                 'the CRS field, set ignore_crs_field=True in '
                 'GeoJSONVectorSourceConfig.')
-
         return geojson

--- a/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source_config.py
+++ b/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source_config.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Union
 from rastervision.core.data.vector_source import (VectorSourceConfig,
                                                   GeoJSONVectorSource)
 from rastervision.pipeline.config import register_config, Field
@@ -7,11 +7,21 @@ if TYPE_CHECKING:
     from rastervision.core.data import (ClassConfig, CRSTransformer)
 
 
-@register_config('geojson_vector_source')
+def geojson_vector_source_config_upgrader(cfg_dict: dict,
+                                          version: int) -> dict:
+    if version == 7:
+        cfg_dict['uris'] = cfg_dict['uri']
+        del cfg_dict['uri']
+    return cfg_dict
+
+
+@register_config(
+    'geojson_vector_source', upgrader=geojson_vector_source_config_upgrader)
 class GeoJSONVectorSourceConfig(VectorSourceConfig):
     """Configure a :class:`.GeoJSONVectorSource`."""
 
-    uri: str = Field(..., description='The URI of a GeoJSON file.')
+    uris: Union[str, List[str]] = Field(
+        ..., description='URI(s) of GeoJSON file(s).')
     ignore_crs_field: bool = False
 
     def build(self,
@@ -26,7 +36,7 @@ class GeoJSONVectorSourceConfig(VectorSourceConfig):
             transformers = []
 
         return GeoJSONVectorSource(
-            uri=self.uri,
+            uris=self.uris,
             ignore_crs_field=self.ignore_crs_field,
             crs_transformer=crs_transformer,
             vector_transformers=transformers)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -97,7 +97,7 @@ def get_config(runner,
             channel_order=[0, 1, 2], uris=[raster_uri])
         label_source = ChipClassificationLabelSourceConfig(
             vector_source=GeoJSONVectorSourceConfig(
-                uri=label_uri,
+                uris=label_uri,
                 ignore_crs_field=True,
                 transformers=[
                     ClassInferenceTransformerConfig(default_class_id=1)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
@@ -88,7 +88,7 @@ def get_config(runner,
             uris=[raster_uri], channel_order=channel_order)
 
         vector_source = GeoJSONVectorSourceConfig(
-            uri=label_uri,
+            uris=label_uri,
             ignore_crs_field=True,
             transformers=[ClassInferenceTransformerConfig(default_class_id=0)])
         label_source = ObjectDetectionLabelSourceConfig(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
@@ -66,7 +66,7 @@ def get_config(runner,
 
         label_source = ObjectDetectionLabelSourceConfig(
             vector_source=GeoJSONVectorSourceConfig(
-                uri=label_uri,
+                uris=label_uri,
                 ignore_crs_field=True,
                 transformers=[
                     ClassInferenceTransformerConfig(default_class_id=0)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
@@ -102,7 +102,7 @@ def build_scene(spacenet_cfg: SpacenetConfig,
 
     # Set a line buffer to convert line strings to polygons.
     vector_source = GeoJSONVectorSourceConfig(
-        uri=label_uri,
+        uris=label_uri,
         ignore_crs_field=True,
         transformers=[
             ClassInferenceTransformerConfig(default_class_id=0),

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
@@ -65,7 +65,7 @@ def make_scene(scene_id: str, image_uri: str, label_uri: str,
 
     # configure GeoJSON reading
     vector_source = GeoJSONVectorSourceConfig(
-        uri=label_uri,
+        uris=label_uri,
         # This assumes the CRS is WGS-84 and ignores whatever the CRS specified
         # in the file is.
         ignore_crs_field=True,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
@@ -94,7 +94,7 @@ def save_image_crop(image_uri,
                 crs_transformer = RasterioCRSTransformer.from_dataset(
                     im_dataset)
                 geojson_vs_config = GeoJSONVectorSourceConfig(
-                    uri=label_uri,
+                    uris=label_uri,
                     ignore_crs_field=True,
                     transformers=[
                         ClassInferenceTransformerConfig(default_class_id=0)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,18 @@
+from typing import Callable
 import os
 
 
-def data_file_path(rel_path):
+def data_file_path(rel_path: str) -> str:
     data_dir = os.path.join(os.path.dirname(__file__), 'data_files')
     return os.path.join(data_dir, rel_path)
+
+
+def test_config_upgrader(cfg_class: type, old_cfg_dict: dict,
+                         upgrader: Callable, curr_version: int) -> None:
+    """Try to use upgrader to update cfg dict to curr_version."""
+    from rastervision.pipeline.config import build_config
+
+    for i in range(curr_version):
+        old_cfg_dict = upgrader(old_cfg_dict, version=i)
+    new_cfg = build_config(old_cfg_dict)
+    assert isinstance(new_cfg, cfg_class)

--- a/tests/core/data/label_source/test_chip_classification_label_source.py
+++ b/tests/core/data/label_source/test_chip_classification_label_source.py
@@ -20,7 +20,7 @@ class TestChipClassificationLabelSourceConfig(unittest.TestCase):
     def test_ensure_required_transformers(self):
         uri = data_file_path('bboxes.geojson')
         cfg = ChipClassificationLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=uri))
+            vector_source=GeoJSONVectorSourceConfig(uris=uri))
         tfs = cfg.vector_source.transformers
         has_inf_tf = any(
             isinstance(tf, ClassInferenceTransformerConfig) for tf in tfs)
@@ -233,7 +233,7 @@ class TestChipClassificationLabelSource(unittest.TestCase):
         extent = Box.make_square(0, 0, 8)
 
         config = ChipClassificationLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=self.uri),
+            vector_source=GeoJSONVectorSourceConfig(uris=self.uri),
             ioa_thresh=0.5,
             use_intersection_over_cell=False,
             pick_min_class_id=False,
@@ -260,7 +260,7 @@ class TestChipClassificationLabelSource(unittest.TestCase):
         extent = Box.make_square(0, 0, 2)
 
         config = ChipClassificationLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=self.uri))
+            vector_source=GeoJSONVectorSourceConfig(uris=self.uri))
         source = config.build(self.class_config, self.crs_transformer, extent,
                               self.tmp_dir.name)
         labels = source.get_labels()
@@ -277,7 +277,7 @@ class TestChipClassificationLabelSource(unittest.TestCase):
         extent = Box.make_square(0, 0, 8)
 
         config = ChipClassificationLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=self.uri))
+            vector_source=GeoJSONVectorSourceConfig(uris=self.uri))
         source = config.build(self.class_config, self.crs_transformer, extent,
                               self.tmp_dir.name)
         labels = source.get_labels()
@@ -294,7 +294,7 @@ class TestChipClassificationLabelSource(unittest.TestCase):
         extent = Box.make_square(0, 0, 8)
 
         config = ChipClassificationLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=self.uri))
+            vector_source=GeoJSONVectorSourceConfig(uris=self.uri))
         source = config.build(self.class_config, self.crs_transformer, extent,
                               self.tmp_dir.name)
         labels = source.get_labels()

--- a/tests/core/data/label_source/test_object_detection_label_source.py
+++ b/tests/core/data/label_source/test_object_detection_label_source.py
@@ -18,7 +18,7 @@ class TestObjectDetectionLabelSourceConfig(unittest.TestCase):
     def test_ensure_required_transformers(self):
         uri = data_file_path('bboxes.geojson')
         cfg = ObjectDetectionLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=uri))
+            vector_source=GeoJSONVectorSourceConfig(uris=uri))
         tfs = cfg.vector_source.transformers
         has_inf_tf = any(
             isinstance(tf, ClassInferenceTransformerConfig) for tf in tfs)
@@ -73,7 +73,7 @@ class TestObjectDetectionLabelSource(unittest.TestCase):
 
     def test_read_without_extent(self):
         config = ObjectDetectionLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=self.file_path))
+            vector_source=GeoJSONVectorSourceConfig(uris=self.file_path))
         extent = None
         source = config.build(self.class_config, self.crs_transformer, extent,
                               self.tmp_dir.name)
@@ -90,7 +90,7 @@ class TestObjectDetectionLabelSource(unittest.TestCase):
         # Extent only includes the first box.
         extent = Box.make_square(0, 0, 3)
         config = ObjectDetectionLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=self.file_path))
+            vector_source=GeoJSONVectorSourceConfig(uris=self.file_path))
         source = config.build(self.class_config, self.crs_transformer, extent,
                               self.tmp_dir.name)
         labels = source.get_labels()
@@ -105,7 +105,7 @@ class TestObjectDetectionLabelSource(unittest.TestCase):
         # Extent includes both boxes, but clips the second.
         extent = Box.make_square(0, 0, 3.9)
         config = ObjectDetectionLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=self.file_path))
+            vector_source=GeoJSONVectorSourceConfig(uris=self.file_path))
         source = config.build(self.class_config, self.crs_transformer, extent,
                               self.tmp_dir.name)
         labels = source.get_labels()

--- a/tests/core/data/raster_source/test_rasterized_source.py
+++ b/tests/core/data/raster_source/test_rasterized_source.py
@@ -17,7 +17,7 @@ class TestRasterizedSourceConfig(unittest.TestCase):
     def test_ensure_required_transformers(self):
         uri = data_file_path('bboxes.geojson')
         cfg = RasterizedSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=uri),
+            vector_source=GeoJSONVectorSourceConfig(uris=uri),
             rasterizer_config=RasterizerConfig(background_class_id=0))
         tfs = cfg.vector_source.transformers
         has_inf_tf = any(
@@ -46,7 +46,7 @@ class TestRasterizedSource(unittest.TestCase):
         json_to_file(geojson, self.uri)
 
         config = RasterizedSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=self.uri),
+            vector_source=GeoJSONVectorSourceConfig(uris=self.uri),
             rasterizer_config=RasterizerConfig(
                 background_class_id=self.background_class_id,
                 all_touched=all_touched))

--- a/tests/core/data/utils/test_geojson.py
+++ b/tests/core/data/utils/test_geojson.py
@@ -7,7 +7,8 @@ from shapely.geometry import (Polygon, MultiPolygon, Point, MultiPoint,
 from rastervision.core.data.utils import (
     geometry_to_feature, geometries_to_geojson, is_empty_feature,
     remove_empty_features, split_multi_geometries, map_to_pixel_coords,
-    pixel_to_map_coords, buffer_geoms, all_geoms_valid)
+    pixel_to_map_coords, buffer_geoms, all_geoms_valid, geoms_to_geojson,
+    merge_geojsons, geojson_to_geoms)
 from tests.core.data.mock_crs_transformer import DoubleCRSTransformer
 
 
@@ -147,6 +148,26 @@ class TestGeojsonUtils(unittest.TestCase):
             geojson_in, geom_type='LineString', class_bufs=class_bufs)
         geom_out = shape(geojson_out['features'][0]['geometry'])
         self.assertTrue(geom_out.equals(geom_in.buffer(5)))
+
+    def test_geoms_to_geojson_and_geojson_to_geoms(self):
+        geoms_in = [
+            Polygon.from_bounds(0, 0, 10, 10),
+            Polygon.from_bounds(10, 10, 100, 100),
+        ]
+        geojson = geoms_to_geojson(geoms_in)
+        geoms_out = list(geojson_to_geoms(geojson))
+        self.assertListEqual(geoms_out, geoms_in)
+
+    def test_merge_geojsons(self):
+        geom_in_1 = Polygon.from_bounds(0, 0, 10, 10)
+        geom_in_2 = Polygon.from_bounds(10, 10, 100, 100)
+        geojson_1 = geoms_to_geojson([geom_in_1])
+        geojson_2 = geoms_to_geojson([geom_in_2])
+        geojson_merged = merge_geojsons([geojson_1, geojson_2])
+        geom_out_1 = shape(geojson_merged['features'][0]['geometry'])
+        geom_out_2 = shape(geojson_merged['features'][1]['geometry'])
+        self.assertEqual(geom_out_1, geom_in_1)
+        self.assertEqual(geom_out_2, geom_in_2)
 
 
 if __name__ == '__main__':

--- a/tests/core/data/utils/test_geojson.py
+++ b/tests/core/data/utils/test_geojson.py
@@ -89,7 +89,7 @@ class TestGeojsonUtils(unittest.TestCase):
         geojson_in = geometries_to_geojson([feat])
         geojson_out = map_to_pixel_coords(geojson_in, crs_transformer)
         geom_out = shape(geojson_out['features'][0]['geometry'])
-        coords_out = np.array(geom_out)
+        coords_out = np.array(geom_out.coords).squeeze()
         np.testing.assert_array_almost_equal(coords_out, coords_in * 2)
 
     def test_pixel_to_map_coords(self):
@@ -99,7 +99,7 @@ class TestGeojsonUtils(unittest.TestCase):
         geojson_in = geometries_to_geojson([feat])
         geojson_out = pixel_to_map_coords(geojson_in, crs_transformer)
         geom_out = shape(geojson_out['features'][0]['geometry'])
-        coords_out = np.array(geom_out)
+        coords_out = np.array(geom_out.coords).squeeze()
         np.testing.assert_array_almost_equal(coords_out, coords_in / 2)
 
     def test_simplify_polygons(self):
@@ -129,7 +129,7 @@ class TestGeojsonUtils(unittest.TestCase):
         geojson_out = buffer_geoms(
             geojson_in, geom_type='Polygon', class_bufs=class_bufs)
         geom_out = shape(geojson_out['features'][0]['geometry'])
-        self.assertTrue(geom_out.equals(geom_in.buffer(5)))
+        self.assertEqual(geom_out, geom_in.buffer(5))
 
         # points
         geom_in = Point(0, 0)
@@ -138,7 +138,7 @@ class TestGeojsonUtils(unittest.TestCase):
         geojson_out = buffer_geoms(
             geojson_in, geom_type='Point', class_bufs=class_bufs)
         geom_out = shape(geojson_out['features'][0]['geometry'])
-        self.assertTrue(geom_out.equals(geom_in.buffer(5)))
+        self.assertEqual(geom_out, geom_in.buffer(5))
 
         # linestrings
         geom_in = LineString([(0, 0), (1, 1), (2, 2)])
@@ -147,7 +147,7 @@ class TestGeojsonUtils(unittest.TestCase):
         geojson_out = buffer_geoms(
             geojson_in, geom_type='LineString', class_bufs=class_bufs)
         geom_out = shape(geojson_out['features'][0]['geometry'])
-        self.assertTrue(geom_out.equals(geom_in.buffer(5)))
+        self.assertEqual(geom_out, geom_in.buffer(5))
 
     def test_geoms_to_geojson_and_geojson_to_geoms(self):
         geoms_in = [

--- a/tests/core/data/vector_source/test_geojson_vector_source.py
+++ b/tests/core/data/vector_source/test_geojson_vector_source.py
@@ -3,12 +3,28 @@ import os
 
 from shapely.geometry import shape
 
-from rastervision.core.data import (
-    GeoJSONVectorSourceConfig, ClassConfig, IdentityCRSTransformer,
-    ClassInferenceTransformerConfig, BufferTransformerConfig)
+from rastervision.core.data.vector_source.geojson_vector_source_config import (
+    GeoJSONVectorSourceConfig, geojson_vector_source_config_upgrader)
+from rastervision.core.data import (ClassConfig, IdentityCRSTransformer,
+                                    ClassInferenceTransformerConfig,
+                                    BufferTransformerConfig)
 from rastervision.pipeline.file_system import json_to_file, get_tmp_dir
 
+from tests import test_config_upgrader
 from tests.core.data.mock_crs_transformer import DoubleCRSTransformer
+
+
+class TestGeoJSONVectorSourceConfig(unittest.TestCase):
+    def test_upgrader(self):
+        cfg = GeoJSONVectorSourceConfig(uris=['a', 'b'])
+        old_cfg_dict = cfg.dict()
+        old_cfg_dict['uri'] = old_cfg_dict['uris']
+        del old_cfg_dict['uris']
+        test_config_upgrader(
+            cfg_class=GeoJSONVectorSourceConfig,
+            old_cfg_dict=old_cfg_dict,
+            upgrader=geojson_vector_source_config_upgrader,
+            curr_version=8)
 
 
 class TestGeoJSONVectorSource(unittest.TestCase):

--- a/tests/core/data/vector_source/test_geojson_vector_source.py
+++ b/tests/core/data/vector_source/test_geojson_vector_source.py
@@ -35,7 +35,7 @@ class TestGeoJSONVectorSource(unittest.TestCase):
         class_config = ClassConfig(names=['building'])
         json_to_file(geojson, self.uri)
         cfg = GeoJSONVectorSourceConfig(
-            uri=self.uri,
+            uris=self.uri,
             transformers=[
                 ClassInferenceTransformerConfig(default_class_id=0),
                 BufferTransformerConfig(

--- a/tests/core/evaluation/test_chip_classification_evaluator.py
+++ b/tests/core/evaluation/test_chip_classification_evaluator.py
@@ -16,7 +16,7 @@ class TestChipClassificationEvaluator(unittest.TestCase):
 
         label_source_uri = data_file_path('evaluator/cc-label-filtered.json')
         label_source_cfg = ChipClassificationLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(uri=label_source_uri))
+            vector_source=GeoJSONVectorSourceConfig(uris=label_source_uri))
 
         label_store_uri = data_file_path('evaluator/cc-label-full.json')
         label_store_cfg = ChipClassificationGeoJSONStoreConfig(

--- a/tests/core/evaluation/test_semantic_segmentation_evaluator.py
+++ b/tests/core/evaluation/test_semantic_segmentation_evaluator.py
@@ -82,7 +82,7 @@ class TestSemanticSegmentationEvaluator(unittest.TestCase):
 
         config = RasterizedSourceConfig(
             vector_source=GeoJSONVectorSourceConfig(
-                uri=gt_uri,
+                uris=gt_uri,
                 transformers=[
                     ClassInferenceTransformerConfig(default_class_id=0)
                 ]),
@@ -92,7 +92,7 @@ class TestSemanticSegmentationEvaluator(unittest.TestCase):
 
         config = RasterizedSourceConfig(
             vector_source=GeoJSONVectorSourceConfig(
-                uri=pred_uri,
+                uris=pred_uri,
                 transformers=[
                     ClassInferenceTransformerConfig(default_class_id=0)
                 ]),

--- a/tests/pytorch_learner/test_classification_learner.py
+++ b/tests/pytorch_learner/test_classification_learner.py
@@ -52,7 +52,7 @@ def make_scene(num_channels: int, num_classes: int,
     json_to_file(geojson, uri)
     label_source_cfg = ChipClassificationLabelSourceConfig(
         vector_source=GeoJSONVectorSourceConfig(
-            uri=uri,
+            uris=uri,
             transformers=[ClassInferenceTransformerConfig(default_class_id=0)
                           ]),
         background_class_id=0)

--- a/tests/pytorch_learner/test_data_config.py
+++ b/tests/pytorch_learner/test_data_config.py
@@ -19,47 +19,47 @@ from rastervision.core.data import DatasetConfig, ClassConfig
 class TestDataConfigToImageDataConfigUpgrade(unittest.TestCase):
     """Version 1 DataConfig should get upgraded to ImageDataConfigs."""
 
-    def _test_config_upgrader(self, OldCfgType, NewCfgType, upgrader,
-                              curr_version):
-        old_cfg = OldCfgType()
+    def _test_config_upgrader(self, old_cfg_type: type, new_cfg_type: type,
+                              upgrader: Callable, curr_version: int):
+        old_cfg = old_cfg_type()
         old_cfg_dict = old_cfg.dict()
         for i in range(curr_version):
             old_cfg_dict = upgrader(old_cfg_dict, version=i)
         new_cfg = build_config(old_cfg_dict)
-        self.assertTrue(isinstance(new_cfg, NewCfgType))
+        self.assertTrue(isinstance(new_cfg, new_cfg_type))
 
     def test_data_config_upgrader(self):
         self._test_config_upgrader(
-            OldCfgType=DataConfig,
-            NewCfgType=ImageDataConfig,
+            old_cfg_type=DataConfig,
+            new_cfg_type=ImageDataConfig,
             upgrader=data_config_upgrader,
             curr_version=3)
 
     def test_ss_data_config_upgrader(self):
         self._test_config_upgrader(
-            OldCfgType=SemanticSegmentationDataConfig,
-            NewCfgType=SemanticSegmentationImageDataConfig,
+            old_cfg_type=SemanticSegmentationDataConfig,
+            new_cfg_type=SemanticSegmentationImageDataConfig,
             upgrader=ss_data_config_upgrader,
             curr_version=3)
 
     def test_clf_data_config_upgrader(self):
         self._test_config_upgrader(
-            OldCfgType=ClassificationDataConfig,
-            NewCfgType=ClassificationImageDataConfig,
+            old_cfg_type=ClassificationDataConfig,
+            new_cfg_type=ClassificationImageDataConfig,
             upgrader=clf_data_config_upgrader,
             curr_version=3)
 
     def test_reg_data_config_upgrader(self):
         self._test_config_upgrader(
-            OldCfgType=RegressionDataConfig,
-            NewCfgType=RegressionImageDataConfig,
+            old_cfg_type=RegressionDataConfig,
+            new_cfg_type=RegressionImageDataConfig,
             upgrader=reg_data_config_upgrader,
             curr_version=3)
 
     def test_objdet_data_config_upgrader(self):
         self._test_config_upgrader(
-            OldCfgType=ObjectDetectionDataConfig,
-            NewCfgType=ObjectDetectionImageDataConfig,
+            old_cfg_type=ObjectDetectionDataConfig,
+            new_cfg_type=ObjectDetectionImageDataConfig,
             upgrader=objdet_data_config_upgrader,
             curr_version=3)
 

--- a/tests/pytorch_learner/test_object_detection_learner.py
+++ b/tests/pytorch_learner/test_object_detection_learner.py
@@ -36,7 +36,7 @@ def make_scene(num_channels: int, num_classes: int,
 
     label_source_cfg = ObjectDetectionLabelSourceConfig(
         vector_source=GeoJSONVectorSourceConfig(
-            uri=data_file_path('bboxes.geojson'),
+            uris=data_file_path('bboxes.geojson'),
             transformers=[ClassInferenceTransformerConfig(
                 default_class_id=0)]))
     scene_cfg = SceneConfig(


### PR DESCRIPTION
## Overview

This PR refactors `GeoJSONVectorSource` (and `GeoJSONVectorSourceConfig`) so that it accepts multiple URIs, similar to `RasterioSource`. This is equivalent to merging multiple GeoJSON files into one and then reading that file.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

See updated unit tests.
