### PR TITLE
Remove `codecov` dependency to fix CI build error

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 flake8==5.0.4
 moto==4.0.8
 coverage==7.2.0
-codecov==2.1.12
 yapf==0.23.0
 unify==0.5
 sphinx-autobuild==2021.3.14


### PR DESCRIPTION
Apparently the `codecov` package had been deprecated for a while and has now been removed from PyPi.

See: https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259