### PR TITLE
Temporarily disable PDF build of docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,8 +21,9 @@ sphinx:
 #  configuration: mkdocs.yml
 
 # Optionally build your docs in additional formats such as PDF
-formats:
-  - pdf
+# Disabled due to: https://github.com/readthedocs/readthedocs.org/issues/10015
+# formats:
+#   - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
Non-PR builds have recently started running into this error: https://github.com/readthedocs/readthedocs.org/issues/10015 ([example](https://readthedocs.org/projects/raster-vision/builds/19549661/)). This causes the HTML build to not update as well.

This PR disables the PDF build for now.