### PR TITLE
Ensure `RasterSource` and `LabelSource` extents match up in `Scene`

### DIFF
--- a/rastervision_core/rastervision/core/data/crs_transformer/crs_transformer.py
+++ b/rastervision_core/rastervision/core/data/crs_transformer/crs_transformer.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Optional, overload, Tuple
 
-from rasterio.windows import Window
 from shapely.ops import transform
 from shapely.geometry.base import BaseGeometry
 
@@ -39,10 +38,6 @@ class CRSTransformer(ABC):
         ...
 
     @overload
-    def map_to_pixel(self, inp: Window) -> Window:
-        ...
-
-    @overload
     def map_to_pixel(self, inp: BaseGeometry) -> BaseGeometry:
         ...
 
@@ -50,9 +45,8 @@ class CRSTransformer(ABC):
         """Transform input from pixel to map coords.
 
         Args:
-            inp: (x, y) tuple or Box or rasterio Window or shapely geometry in
-                pixel coordinates. If tuple, x and y can be single values or
-                array-like.
+            inp: (x, y) tuple or Box or shapely geometry in map coordinates.
+                If tuple, x and y can be single values or array-like.
 
         Returns:
             Coordinate-transformed input in the same format.
@@ -64,14 +58,6 @@ class CRSTransformer(ABC):
             xmax_tf, ymax_tf = self._map_to_pixel((xmax, ymax))
             box_out = Box(ymin_tf, xmin_tf, ymax_tf, xmax_tf)
             return box_out
-        elif isinstance(inp, Window):
-            window_in = inp
-            (ymin, ymax), (xmin, xmax) = window_in.toranges()
-            xmin_tf, ymin_tf = self._map_to_pixel((xmin, ymin))
-            xmax_tf, ymax_tf = self._map_to_pixel((xmax, ymax))
-            window_out = Window.from_slices(
-                slice(ymin_tf, ymax_tf), slice(xmin_tf, xmax_tf))
-            return window_out
         elif isinstance(inp, BaseGeometry):
             geom_in = inp
             geom_out = transform(
@@ -80,8 +66,8 @@ class CRSTransformer(ABC):
         elif len(inp) == 2:
             return self._map_to_pixel(inp)
         else:
-            raise TypeError('Input must be 2-tuple or Box or rasterio Window '
-                            'or shapely geometry.')
+            raise TypeError(
+                'Input must be 2-tuple or Box or shapely geometry.')
 
     @overload
     def pixel_to_map(self, inp: Tuple[float, float]) -> Tuple[float, float]:

--- a/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source.py
@@ -143,7 +143,7 @@ class ChipClassificationLabelSource(LabelSource):
     def __init__(self,
                  label_source_config: 'ChipClassificationLabelSourceConfig',
                  vector_source: 'VectorSource',
-                 extent: Box = None,
+                 extent: Optional[Box] = None,
                  lazy: bool = False):
         """Constructs a LabelSource for chip classification.
 
@@ -151,9 +151,9 @@ class ChipClassificationLabelSource(LabelSource):
             label_source_config (ChipClassificationLabelSourceConfig): Config
                 for class inference.
             vector_source (VectorSource): Source of vector labels.
-            extent (Box): Box used to filter the labels by extent or
-                compute grid.
-            lazy (bool, optional): If True, labels are not populated during
+            extent (Optional[Box]): Use-specified extent. If None, the full
+                extent of the vector source is used.
+            lazy (bool): If True, labels are not populated during
                 initialization. Defaults to False.
         """
         self.cfg = label_source_config

--- a/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional
 
-import numpy as np
 import geopandas as gpd
 
 from rastervision.core.data.label import ChipClassificationLabels
@@ -9,7 +8,7 @@ from rastervision.core.box import Box
 
 if TYPE_CHECKING:
     from rastervision.core.data import (ChipClassificationLabelSourceConfig,
-                                        VectorSource)
+                                        CRSTransformer, VectorSource)
 
 
 def infer_cells(cells: List[Box], labels_df: gpd.GeoDataFrame,
@@ -110,16 +109,9 @@ def read_labels(labels_df: gpd.GeoDataFrame,
     Returns:
        ChipClassificationLabels
     """
+    boxes = [Box.from_shapely(g).to_int() for g in labels_df.geometry]
     if extent is not None:
-        extent_polygon = extent.to_shapely()
-        labels_df = labels_df[labels_df.intersects(extent_polygon)]
-        boxes = np.array([
-            Box.from_shapely(c).to_int().shift_origin(extent)
-            for c in labels_df.geometry
-        ])
-    else:
-        boxes = np.array(
-            [Box.from_shapely(c).to_int() for c in labels_df.geometry])
+        boxes = [b for b in boxes if b.intersects(extent)]
     class_ids = labels_df['class_id'].astype(int)
     cells_to_class_id = {
         cell: (class_id, None)
@@ -151,18 +143,22 @@ class ChipClassificationLabelSource(LabelSource):
             label_source_config (ChipClassificationLabelSourceConfig): Config
                 for class inference.
             vector_source (VectorSource): Source of vector labels.
-            extent (Optional[Box]): Use-specified extent. If None, the full
+            extent (Optional[Box]): User-specified extent. If None, the full
                 extent of the vector source is used.
             lazy (bool): If True, labels are not populated during
                 initialization. Defaults to False.
         """
         self.cfg = label_source_config
+        self.vector_source = vector_source
+        if extent is None:
+            extent = vector_source.extent
         self._extent = extent
+        self.lazy = lazy
         self.labels_df = vector_source.get_dataframe()
         self.validate_labels(self.labels_df)
 
         self.labels = ChipClassificationLabels.make_empty()
-        if not lazy:
+        if not self.lazy:
             self.populate_labels()
 
     def populate_labels(self, cells: Optional[Iterable[Box]] = None) -> None:
@@ -245,3 +241,12 @@ class ChipClassificationLabelSource(LabelSource):
     @property
     def extent(self) -> Box:
         return self._extent
+
+    @property
+    def crs_transformer(self) -> 'CRSTransformer':
+        return self.vector_source.crs_transformer
+
+    def set_extent(self, extent: 'Box') -> None:
+        self._extent = extent
+        if not self.lazy:
+            self.populate_labels()

--- a/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source_config.py
@@ -93,7 +93,8 @@ class ChipClassificationLabelSourceConfig(LabelSourceConfig):
                 'background_class_id is required if infer_cells=True.')
         return values
 
-    def build(self, class_config, crs_transformer, extent=None, tmp_dir=None):
+    def build(self, class_config, crs_transformer, extent=None,
+              tmp_dir=None) -> ChipClassificationLabelSource:
         if self.vector_source is None:
             raise ValueError('Cannot build with a None vector_source.')
         if self.infer_cells and self.cell_sz is None and not self.lazy:

--- a/rastervision_core/rastervision/core/data/label_source/label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/label_source.py
@@ -1,20 +1,21 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional
 from abc import ABC, abstractmethod, abstractproperty
 
-from rastervision.core.box import Box
+if TYPE_CHECKING:
+    from rastervision.core.box import Box
 
 
 class LabelSource(ABC):
     """An interface for storage of labels for a scene.
 
-    An LabelSource is a read source of labels for a scene
+    A LabelSource is a read-only source of labels for a scene
     that could be backed by a file, a database, an API, etc. The difference
     between LabelSources and Labels can be understood by analogy to the
     difference between a database and result sets queried from a database.
     """
 
     @abstractmethod
-    def get_labels(self, window=None):
+    def get_labels(self, window: Optional['Box'] = None) -> 'Labels':
         """Return labels overlapping with window.
 
         Args:
@@ -27,7 +28,7 @@ class LabelSource(ABC):
         pass
 
     @abstractproperty
-    def extent(self) -> Box:
+    def extent(self) -> 'Box':
         pass
 
     def __getitem__(self, key: Any) -> Any:

--- a/rastervision_core/rastervision/core/data/label_source/label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/label_source.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod, abstractproperty
 
 if TYPE_CHECKING:
     from rastervision.core.box import Box
+    from rastervision.core.data import CRSTransformer, Labels
 
 
 class LabelSource(ABC):
@@ -29,6 +30,21 @@ class LabelSource(ABC):
 
     @abstractproperty
     def extent(self) -> 'Box':
+        pass
+
+    @abstractproperty
+    def crs_transformer(self) -> 'CRSTransformer':
+        pass
+
+    @abstractmethod
+    def set_extent(self, extent: 'Box') -> None:
+        """Set self.extent to the given value.
+
+        .. note:: This method is idempotent.
+
+        Args:
+            extent (Box): User-specified extent in pixel coordinates.
+        """
         pass
 
     def __getitem__(self, key: Any) -> Any:

--- a/rastervision_core/rastervision/core/data/label_source/label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/label_source_config.py
@@ -1,12 +1,26 @@
+from typing import TYPE_CHECKING, Optional
+
 from rastervision.pipeline.config import Config, register_config
+
+if TYPE_CHECKING:
+    from rastervision.core.box import Box
+    from rastervision.core.data import (ClassConfig, CRSTransformer,
+                                        LabelSource, SceneConfig)
+    from rastervision.core.rv_pipeline import RVPipelineConfig
 
 
 @register_config('label_source')
 class LabelSourceConfig(Config):
     """Configure a :class:`.LabelSource`."""
 
-    def build(self, class_config, crs_transformer, extent, tmp_dir):
+    def build(self,
+              class_config: 'ClassConfig',
+              crs_transformer: 'CRSTransformer',
+              extent: Optional['Box'] = None,
+              tmp_dir: Optional[str] = None) -> 'LabelSource':
         raise NotImplementedError()
 
-    def update(self, pipeline=None, scene=None):
+    def update(self,
+               pipeline: Optional['RVPipelineConfig'] = None,
+               scene: Optional['SceneConfig'] = None) -> None:
         pass

--- a/rastervision_core/rastervision/core/data/label_source/object_detection_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/object_detection_label_source.py
@@ -13,7 +13,7 @@ class ObjectDetectionLabelSource(LabelSource):
 
     def __init__(self,
                  vector_source: VectorSource,
-                 extent: Box,
+                 extent: Optional[Box] = None,
                  ioa_thresh: Optional[float] = None,
                  clip: bool = False):
         """Constructor.

--- a/rastervision_core/rastervision/core/data/label_source/object_detection_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/object_detection_label_source.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 import numpy as np
 
@@ -6,6 +6,9 @@ from rastervision.core.box import Box
 from rastervision.core.data.label import ObjectDetectionLabels
 from rastervision.core.data.label_source import LabelSource
 from rastervision.core.data.vector_source import VectorSource
+
+if TYPE_CHECKING:
+    from rastervision.core.data import CRSTransformer
 
 
 class ObjectDetectionLabelSource(LabelSource):
@@ -20,7 +23,8 @@ class ObjectDetectionLabelSource(LabelSource):
 
         Args:
             vector_source (VectorSource): A VectorSource.
-            extent (Box): Box used to filter the labels by extent.
+            extent (Optional[Box]): User-specified extent. If None, the full
+                extent of the vector source is used.
             ioa_thresh (Optional[float], optional): IOA threshold to apply when
                 retieving labels for a window. Defaults to None.
             clip (bool, optional): Clip bounding boxes to window limits when
@@ -31,6 +35,8 @@ class ObjectDetectionLabelSource(LabelSource):
         self.validate_geojson(geojson)
         self.labels = ObjectDetectionLabels.from_geojson(
             geojson, extent=extent)
+        if extent is None:
+            extent = vector_source.extent
         self._extent = extent
         self.ioa_thresh = ioa_thresh if ioa_thresh is not None else 1e-6
         self.clip = clip
@@ -138,3 +144,10 @@ class ObjectDetectionLabelSource(LabelSource):
     @property
     def extent(self) -> Box:
         return self._extent
+
+    @property
+    def crs_transformer(self) -> 'CRSTransformer':
+        return self.vector_source.crs_transformer
+
+    def set_extent(self, extent: 'Box') -> None:
+        self._extent = extent

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
@@ -26,7 +26,8 @@ class SemanticSegmentationLabelSourceConfig(LabelSourceConfig):
     raster_source: Union[RasterSourceConfig, RasterizedSourceConfig] = Field(
         ..., description='The labels in the form of rasters.')
 
-    def build(self, class_config, crs_transformer, extent, tmp_dir):
+    def build(self, class_config, crs_transformer, extent=None,
+              tmp_dir=None) -> SemanticSegmentationLabelSource:
         if isinstance(self.raster_source, RasterizedSourceConfig):
             rs = self.raster_source.build(class_config, crs_transformer,
                                           extent)

--- a/rastervision_core/rastervision/core/data/label_store/label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/label_store.py
@@ -1,4 +1,9 @@
-from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Optional
+from abc import ABC, abstractmethod, abstractproperty
+
+if TYPE_CHECKING:
+    from rastervision.core.box import Box
+    from rastervision.core.data import CRSTransformer
 
 
 class LabelStore(ABC):
@@ -22,4 +27,23 @@ class LabelStore(ABC):
     @abstractmethod
     def empty_labels(self):
         """Produces an empty Labels"""
+        pass
+
+    @abstractproperty
+    def extent(self) -> Optional['Box']:
+        pass
+
+    @abstractproperty
+    def crs_transformer(self) -> 'CRSTransformer':
+        pass
+
+    @abstractmethod
+    def set_extent(self, extent: 'Box') -> None:
+        """Set self.extent to the given value.
+
+        .. note:: This method is idempotent.
+
+        Args:
+            extent (Box): User-specified extent in pixel coordinates.
+        """
         pass

--- a/rastervision_core/rastervision/core/data/label_store/label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/label_store_config.py
@@ -1,12 +1,26 @@
+from typing import TYPE_CHECKING, Optional
+
 from rastervision.pipeline.config import Config, register_config
+
+if TYPE_CHECKING:
+    from rastervision.core.box import Box
+    from rastervision.core.data import (ClassConfig, CRSTransformer,
+                                        LabelStore, SceneConfig)
+    from rastervision.core.rv_pipeline import RVPipelineConfig
 
 
 @register_config('label_store')
 class LabelStoreConfig(Config):
     """Configure a :class:`.LabelStore`."""
 
-    def build(self, class_config, crs_transformer, extent, tmp_dir):
-        pass
+    def build(self,
+              class_config: 'ClassConfig',
+              crs_transformer: 'CRSTransformer',
+              extent: 'Box',
+              tmp_dir: Optional[str] = None) -> 'LabelStore':
+        raise NotImplementedError()
 
-    def update(self, pipeline=None, scene=None):
+    def update(self,
+               pipeline: Optional['RVPipelineConfig'] = None,
+               scene: Optional['SceneConfig'] = None) -> None:
         pass

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -34,6 +34,9 @@ class MultiRasterSource(RasterSource):
                 that will be used by .get_chip(). Defaults to None.
             raster_transformers (Sequence, optional): Sequence of transformers.
                 Defaults to [].
+            extent (Optional[Box], optional): User-specified extent. If given,
+                the primary raster source's extent is set to this. If None,
+                the full extent of the primary raster source is used.
         """
         num_channels_raw = sum(rs.num_channels_raw for rs in raster_sources)
         if not channel_order:
@@ -47,6 +50,8 @@ class MultiRasterSource(RasterSource):
 
         if extent is None:
             extent = raster_sources[primary_source_idx].extent
+        else:
+            raster_sources[primary_source_idx].set_extent(extent)
 
         super().__init__(
             channel_order,

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source.py
@@ -38,7 +38,7 @@ class RasterSource(ABC):
                 applying channel_order.
             raster_transformers: ``RasterTransformers`` for transforming chips
                 whenever they are retrieved. Defaults to ``[]``.
-            extent: Use-specified extent. If None, the full extent of the
+            extent: User-specified extent. If None, the full extent of the
                 raster source is used.
         """
         if channel_order is None:
@@ -77,6 +77,16 @@ class RasterSource(ABC):
     def crs_transformer(self) -> 'CRSTransformer':
         """Associated :class:`.CRSTransformer`."""
         pass
+
+    def set_extent(self, extent: 'Box') -> None:
+        """Set self.extent to the given value.
+
+        .. note:: This method is idempotent.
+
+        Args:
+            extent (Box): User-specified extent in pixel coordinates.
+        """
+        self._extent = extent
 
     @abstractmethod
     def _get_chip(self, window: 'Box') -> 'np.ndarray':

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -1,9 +1,13 @@
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from rastervision.core.box import Box
 from rastervision.pipeline.config import (Config, register_config, Field,
                                           validator, ConfigError)
 from rastervision.core.data.raster_transformer import RasterTransformerConfig
+
+if TYPE_CHECKING:
+    from rastervision.core.data import (RasterSource, SceneConfig)
+    from rastervision.core.rv_pipeline import RVPipelineConfig
 
 
 def rs_config_upgrader(cfg_dict: dict, version: int) -> dict:
@@ -33,10 +37,14 @@ class RasterSourceConfig(Config):
         '(ymin, xmin, ymax, xmax). Useful for cropping the raster source so '
         'that only part of the raster is read from.')
 
-    def build(self, tmp_dir, use_transformers=True):
+    def build(self,
+              tmp_dir: Optional[str] = None,
+              use_transformers: bool = True) -> 'RasterSource':
         raise NotImplementedError()
 
-    def update(self, pipeline=None, scene=None):
+    def update(self,
+               pipeline: Optional['RVPipelineConfig'] = None,
+               scene: Optional['SceneConfig'] = None) -> None:
         for t in self.transformers:
             t.update(pipeline, scene)
 

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -33,7 +33,7 @@ class RasterSourceConfig(Config):
     transformers: List[RasterTransformerConfig] = []
     extent: Optional[Tuple[int, int, int, int]] = Field(
         None,
-        description='Use-specified extent in pixel coords in the form '
+        description='User-specified extent in pixel coords in the form '
         '(ymin, xmin, ymax, xmax). Useful for cropping the raster source so '
         'that only part of the raster is read from.')
 

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -197,7 +197,7 @@ class RasterioSource(RasterSource):
                 channels to extract from raw imagery. Can be a subset of the
                 available channels. If None, all channels available in the
                 image will be read. Defaults to None.
-            extent (Optional[Box], optional): Use-specified extent. If None,
+            extent (Optional[Box], optional): User-specified extent. If None,
                 the full extent of the raster source is used.
             tmp_dir (Optional[str]): Directory to use for storing the VRT
                 (needed if multiple uris or allow_streaming=True). If None,

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -245,10 +245,11 @@ class RasterioSource(RasterSource):
         mask_flags = self.image_dataset.mask_flag_enums
         self.is_masked = any(m for m in mask_flags if m != MaskFlags.all_valid)
 
+        height = self.image_dataset.height
+        width = self.image_dataset.width
+        self.extent_original = Box(0, 0, height, width)
         if extent is None:
-            height = self.image_dataset.height
-            width = self.image_dataset.width
-            extent = Box(0, 0, height, width)
+            extent = self.extent_original
 
         super().__init__(
             channel_order,

--- a/rastervision_core/rastervision/core/data/raster_source/rasterized_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterized_source.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 import logging
 
 from rasterio.features import rasterize
@@ -63,7 +63,7 @@ class RasterizedSource(RasterSource):
     def __init__(self,
                  vector_source: 'VectorSource',
                  background_class_id: int,
-                 extent: 'Box',
+                 extent: Optional['Box'] = None,
                  all_touched: bool = False,
                  raster_transformers: List['RasterTransformer'] = []):
         """Constructor.
@@ -72,7 +72,8 @@ class RasterizedSource(RasterSource):
             vector_source (VectorSource): The VectorSource to rasterize.
             background_class_id (int): The class_id to use for any background
                 pixels, ie. pixels not covered by a polygon.
-            extent (Box): Extent of corresponding imagery RasterSource.
+            extent (Optional[Box], optional): User-specified extent. If None,
+                the full extent of the vector source is used.
             all_touched (bool, optional): If True, all pixels touched by
                 geometries will be burned in. If false, only pixels whose
                 center is within the polygon or that are selected by
@@ -86,6 +87,9 @@ class RasterizedSource(RasterSource):
 
         self.df = self.vector_source.get_dataframe()
         self.validate_labels(self.df)
+
+        if extent is None:
+            extent = self.vector_source.extent
 
         super().__init__(
             channel_order=[0],

--- a/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
@@ -55,7 +55,7 @@ class RasterizedSourceConfig(Config):
         super().update(pipeline, scene)
         self.vector_source.update(pipeline, scene)
 
-    def build(self, class_config, crs_transformer, extent):
+    def build(self, class_config, crs_transformer, extent) -> RasterizedSource:
         vector_source = self.vector_source.build(class_config, crs_transformer)
         return RasterizedSource(
             vector_source=vector_source,

--- a/rastervision_core/rastervision/core/data/scene.py
+++ b/rastervision_core/rastervision/core/data/scene.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 
+from rastervision.core.data.utils import match_extents
+
 if TYPE_CHECKING:
     from rastervision.core.box import Box
     from rastervision.core.data import (RasterSource, LabelSource, LabelStore)
@@ -14,19 +16,30 @@ class Scene:
                  label_source: Optional['LabelSource'] = None,
                  label_store: Optional['LabelStore'] = None,
                  aoi_polygons: Optional[list] = None):
-        """Construct a new Scene.
+        """Constructor.
+
+        During initialization, ``Scene`` attempts to set the extents of the
+        given ``label_source`` and the ``label_store`` to be identical to the
+        extent of the given ``raster_source``.
 
         Args:
-            id: ID for this scene
-            raster_source: RasterSource for this scene
-            ground_truth_label_store: optional LabelSource
-            label_store: optional LabelStore
-            aoi: Optional list of AOI polygons in pixel coordinates
+            id: ID for this scene.
+            raster_source: Source of imagery for this scene.
+            label_source: Source of labels for this scene.
+            label_store: Store of predictions for this scene.
+            aoi: Optional list of AOI polygons in pixel coordinates.
         """
+        if label_source is not None:
+            match_extents(raster_source, label_source)
+
+        if label_store is not None:
+            match_extents(raster_source, label_store)
+
         self.id = id
         self.raster_source = raster_source
         self.label_source = label_source
         self.label_store = label_store
+
         if aoi_polygons is None:
             self.aoi_polygons = []
         else:

--- a/tests/core/data/crs_transformer/test_rasterio_crs_transformer.py
+++ b/tests/core/data/crs_transformer/test_rasterio_crs_transformer.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy as np
 import rasterio
-from rasterio.windows import Window as RioWindow
 from shapely.geometry import Point
 
 from rastervision.core.box import Box
@@ -50,16 +49,6 @@ class TestRasterioCRSTransformer(unittest.TestCase):
         pix_geom_expected = Point(self.pix_point)
         self.assertEqual(pix_geom, pix_geom_expected)
 
-        # rasterio window
-        map_box = Box(*self.lon_lat[::-1], *self.lon_lat[::-1])
-        map_window = RioWindow.from_slices(
-            *map_box.to_slices(), height=0, width=0)
-        pix_window = self.crs_trans.map_to_pixel(map_window)
-        pix_box_expected = Box(*self.pix_point[::-1], *self.pix_point[::-1])
-        pix_window_expected = RioWindow.from_slices(
-            *pix_box_expected.to_slices(), height=0, width=0)
-        self.assertEqual(pix_window, pix_window_expected)
-
         # invalid input type
         self.assertRaises(TypeError,
                           lambda: self.crs_trans.map_to_pixel((1, 2, 3)))
@@ -105,13 +94,6 @@ class TestRasterioCRSTransformer(unittest.TestCase):
             np.concatenate(map_geom.xy).reshape(-1),
             np.concatenate(map_geom_expected.xy).reshape(-1),
             decimal=3)
-
-        # rasterio window
-        pix_box = Box(*self.pix_point[::-1], self.pix_point[1] + 10,
-                      self.pix_point[0] + 10)
-        pix_window = pix_box.to_rasterio()
-        self.assertRaises(TypeError,
-                          lambda: self.crs_trans.pixel_to_map(pix_window))
 
         # invalid input type
         self.assertRaises(TypeError,

--- a/tests/core/data/utils/test_misc.py
+++ b/tests/core/data/utils/test_misc.py
@@ -1,0 +1,94 @@
+import unittest
+from os.path import join
+
+from rastervision.pipeline.file_system.utils import get_tmp_dir, json_to_file
+from rastervision.core.box import Box
+from rastervision.core.data import (
+    ClassConfig, GeoJSONVectorSource, RasterioSource,
+    ChipClassificationLabelSource, ChipClassificationLabelSourceConfig,
+    ChipClassificationGeoJSONStore, ObjectDetectionLabelSource,
+    ObjectDetectionGeoJSONStore, SemanticSegmentationLabelSource,
+    SemanticSegmentationLabelStore)
+from rastervision.core.data.utils.geojson import geoms_to_geojson
+from rastervision.core.data.utils.misc import (match_extents)
+
+from tests import data_file_path
+
+
+class TestMatchExtents(unittest.TestCase):
+    def setUp(self) -> None:
+        self.class_config = ClassConfig(names=['class_1'])
+        self.rs_path = data_file_path(
+            'multi_raster_source/const_100_600x600.tiff')
+        self.extent_rs = Box(4, 4, 8, 8)
+        self.raster_source = RasterioSource(
+            self.rs_path, extent=self.extent_rs)
+        self.crs_tf = self.raster_source.crs_transformer
+
+        self.extent_ls = Box(0, 0, 12, 12)
+        geoms = [b.to_shapely() for b in self.extent_ls.get_windows(2, 2)]
+        geoms = [self.crs_tf.pixel_to_map(g) for g in geoms]
+        properties = [dict(class_id=0) for _ in geoms]
+        geojson = geoms_to_geojson(geoms, properties)
+        self._tmp_dir = get_tmp_dir()
+        self.tmp_dir = self._tmp_dir.name
+        uri = join(self.tmp_dir, 'labels.json')
+        json_to_file(geojson, uri)
+        self.vector_source = GeoJSONVectorSource(
+            uri, self.raster_source.crs_transformer, ignore_crs_field=True)
+
+    def tearDown(self) -> None:
+        self._tmp_dir.cleanup()
+
+    def test_cc_label_source(self):
+        label_source = ChipClassificationLabelSource(
+            ChipClassificationLabelSourceConfig(),
+            vector_source=self.vector_source)
+        self.assertEqual(label_source.extent, self.extent_ls)
+        match_extents(self.raster_source, label_source)
+        self.assertEqual(label_source.extent, self.raster_source.extent)
+
+    def test_cc_label_store(self):
+        uri = join(self.tmp_dir, 'cc_labels.json')
+        label_store = ChipClassificationGeoJSONStore(uri, self.class_config,
+                                                     self.crs_tf)
+        self.assertIsNone(label_store.extent)
+        match_extents(self.raster_source, label_store)
+        self.assertEqual(label_store.extent, self.raster_source.extent)
+
+    def test_od_label_source(self):
+        label_source = ObjectDetectionLabelSource(
+            vector_source=self.vector_source)
+        self.assertEqual(label_source.extent, self.extent_ls)
+        match_extents(self.raster_source, label_source)
+        self.assertEqual(label_source.extent, self.raster_source.extent)
+
+    def test_od_label_store(self):
+        uri = join(self.tmp_dir, 'od_labels.json')
+        label_store = ObjectDetectionGeoJSONStore(uri, self.class_config,
+                                                  self.crs_tf)
+        self.assertIsNone(label_store.extent)
+        match_extents(self.raster_source, label_store)
+        self.assertEqual(label_store.extent, self.raster_source.extent)
+
+    def test_ss_label_source(self):
+        label_source = SemanticSegmentationLabelSource(
+            self.raster_source, class_config=self.class_config)
+        self.assertEqual(label_source.extent, self.extent_rs)
+        match_extents(self.raster_source, label_source)
+        self.assertEqual(label_source.extent, self.raster_source.extent)
+
+    def test_ss_label_store(self):
+        uri = join(self.tmp_dir, 'ss_labels')
+        label_store = SemanticSegmentationLabelStore(
+            uri,
+            extent=self.extent_ls,
+            crs_transformer=self.crs_tf,
+            class_config=self.class_config)
+        self.assertEqual(label_store.extent, self.extent_ls)
+        match_extents(self.raster_source, label_store)
+        self.assertEqual(label_store.extent, self.raster_source.extent)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/test_box.py
+++ b/tests/core/test_box.py
@@ -407,6 +407,10 @@ class TestBox(unittest.TestCase):
         self.assertTrue(Box.within_aoi(windows[2], aoi_polygons))
         self.assertFalse(Box.within_aoi(windows[3], aoi_polygons))
 
+    def test_normalize(self):
+        self.assertEqual(Box(4, 3, 2, 1).normalize(), Box(2, 1, 4, 3))
+        self.assertEqual(Box(1, 2, 3, 4).normalize(), Box(1, 2, 3, 4))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

This PR
- allows setting the extents of `RasterSource`, `LabelSource`, and `LabelStore` subclasses to a custom values
- makes `Scene.__init__()` set the extents of the label source/store to the corresponding raster source's extent
	- Previously, this was done in `SceneConfig.build()`, where the raster source's extent was used to build the labels source and store.

Other changes:
- `Box` no longer automatically enforces `ymin <= ymax` and `xmin <= xmax`. This is a return to pre-v0.20 behavior.
	- The problem with switching min and max is that it can result in `box_pixel != map_to_pixel(pixel_to_map(box_pixel))` etc. if `RasterioCRSTransformer.transfore.is_proper == False` (i.e., the affine transformation includes a reflection).
- `Scene.__init__()` now logs a warning if the extents of the raster and label source/store don't intersect in map coordinates.
- `SemanticSegmentationLabelStore` now allows instantiation with extent not equal to the extent of the previously written GeoTIFF. However, writing to file is not allowed in this case (new extent != old extent).


### Checklist

- ~[ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release~
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* See new unit tests.

Closes #1739 
