### PR TITLE
Fix inconsistent handling of `RasterSourceConfig.bbox`'s type

### DIFF
--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -1,6 +1,7 @@
 from pydantic import conint, conlist
 
 from rastervision.pipeline.config import (Field, register_config, validator)
+from rastervision.core.box import Box
 from rastervision.core.data.raster_source import (RasterSourceConfig,
                                                   MultiRasterSource)
 
@@ -66,6 +67,8 @@ class MultiRasterSourceConfig(RasterSourceConfig):
         built_raster_sources = [
             rs.build(tmp_dir, use_transformers) for rs in self.raster_sources
         ]
+        bbox = Box(*self.bbox) if self.bbox is not None else None
+
         if self.temporal:
             from rastervision.core.data.raster_source import (
                 TemporalMultiRasterSource)
@@ -74,7 +77,7 @@ class MultiRasterSourceConfig(RasterSourceConfig):
                 primary_source_idx=self.primary_source_idx,
                 force_same_dtype=self.force_same_dtype,
                 raster_transformers=raster_transformers,
-                bbox=self.bbox)
+                bbox=bbox)
         else:
             multi_raster_source = MultiRasterSource(
                 raster_sources=built_raster_sources,
@@ -82,7 +85,7 @@ class MultiRasterSourceConfig(RasterSourceConfig):
                 force_same_dtype=self.force_same_dtype,
                 channel_order=self.channel_order,
                 raster_transformers=raster_transformers,
-                bbox=self.bbox)
+                bbox=bbox)
         return multi_raster_source
 
     def update(self, pipeline=None, scene=None):

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source_config.py
@@ -1,8 +1,7 @@
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from rastervision.core.box import Box
 from rastervision.pipeline.config import (Config, register_config, Field,
-                                          validator, ConfigError)
+                                          ConfigError)
 from rastervision.core.data.raster_transformer import RasterTransformerConfig
 
 if TYPE_CHECKING:
@@ -54,9 +53,3 @@ class RasterSourceConfig(Config):
                scene: Optional['SceneConfig'] = None) -> None:
         for t in self.transformers:
             t.update(pipeline, scene)
-
-    @validator('bbox')
-    def validate_bbox(cls, v):
-        if v is None:
-            return None
-        return Box(*v)

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
@@ -1,5 +1,6 @@
 from typing import List, Union
 
+from rastervision.core.box import Box
 from rastervision.core.data.raster_source import RasterSourceConfig, RasterioSource
 from rastervision.pipeline.config import ConfigError, Field, register_config
 
@@ -37,11 +38,11 @@ class RasterioSourceConfig(RasterSourceConfig):
     def build(self, tmp_dir, use_transformers=True):
         raster_transformers = ([rt.build() for rt in self.transformers]
                                if use_transformers else [])
-
+        bbox = Box(*self.bbox) if self.bbox is not None else None
         return RasterioSource(
             uris=self.uris,
             raster_transformers=raster_transformers,
             tmp_dir=tmp_dir,
             allow_streaming=self.allow_streaming,
             channel_order=self.channel_order,
-            bbox=self.bbox)
+            bbox=bbox)

--- a/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterized_source_config.py
@@ -1,9 +1,15 @@
+from typing import TYPE_CHECKING, Optional
+
 from rastervision.core.data.raster_source import (RasterizedSource)
 from rastervision.core.data.vector_source import (VectorSourceConfig)
 from rastervision.core.data.vector_transformer import (
     ClassInferenceTransformerConfig, BufferTransformerConfig)
 from rastervision.pipeline.config import (register_config, Config, Field,
                                           validator)
+
+if TYPE_CHECKING:
+    from rastervision.core.box import Box
+    from rastervision.core.data import ClassConfig, CRSTransformer
 
 
 @register_config('rasterizer')
@@ -55,7 +61,10 @@ class RasterizedSourceConfig(Config):
         super().update(pipeline, scene)
         self.vector_source.update(pipeline, scene)
 
-    def build(self, class_config, crs_transformer, bbox) -> RasterizedSource:
+    def build(self,
+              class_config: 'ClassConfig',
+              crs_transformer: 'CRSTransformer',
+              bbox: Optional['Box'] = None) -> RasterizedSource:
         vector_source = self.vector_source.build(class_config, crs_transformer)
         return RasterizedSource(
             vector_source=vector_source,

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -71,6 +71,11 @@ class TestMultiRasterSourceConfig(unittest.TestCase):
         cfg = make_cfg()
         self.assertNoError(lambda: cfg.build(tmp_dir=get_tmp_dir()))
 
+    def test_build_with_bbox(self):
+        cfg = make_cfg(bbox=(0, 0, 1, 1))
+        rs = cfg.build(tmp_dir=get_tmp_dir())
+        self.assertEqual(rs.bbox, Box(0, 0, 1, 1))
+
     def test_build_temporal(self):
         cfg = make_cfg(temporal=True)
         rs = cfg.build(tmp_dir=get_tmp_dir())
@@ -127,10 +132,6 @@ class TestMultiRasterSource(unittest.TestCase):
         rs = cfg.build(tmp_dir=self.tmp_dir)
         self.assertEqual(rs.bbox, Box(0, 0, 256, 256))
         self.assertEqual(rs.extent, Box(0, 0, 256, 256))
-
-        # test validators
-        cfg = make_cfg('small-rgb-tile.tif', bbox=(64, 64, 192, 192))
-        self.assertIsInstance(cfg.bbox, Box)
 
         # /w user specified extent
         cfg_crop = make_cfg('small-rgb-tile.tif', bbox=(64, 64, 192, 192))

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -1,3 +1,4 @@
+from typing import Callable
 import unittest
 from os.path import join
 from tempfile import NamedTemporaryFile
@@ -14,6 +15,25 @@ from rastervision.core.data.raster_source import (
 from rastervision.core.data.raster_transformer import StatsTransformerConfig
 
 from tests import data_file_path
+
+
+class TestRasterioSourceConfig(unittest.TestCase):
+    def assertNoError(self, fn: Callable, msg: str = ''):
+        try:
+            fn()
+        except Exception:
+            self.fail(msg)
+
+    def test_build(self):
+        img_path = data_file_path('small-rgb-tile.tif')
+        cfg = RasterioSourceConfig(uris=[img_path])
+        self.assertNoError(lambda: cfg.build(tmp_dir=get_tmp_dir()))
+
+    def test_build_with_bbox(self):
+        img_path = data_file_path('small-rgb-tile.tif')
+        cfg = RasterioSourceConfig(uris=[img_path], bbox=(0, 0, 1, 1))
+        rs = cfg.build(tmp_dir=get_tmp_dir())
+        self.assertEqual(rs.bbox, Box(0, 0, 1, 1))
 
 
 class TestRasterioSource(unittest.TestCase):
@@ -225,10 +245,6 @@ class TestRasterioSource(unittest.TestCase):
         # test bbox box
         self.assertEqual(rs_crop.bbox, Box(64, 64, 192, 192))
         self.assertEqual(rs_crop.extent, Box(0, 0, 128, 128))
-
-        # test validators
-        rs_cfg = RasterioSourceConfig(uris=[img_path], bbox=(0, 0, 1, 1))
-        self.assertIsInstance(rs_cfg.bbox, Box)
 
     def test_extent_overflow(self):
         arr = np.ones((100, 100), dtype=np.uint8)


### PR DESCRIPTION
## Overview

This PR makes it so that `RasterSourceConfig.bbox` is always a tuple, to allow it to be serialized and deserialized by pydantic.

Motivation: previously, `RasterSourceConfig.bbox` was defined as a tuple in the `RasterSourceConfig` definition, but was automatically converted to a `Box` in its pydantic validator. This meant that although the field could be initialized as a `Box`, it could not be serialized by pydantic. This was not caught in the integration tests, because none of them use the `bbox` field.

The error can be reproduced by e.g. adding `bbox=(0, 0, 328, 1342)` to `RasterioSourceConfig` the `chip_classification.basic` integration test.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This PR is an alternative to #1895.

## Testing Instructions

* See new unit tests.
* Check if `chip_classification.basic` integration test runs with `bbox=(0, 0, 328, 1342)` added to `RasterioSourceConfig`.
