### PR TITLE
Conform to new torchvision API for specifying pretrained weights

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -102,10 +102,12 @@ class ClassificationModelConfig(ModelConfig):
                             in_channels: int) -> nn.Module:
         from torchvision import models
 
-        pretrained = self.pretrained
         backbone_name = self.get_backbone_str()
-        model_factory_func: Callable = getattr(models, backbone_name)
-        model = model_factory_func(pretrained=pretrained, **self.extra_args)
+        pretrained = self.pretrained
+        weights = 'DEFAULT' if pretrained else None
+        model_factory_func: Callable[..., nn.Module] = getattr(
+            models, backbone_name)
+        model = model_factory_func(weights=weights, **self.extra_args)
 
         if in_channels != 3:
             if not backbone_name.startswith('resnet'):

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/object_detection_learner_config.py
@@ -173,9 +173,11 @@ class ObjectDetectionModelConfig(ModelConfig):
         Returns:
             FasterRCNN: a FasterRCNN model.
         """
-        pretrained = self.pretrained
         backbone_arch = self.get_backbone_str()
-        backbone = resnet_fpn_backbone(backbone_arch, pretrained)
+        pretrained = self.pretrained
+        weights = 'DEFAULT' if pretrained else None
+        backbone = resnet_fpn_backbone(
+            backbone_name=backbone_arch, weights=weights)
 
         # default values from FasterRCNN constructor
         image_mean = [0.485, 0.456, 0.406]

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/semantic_segmentation_learner_config.py
@@ -151,9 +151,8 @@ class SemanticSegmentationModelConfig(ModelConfig):
 
     backbone: Backbone = Field(
         Backbone.resnet50,
-        description=(
-            'The torchvision.models backbone to use. At the moment only '
-            'resnet50 or resnet101 will work.'))
+        description='The torchvision.models backbone to use. Currently, only '
+        'resnet50 and resnet101 are supported.')
 
     @validator('backbone')
     def only_valid_backbones(cls, v):
@@ -165,14 +164,14 @@ class SemanticSegmentationModelConfig(ModelConfig):
 
     def build_default_model(self, num_classes: int,
                             in_channels: int) -> nn.Module:
-        pretrained = self.pretrained
         backbone_name = self.get_backbone_str()
-
+        pretrained = self.pretrained
+        weights = 'DEFAULT' if pretrained else None
         model_factory_func: Callable = getattr(models.segmentation,
                                                f'deeplabv3_{backbone_name}')
         model = model_factory_func(
             num_classes=num_classes,
-            pretrained_backbone=pretrained,
+            weights_backbone=weights,
             aux_loss=False,
             **self.extra_args)
 


### PR DESCRIPTION
## Overview

[In version 0.13, TorchVision introduced a new API for specifying pretrained weights](https://pytorch.org/blog/introducing-torchvision-new-multi-weight-support-api/) and added a deprecation warning for the old API. This PR updates the instances of the use of the old API within Raster Vision to the new API.

This is entirely an internal change and does not affect the [`ModelConfig`](https://docs.rastervision.io/en/latest/api_reference/_generated/rastervision.pytorch_learner.learner_config.ModelConfig.html#modelconfig) API, which still accepts the `pretrained` field.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* There should no longer be deprecation warnings when creating models.
