### PR TITLE
Fix bugs related to extent-cropping

### DIFF
--- a/docs/usage/tutorials/reading_labels.ipynb
+++ b/docs/usage/tutorials/reading_labels.ipynb
@@ -507,7 +507,7 @@
     "label_raster_source = RasterizedSource(\n",
     "    vector_source,\n",
     "    background_class_id=class_config.null_class_id,\n",
-    "    extent=img_raster_source.extent)"
+    "    bbox=img_raster_source.bbox)"
    ]
   },
   {
@@ -708,7 +708,7 @@
     "            default_class_id=class_config.get_class_id('car'))])\n",
     "\n",
     "label_source = ObjectDetectionLabelSource(\n",
-    "    vector_source, extent=raster_source.extent, ioa_thresh=0.2, clip=False)"
+    "    vector_source, bbox=raster_source.bbox, ioa_thresh=0.2, clip=False)"
    ]
   },
   {
@@ -1045,7 +1045,7 @@
     "    infer_cells=True)\n",
     "\n",
     "label_source = ChipClassificationLabelSource(\n",
-    "    cfg, vector_source, extent=raster_source.extent, lazy=True)"
+    "    cfg, vector_source, bbox=raster_source.bbox, lazy=True)"
    ]
   },
   {

--- a/docs/usage/tutorials/reading_vector_data.ipynb
+++ b/docs/usage/tutorials/reading_vector_data.ipynb
@@ -921,7 +921,7 @@
     "    vector_source,\n",
     "    background_class_id=0,\n",
     "    # Normally we'd pass in the RasterSource's extent, but we don't have that here.\n",
-    "    extent=vector_source.extent)"
+    "    bbox=vector_source.extent)"
    ]
   },
   {

--- a/docs/usage/tutorials/scenes_and_aois.ipynb
+++ b/docs/usage/tutorials/scenes_and_aois.ipynb
@@ -141,7 +141,7 @@
     "label_raster_source = RasterizedSource(\n",
     "    vector_source=vector_source,\n",
     "    background_class_id=class_config.null_class_id,\n",
-    "    extent=raster_source.extent)"
+    "    bbox=raster_source.bbox)"
    ]
   },
   {

--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -59,6 +59,11 @@ class Box():
         return self.xmax - self.xmin
 
     @property
+    def extent(self) -> 'Box':
+        """Return a (0, 0, h, w) Box representing the size of this Box."""
+        return Box(0, 0, self.height, self.width)
+
+    @property
     def size(self) -> Tuple[int, int]:
         return self.height, self.width
 
@@ -272,13 +277,25 @@ class Box():
         ymin, xmin, ymax, xmax = self
         return Box(ymin + dy, xmin + dx, ymax + dy, xmax + dx)
 
-    def shift_origin(self, extent: 'Box') -> 'Box':
-        """Shift origin of window coords to (extent.xmin, extent.ymin)."""
-        return self.translate(dy=extent.ymin, dx=extent.xmin)
+    def to_global_coords(self, bbox: 'Box') -> 'Box':
+        """Go from bbox coords to global coords.
 
-    def to_offsets(self, container: 'Box') -> 'Box':
-        """Convert coords to offsets from (container.xmin, container.ymin)."""
-        return self.translate(dy=-container.ymin, dx=-container.xmin)
+        E.g., Given a box Box(20, 20, 40, 40) and bbox Box(20, 20, 100, 100),
+        the box becomes Box(40, 40, 60, 60).
+
+        Inverse of Box.to_local_coords().
+        """
+        return self.translate(dy=bbox.ymin, dx=bbox.xmin)
+
+    def to_local_coords(self, bbox: 'Box') -> 'Box':
+        """Go from to global coords bbox coords.
+
+        E.g., Given a box Box(40, 40, 60, 60) and bbox Box(20, 20, 100, 100),
+        the box becomes Box(20, 20, 40, 40).
+
+        Inverse of Box.to_global_coords().
+        """
+        return self.translate(dy=-bbox.ymin, dx=-bbox.xmin)
 
     def reproject(self, transform_fn: Callable) -> 'Box':
         """Reprojects this box based on a transform function.

--- a/rastervision_core/rastervision/core/data/crs_transformer/crs_transformer.py
+++ b/rastervision_core/rastervision/core/data/crs_transformer/crs_transformer.py
@@ -25,38 +25,54 @@ class CRSTransformer(ABC):
         self.map_crs = map_crs
 
     @overload
-    def map_to_pixel(self, inp: Tuple[float, float]) -> Tuple[int, int]:
+    def map_to_pixel(self,
+                     inp: Tuple[float, float],
+                     bbox: Optional[Box] = None) -> Tuple[int, int]:
         ...
 
     @overload
-    def map_to_pixel(self, inp: Tuple['np.array', 'np.array']
+    def map_to_pixel(self,
+                     inp: Tuple['np.array', 'np.array'],
+                     bbox: Optional[Box] = None
                      ) -> Tuple['np.array', 'np.array']:
         ...
 
     @overload
-    def map_to_pixel(self, inp: Box) -> Box:
+    def map_to_pixel(self, inp: Box, bbox: Optional[Box] = None) -> Box:
         ...
 
     @overload
-    def map_to_pixel(self, inp: BaseGeometry) -> BaseGeometry:
+    def map_to_pixel(self, inp: BaseGeometry,
+                     bbox: Optional[Box] = None) -> BaseGeometry:
         ...
 
-    def map_to_pixel(self, inp):
-        """Transform input from pixel to map coords.
+    def map_to_pixel(self, inp, bbox: Optional[Box] = None):
+        """Transform input from map to pixel coords.
 
         Args:
             inp: (x, y) tuple or Box or shapely geometry in map coordinates.
                 If tuple, x and y can be single values or array-like.
+            bbox: If the extent of the associated RasterSource is constrained
+                via a bbox, it can be passed here to get an output Box that is
+                compatible with the RasterSource's get_chip(). In other words,
+                the output Box will be in coordinates of the bbox rather than
+                the full extent of the data source of the RasterSource. Only
+                supported if ``inp`` is a :class:`.Box`. Defaults to None.
 
         Returns:
             Coordinate-transformed input in the same format.
         """
+        if bbox is not None and not isinstance(inp, Box):
+            raise NotImplementedError(
+                'bbox is only supported if inp is a Box.')
         if isinstance(inp, Box):
             box_in = inp
             ymin, xmin, ymax, xmax = box_in
             xmin_tf, ymin_tf = self._map_to_pixel((xmin, ymin))
             xmax_tf, ymax_tf = self._map_to_pixel((xmax, ymax))
             box_out = Box(ymin_tf, xmin_tf, ymax_tf, xmax_tf)
+            if bbox is not None:
+                box_out = box_out.to_local_coords(bbox)
             return box_out
         elif isinstance(inp, BaseGeometry):
             geom_in = inp
@@ -70,34 +86,49 @@ class CRSTransformer(ABC):
                 'Input must be 2-tuple or Box or shapely geometry.')
 
     @overload
-    def pixel_to_map(self, inp: Tuple[float, float]) -> Tuple[float, float]:
+    def pixel_to_map(self,
+                     inp: Tuple[float, float],
+                     bbox: Optional[Box] = None) -> Tuple[float, float]:
         ...
 
     @overload
-    def pixel_to_map(self, inp: Tuple['np.array', 'np.array']
+    def pixel_to_map(self,
+                     inp: Tuple['np.array', 'np.array'],
+                     bbox: Optional[Box] = None
                      ) -> Tuple['np.array', 'np.array']:
         ...
 
     @overload
-    def pixel_to_map(self, inp: Box) -> Box:
+    def pixel_to_map(self, inp: Box, bbox: Optional[Box] = None) -> Box:
         ...
 
     @overload
-    def pixel_to_map(self, inp: BaseGeometry) -> BaseGeometry:
+    def pixel_to_map(self, inp: BaseGeometry,
+                     bbox: Optional[Box] = None) -> BaseGeometry:
         ...
 
-    def pixel_to_map(self, inp):
+    def pixel_to_map(self, inp, bbox: Optional[Box] = None):
         """Transform input from pixel to map coords.
 
         Args:
             inp: (x, y) tuple or Box or shapely geometry in pixel coordinates.
                 If tuple, x and y can be single values or array-like.
+            bbox: If the extent of the associated RasterSource is constrained
+                via a bbox, it can be passed here so that the box is
+                interpreted to be in coordinates of the bbox rather than the
+                full extent of the data source of the RasterSource. Only
+                supported if ``inp`` is a :class:`.Box`. Defaults to None.
 
         Returns:
             Coordinate-transformed input in the same format.
         """
+        if bbox is not None and not isinstance(inp, Box):
+            raise NotImplementedError(
+                'bbox is only supported if inp is a Box.')
         if isinstance(inp, Box):
             box_in = inp
+            if bbox is not None:
+                box_in = box_in.to_global_coords(bbox)
             ymin, xmin, ymax, xmax = box_in
             xmin_tf, ymin_tf = self._pixel_to_map((xmin, ymin))
             xmax_tf, ymax_tf = self._pixel_to_map((xmax, ymax))

--- a/rastervision_core/rastervision/core/data/label/utils.py
+++ b/rastervision_core/rastervision/core/data/label/utils.py
@@ -19,7 +19,8 @@ def discard_prediction_edges(
     """
     windows_cropped = [w.center_crop(crop_sz, crop_sz) for w in windows]
     array_slices = [
-        wc.to_offsets(w).to_slices() for w, wc in zip(windows, windows_cropped)
+        wc.to_local_coords(w).to_slices()
+        for w, wc in zip(windows, windows_cropped)
     ]
     predictions_cropped = (p[..., yslice, xslice]
                            for p, (xslice,

--- a/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source_config.py
@@ -93,7 +93,7 @@ class ChipClassificationLabelSourceConfig(LabelSourceConfig):
                 'background_class_id is required if infer_cells=True.')
         return values
 
-    def build(self, class_config, crs_transformer, extent=None,
+    def build(self, class_config, crs_transformer, bbox=None,
               tmp_dir=None) -> ChipClassificationLabelSource:
         if self.vector_source is None:
             raise ValueError('Cannot build with a None vector_source.')
@@ -102,7 +102,7 @@ class ChipClassificationLabelSourceConfig(LabelSourceConfig):
                              'cell_sz=None and lazy=True.')
         vector_source = self.vector_source.build(class_config, crs_transformer)
         return ChipClassificationLabelSource(
-            self, vector_source, extent=extent, lazy=self.lazy)
+            self, vector_source, bbox=bbox, lazy=self.lazy)
 
     def update(self, pipeline=None, scene=None):
         super().update(pipeline, scene)

--- a/rastervision_core/rastervision/core/data/label_source/label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/label_source.py
@@ -30,8 +30,14 @@ class LabelSource(ABC):
         """
         pass
 
-    @abstractproperty
+    @property
     def extent(self) -> 'Box':
+        """Extent of the ``LabelSource``."""
+        return self.bbox.extent
+
+    @abstractproperty
+    def bbox(self) -> 'Box':
+        """Bounding box applied to the source."""
         pass
 
     @abstractproperty
@@ -39,7 +45,7 @@ class LabelSource(ABC):
         pass
 
     @abstractmethod
-    def set_extent(self, extent: 'Box') -> None:
+    def set_bbox(self, extent: 'Box') -> None:
         """Set self.extent to the given value.
 
         .. note:: This method is idempotent.

--- a/rastervision_core/rastervision/core/data/label_source/label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/label_source_config.py
@@ -16,7 +16,7 @@ class LabelSourceConfig(Config):
     def build(self,
               class_config: 'ClassConfig',
               crs_transformer: 'CRSTransformer',
-              extent: Optional['Box'] = None,
+              bbox: Optional['Box'] = None,
               tmp_dir: Optional[str] = None) -> 'LabelSource':
         raise NotImplementedError()
 

--- a/rastervision_core/rastervision/core/data/label_source/object_detection_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/object_detection_label_source_config.py
@@ -38,7 +38,7 @@ class ObjectDetectionLabelSourceConfig(LabelSourceConfig):
         super().update(pipeline, scene)
         self.vector_source.update(pipeline, scene)
 
-    def build(self, class_config, crs_transformer, extent,
+    def build(self, class_config, crs_transformer, bbox,
               tmp_dir=None) -> ObjectDetectionLabelSource:
         vs = self.vector_source.build(class_config, crs_transformer)
-        return ObjectDetectionLabelSource(vs, extent)
+        return ObjectDetectionLabelSource(vs, bbox)

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -31,7 +31,7 @@ class SemanticSegmentationLabelSource(LabelSource):
     def __init__(self,
                  raster_source: RasterSource,
                  class_config: ClassConfig,
-                 extent: Optional[Box] = None):
+                 bbox: Optional[Box] = None):
         """Constructor.
 
         Args:
@@ -40,13 +40,13 @@ class SemanticSegmentationLabelSource(LabelSource):
             null_class_id (int): the null class id used as fill values for when
                 windows go over the edge of the label array. This can be
                 retrieved using class_config.null_class_id.
-            extent (Optional[Box]): User-specified extent. If None, the full
-                extent of the vector source is used.
+            bbox (Optional[Box], optional): User-specified crop of the extent.
+                If None, the full extent available in the source file is used.
         """
         self.raster_source = raster_source
         self.class_config = class_config
-        if extent is not None:
-            self.set_extent(extent)
+        if bbox is not None:
+            self.set_bbox(bbox)
 
     def enough_target_pixels(self, window: Box, target_count_threshold: int,
                              target_classes: List[int]) -> bool:
@@ -118,15 +118,15 @@ class SemanticSegmentationLabelSource(LabelSource):
         return label_arr
 
     @property
-    def extent(self) -> Box:
-        return self.raster_source.extent
+    def bbox(self) -> Box:
+        return self.raster_source.bbox
 
     @property
     def crs_transformer(self) -> 'CRSTransformer':
         return self.raster_source.crs_transformer
 
-    def set_extent(self, extent: 'Box') -> None:
-        self.raster_source.set_extent(extent)
+    def set_bbox(self, bbox: 'Box') -> None:
+        self.raster_source.set_bbox(bbox)
 
     def __getitem__(self, key: Any) -> Any:
         if isinstance(key, Box):

--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source_config.py
@@ -26,11 +26,10 @@ class SemanticSegmentationLabelSourceConfig(LabelSourceConfig):
     raster_source: Union[RasterSourceConfig, RasterizedSourceConfig] = Field(
         ..., description='The labels in the form of rasters.')
 
-    def build(self, class_config, crs_transformer, extent=None,
+    def build(self, class_config, crs_transformer, bbox=None,
               tmp_dir=None) -> SemanticSegmentationLabelSource:
         if isinstance(self.raster_source, RasterizedSourceConfig):
-            rs = self.raster_source.build(class_config, crs_transformer,
-                                          extent)
+            rs = self.raster_source.build(class_config, crs_transformer, bbox)
         else:
             rs = self.raster_source.build(tmp_dir)
         return SemanticSegmentationLabelSource(rs, class_config)

--- a/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
@@ -20,7 +20,7 @@ class ChipClassificationGeoJSONStore(LabelStore):
                  uri: str,
                  class_config: 'ClassConfig',
                  crs_transformer: 'CRSTransformer',
-                 extent: Optional['Box'] = None):
+                 bbox: Optional['Box'] = None):
         """Constructor.
 
         Args:
@@ -28,14 +28,14 @@ class ChipClassificationGeoJSONStore(LabelStore):
             class_config: ClassConfig
             crs_transformer: CRSTransformer to convert from map coords in label
                 in GeoJSON file to pixel coords.
-            extent (Optional[Box]): User-specified extent. If provided, only
-                labels falling inside it are returned by
+            bbox (Optional[Box], optional): User-specified crop of the extent.
+                If provided, only labels falling inside it are returned by
                 :meth:`.ChipClassificationGeoJSONStore.get_labels`.
         """
         self.uri = uri
         self.class_config = class_config
         self._crs_transformer = crs_transformer
-        self._extent = extent
+        self._bbox = bbox
 
     def save(self, labels: ChipClassificationLabels) -> None:
         """Save labels to URI if writable.
@@ -59,19 +59,16 @@ class ChipClassificationGeoJSONStore(LabelStore):
         ls = ChipClassificationLabelSourceConfig(vector_source=vs).build(
             class_config=self.class_config,
             crs_transformer=self.crs_transformer,
-            extent=self.extent)
+            bbox=self.bbox)
         return ls.get_labels()
 
-    def empty_labels(self) -> ChipClassificationLabels:
-        return ChipClassificationLabels()
-
     @property
-    def extent(self) -> Optional['Box']:
-        return self._extent
+    def bbox(self) -> 'Box':
+        return self._bbox
 
     @property
     def crs_transformer(self) -> 'CRSTransformer':
         return self._crs_transformer
 
-    def set_extent(self, extent: 'Box') -> None:
-        self._extent = extent
+    def set_bbox(self, bbox: 'Box') -> None:
+        self._bbox = bbox

--- a/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store_config.py
@@ -17,9 +17,9 @@ class ChipClassificationGeoJSONStoreConfig(LabelStoreConfig):
          'a SceneConfig inside an RVPipelineConfig, it will be auto-generated.'
          ))
 
-    def build(self, class_config, crs_transformer, extent=None, tmp_dir=None):
-        return ChipClassificationGeoJSONStore(self.uri, class_config,
-                                              crs_transformer)
+    def build(self, class_config, crs_transformer, bbox=None, tmp_dir=None):
+        return ChipClassificationGeoJSONStore(
+            self.uri, class_config, crs_transformer, bbox=bbox)
 
     def update(self, pipeline=None, scene=None):
         if self.uri is None and pipeline is not None and scene is not None:

--- a/rastervision_core/rastervision/core/data/label_store/label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/label_store.py
@@ -24,13 +24,8 @@ class LabelStore(ABC):
         """Loads Labels from this label store."""
         pass
 
-    @abstractmethod
-    def empty_labels(self):
-        """Produces an empty Labels"""
-        pass
-
     @abstractproperty
-    def extent(self) -> Optional['Box']:
+    def bbox(self) -> Optional['Box']:
         pass
 
     @abstractproperty
@@ -38,7 +33,7 @@ class LabelStore(ABC):
         pass
 
     @abstractmethod
-    def set_extent(self, extent: 'Box') -> None:
+    def set_bbox(self, extent: 'Box') -> None:
         """Set self.extent to the given value.
 
         .. note:: This method is idempotent.

--- a/rastervision_core/rastervision/core/data/label_store/label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/label_store_config.py
@@ -16,7 +16,7 @@ class LabelStoreConfig(Config):
     def build(self,
               class_config: 'ClassConfig',
               crs_transformer: 'CRSTransformer',
-              extent: 'Box',
+              bbox: Optional['Box'] = None,
               tmp_dir: Optional[str] = None) -> 'LabelStore':
         raise NotImplementedError()
 

--- a/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
@@ -21,7 +21,7 @@ class ObjectDetectionGeoJSONStore(LabelStore):
                  uri: str,
                  class_config: 'ClassConfig',
                  crs_transformer: 'CRSTransformer',
-                 extent: Optional['Box'] = None):
+                 bbox: Optional['Box'] = None):
         """Constructor.
 
         Args:
@@ -30,14 +30,14 @@ class ObjectDetectionGeoJSONStore(LabelStore):
                 (or label) field
             crs_transformer: CRSTransformer to convert from map coords in label
                 in GeoJSON file to pixel coords.
-            extent (Optional[Box]): User-specified extent. If provided, only
-                labels falling inside it are returned by
+            bbox (Optional[Box], optional): User-specified crop of the extent.
+                If provided, only labels falling inside it are returned by
                 :meth:`.ObjectDetectionGeoJSONStore.get_labels`.
         """
         self.uri = uri
         self.class_config = class_config
         self._crs_transformer = crs_transformer
-        self._extent = extent
+        self._bbox = bbox
 
     def save(self, labels: ObjectDetectionLabels) -> None:
         """Save labels to URI."""
@@ -59,20 +59,17 @@ class ObjectDetectionGeoJSONStore(LabelStore):
             crs_transformer=self.crs_transformer)
         labels = ObjectDetectionLabels.from_geojson(
             vector_source.get_geojson())
-        if self.extent is not None:
-            labels = ObjectDetectionLabels.get_overlapping(labels, self.extent)
+        if self.bbox is not None:
+            labels = ObjectDetectionLabels.get_overlapping(labels, self.bbox)
         return labels
 
-    def empty_labels(self) -> ObjectDetectionLabels:
-        return ObjectDetectionLabels.make_empty()
-
     @property
-    def extent(self) -> 'Box':
-        return self._extent
+    def bbox(self) -> 'Box':
+        return self._bbox
 
     @property
     def crs_transformer(self) -> 'CRSTransformer':
         return self._crs_transformer
 
-    def set_extent(self, extent: 'Box') -> None:
-        self._extent = extent
+    def set_bbox(self, bbox: 'Box') -> None:
+        self._bbox = bbox

--- a/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store_config.py
@@ -17,9 +17,9 @@ class ObjectDetectionGeoJSONStoreConfig(LabelStoreConfig):
          'a SceneConfig inside an RVPipelineConfig, it will be auto-generated.'
          ))
 
-    def build(self, class_config, crs_transformer, extent=None, tmp_dir=None):
-        return ObjectDetectionGeoJSONStore(self.uri, class_config,
-                                           crs_transformer)
+    def build(self, class_config, crs_transformer, bbox=None, tmp_dir=None):
+        return ObjectDetectionGeoJSONStore(
+            self.uri, class_config, crs_transformer, bbox=bbox)
 
     def update(self, pipeline=None, scene=None):
         if pipeline is not None and scene is not None:

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
@@ -11,7 +11,9 @@ if TYPE_CHECKING:
     import numpy as np
     from shapely.geometry.base import BaseGeometry
 
-    from rastervision.core.data import ClassConfig, SceneConfig
+    from rastervision.core.box import Box
+    from rastervision.core.data import (ClassConfig, CRSTransformer,
+                                        SceneConfig)
     from rastervision.core.rv_pipeline import RVPipelineConfig
 
 
@@ -141,14 +143,18 @@ class SemanticSegmentationLabelStoreConfig(LabelStoreConfig):
         description='blockxsize and blockysize params in rasterio.open() will '
         'be set to this.')
 
-    def build(self, class_config, crs_transformer, extent, tmp_dir):
+    def build(self,
+              class_config: 'ClassConfig',
+              crs_transformer: 'CRSTransformer',
+              bbox: 'Box',
+              tmp_dir: Optional[str] = None) -> SemanticSegmentationLabelStore:
         class_config.ensure_null_class()
 
         label_store = SemanticSegmentationLabelStore(
             uri=self.uri,
-            extent=extent,
             crs_transformer=crs_transformer,
             class_config=class_config,
+            bbox=bbox,
             tmp_dir=tmp_dir,
             vector_outputs=self.vector_output,
             save_as_rgb=self.rgb,

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -57,7 +57,7 @@ class MultiRasterSourceConfig(RasterSourceConfig):
             force_same_dtype=self.force_same_dtype,
             channel_order=self.channel_order,
             raster_transformers=raster_transformers,
-            extent=self.extent)
+            bbox=self.bbox)
         return multi_raster_source
 
     def update(self, pipeline=None, scene=None):

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -31,9 +31,9 @@ class RasterSourceConfig(Config):
         description=
         'The sequence of channel indices to use when reading imagery.')
     transformers: List[RasterTransformerConfig] = []
-    extent: Optional[Tuple[int, int, int, int]] = Field(
+    bbox: Optional[Tuple[int, int, int, int]] = Field(
         None,
-        description='User-specified extent in pixel coords in the form '
+        description='User-specified bbox in pixel coords in the form '
         '(ymin, xmin, ymax, xmax). Useful for cropping the raster source so '
         'that only part of the raster is read from.')
 
@@ -48,8 +48,8 @@ class RasterSourceConfig(Config):
         for t in self.transformers:
             t.update(pipeline, scene)
 
-    @validator('extent')
-    def validate_extent(cls, v):
+    @validator('bbox')
+    def validate_bbox(cls, v):
         if v is None:
             return None
         return Box(*v)

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
@@ -44,4 +44,4 @@ class RasterioSourceConfig(RasterSourceConfig):
             tmp_dir=tmp_dir,
             allow_streaming=self.allow_streaming,
             channel_order=self.channel_order,
-            extent=self.extent)
+            bbox=self.bbox)

--- a/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
@@ -55,10 +55,10 @@ class RasterizedSourceConfig(Config):
         super().update(pipeline, scene)
         self.vector_source.update(pipeline, scene)
 
-    def build(self, class_config, crs_transformer, extent) -> RasterizedSource:
+    def build(self, class_config, crs_transformer, bbox) -> RasterizedSource:
         vector_source = self.vector_source.build(class_config, crs_transformer)
         return RasterizedSource(
             vector_source=vector_source,
             background_class_id=self.rasterizer_config.background_class_id,
-            extent=extent,
+            bbox=bbox,
             all_touched=self.rasterizer_config.all_touched)

--- a/rastervision_core/rastervision/core/data/scene.py
+++ b/rastervision_core/rastervision/core/data/scene.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-from rastervision.core.data.utils import match_extents
+from rastervision.core.data.utils import match_bboxes
 
 if TYPE_CHECKING:
     from rastervision.core.box import Box
@@ -30,10 +30,10 @@ class Scene:
             aoi: Optional list of AOI polygons in pixel coordinates.
         """
         if label_source is not None:
-            match_extents(raster_source, label_source)
+            match_bboxes(raster_source, label_source)
 
         if label_store is not None:
-            match_extents(raster_source, label_store)
+            match_bboxes(raster_source, label_store)
 
         self.id = id
         self.raster_source = raster_source

--- a/rastervision_core/rastervision/core/data/scene_config.py
+++ b/rastervision_core/rastervision/core/data/scene_config.py
@@ -51,16 +51,22 @@ class SceneConfig(Config):
         raster_source = self.raster_source.build(
             tmp_dir, use_transformers=use_transformers)
         crs_transformer = raster_source.crs_transformer
-        extent = raster_source.extent
+        bbox = raster_source.bbox
 
         label_source = None
         label_store = None
         if self.label_source is not None:
             label_source = self.label_source.build(
-                class_config, crs_transformer, extent, tmp_dir)
+                class_config=class_config,
+                crs_transformer=crs_transformer,
+                bbox=bbox,
+                tmp_dir=tmp_dir)
         if self.label_store is not None:
-            label_store = self.label_store.build(class_config, crs_transformer,
-                                                 extent, tmp_dir)
+            label_store = self.label_store.build(
+                class_config=class_config,
+                crs_transformer=crs_transformer,
+                bbox=bbox,
+                tmp_dir=tmp_dir)
 
         aoi_polygons = []
         if self.aoi_uris is not None:

--- a/rastervision_core/rastervision/core/data/utils/factory.py
+++ b/rastervision_core/rastervision/core/data/utils/factory.py
@@ -82,7 +82,7 @@ def make_ss_scene(image_uri: Union[str, List[str]],
     raster_source = RasterioSource(uris=image_uri, **image_raster_source_kw)
 
     crs_transformer = raster_source.crs_transformer
-    extent = raster_source.extent
+    bbox = raster_source.bbox
 
     label_raster_source = None
     if label_raster_uri is not None:
@@ -106,7 +106,7 @@ def make_ss_scene(image_uri: Union[str, List[str]],
             vector_source=vector_source,
             background_class_id=label_raster_source_kw.pop(
                 'background_class_id', class_config.null_class_id),
-            extent=extent,
+            bbox=bbox,
             **label_raster_source_kw)
 
     label_source = None
@@ -182,7 +182,7 @@ def make_cc_scene(image_uri: Union[str, List[str]],
     raster_source = RasterioSource(image_uri, **image_raster_source_kw)
 
     crs_transformer = raster_source.crs_transformer
-    extent = raster_source.extent
+    bbox = raster_source.bbox
 
     label_source = None
     if label_vector_uri is not None:
@@ -203,7 +203,7 @@ def make_cc_scene(image_uri: Union[str, List[str]],
         label_source_cfg = ChipClassificationLabelSourceConfig(
             vector_source=geojson_cfg, **label_source_kw)
         label_source = label_source_cfg.build(
-            class_config, crs_transformer, extent=extent)
+            class_config, crs_transformer, bbox=bbox)
 
     aoi_polygons = get_polygons_from_uris(aoi_uri, crs_transformer)
     scene = Scene(
@@ -273,7 +273,7 @@ def make_od_scene(image_uri: Union[str, List[str]],
     raster_source = RasterioSource(image_uri, **image_raster_source_kw)
 
     crs_transformer = raster_source.crs_transformer
-    extent = raster_source.extent
+    bbox = raster_source.bbox
 
     label_source = None
     if label_vector_uri is not None:
@@ -294,7 +294,7 @@ def make_od_scene(image_uri: Union[str, List[str]],
         label_source_cfg = ObjectDetectionLabelSourceConfig(
             vector_source=geojson_cfg, **label_source_kw)
         label_source = label_source_cfg.build(
-            class_config, crs_transformer, extent=extent)
+            class_config, crs_transformer, bbox=bbox)
 
     aoi_polygons = get_polygons_from_uris(aoi_uri, crs_transformer)
     scene = Scene(

--- a/rastervision_core/rastervision/core/data/utils/misc.py
+++ b/rastervision_core/rastervision/core/data/utils/misc.py
@@ -97,9 +97,9 @@ def listify_uris(uris: Union[str, List[str]]) -> List[str]:
     return uris
 
 
-def match_extents(raster_source: 'RasterSource',
-                  label_source: Union['LabelSource', 'LabelStore']) -> None:
-    """Set ``label_souce`` extent equal to ``raster_source`` extent.
+def match_bboxes(raster_source: 'RasterSource',
+                 label_source: Union['LabelSource', 'LabelStore']) -> None:
+    """Set ``label_souce`` bbox equal to ``raster_source`` bbox.
 
     Logs a warning if ``raster_source`` and ``label_source`` extents don't
     intersect when converted to map coordinates.
@@ -111,18 +111,18 @@ def match_extents(raster_source: 'RasterSource',
     """
     crs_tf_img = raster_source.crs_transformer
     crs_tf_label = label_source.crs_transformer
-    extent_img_map = crs_tf_img.pixel_to_map(raster_source.extent)
-    if label_source.extent is not None:
-        extent_label_map = crs_tf_label.pixel_to_map(label_source.extent)
-        if not extent_img_map.intersects(extent_label_map):
+    bbox_img_map = crs_tf_img.pixel_to_map(raster_source.bbox)
+    if label_source.bbox is not None:
+        bbox_label_map = crs_tf_label.pixel_to_map(label_source.bbox)
+        if not bbox_img_map.intersects(bbox_label_map):
             rs_cls = type(raster_source).__name__
             ls_cls = type(label_source).__name__
-            log.warning(f'{rs_cls} extent ({extent_img_map}) does '
-                        f'not intersect with {ls_cls} extent '
-                        f'({extent_label_map}).')
-    # set LabelStore extent to RasterSource extent
-    extent_label_pixel = crs_tf_label.map_to_pixel(extent_img_map)
-    label_source.set_extent(extent_label_pixel)
+            log.warning(f'{rs_cls} bbox ({bbox_img_map}) does '
+                        f'not intersect with {ls_cls} bbox '
+                        f'({bbox_label_map}).')
+    # set LabelStore bbox to RasterSource bbox
+    bbox_label_pixel = crs_tf_label.map_to_pixel(bbox_img_map)
+    label_source.set_bbox(bbox_label_pixel)
 
 
 def parse_array_slices(key: Union[tuple, slice], extent: Box,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation.py
@@ -98,7 +98,7 @@ class PyTorchSemanticSegmentation(PyTorchLearnerBackend):
             ds.windows,
             predictions,
             smooth=raw_out,
-            extent=label_store.extent,
+            extent=scene.extent,
             num_classes=len(label_store.class_config),
             crop_sz=crop_sz)
 

--- a/tests/core/data/crs_transformer/test_rasterio_crs_transformer.py
+++ b/tests/core/data/crs_transformer/test_rasterio_crs_transformer.py
@@ -38,9 +38,20 @@ class TestRasterioCRSTransformer(unittest.TestCase):
         np.testing.assert_equal(pix_point[1], pix_point_expected[:, 1])
 
         # Box
-        map_box = Box(*self.lon_lat[::-1], *self.lon_lat[::-1])
+        map_x, map_y = self.lon_lat
+        map_box = Box(map_y, map_x, map_y, map_x)
         pix_box = self.crs_trans.map_to_pixel(map_box)
-        pix_box_expected = Box(*self.pix_point[::-1], *self.pix_point[::-1])
+        pix_x, pix_y = self.pix_point
+        pix_box_expected = Box(pix_y, pix_x, pix_y, pix_x)
+        self.assertEqual(pix_box, pix_box_expected)
+
+        # Box + bbox
+        bbox = Box(20, 20, 80, 80)
+        map_x, map_y = self.lon_lat
+        map_box = Box(map_y, map_x, map_y, map_x)
+        pix_box = self.crs_trans.map_to_pixel(map_box, bbox=bbox)
+        pix_x, pix_y = self.pix_point
+        pix_box_expected = Box(pix_y - 20, pix_x - 20, pix_y - 20, pix_x - 20)
         self.assertEqual(pix_box, pix_box_expected)
 
         # shapely
@@ -78,9 +89,23 @@ class TestRasterioCRSTransformer(unittest.TestCase):
             map_point[1], map_point_expected[:, 1], decimal=3)
 
         # Box
-        pix_box = Box(*self.pix_point[::-1], *self.pix_point[::-1])
+        pix_x, pix_y = self.pix_point
+        pix_box = Box(pix_y, pix_x, pix_y, pix_x)
         map_box = self.crs_trans.pixel_to_map(pix_box)
-        map_box_expected = Box(*self.lon_lat[::-1], *self.lon_lat[::-1])
+        map_x, map_y = self.lon_lat
+        map_box_expected = Box(map_y, map_x, map_y, map_x)
+        np.testing.assert_almost_equal(
+            np.array(map_box.tuple_format()),
+            np.array(map_box_expected.tuple_format()),
+            decimal=3)
+
+        # Box + bbox
+        bbox = Box(20, 20, 80, 80)
+        pix_x, pix_y = self.pix_point
+        pix_box = Box(pix_y - 20, pix_x - 20, pix_y - 20, pix_x - 20)
+        map_box = self.crs_trans.pixel_to_map(pix_box, bbox=bbox)
+        map_x, map_y = self.lon_lat
+        map_box_expected = Box(map_y, map_x, map_y, map_x)
         np.testing.assert_almost_equal(
             np.array(map_box.tuple_format()),
             np.array(map_box_expected.tuple_format()),

--- a/tests/core/data/mock_raster_source.py
+++ b/tests/core/data/mock_raster_source.py
@@ -8,18 +8,22 @@ from rastervision.core.data import RasterSource, IdentityCRSTransformer
 class MockRasterSource(RasterSource):
     def __init__(self, channel_order, num_channels_raw,
                  raster_transformers=[]):
-        super().__init__(channel_order, num_channels_raw, raster_transformers)
+        super().__init__(
+            channel_order,
+            num_channels_raw,
+            bbox=Box.make_square(0, 0, 2),
+            raster_transformers=raster_transformers)
         self.mock = Mock()
         self.set_return_vals()
 
     def set_return_vals(self, raster=None):
         self._dtype = np.uint8
-        self._extent = Box.make_square(0, 0, 2)
+        # self._extent = Box.make_square(0, 0, 2)
         self._crs_transformer = IdentityCRSTransformer()
         self.mock._get_chip.return_value = np.random.rand(1, 2, 2, 3)
 
         if raster is not None:
-            self._extent = Box(0, 0, raster.shape[0], raster.shape[1])
+            self._bbox = Box(0, 0, raster.shape[0], raster.shape[1])
             self._dtype = raster.dtype
 
             def get_chip(window):
@@ -36,7 +40,7 @@ class MockRasterSource(RasterSource):
     def crs_transformer(self):
         return self._crs_transformer
 
-    def _get_chip(self, window):
+    def _get_chip(self, window, out_shape=None):
         return self.mock._get_chip(window)
 
     def set_raster(self, raster):

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -88,22 +88,24 @@ class TestMultiRasterSource(unittest.TestCase):
                          primary_rs.crs_transformer.transform)
         self.assertNotEqual(rs.crs_transformer, non_primary_rs.crs_transformer)
 
-    def test_user_specified_extent(self):
+    def test_bbox(self):
         # /wo user specified extent
         cfg = make_cfg('small-rgb-tile.tif')
         rs = cfg.build(tmp_dir=self.tmp_dir)
+        self.assertEqual(rs.bbox, Box(0, 0, 256, 256))
         self.assertEqual(rs.extent, Box(0, 0, 256, 256))
 
         # test validators
-        cfg = make_cfg('small-rgb-tile.tif', extent=(64, 64, 192, 192))
-        self.assertIsInstance(cfg.extent, Box)
+        cfg = make_cfg('small-rgb-tile.tif', bbox=(64, 64, 192, 192))
+        self.assertIsInstance(cfg.bbox, Box)
 
         # /w user specified extent
-        cfg_crop = make_cfg('small-rgb-tile.tif', extent=(64, 64, 192, 192))
+        cfg_crop = make_cfg('small-rgb-tile.tif', bbox=(64, 64, 192, 192))
         rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)
 
         # test extent box
-        self.assertEqual(rs_crop.extent, Box(64, 64, 192, 192))
+        self.assertEqual(rs_crop.bbox, Box(64, 64, 192, 192))
+        self.assertEqual(rs_crop.extent, Box(0, 0, 128, 128))
 
     def test_get_chip(self):
         # create a 3-channel raster from a 1-channel raster

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -219,22 +219,24 @@ class TestRasterioSource(unittest.TestCase):
         self.assertEqual(ymax, 256)
         self.assertEqual(xmax, 256)
 
-    def test_user_specified_extent(self):
+    def test_bbox(self):
         img_path = data_file_path('small-rgb-tile.tif')
 
-        # /wo user specified extent
+        # /wo user specified bbox
         rs = RasterioSource(uris=img_path)
+        self.assertEqual(rs.bbox, Box(0, 0, 256, 256))
         self.assertEqual(rs.extent, Box(0, 0, 256, 256))
 
-        # /w user specified extent
-        rs_crop = RasterioSource(uris=img_path, extent=Box(64, 64, 192, 192))
+        # /w user specified bbox
+        rs_crop = RasterioSource(uris=img_path, bbox=Box(64, 64, 192, 192))
 
-        # test extent box
-        self.assertEqual(rs_crop.extent, Box(64, 64, 192, 192))
+        # test bbox box
+        self.assertEqual(rs_crop.bbox, Box(64, 64, 192, 192))
+        self.assertEqual(rs_crop.extent, Box(0, 0, 128, 128))
 
         # test validators
-        rs_cfg = RasterioSourceConfig(uris=[img_path], extent=(0, 0, 1, 1))
-        self.assertIsInstance(rs_cfg.extent, Box)
+        rs_cfg = RasterioSourceConfig(uris=[img_path], bbox=(0, 0, 1, 1))
+        self.assertIsInstance(rs_cfg.bbox, Box)
 
     def test_fill_overflow(self):
         extent = Box(10, 10, 90, 90)
@@ -267,7 +269,7 @@ class TestRasterioSource(unittest.TestCase):
                     count=1,
                     dtype=np.uint8) as ds:
                 ds.write_band(1, arr)
-            rs = RasterioSource(uris=uri, extent=Box(10, 10, 90, 90))
+            rs = RasterioSource(uris=uri, bbox=Box(10, 10, 90, 90))
             out = rs.get_chip(Box(0, 0, 100, 100))[..., 0]
 
         mask = np.zeros((100, 100), dtype=bool)

--- a/tests/core/test_box.py
+++ b/tests/core/test_box.py
@@ -189,15 +189,15 @@ class TestBox(unittest.TestCase):
             box.translate(dy, dx),
             Box(box.ymin + dy, box.xmin + dx, box.ymax + dy, box.xmax + dx))
 
-    def test_shift_origin(self):
+    def test_to_global_coords(self):
         extent = Box(5, 5, 8, 8)
         box = Box(0, 0, 10, 10)
-        self.assertEqual(box.shift_origin(extent), Box(5, 5, 15, 15))
+        self.assertEqual(box.to_global_coords(extent), Box(5, 5, 15, 15))
 
-    def test_to_offsets(self):
+    def test_to_local_coords(self):
         outer = Box(10, 10, 20, 20)
         inner = Box(15, 15, 18, 18)
-        self.assertEqual(inner.to_offsets(outer), Box(5, 5, 8, 8))
+        self.assertEqual(inner.to_local_coords(outer), Box(5, 5, 8, 8))
 
     def test_to_shapely(self):
         bounds = self.box.to_shapely().bounds
@@ -410,6 +410,10 @@ class TestBox(unittest.TestCase):
     def test_normalize(self):
         self.assertEqual(Box(4, 3, 2, 1).normalize(), Box(2, 1, 4, 3))
         self.assertEqual(Box(1, 2, 3, 4).normalize(), Box(1, 2, 3, 4))
+
+    def test_extent(self):
+        self.assertEqual(Box(2, 3, 5, 7).extent, Box(0, 0, 3, 4))
+        self.assertEqual(Box(0, 0, 5, 7).extent, Box(0, 0, 5, 7))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Overview

Currently in RV, the concept of _extent_ is overloaded to refer to the both the full extent of the data in the data source file as well as a user-specified subset of it. See #1766 for more discussion.

This PR attempts to correct this by disentangling these into _extent_ and _bbox_. A `RasterioSource` that reads from a 100x100 GeoTIFF that is cropped to exclude 10 pixels on all sides, for example, will now have `.bbox == Box(10, 10, 90, 90)` and `.extent == Box(0, 0, 80, 80)`. Moreover, the user is expected to interact with the `RasterioSource` using local coordinates; i.e. coordinates relative to its `bbox` rather than global coordinates. See "option 2" [here](https://github.com/azavea/raster-vision/issues/1766#issuecomment-1498714475).

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

See updated unit tests.

Closes #1766 
