### PR TITLE
Include `__getitem__`, `__setitem__`, `__contains__`, and `__add__` in class API reference

### DIFF
--- a/docs/_templates/class.rst
+++ b/docs/_templates/class.rst
@@ -5,6 +5,7 @@
 .. autoclass:: {{ objname }}
    :show-inheritance:
    :members:
+   :special-members: __getitem__, __setitem__, __contains__, __add__
    :undoc-members:
    :inherited-members:
 


### PR DESCRIPTION
## Overview

This PR makes it so that `__getitem__`, `__setitem__`, `__contains__`, and `__add__` are included in the API reference if implemented.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* Check docs CI build.