### PR TITLE
Update CI workflow to free up disk space before running CI job

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,8 +14,10 @@ jobs:
       DOCKER_BUILDKIT: 1
       IMAGE_TYPE: ${{ matrix.image_type }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - run: ./scripts/cibuild
+      - name: Free up disk space
+        run: rm -rf /opt/hostedtoolcache
 
-      - uses: codecov/codecov-action@v2
+      - name: Build docker image and run tests
+        run: ./scripts/cibuild

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -20,12 +20,12 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         DOCKER_BUILDKIT=1 docker build \
 	    --build-arg BUILDKIT_INLINE_CACHE=1 \
 	    --build-arg BUILD_TYPE=fullbuild \
-            --platform linux/amd64 \
-            --build-arg CUDA_VERSION="12.1.1" \
-            --build-arg UBUNTU_VERSION="22.04" \
+        --platform linux/amd64 \
+        --build-arg CUDA_VERSION="12.1.1" \
+        --build-arg UBUNTU_VERSION="22.04" \
 	    --cache-from=quay.io/azavea/raster-vision:pytorch-latest \
-            -t "raster-vision-${IMAGE_TYPE}" \
-            -f Dockerfile .
+        -t "raster-vision-${IMAGE_TYPE}" \
+        -f Dockerfile .
 
         ./scripts/test
     fi


### PR DESCRIPTION
## Overview

This PR updates the CI workflow to free up disk space before it builds the Docker image and runs tests. It also updates `actions/checkout@v2` to `actions/checkout@v3`.

This is to avoid errors of the kind shown in the pic below which started appearing after #1866 though it's unclear how #1866 would cause this.

![image](https://github.com/azavea/raster-vision/assets/13014700/f54b87ef-3d3f-421b-bc73-0a299922d9ed)


### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Adapted from https://github.com/orgs/community/discussions/25678#discussioncomment-5242449

## Testing Instructions

* Check if the same problem occurs on the CI for this PR.
