### PR TITLE
Remove the `uri` field from `VectorOutputConfig`

### DIFF
--- a/rastervision_core/rastervision/core/__init__.py
+++ b/rastervision_core/rastervision/core/__init__.py
@@ -2,7 +2,7 @@
 
 
 def register_plugin(registry):
-    registry.set_plugin_version('rastervision.core', 8)
+    registry.set_plugin_version('rastervision.core', 9)
     from rastervision.core.cli import predict
     registry.add_plugin_command(predict)
 

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
@@ -1,13 +1,18 @@
-from typing import TYPE_CHECKING, Optional, List
+from typing import TYPE_CHECKING, Iterator, List, Optional
 from os.path import join
 
+from rastervision.pipeline.config import register_config, Config, Field
 from rastervision.core.data.label_store import (LabelStoreConfig,
                                                 SemanticSegmentationLabelStore)
-from rastervision.pipeline.config import register_config, Config, Field
+from rastervision.core.data.utils import (denoise, mask_to_building_polygons,
+                                          mask_to_polygons)
 
 if TYPE_CHECKING:
-    from rastervision.core.data import SceneConfig  # noqa
-    from rastervision.core.rv_pipeline import RVPipelineConfig  # noqa
+    import numpy as np
+    from shapely.geometry.base import BaseGeometry
+
+    from rastervision.core.data import ClassConfig, SceneConfig
+    from rastervision.core.rv_pipeline import RVPipelineConfig
 
 
 def vo_config_upgrader(cfg_dict: dict, version: int) -> dict:
@@ -34,16 +39,29 @@ class VectorOutputConfig(Config):
         'images). Larger values will remove more noise and make vectorization '
         'faster but might also remove legitimate detections.')
 
-    def get_mode(self) -> str:
+    def vectorize(self, mask: 'np.ndarray') -> Iterator['BaseGeometry']:
+        """Vectorize binary mask representing the target class into polygons.
+        """
         raise NotImplementedError()
+
+    def get_uri(self, root: str,
+                class_config: Optional['ClassConfig'] = None) -> str:
+        if class_config is not None:
+            class_name = class_config.get_name(self.class_id)
+            uri = join(root, f'class-{self.class_id}-{class_name}.json')
+        else:
+            uri = join(root, f'class-{self.class_id}.json')
+        return uri
 
 
 @register_config('polygon_vector_output')
 class PolygonVectorOutputConfig(VectorOutputConfig):
     """Config for vectorized semantic segmentation predictions."""
 
-    def get_mode(self) -> str:
-        return 'polygons'
+    def vectorize(self, mask: 'np.ndarray') -> Iterator['BaseGeometry']:
+        if self.denoise > 0:
+            mask = denoise(mask, self.denoise)
+        return mask_to_polygons(mask)
 
 
 def building_vo_config_upgrader(cfg_dict: dict, version: int) -> dict:
@@ -77,8 +95,15 @@ class BuildingVectorOutputConfig(VectorOutputConfig):
         description='Thickness of the structural element that is used to '
         'break building clusters.')
 
-    def get_mode(self) -> str:
-        return 'buildings'
+    def vectorize(self, mask: 'np.ndarray') -> Iterator['BaseGeometry']:
+        if self.denoise > 0:
+            mask = denoise(mask, self.denoise)
+        polygons = mask_to_building_polygons(
+            mask=mask,
+            min_area=self.min_area,
+            width_factor=self.element_width_factor,
+            thickness=self.element_thickness)
+        return polygons
 
 
 @register_config('semantic_segmentation_label_store')

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
@@ -33,11 +33,12 @@ class VectorOutputConfig(Config):
         description='The prediction class that is to turned into vectors.')
     denoise: int = Field(
         8,
-        description='Radius of the structural element used to remove '
-        'high-frequency signals from the image. Smaller values will reduce '
-        'less noise and make vectorization slower (especially for large '
-        'images). Larger values will remove more noise and make vectorization '
-        'faster but might also remove legitimate detections.')
+        description='Diameter of the circular structural element used to '
+        'remove high-frequency signals from the image. Smaller values will '
+        'reduce less noise and make vectorization slower and more memory '
+        'intensive (especially for large images). Larger values will remove '
+        'more noise and make vectorization faster but might also remove '
+        'legitimate detections.')
 
     def vectorize(self, mask: 'np.ndarray') -> Iterator['BaseGeometry']:
         """Vectorize binary mask representing the target class into polygons.

--- a/rastervision_core/rastervision/core/data/utils/vectorization.py
+++ b/rastervision_core/rastervision/core/data/utils/vectorization.py
@@ -149,17 +149,18 @@ def get_kernel(rectangle: RotatedRectange,
 
 
 # Adapted from https://github.com/mapbox/robosat/blob/a8e0e3d676b454b61df03897e43e003867b6ef48/robosat/features/core.py#L65-L77  # noqa
-def denoise(mask: np.ndarray, radius: int) -> np.ndarray:
+def denoise(mask: np.ndarray, diameter: int) -> np.ndarray:
     """Apply morphological opening /w circular kernel to remove hi-freq noise.
 
     Args:
-        mask (np.ndarray): the binary mask to remove noise from.
-        radius (int): size in pixels of kernel for morphological op.
+        mask (np.ndarray): The binary mask to remove noise from.
+        diameter (int): Size in pixels of the diameter of the circular kernel
+            that will be used for the morphological op.
 
     Returns:
         np.ndarray: The mask after applying denoising.
     """
     kernel = cv2.getStructuringElement(
-        shape=cv2.MORPH_ELLIPSE, ksize=(radius, radius))
+        shape=cv2.MORPH_ELLIPSE, ksize=(diameter, diameter))
     out = cv2.morphologyEx(src=mask, op=cv2.MORPH_OPEN, kernel=kernel)
     return out

--- a/rastervision_core/rastervision/core/predictor.py
+++ b/rastervision_core/rastervision/core/predictor.py
@@ -114,15 +114,11 @@ class Predictor():
 
         if isinstance(self.scene.label_store,
                       SemanticSegmentationLabelStoreConfig):
-            # create vector outputs for each class without specifying URIs
+            # create vector outputs for each class
             self.scene.label_store.vector_output = [
                 PolygonVectorOutputConfig(class_id=i)
                 for i, _ in enumerate(self.config.dataset.class_config.names)
             ]
-            # set URIs
-            self.scene.label_store.uri = label_uri
-            for vo in self.scene.label_store.vector_output:
-                vo.update(self.config, self.scene, uri_prefix=label_uri)
 
         try:
             if self.update_stats:


### PR DESCRIPTION
## Overview

This PR removes the `uri` field from `VectorOutputConfig`; vector outputs are now always written to `<pred root URI>/vector_outputs/class-<i>-<class name>.json`. This makes it consistent with other `SemanticSegmentationLabelStore` outputs (`labels.tif` and `scores.tif`) that are also written to a fixed pre-defined path within the pred root directory.

Other changes:
- remove `VectorOutputConfig.get_mode()`
- move vectorization logic to `VectorOutputConfig.vectorize()`
- update unit tests

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* See new unit tests.