### PR TITLE
Update Docker build to improve caching and image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,38 @@
+ARG BUILDERA=newbuild
 ARG CUDA_VERSION
+ARG PYTHON_VERSION=3.10
 ARG UBUNTU_VERSION
-FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu${UBUNTU_VERSION}
+
+########################################################################
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu${UBUNTU_VERSION} as newbuild
+
+ARG PYTHON_VERSION=3.10
+
+# build-essential: installs gcc which is needed to install some deps like rasterio
+# libGL1: needed to avoid following error when using cv2
+# ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+# See https://stackoverflow.com/questions/55313610/importerror-libgl-so-1-cannot-open-shared-object-file-no-such-file-or-directo
+RUN --mount=type=cache,target=/var/cache/apt apt update && \
+    apt install -y wget=1.21.2-2ubuntu1 build-essential=12.9ubuntu3 libgl1=1.4.0-1 curl=7.81.0-1ubuntu1.13 git=1:2.34.1-1ubuntu1.10 tree=2.0.2-1 && \
+    apt install -y gdal-bin=3.4.1+dfsg-1build4 libgdal-dev=3.4.1+dfsg-1build4 && \
+    curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt install -y nodejs=16.20.2-deb-1nodesource1 && \
+    apt autoremove && apt autoclean && apt clean
+
+RUN --mount=type=cache,target=/var/cache/apt apt install -y python${PYTHON_VERSION} python$(echo ${PYTHON_VERSION} | sed 's,\(.\).*,\1,')-pip && \
+    update-alternatives --install /usr/bin/python$(echo ${PYTHON_VERSION} | sed 's,\(.\).*,\1,') python$(echo ${PYTHON_VERSION} | sed 's,\(.\).*,\1,') /usr/bin/python${PYTHON_VERSION} 1 && \
+    apt autoremove && apt autoclean && apt clean
+
+########################################################################
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu${UBUNTU_VERSION} as legacybuild
+
+ARG PYTHON_VERSION=3.10
+ARG TARGETPLATFORM
+
+ENV PATH /opt/conda/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
 
 # wget: needed below to install conda
 # build-essential: installs gcc which is needed to install some deps like rasterio
@@ -10,9 +42,6 @@ FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-runtime-ubuntu${UBUNTU_VERSION}
 RUN apt-get update && \
     apt-get install -y wget=1.* build-essential libgl1 curl git tree && \
     apt-get autoremove && apt-get autoclean && apt-get clean
-
-ARG PYTHON_VERSION=3.10
-ARG TARGETPLATFORM
 
 RUN case ${TARGETPLATFORM} in \
          "linux/arm64")  LINUX_ARCH=aarch64  ;; \
@@ -44,69 +73,16 @@ ENV GDAL_DATA=/opt/conda/lib/python${PYTHON_VERSION}/site-packages/rasterio/gdal
 RUN rm /opt/conda/lib/libtinfo.so.6 && \
     ln -s /lib/$(cat /root/linux_arch)-linux-gnu/libtinfo.so.6 /opt/conda/lib/libtinfo.so.6
 
-WORKDIR /opt/src/
+########################################################################
 
-COPY ./requirements-dev.txt /opt/src/requirements-dev.txt
-RUN pip install -r requirements-dev.txt
+FROM ${BUILDERA:-newbuild} AS final_stage
 
-# Ideally we'd just pip install each package, but if we do that, then a lot of the image
-# will have to be re-built each time we make a change to source code. So, we split the
-# install into installing all the requirements first (filtering out any prefixed with
-# rastervision_*), and then copy over the source code.
-
-# Install requirements for each package.
-# -E "^\s*$|^#|rastervision_*" means exclude blank lines, comment lines,
-# and rastervision plugins.
-COPY ./rastervision_pipeline/requirements.txt /opt/src/requirements.txt
-RUN pip install $(grep -ivE "^\s*$|^#|rastervision_*" requirements.txt)
-
-COPY ./rastervision_aws_s3/requirements.txt /opt/src/requirements.txt
-RUN pip install $(grep -ivE "^\s*$|^#|rastervision_*" requirements.txt)
-
-COPY ./rastervision_aws_batch/requirements.txt /opt/src/requirements.txt
-RUN pip install $(grep -ivE "^\s*$|^#|rastervision_*" requirements.txt)
-
-COPY ./rastervision_core/requirements.txt /opt/src/requirements.txt
-RUN pip install $(grep -ivE "^\s*$|^#|rastervision_*" requirements.txt)
-
-COPY ./rastervision_pytorch_learner/requirements.txt /opt/src/requirements.txt
-RUN pip install $(grep -ivE "^\s*$|^#|rastervision_*" requirements.txt)
-
-COPY ./rastervision_gdal_vsi/requirements.txt /opt/src/requirements.txt
-RUN pip install $(grep -ivE "^\s*$|^#|rastervision_*" requirements.txt)
-
-# Commented out because there are no non-RV deps and it will fail if uncommented.
-# COPY ./rastervision_pytorch_backend/requirements.txt /opt/src/requirements.txt
-# RUN pip install $(grep -ivE "^\s*$|^#|rastervision_*" requirements.txt)
-
-#########################
-# Docs
-#########################
-# Install docs/requirements.txt
-COPY ./docs/requirements.txt /opt/src/docs/requirements.txt
-RUN pip install -r docs/requirements.txt
-
-# Install pandoc, needed for rendering notebooks
-# Get latest release link from here: https://github.com/jgm/pandoc/releases
 ARG TARGETARCH
-RUN wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-${TARGETARCH}.deb && \
-    dpkg -i pandoc-2.19.2-1-${TARGETARCH}.deb && rm pandoc-2.19.2-1-${TARGETARCH}.deb
-#########################
 
-COPY scripts /opt/src/scripts/
-COPY scripts/rastervision /usr/local/bin/rastervision
-COPY tests /opt/src/tests/
-COPY integration_tests /opt/src/integration_tests/
-COPY .flake8 /opt/src/.flake8
-COPY .coveragerc /opt/src/.coveragerc
-
-# Needed for click to work
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
-# Needed for GDAL 3.0
 ENV PROJ_LIB /opt/conda/share/proj/
 
-# Copy code for each package.
 ENV PYTHONPATH=/opt/src:$PYTHONPATH
 ENV PYTHONPATH=/opt/src/rastervision_pipeline/:$PYTHONPATH
 ENV PYTHONPATH=/opt/src/rastervision_aws_s3/:$PYTHONPATH
@@ -116,13 +92,29 @@ ENV PYTHONPATH=/opt/src/rastervision_core/:$PYTHONPATH
 ENV PYTHONPATH=/opt/src/rastervision_pytorch_learner/:$PYTHONPATH
 ENV PYTHONPATH=/opt/src/rastervision_pytorch_backend/:$PYTHONPATH
 
-COPY ./rastervision_pipeline/ /opt/src/rastervision_pipeline/
-COPY ./rastervision_aws_s3/ /opt/src/rastervision_aws_s3/
-COPY ./rastervision_aws_batch/ /opt/src/rastervision_aws_batch/
-COPY ./rastervision_core/ /opt/src/rastervision_core/
-COPY ./rastervision_pytorch_learner/ /opt/src/rastervision_pytorch_learner/
-COPY ./rastervision_pytorch_backend/ /opt/src/rastervision_pytorch_backend/
-COPY ./rastervision_gdal_vsi/ /opt/src/rastervision_gdal_vsi/
+WORKDIR /opt/src/
+
+COPY ./requirements-dev.txt /opt/src/requirements-dev.txt
+COPY ./rastervision_pipeline/requirements.txt /opt/src/pipeline-requirements.txt
+COPY ./rastervision_aws_s3/requirements.txt /opt/src/s3-requirements.txt
+COPY ./rastervision_aws_batch/requirements.txt /opt/src/batch-requirements.txt
+COPY ./rastervision_core/requirements.txt /opt/src/core-requirements.txt
+COPY ./rastervision_pytorch_learner/requirements.txt /opt/src/pytorch-requirements.txt
+COPY ./rastervision_gdal_vsi/requirements.txt /opt/src/gdal-requirements.txt
+
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements-dev.txt && \
+    pip install $(grep -ivE "^\s*$|^#|rastervision_*" pipeline-requirements.txt) && \
+    pip install $(grep -ivE "^\s*$|^#|rastervision_*" s3-requirements.txt) && \
+    pip install $(grep -ivE "^\s*$|^#|rastervision_*" batch-requirements.txt) && \
+    pip install $(grep -ivE "^\s*$|^#|rastervision_*" core-requirements.txt) && \
+    pip install $(grep -ivE "^\s*$|^#|rastervision_*" pytorch-requirements.txt) && \
+    pip install $(grep -ivE "^\s*$|^#|rastervision_*" gdal-requirements.txt)
+
+# pandoc
+COPY ./docs/requirements.txt /opt/src/docs/pandoc-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r docs/pandoc-requirements.txt && \
+    wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-${TARGETARCH}.deb && \
+    dpkg -i pandoc-2.19.2-1-${TARGETARCH}.deb && rm pandoc-2.19.2-1-${TARGETARCH}.deb
 
 # This gets rid of the following error when importing cv2 on arm64.
 # We cannot use the ENV directive since it cannot be used conditionally.
@@ -130,5 +122,20 @@ COPY ./rastervision_gdal_vsi/ /opt/src/rastervision_gdal_vsi/
 # ImportError: /lib/aarch64-linux-gnu/libGLdispatch.so.0: cannot allocate memory in static TLS block
 RUN if [${TARGETARCH} == "arm64"]; \
     then echo "export LD_PRELOAD=/lib/$(cat /root/linux_arch)-linux-gnu/libGLdispatch.so.0:$LD_PRELOAD" >> /root/.bashrc; fi
+
+COPY scripts /opt/src/scripts/
+COPY scripts/rastervision /usr/local/bin/rastervision
+COPY tests /opt/src/tests/
+COPY integration_tests /opt/src/integration_tests/
+COPY .flake8 /opt/src/.flake8
+COPY .coveragerc /opt/src/.coveragerc
+
+COPY ./rastervision_pipeline/ /opt/src/rastervision_pipeline/
+COPY ./rastervision_aws_s3/ /opt/src/rastervision_aws_s3/
+COPY ./rastervision_aws_batch/ /opt/src/rastervision_aws_batch/
+COPY ./rastervision_core/ /opt/src/rastervision_core/
+COPY ./rastervision_pytorch_learner/ /opt/src/rastervision_pytorch_learner/
+COPY ./rastervision_pytorch_backend/ /opt/src/rastervision_pytorch_backend/
+COPY ./rastervision_gdal_vsi/ /opt/src/rastervision_gdal_vsi/
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 ARG BUILD_TYPE
 ARG CUDA_VERSION
-ARG PYTHON_VERSION=3.10
 ARG UBUNTU_VERSION
 
 ########################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,15 +86,6 @@ ARG TARGETARCH
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
-ENV PYTHONPATH=/opt/src:$PYTHONPATH
-ENV PYTHONPATH=/opt/src/rastervision_pipeline/:$PYTHONPATH
-ENV PYTHONPATH=/opt/src/rastervision_aws_s3/:$PYTHONPATH
-ENV PYTHONPATH=/opt/src/rastervision_aws_batch/:$PYTHONPATH
-ENV PYTHONPATH=/opt/src/rastervision_gdal_vsi/:$PYTHONPATH
-ENV PYTHONPATH=/opt/src/rastervision_core/:$PYTHONPATH
-ENV PYTHONPATH=/opt/src/rastervision_pytorch_learner/:$PYTHONPATH
-ENV PYTHONPATH=/opt/src/rastervision_pytorch_backend/:$PYTHONPATH
-
 WORKDIR /opt/src/
 
 #------------------------------------------------------------------------
@@ -123,6 +114,15 @@ RUN --mount=type=cache,target=/root/.cache/pip pip install -r docs/pandoc-requir
     dpkg -i pandoc-2.19.2-1-${TARGETARCH}.deb && rm pandoc-2.19.2-1-${TARGETARCH}.deb
 
 #------------------------------------------------------------------------
+
+ENV PYTHONPATH=/opt/src:$PYTHONPATH
+ENV PYTHONPATH=/opt/src/rastervision_pipeline/:$PYTHONPATH
+ENV PYTHONPATH=/opt/src/rastervision_aws_s3/:$PYTHONPATH
+ENV PYTHONPATH=/opt/src/rastervision_aws_batch/:$PYTHONPATH
+ENV PYTHONPATH=/opt/src/rastervision_gdal_vsi/:$PYTHONPATH
+ENV PYTHONPATH=/opt/src/rastervision_core/:$PYTHONPATH
+ENV PYTHONPATH=/opt/src/rastervision_pytorch_learner/:$PYTHONPATH
+ENV PYTHONPATH=/opt/src/rastervision_pytorch_backend/:$PYTHONPATH
 
 COPY scripts /opt/src/scripts/
 COPY scripts/rastervision /usr/local/bin/rastervision

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,12 @@ RUN --mount=type=cache,target=/var/cache/apt apt update && \
     apt install -y gdal-bin=3.4.1+dfsg-1build4 libgdal-dev=3.4.1+dfsg-1build4 && \
     curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
     apt install -y nodejs=16.20.2-deb-1nodesource1 && \
-    apt autoremove && apt autoclean && apt clean
+    apt autoremove
 
 RUN --mount=type=cache,target=/var/cache/apt apt install -y python${PYTHON_VERSION} python$(echo ${PYTHON_VERSION} | sed 's,\(.\).*,\1,')-pip && \
     update-alternatives --install /usr/bin/python$(echo ${PYTHON_VERSION} | sed 's,\(.\).*,\1,') python$(echo ${PYTHON_VERSION} | sed 's,\(.\).*,\1,') /usr/bin/python${PYTHON_VERSION} 1 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1 && \
-    apt autoremove && apt autoclean && apt clean
+    apt autoremove
 
 ########################################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,25 +90,49 @@ WORKDIR /opt/src/
 
 #------------------------------------------------------------------------
 
-COPY ./rastervision_gdal_vsi/requirements.txt /opt/src/gdal-requirements.txt
-COPY ./rastervision_aws_s3/requirements.txt /opt/src/s3-requirements.txt
-COPY ./rastervision_aws_batch/requirements.txt /opt/src/batch-requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip cat gdal-requirements.txt s3-requirements.txt batch-requirements.txt | sort | uniq > all-requirements.txt && \
-    pip install $(grep -ivE "^\s*$|^#|rastervision_*" all-requirements.txt) && \
-    rm all-requirements.txt
+# Ideally we'd just pip install each package, but if we do that, then
+# a lot of the image will have to be re-built each time we make a
+# change to the code. So, we split the install into installing all the
+# requirements in bunches (filtering out any prefixed with
+# rastervision_*), and then copy over the source code.  The
+# dependencies are installed in bunches rather than package-by-package
+# or on a per-RV component basis to reduce the build time, the number
+# of layers, and the overall image size, and to reduce churn
+# (installing and uninstalling of Python packages during the build).
+#
+# The bunches are heuristic and are meant to keep the heaviest and/or
+# least-frequently-changing dependencies before the more variable
+# ones.  At time of writing, the amount of image size attributable to
+# PyTorch (and the amount of image size overall) is heavily dominated
+# by PyTorch, so it is first.
 
-COPY ./rastervision_pipeline/requirements.txt /opt/src/pipeline-requirements.txt
-COPY ./rastervision_core/requirements.txt /opt/src/core-requirements.txt
+# Install requirements.
+# -E "^\s*$|^#|rastervision_*" means exclude blank lines, comment lines,
+# and rastervision plugins.
+
 COPY ./rastervision_pytorch_learner/requirements.txt /opt/src/pytorch-requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip cat pipeline-requirements.txt core-requirements.txt pytorch-requirements.txt | sort | uniq > all-requirements.txt && \
+RUN --mount=type=cache,target=/root/.cache/pip cat pytorch-requirements.txt | sort | uniq > all-requirements.txt && \
     pip install $(grep -ivE "^\s*$|^#|rastervision_*" all-requirements.txt) && \
     rm all-requirements.txt
 
+COPY ./rastervision_aws_batch/requirements.txt /opt/src/batch-requirements.txt
+COPY ./rastervision_aws_s3/requirements.txt /opt/src/s3-requirements.txt
+COPY ./rastervision_core/requirements.txt /opt/src/core-requirements.txt
+COPY ./rastervision_gdal_vsi/requirements.txt /opt/src/gdal-requirements.txt
+COPY ./rastervision_pipeline/requirements.txt /opt/src/pipeline-requirements.txt
 COPY ./requirements-dev.txt /opt/src/requirements-dev.txt
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements-dev.txt
+RUN --mount=type=cache,target=/root/.cache/pip cat batch-requirements.txt s3-requirements.txt core-requirements.txt gdal-requirements.txt pipeline-requirements.txt requirements-dev.txt | sort | uniq > all-requirements.txt && \
+    pip install $(grep -ivE "^\s*$|^#|rastervision_*" all-requirements.txt) && \
+    rm all-requirements.txt
 
-# pandoc
+#########################
+# Docs
+#########################
+# Install docs/requirements.txt
 COPY ./docs/requirements.txt /opt/src/docs/pandoc-requirements.txt
+
+# Install pandoc, needed for rendering notebooks
+# Get latest release link from here: https://github.com/jgm/pandoc/releases
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r docs/pandoc-requirements.txt && \
     wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-${TARGETARCH}.deb && \
     dpkg -i pandoc-2.19.2-1-${TARGETARCH}.deb && rm pandoc-2.19.2-1-${TARGETARCH}.deb

--- a/rastervision_gdal_vsi/requirements.txt
+++ b/rastervision_gdal_vsi/requirements.txt
@@ -1,2 +1,2 @@
 rastervision_pipeline==0.21
-gdal==3.6.3
+gdal>=3.4.1

--- a/rastervision_gdal_vsi/requirements.txt
+++ b/rastervision_gdal_vsi/requirements.txt
@@ -1,2 +1,2 @@
 rastervision_pipeline==0.21
-gdal>=3.4.1
+gdal>=3.4.1<=3.6.3

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -17,10 +17,12 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "${1:-}" == "--help" ]]; then
         usage
     else
-        docker build \
+        DOCKER_BUILDKIT=1 docker build \
+	    --build-arg BUILDKIT_INLINE_CACHE=1 \
             --platform linux/amd64 \
             --build-arg CUDA_VERSION="12.1.1" \
             --build-arg UBUNTU_VERSION="22.04" \
+	    --cache-from=quay.io/azavea/raster-vision:latest \
             -t "raster-vision-${IMAGE_TYPE}" \
             -f Dockerfile .
 

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -19,6 +19,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     else
         DOCKER_BUILDKIT=1 docker build \
 	    --build-arg BUILDKIT_INLINE_CACHE=1 \
+	    --build-arg BUILD_TYPE=fullbuild \
             --platform linux/amd64 \
             --build-arg CUDA_VERSION="12.1.1" \
             --build-arg UBUNTU_VERSION="22.04" \

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,7 +23,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
             --platform linux/amd64 \
             --build-arg CUDA_VERSION="12.1.1" \
             --build-arg UBUNTU_VERSION="22.04" \
-	    --cache-from=quay.io/azavea/raster-vision:latest \
+	    --cache-from=quay.io/azavea/raster-vision:pytorch-latest \
             -t "raster-vision-${IMAGE_TYPE}" \
             -f Dockerfile .
 


### PR DESCRIPTION
## Overview

The goal here is to improve the Docker image build to reduce its size and improve the caching of layers (preserve layers from one build to the next, so that pulling "the next image" is fast and takes little space).

![image](https://github.com/azavea/raster-vision/assets/11281373/e606fceb-b047-476f-9550-d2ada263440f)

This is conservative in that the old build is retained as an option (including `aarch64` which must use the old build).  In the screenshot above `raster-vision-xxx` is the new build and `raster-vision-yyy` is the legacy build with some additional caching related functionality turned on and a slightly reorganized approach to installing dependencies.

Local build:
```bash
DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 --platform linux/amd64 --build-arg CUDA_VERSION=12.1.1 --build-arg UBUNTU_VERSION=22.04 -t raster-vision-xxx -f Dockerfile .
```

Local legacy build:
```bash
DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 --platform linux/amd64 --build-arg BUILDERA=legacybuild --build-arg CUDA_VERSION=12.1.1 --build-arg UBUNTU_VERSION=22.04 -t raster-vision-yyy -f Dockerfile .
```

- [x] Initial test of new build (tests pass locally and on CI)
- ~~Comprehensive test of new build~~
- [x] Confirm old build (test pass locally)
- ~~Confirm ARM build~~ (ARM64 build is currently broken independent of this: https://github.com/azavea/raster-vision/issues/1867)

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
