### PR TITLE
Improve geometry-related validation in `Scene` and `GeoJSONVectorSource`

### DIFF
--- a/rastervision_core/rastervision/core/data/scene.py
+++ b/rastervision_core/rastervision/core/data/scene.py
@@ -45,6 +45,11 @@ class Scene:
             self.aoi_polygons = []
             self.aoi_polygons_bbox_coords = []
         else:
+            for p in aoi_polygons:
+                if p.geom_type not in ['Polygon', 'MultiPolygon']:
+                    raise ValueError(
+                        'Expected all AOI geometries to be Polygons or '
+                        f'MultiPolygons. Found: {p.geom_type}.')
             bbox = self.raster_source.bbox
             bbox_geom = bbox.to_shapely()
             self.aoi_polygons = [

--- a/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
+++ b/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
@@ -69,4 +69,10 @@ class GeoJSONVectorSource(VectorSource):
                 # geojson is passed to code that *does* respect the CRS field
                 # (e.g. geopandas).
                 del geojson['crs']
+                # Also delete any "crs" keys in features' properties.
+                for f in geojson.get('features', []):
+                    try:
+                        del f['properties']['crs']
+                    except KeyError:
+                        pass
         return geojson

--- a/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
+++ b/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, List, Optional, Union
+import logging
 
 from rastervision.pipeline.file_system import download_if_needed, file_to_json
 from rastervision.core.box import Box
@@ -7,6 +8,8 @@ from rastervision.core.data.utils import listify_uris, merge_geojsons
 
 if TYPE_CHECKING:
     from rastervision.core.data import CRSTransformer, VectorTransformer
+
+log = logging.getLogger(__name__)
 
 
 class GeoJSONVectorSource(VectorSource):
@@ -49,13 +52,21 @@ class GeoJSONVectorSource(VectorSource):
     def _get_geojson_single(self, uri: str) -> dict:
         # download first so that it gets cached
         geojson = file_to_json(download_if_needed(uri))
-        if not self.ignore_crs_field and 'crs' in geojson:
-            raise NotImplementedError(
-                f'The GeoJSON file at {uri} contains a CRS field which '
-                'is not allowed by the current GeoJSON standard or by '
-                'Raster Vision. All coordinates are expected to be in '
-                'EPSG:4326 CRS. If the file uses EPSG:4326 (ie. lat/lng on '
-                'the WGS84 reference ellipsoid) and you would like to ignore '
-                'the CRS field, set ignore_crs_field=True in '
-                'GeoJSONVectorSourceConfig.')
+        if 'crs' in geojson:
+            if not self.ignore_crs_field:
+                raise NotImplementedError(
+                    f'The GeoJSON file at {uri} contains a CRS field which '
+                    'is not allowed by the current GeoJSON standard or by '
+                    'Raster Vision. All coordinates are expected to be in '
+                    'EPSG:4326 CRS. If the file uses EPSG:4326 (ie. lat/lng '
+                    'on the WGS84 reference ellipsoid) and you would like to '
+                    'ignore the CRS field, set ignore_crs_field=True.')
+            else:
+                crs = geojson['crs']
+                log.info(f'Ignoring CRS ({crs}) specified in {uri} '
+                         'and assuming EPSG:4326 instead.')
+                # Delete the CRS field to avoid discrepancies in case the
+                # geojson is passed to code that *does* respect the CRS field
+                # (e.g. geopandas).
+                del geojson['crs']
         return geojson

--- a/tests/core/data/test_scene.py
+++ b/tests/core/data/test_scene.py
@@ -43,6 +43,19 @@ class TestScene(unittest.TestCase):
         self.assertListEqual(scene.aoi_polygons_bbox_coords,
                              aoi_polygons_bbox_coords)
 
+    def test_invalid_aoi_polygons(self):
+        bbox = Box(100, 100, 200, 200)
+        rs = RasterioSource(self.img_uri, bbox=bbox)
+
+        aoi_polygons = [
+            Box(50, 50, 150, 150).to_shapely(),
+            Box(150, 150, 250, 250).to_shapely(),
+            # not a polygon:
+            Box(150, 150, 250, 250).to_shapely().exterior,
+        ]
+        with self.assertRaises(ValueError):
+            _ = Scene(id='', raster_source=rs, aoi_polygons=aoi_polygons)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/pytorch_learner/dataset/test_aoi_sampler.py
+++ b/tests/pytorch_learner/dataset/test_aoi_sampler.py
@@ -1,3 +1,4 @@
+from typing import Callable
 import unittest
 from itertools import product
 
@@ -9,6 +10,18 @@ from rastervision.pytorch_learner.dataset.utils import AoiSampler
 
 
 class TestAoiSampler(unittest.TestCase):
+    def assertNoError(self, fn: Callable, msg: str = ''):
+        try:
+            fn()
+        except Exception:
+            self.fail(msg)
+
+    def test_polygon_with_holes(self):
+        p1 = Polygon.from_bounds(0, 0, 20, 20)
+        p2 = Polygon.from_bounds(5, 5, 15, 15)
+        polygon_with_holes = p1 - p2
+        self.assertNoError(lambda: AoiSampler([polygon_with_holes]).sample())
+
     def test_sampler(self, nsamples: int = 200):
         """Attempt to check if points are distributed uniformly within an AOI.
 


### PR DESCRIPTION
## Overview

This PR makes some fixes motivated by #1855:
- Adds a validation check for AOI polygons to ensure that they are in fact polygons and not some other type of geometry
- Makes it so that the CRS key (if present) in the GeoJSON dict read by `GeoJSONVectorSource` is deleted. This is to avoid discrepancies in case the GeoJSON is subsequently passed to code that *does* respect the CRS field (e.g. geopandas).
- Fixes compatibility issues with shapely v2.0 in `AoiSampler`

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

* See new unit tests.
