### PR TITLE
Allow specifying extra args for default model in `ModelConfig`

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Callable, Optional, Union
 from enum import Enum
 import logging
 
@@ -104,8 +104,8 @@ class ClassificationModelConfig(ModelConfig):
 
         pretrained = self.pretrained
         backbone_name = self.get_backbone_str()
-
-        model = getattr(models, backbone_name)(pretrained=pretrained)
+        model_factory_func: Callable = getattr(models, backbone_name)
+        model = model_factory_func(pretrained=pretrained, **self.extra_args)
 
         if in_channels != 3:
             if not backbone_name.startswith('resnet'):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -239,6 +239,11 @@ class ModelConfig(Config):
         None,
         description='If specified, the model will be built from the '
         'definition from this external source, using Torch Hub.')
+    extra_args: dict = Field(
+        {},
+        description='Other implementation-specific args that might be useful '
+        'for constructing the default model. This is ignored if using an '
+        'external model.')
 
     def get_backbone_str(self):
         return self.backbone.name

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -210,7 +210,9 @@ class ObjectDetectionModelConfig(ModelConfig):
             min_size=img_sz,
             max_size=img_sz,
             image_mean=image_mean,
-            image_std=image_std)
+            image_std=image_std,
+            **self.extra_args,
+        )
         return model
 
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
@@ -173,7 +173,8 @@ class SemanticSegmentationModelConfig(ModelConfig):
         model = model_factory_func(
             num_classes=num_classes,
             pretrained_backbone=pretrained,
-            aux_loss=False)
+            aux_loss=False,
+            **self.extra_args)
 
         if in_channels != 3:
             if not backbone_name.startswith('resnet'):

--- a/tests/pytorch_learner/test_object_detection_learner_config.py
+++ b/tests/pytorch_learner/test_object_detection_learner_config.py
@@ -1,0 +1,14 @@
+import unittest
+
+from rastervision.pytorch_learner import Backbone, ObjectDetectionModelConfig
+
+
+class TestObjectDetectionModelConfig(unittest.TestCase):
+    def test_extra_args(self):
+        cfg = ObjectDetectionModelConfig(
+            backbone=Backbone.resnet18,
+            pretrained=False,
+            extra_args=dict(box_nms_thresh=0.4))
+        model = cfg.build_default_model(
+            num_classes=2, in_channels=3, img_sz=256)
+        self.assertEqual(model.roi_heads.nms_thresh, 0.4)


### PR DESCRIPTION
## Overview

This PR adds an `extra_args` field to `ModelConfig` which accepts a `dict`. In each `ModelConfig` subclass, these args are passed as keyword args to the torchvision function used to construct the default model.

This is mainly motivated by the `FasterCNN` used in OD which accepts a large number of keyword args that can be important but are too many to be added as individual fields to `ObjectDetectionModelConfig`.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

See new unit test.