### PR TITLE
Allow all constituent object detection losses to be logged

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
@@ -64,7 +64,8 @@ class ObjectDetectionLearner(Learner):
     def train_step(self, batch, batch_ind):
         x, y = batch
         loss_dict = self.model(x, y)
-        return {'train_loss': loss_dict['total_loss']}
+        loss_dict['train_loss'] = sum(loss_dict.values())
+        return loss_dict
 
     def validate_step(self, batch, batch_ind):
         x, y = batch
@@ -83,10 +84,10 @@ class ObjectDetectionLearner(Learner):
         num_class_ids = len(self.cfg.data.class_names)
         coco_eval = compute_coco_eval(outs, ys, num_class_ids)
 
-        metrics = {'map': 0.0, 'map50': 0.0}
+        metrics = {'mAP': 0.0, 'mAP50': 0.0}
         if coco_eval is not None:
             coco_metrics = coco_eval.stats
-            metrics = {'map': coco_metrics[0], 'map50': coco_metrics[1]}
+            metrics = {'mAP': coco_metrics[0], 'mAP50': coco_metrics[1]}
         return metrics
 
     def predict(self,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
@@ -58,12 +58,6 @@ class ObjectDetectionLearner(Learner):
         self.model.to(self.device)
         self.load_init_weights(model_weights_path)
 
-    def build_metric_names(self):
-        metric_names = [
-            'epoch', 'train_time', 'valid_time', 'train_loss', 'map', 'map50'
-        ]
-        return metric_names
-
     def get_collate_fn(self):
         return collate_fn
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner.py
@@ -74,7 +74,7 @@ class ObjectDetectionLearner(Learner):
 
         return {'ys': ys, 'outs': outs}
 
-    def validate_end(self, outputs, num_samples):
+    def validate_end(self, outputs):
         outs = []
         ys = []
         for o in outputs:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -6,6 +6,7 @@ import logging
 import albumentations as A
 
 from torchvision.models.detection.backbone_utils import resnet_fpn_backbone
+from torchvision.models.detection.faster_rcnn import FasterRCNN
 
 from rastervision.core.data import Scene
 from rastervision.pipeline.config import (Config, register_config, Field,
@@ -17,7 +18,6 @@ from rastervision.pytorch_learner.dataset import (
     ObjectDetectionImageDataset, ObjectDetectionSlidingWindowGeoDataset,
     ObjectDetectionRandomWindowGeoDataset)
 from rastervision.pytorch_learner.utils import adjust_conv_channels
-from torchvision.models.detection.faster_rcnn import FasterRCNN
 
 if TYPE_CHECKING:
     from rastervision.pytorch_learner.learner_config import SolverConfig

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_utils.py
@@ -317,7 +317,7 @@ class TorchVisionODAdapter(nn.Module):
     def forward(self,
                 input: torch.Tensor,
                 targets: Optional[Iterable[BoxList]] = None
-                ) -> Union[dict, List[BoxList]]:
+                ) -> Union[Dict[str, Any], List[BoxList]]:
         """Forward pass.
 
         Args:
@@ -340,10 +340,7 @@ class TorchVisionODAdapter(nn.Module):
             # models: a dict with keys, 'boxes' and 'labels'.
             # Note: labels (class IDs) must start at 1.
             _targets = [self.boxlist_to_model_input_dict(bl) for bl in targets]
-
             loss_dict = self.model(input, _targets)
-            loss_dict['total_loss'] = sum(list(loss_dict.values()))
-
             return loss_dict
 
         outs = self.model(input)
@@ -353,8 +350,9 @@ class TorchVisionODAdapter(nn.Module):
         return boxlists
 
     def boxlist_to_model_input_dict(self, boxlist: BoxList) -> dict:
-        """Convert BoxList to a dict compatible with torchvision detection
-        models. Also, make class labels 1-indexed.
+        """Convert BoxList to dict compatible w/ torchvision detection models.
+
+        Also, make class labels 1-indexed.
 
         Args:
             boxlist (BoxList): A BoxList with a "class_ids" field.
@@ -369,8 +367,9 @@ class TorchVisionODAdapter(nn.Module):
         }
 
     def model_output_dict_to_boxlist(self, out: dict) -> BoxList:
-        """Convert torchvision detection dict to BoxList. Also, exclude any
-        null classes and make class labels 0-indexed.
+        """Convert model output dict to BoxList.
+
+        Also, exclude any null classes and make class labels 0-indexed.
 
         Args:
             out (dict): A dict output by a torchvision detection model in eval

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
@@ -52,17 +52,6 @@ class RegressionLearner(Learner):
         y = torch.cat(ys, dim=0)
         self.target_medians = y.median(dim=0).values.to(self.device)
 
-    def build_metric_names(self):
-        metric_names = [
-            'epoch', 'train_time', 'valid_time', 'train_loss', 'val_loss'
-        ]
-        for label in self.cfg.data.class_names:
-            metric_names.extend([
-                '{}_abs_error'.format(label),
-                '{}_scaled_abs_error'.format(label)
-            ])
-        return metric_names
-
     def train_step(self, batch, batch_ind):
         x, y = batch
         out = self.post_forward(self.model(x))

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
@@ -66,10 +66,9 @@ class RegressionLearner(Learner):
             torch.abs(out - y) / self.target_medians).sum(dim=0)
 
         metrics = {'val_loss': val_loss}
-        for ind, label in enumerate(self.cfg.data.class_names):
-            metrics['{}_abs_error'.format(label)] = abs_error[ind]
-            metrics['{}_scaled_abs_error'.format(label)] = scaled_abs_error[
-                ind]
+        for i, label in enumerate(self.cfg.data.class_names):
+            metrics[f'{label}_abs_error'] = abs_error[i]
+            metrics[f'{label}_scaled_abs_error'] = scaled_abs_error[i]
 
         return metrics
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner.py
@@ -7,8 +7,8 @@ import torch
 from torch.nn import functional as F
 
 from rastervision.pytorch_learner.learner import Learner
-from rastervision.pytorch_learner.utils import (compute_conf_mat_metrics,
-                                                compute_conf_mat)
+from rastervision.pytorch_learner.utils import (
+    compute_conf_mat_metrics, compute_conf_mat, aggregate_metrics)
 from rastervision.pytorch_learner.dataset.visualizer import (
     SemanticSegmentationVisualizer)
 
@@ -38,16 +38,12 @@ class SemanticSegmentationLearner(Learner):
 
         return {'val_loss': val_loss, 'conf_mat': conf_mat}
 
-    def validate_end(self, outputs, num_samples):
+    def validate_end(self, outputs):
+        metrics = aggregate_metrics(outputs, exclude_keys={'conf_mat'})
         conf_mat = sum([o['conf_mat'] for o in outputs])
-        val_loss = torch.stack([o['val_loss']
-                                for o in outputs]).sum() / num_samples
         conf_mat_metrics = compute_conf_mat_metrics(conf_mat,
                                                     self.cfg.data.class_names)
-
-        metrics = {'val_loss': val_loss.item()}
         metrics.update(conf_mat_metrics)
-
         return metrics
 
     def post_forward(self, x):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Sequence, Tuple, Optional, Union, List, Iterable
+from typing import (Any, Dict, Sequence, Tuple, Optional, Union, List,
+                    Iterable, Container)
 from os.path import basename, join, isfile
 import logging
 
@@ -359,3 +360,35 @@ def log_metrics_to_csv(csv_path: str, metrics: Dict[str, Any]):
     log_file_exists = isfile(csv_path)
     metrics_df.to_csv(
         csv_path, mode='a', header=(not log_file_exists), index=False)
+
+
+def aggregate_metrics(
+        outputs: List[Dict[str, Union[float, torch.Tensor]]],
+        exclude_keys: Container[str] = set('conf_mat')) -> Dict[str, float]:
+    """Aggregate the ouput of validate_step at the end of the epoch.
+
+    Args:
+        outputs: A list of outputs of Learner.validate_step().
+        exclude_keys: Keys to ignore. These will not be aggregated and will not
+            be included in the output. Defaults to {'conf_mat'}.
+
+    Returns:
+        Dict[str, float]: Dict with aggregated values.
+    """
+    metrics = {}
+    metric_names = outputs[0].keys()
+    for metric_name in metric_names:
+        if metric_name in exclude_keys:
+            continue
+        metric_vals = [out[metric_name] for out in outputs]
+        elem = metric_vals[0]
+        if isinstance(elem, torch.Tensor):
+            if elem.ndim == 0:
+                metric_vals = torch.stack(metric_vals)
+            else:
+                metric_vals = torch.cat(metric_vals)
+            metric_avg = metric_vals.float().mean().item()
+        else:
+            metric_avg = sum(metric_vals) / len(metric_vals)
+        metrics[metric_name] = metric_avg
+    return metrics

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
@@ -1,5 +1,5 @@
-from typing import Dict, Sequence, Tuple, Optional, Union, List, Iterable
-from os.path import basename, join
+from typing import Any, Dict, Sequence, Tuple, Optional, Union, List, Iterable
+from os.path import basename, join, isfile
 import logging
 
 import torch
@@ -10,6 +10,7 @@ from PIL import ImageColor
 import albumentations as A
 from albumentations.core.transforms_interface import ImageOnlyTransform
 import cv2
+import pandas as pd
 
 from rastervision.pipeline.file_system import get_tmp_dir
 from rastervision.pipeline.config import ConfigError
@@ -348,3 +349,13 @@ def channel_groups_to_imgs(
             img = x[..., ch_inds[:3]]
         imgs.append(img)
     return imgs
+
+
+def log_metrics_to_csv(csv_path: str, metrics: Dict[str, Any]):
+    """Append epoch metrics to CSV file."""
+    # dict --> single-row DataFrame
+    metrics_df = pd.DataFrame.from_records([metrics])
+    # if file already exist, append row
+    log_file_exists = isfile(csv_path)
+    metrics_df.to_csv(
+        csv_path, mode='a', header=(not log_file_exists), index=False)

--- a/tests/pytorch_learner/test_object_detection_utils.py
+++ b/tests/pytorch_learner/test_object_detection_utils.py
@@ -47,7 +47,6 @@ class TestTorchVisionODAdapter(unittest.TestCase):
         self.assertRaises(Exception, lambda: model(x))
         out = model(x, y)
         self.assertIsInstance(out, dict)
-        self.assertIn('total_loss', out)
 
     def test_eval_output_with_bogus_class(self):
         true_num_classes = 3


### PR DESCRIPTION
## Overview

This PR removes `Learner.build_metric_names()`. This means that all metrics returned by `Learner.train_step()` and `Learner.validation_step()` can be logged without needing to be pre-specified in `Learner.build_metric_names()`, which means losses from different object detection models (which can have different names) can be logged without needing to override the default `ObjectDetectionLearner`.

After the changes, training logs with a FasterRCNN model look like so:
```
{'epoch': 2,
 'loss_classifier': 0.06613687425851822,
 'loss_box_reg': 0.06521709263324738,
 'loss_objectness': 0.01976802386343479,
 'loss_rpn_box_reg': 0.0028790205251425505,
 'train_loss': 0.15400101244449615,
 'train_time': '0:00:12.718091',
 'mAP': 0.007138107431842703,
 'mAP50': 0.047601330107510685,
 'valid_time': '0:00:12.937088'}
```
![image](https://user-images.githubusercontent.com/13014700/221180462-475b8f45-2063-4725-86db-5ff337621b09.png)

With an external model (SSD):
```
{'epoch': 4,
 'bbox_regression': 2.0971059799194336,
 'classification': 2.8579580783843994,
 'train_loss': 4.955064296722412,
 'train_time': '0:00:19.800291',
 'mAP': 0.0027229238176515428,
 'mAP50': 0.011754015726541719,
 'valid_time': '0:00:11.715102'}
```

Other changes:
- Metric aggregation has been refactored slightly.
- New unit tests for metric aggregation and log writing.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

- Run an object detection job and check the logs.
- See new unit tests.
