### PR TITLE
Proper serialization and deserialization of `bbox`  argument

### DIFF
--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -1,3 +1,4 @@
+from pydantic import BaseModel, Field
 from typing import (TYPE_CHECKING, Callable, Dict, List, Optional, Sequence,
                     Tuple, Union)
 from typing_extensions import Literal
@@ -21,27 +22,28 @@ class BoxSizeError(ValueError):
     pass
 
 
-class Box():
+class Box(BaseModel):
     """A multi-purpose box (ie. rectangle) representation ."""
 
-    def __init__(self, ymin, xmin, ymax, xmax):
-        """Construct a bounding box.
+    # yapf: disable
+    ymin: Union[float, int] = Field(..., description='minimum y value (y is row)')
+    xmin: Union[float, int] = Field(..., description='minimum x value (x is column)')
+    ymax: Union[float, int] = Field(..., description='maximum y value')
+    xmax: Union[float, int] = Field(..., description='maximum x value')
+    # yapf: enable
 
-        Unless otherwise stated, the convention is that these coordinates are
-        in pixel coordinates and represent boxes that lie within a
-        RasterSource.
+    def __init__(self,
+                 ymin: Optional[Union[int, float]] = None,
+                 xmin: Optional[Union[int, float]] = None,
+                 ymax: Optional[Union[int, float]] = None,
+                 xmax: Optional[Union[int, float]] = None,
+                 **data):
 
-        Args:
-            ymin: minimum y value (y is row)
-            xmin: minimum x value (x is column)
-            ymax: maximum y value
-            xmax: maximum x value
-
-        """
-        self.ymin = ymin
-        self.xmin = xmin
-        self.ymax = ymax
-        self.xmax = xmax
+        super().__init__(ymin=ymin, xmin=xmin, ymax=ymax, xmax=xmax, **data)
+        for field in ['ymin', 'xmin', 'ymax', 'xmax']:
+            value = getattr(self, field)
+            if isinstance(value, float) and value.is_integer():
+                setattr(self, field, int(value))
 
     def __eq__(self, other: 'Box') -> bool:
         """Return true if other has same coordinates."""
@@ -247,6 +249,7 @@ class Box():
         return Box(yslice.start, xslice.start, yslice.stop, xslice.stop)
 
     def to_xywh(self) -> Tuple[int, int, int, int]:
+        print(self.xmin)
         return (self.xmin, self.ymin, self.width, self.height)
 
     def to_xyxy(self) -> Tuple[int, int, int, int]:

--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -249,7 +249,6 @@ class Box(BaseModel):
         return Box(yslice.start, xslice.start, yslice.stop, xslice.stop)
 
     def to_xywh(self) -> Tuple[int, int, int, int]:
-        print(self.xmin)
         return (self.xmin, self.ymin, self.width, self.height)
 
     def to_xyxy(self) -> Tuple[int, int, int, int]:

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -38,11 +38,12 @@ class RasterSourceConfig(Config):
         description=
         'The sequence of channel indices to use when reading imagery.')
     transformers: List[RasterTransformerConfig] = []
-    bbox: Optional[Tuple[int, int, int, int]] = Field(
-        None,
-        description='User-specified bbox in pixel coords in the form '
-        '(ymin, xmin, ymax, xmax). Useful for cropping the raster source so '
-        'that only part of the raster is read from.')
+    # bbox: Optional[Tuple[int, int, int, int]] = Field(
+    #     None,
+    #     description='User-specified bbox in pixel coords in the form '
+    #     '(ymin, xmin, ymax, xmax). Useful for cropping the raster source so '
+    #     'that only part of the raster is read from.')
+    bbox: Optional['Box'] = None
 
     def build(self,
               tmp_dir: Optional[str] = None,
@@ -54,9 +55,3 @@ class RasterSourceConfig(Config):
                scene: Optional['SceneConfig'] = None) -> None:
         for t in self.transformers:
             t.update(pipeline, scene)
-
-    @validator('bbox')
-    def validate_bbox(cls, v):
-        if v is None:
-            return None
-        return Box(*v)

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -129,11 +129,11 @@ class TestMultiRasterSource(unittest.TestCase):
         self.assertEqual(rs.extent, Box(0, 0, 256, 256))
 
         # test validators
-        cfg = make_cfg('small-rgb-tile.tif', bbox=(64, 64, 192, 192))
+        cfg = make_cfg('small-rgb-tile.tif', bbox=Box(64, 64, 192, 192))
         self.assertIsInstance(cfg.bbox, Box)
 
         # /w user specified extent
-        cfg_crop = make_cfg('small-rgb-tile.tif', bbox=(64, 64, 192, 192))
+        cfg_crop = make_cfg('small-rgb-tile.tif', bbox=Box(64, 64, 192, 192))
         rs_crop = cfg_crop.build(tmp_dir=self.tmp_dir)
 
         # test extent box

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -227,7 +227,7 @@ class TestRasterioSource(unittest.TestCase):
         self.assertEqual(rs_crop.extent, Box(0, 0, 128, 128))
 
         # test validators
-        rs_cfg = RasterioSourceConfig(uris=[img_path], bbox=(0, 0, 1, 1))
+        rs_cfg = RasterioSourceConfig(uris=[img_path], bbox=Box(0, 0, 1, 1))
         self.assertIsInstance(rs_cfg.bbox, Box)
 
     def test_extent_overflow(self):


### PR DESCRIPTION
## Overview

This fixes a bug that causes validation errors when trying to pass a `bbox` argument to to a Rasterio Source Config.  The validator seemed to expect a tuple in some places, though there was a conversion to a `Box` happening in others (seemingly).

Here is what the error looked like:
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/cli.py", line 251, in <module>
    _main()
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/cli.py", line 247, in _main
    main()
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/cli.py", line 175, in run
    _run_pipeline(cfg, runner, tmp_dir, splits, commands,
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/cli.py", line 118, in _run_pipeline
    build_config(cfg.dict())
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/config.py", line 155, in build_config
    new_x[k] = build_config(v)
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/config.py", line 155, in build_config
    new_x[k] = build_config(v)
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/config.py", line 162, in build_config
    return [build_config(v) for v in x]
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/config.py", line 162, in <listcomp>
    return [build_config(v) for v in x]
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/config.py", line 155, in build_config
    new_x[k] = build_config(v)
  File "/opt/src/rastervision_pipeline/rastervision/pipeline/config.py", line 159, in build_config
    new_x = config_cls(**new_x)
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for RasterioSourceConfig
bbox
  value is not a valid tuple (type=type_error.tuple)
```

### Checklist

- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
