### PR TITLE
Update deprecated GitHub actions

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,7 +14,7 @@ jobs:
       DOCKER_BUILDKIT: 1
       IMAGE_TYPE: ${{ matrix.image_type }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: df -hT
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,4 +36,4 @@ jobs:
 
       - run: ./scripts/test "coverage"
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       DOCKER_BUILDKIT: 1
       IMAGE_TYPE: ${{ matrix.image_type }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: ./scripts/cibuild
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - run: ./scripts/test "coverage"
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
 
       - run: ./scripts/cipublish
         env:


### PR DESCRIPTION
## Overview

This PR addresses the following warnings from GitHub Actions:

![image](https://github.com/azavea/raster-vision/assets/13014700/07a86e41-0147-4a05-b5da-ba05f5fa6df3)

![image](https://github.com/azavea/raster-vision/assets/13014700/611eed49-067c-435d-aff2-36354b981e9f)

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* Check if warnings go away.