### PR TITLE
log.warn -> log.warning

### DIFF
--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -172,8 +172,8 @@ class SemanticSegmentationLabelStore(LabelStore):
             hits_uri_local = download_if_needed(self.hits_uri)
             hits_arr = np.load(hits_uri_local)
         except NotReadableError:
-            log.warn(f'Pixel hits array not found at {self.hits_uri}.'
-                     'Setting all pixels hits to 1.')
+            log.warning(f'Pixel hits array not found at {self.hits_uri}.'
+                        'Setting all pixels hits to 1.')
             hits_arr = np.ones(extent.size, dtype=np.uint8)
 
         score_arr = self.score_source.get_chip(extent)

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -80,9 +80,9 @@ class RasterioSource(RasterSource):
 
         block_shapes = set(self.image_dataset.block_shapes)
         if len(block_shapes) > 1:
-            log.warn('Raster bands have non-identical block shapes: '
-                     f'{block_shapes}. This can slow down reading. '
-                     'Consider re-tiling using GDAL.')
+            log.warning('Raster bands have non-identical block shapes: '
+                        f'{block_shapes}. This can slow down reading. '
+                        'Consider re-tiling using GDAL.')
 
         self._crs_transformer = RasterioCRSTransformer.from_dataset(
             self.image_dataset)

--- a/rastervision_core/rastervision/core/data/vector_source/vector_source.py
+++ b/rastervision_core/rastervision/core/data/vector_source/vector_source.py
@@ -172,5 +172,5 @@ def sanitize_geojson(geojson: dict,
     if to_map_coords:
         geojson = pixel_to_map_coords(geojson, crs_transformer)
     if not all_geoms_valid(geojson):
-        log.warn(f'Invalid geometries found in features in the GeoJSON.')
+        log.warning(f'Invalid geometries found in features in the GeoJSON.')
     return geojson

--- a/rastervision_core/rastervision/core/predictor.py
+++ b/rastervision_core/rastervision/core/predictor.py
@@ -70,9 +70,10 @@ class Predictor():
                 if scene_group is not None:
                     t.scene_group = scene_group
                 else:
-                    log.warn(f'Using stats for scene group "{t.scene_group}". '
-                             'To use a different scene group, specify '
-                             '--scene-group <scene-group-name>.')
+                    log.warning(
+                        f'Using stats for scene group "{t.scene_group}". '
+                        'To use a different scene group, specify '
+                        '--scene-group <scene-group-name>.')
             t.update_root(bundle_dir)
 
         if self.update_stats:

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -156,7 +156,7 @@ class SemanticSegmentation(RVPipeline):
         if crop_sz == 'auto':
             overlap_sz = chip_sz - stride
             if overlap_sz % 2 == 1:
-                log.warn(
+                log.warning(
                     'Using crop_sz="auto" but overlap size (chip_sz minus '
                     'stride) is odd. This means that one pixel row/col will '
                     'still overlap after cropping.')

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
@@ -65,7 +65,7 @@ class AlbumentationsDataset(Dataset):
         try:
             x, y = self.transform(val)
         except Exception as exc:
-            log.warn(
+            log.warning(
                 'Many albumentations transforms require uint8 input. Therefore, we '
                 'recommend passing a MinMaxTransformer or StatsTransformer to the '
                 'RasterSource so the input will be converted to uint8.')

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
@@ -266,9 +266,9 @@ class ObjectDetectionRandomWindowGeoDataset(RandomWindowGeoDataset):
             if h >= box_h and w >= box_w:
                 window = bbox.make_random_box_container(h, w)
                 return window
-        log.warn('ObjectDetectionRandomWindowGeoDataset: Failed to find '
-                 'suitable (h, w) for positive window. '
-                 f'Using (hmax, wmax) = ({hmax}, {wmax}) instead.')
+        log.warning('ObjectDetectionRandomWindowGeoDataset: Failed to find '
+                    'suitable (h, w) for positive window. '
+                    f'Using (hmax, wmax) = ({hmax}, {wmax}) instead.')
         window = bbox.make_random_box_container(hmax, wmax)
         return window
 
@@ -285,8 +285,8 @@ class ObjectDetectionRandomWindowGeoDataset(RandomWindowGeoDataset):
             if len(labels) == 0:
                 return window
 
-        log.warn('ObjectDetectionRandomWindowGeoDataset: Failed to find '
-                 'negative window. Returning last sampled window.')
+        log.warning('ObjectDetectionRandomWindowGeoDataset: Failed to find '
+                    'negative window. Returning last sampled window.')
         return window
 
     def _sample_window(self) -> Box:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -165,8 +165,9 @@ class Learner(ABC):
             raise ValueError('output_dir or LearnerConfig.output_uri must '
                              'be specified.')
         if output_dir is not None and cfg.output_uri is not None:
-            log.warn('Both output_dir and LearnerConfig.output_uri specified. '
-                     'LearnerConfig.output_uri will be ignored.')
+            log.warning(
+                'Both output_dir and LearnerConfig.output_uri specified. '
+                'LearnerConfig.output_uri will be ignored.')
         if output_dir is None:
             assert cfg.output_uri is not None
             self.output_dir = cfg.output_uri
@@ -851,7 +852,7 @@ class Learner(ABC):
 
         in_channels = cfg.data.img_channels
         if in_channels is None:
-            log.warn('DataConfig.img_channels is None. Defaulting to 3.')
+            log.warning('DataConfig.img_channels is None. Defaulting to 3.')
             in_channels = 3
 
         model = cfg.model.build(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -910,8 +910,8 @@ class ImageDataConfig(DataConfig):
                 test_mode=test_mode)
 
         if self.uri is not None:
-            log.warn('Both DataConfig.uri and DataConfig.group_uris '
-                     'specified. Only DataConfig.group_uris will be used.')
+            log.warning('Both DataConfig.uri and DataConfig.group_uris '
+                        'specified. Only DataConfig.group_uris will be used.')
 
         train_ds, valid_ds, test_ds = self.get_datasets_from_group_uris(
             self.group_uris,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
@@ -348,8 +348,8 @@ def channel_groups_to_imgs(
             img = torch.cat((img, third_channel), dim=-1)
         elif len(ch_inds) > 3:
             # only use the first 3 channels
-            log.warn(f'Only plotting first 3 channels of channel-group '
-                     f'{title}: {ch_inds}.')
+            log.warning(f'Only plotting first 3 channels of channel-group '
+                        f'{title}: {ch_inds}.')
             img = x[..., ch_inds[:3]]
         imgs.append(img)
     return imgs


### PR DESCRIPTION
## Overview

This just changes all instances of `log.warn` to `log.warning` as the former is apparently depricated.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
