### PR TITLE
Add experimental ONNX support

### DIFF
--- a/rastervision_core/rastervision/core/data/label/object_detection_labels.py
+++ b/rastervision_core/rastervision/core/data/label/object_detection_labels.py
@@ -169,18 +169,21 @@ class ObjectDetectionLabels(Labels):
     def to_boxlist(self) -> BoxList:
         return self.boxlist
 
-    def to_dict(self) -> dict:
+    def to_dict(self, round_boxes: bool = True) -> dict:
         """Returns a dict version of these labels.
 
         The Dict has a Box as a key, and a tuple of (class_id, score)
         as the values.
         """
-        d = {}
-        boxes = list(map(Box.from_npbox, self.get_npboxes()))
-        classes = list(self.get_class_ids())
-        scores = list(self.get_scores())
-        for box, class_id, score in zip(boxes, classes, scores):
-            d[box.tuple_format()] = (class_id, score)
+        npboxes = self.get_npboxes()
+        if round_boxes and np.issubdtype(npboxes.dtype, np.floating):
+            npboxes = npboxes.round(2)
+        classes = self.get_class_ids()
+        scores = self.get_scores().round(6)
+        d = {
+            Box.from_npbox(box): (class_id, score)
+            for box, class_id, score in zip(npboxes, classes, scores)
+        }
         return d
 
     @staticmethod

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_utils.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from os.path import join
 from operator import iand
 from functools import reduce
+from pprint import pformat
 
 import torch
 import torch.nn as nn
@@ -246,6 +247,9 @@ class BoxList():
             if torch.is_tensor(v):
                 self.extras[k] = v.pin_memory()
         return self
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return pformat(dict(boxes=self.boxes, **self.extras))
 
 
 def collate_fn(data: Iterable[Sequence]) -> Tuple[torch.Tensor, List[BoxList]]:

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -4,7 +4,7 @@ numpy==1.23.3
 pillow==9.3.0
 torch==1.12.1
 torchvision==0.13.1
-tensorboard==2.10.1
+tensorboard==2.13.0
 albumentations==1.3.0
 cython==0.29.32
 pycocotools==2.0.5
@@ -14,3 +14,5 @@ opencv-python==4.6.0.66
 opencv-python-headless==4.6.0.66
 matplotlib==3.6.1
 tqdm==4.64.1
+onnx==1.14.0
+onnxruntime-gpu==1.15.0


### PR DESCRIPTION
## Overview

This PR adds support for exporting models in ONNX format as well as doing inference using ONNX-runtime.

Main changes:
- `Learner.save_model_bundle()` now also saves a `model.onnx` file to the model bundle.
- `Learner.from_model_bundle()` can now load `model.onnx` via ONNX-runtime for inference.
    - This is disabled by default. Can be enabled by passing `use_onnx_model=True` to `Learner.from_model_bundle()` or by setting the environment variable `RASTERVISION_USE_ONNX=true`.
    - `RASTERVISION_USE_ONNX=true` also allows the user to use ONNX inference with the `predict` command.
- By default, the ONNX export supports dynamic batch and image sizes.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* The ONNX export is test in unit tests and integration tests via `Learner.save_model_bundle()`
* To test ONNX inference, run 
  ```sh
   RASTERVISION_USE_ONNX=true scripts/integration_tests
  ```

Closes #974 
