### PR TITLE
Add scripts for building packages and publishing them to PyPi

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -66,69 +66,44 @@ Minor or Major Version Release
 
         pip install twine
 
-    To store settings for PyPI you can setup a ``~/.pypirc`` file containing:
+    To store settings for PyPI you can set up a ``~/.pypirc`` file containing:
 
     .. code-block:: console
 
         [pypi]
         username = azavea
 
-    Once packages are published they cannot be changed so be careful. (It's possible to practice using testpypi.) Navigate to the ``raster-vision`` repo on your local filesystem. With the version branch checked out, run something like the following to publish each plugin, and then the top-level package.
+        [testpypi]
+        username = azavea
+
+    Once packages are published they cannot be changed, so be careful. (It's possible to practice using TestPyPI.) Navigate to the repo's root directory on your local filesystem. With the version branch checked out, run the following scripts to build packages and publish to PyPI. 
+    
+    Build:
 
     .. code-block:: console
 
-        export RV="/Users/lfishgold/projects/raster-vision"
+        scripts/pypi_build
+
+    Publish to TestPyPI. (You will be prompted for the PyPI password multiple times--once for each package.)
 
     .. code-block:: console
 
-        cd $RV/rastervision_pipeline
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        scripts/pypi_publish --test
+
+    You can then test it with ``pip`` like so:
 
     .. code-block:: console
 
-        cd $RV/rastervision_aws_batch
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        pip install --index-url https://test.pypi.org/simple/ rastervision
+
+    Finally, if everything looks okay, publish to Pypi.  (You will be prompted for the PyPI password multiple times--once for each package.)
 
     .. code-block:: console
 
-        cd $RV/rastervision_aws_s3
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        scripts/pypi_publish
 
-    .. code-block:: console
-
-        cd $RV/rastervision_core
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
-
-    .. code-block:: console
-
-        cd $RV/rastervision_pytorch_learner
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
-
-    .. code-block:: console
-
-        cd $RV/rastervision_pytorch_backend
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
-
-    .. code-block:: console
-
-        cd $RV/rastervision_gdal_vsi
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
-
-    .. code-block:: console
-
-        cd $RV
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
-
-#.  Announce new release in our `forum <https://github.com/azavea/raster-vision/discussions>`_, and with blog post if it's a big release.
-#.  Make a PR to the master branch that updates the version number to the next development version. For example, if the last release was ``0.20.1``, update the version to ``0.20.2-dev``.
+#.  Announce the new release in our `forum <https://github.com/azavea/raster-vision/discussions>`_, and with a blog post if it's a big release.
+#.  Make a PR to the master branch that updates the version number to the next development version, ``X.Y.Z-dev``. For example, if the last release was ``0.20.1``, update the version to ``0.20.2-dev``.
 
 Bug Fix Release
 -----------------

--- a/scripts/pypi_build
+++ b/scripts/pypi_build
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+SRC_DIR="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
+
+plugins=("rastervision_pipeline" "rastervision_aws_batch" "rastervision_aws_s3" "rastervision_core" "rastervision_pytorch_learner" "rastervision_pytorch_backend" "rastervision_gdal_vsi")
+
+# Function to build a plugin
+build_plugin() {
+    cd "$SRC_DIR/$1"
+    echo "Building $1 ... "
+    python setup.py sdist bdist_wheel
+    echo "Done."
+    cd "$SRC_DIR"
+}
+
+# Build each plugin
+for plugin in "${plugins[@]}"; do
+    build_plugin "$plugin"
+done
+
+# Build the top-level package
+echo "rastervision ... "
+python setup.py sdist bdist_wheel
+echo "Done."

--- a/scripts/pypi_build
+++ b/scripts/pypi_build
@@ -1,14 +1,29 @@
 #!/bin/bash
 
+# Determine the script's directory (even if it's a symbolic link)
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 SRC_DIR="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
 
+# List of plugins to build
 plugins=("rastervision_pipeline" "rastervision_aws_batch" "rastervision_aws_s3" "rastervision_core" "rastervision_pytorch_learner" "rastervision_pytorch_backend" "rastervision_gdal_vsi")
 
+# Usage documentation
+function usage() {
+    echo "Usage: $(basename "$0") [--test]"
+    echo ""
+    echo "Build Raster Vision plugins and top-level package."
+}
+
+# Check for command-line arguments
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    usage
+    exit
+fi
+
 # Function to build a plugin
-build_plugin() {
+function build_plugin() {
     cd "$SRC_DIR/$1"
     echo "Building $1 ... "
     python setup.py sdist bdist_wheel

--- a/scripts/pypi_publish
+++ b/scripts/pypi_publish
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+SRC_DIR="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
+
+plugins=("rastervision_pipeline" "rastervision_aws_batch" "rastervision_aws_s3" "rastervision_core" "rastervision_pytorch_learner" "rastervision_pytorch_backend" "rastervision_gdal_vsi")
+
+# Check if the --test flag is passed
+publish_to_test=false
+if [[ "$1" == "--test" ]]; then
+    publish_to_test=true
+    # Remove the --test flag from the arguments
+    shift
+fi
+
+# Function to publish a plugin
+publish_plugin() {
+    cd "$SRC_DIR/$1"
+    echo "Publishing $1 ... "
+    if [ "$publish_to_test" = true ]; then
+        twine upload --repository testpypi dist/*
+    else
+        twine upload dist/*
+    fi
+    echo "Done."
+    cd "$SRC_DIR"
+}
+
+# Publish each plugin
+for plugin in "${plugins[@]}"; do
+    publish_plugin "$plugin"
+done
+
+# Publish the top-level package
+echo "Publishing rastervision ... "
+if [ "$publish_to_test" = true ]; then
+    twine upload --repository testpypi dist/*
+else
+    twine upload dist/*
+fi
+echo "Done."

--- a/scripts/pypi_publish
+++ b/scripts/pypi_publish
@@ -1,11 +1,63 @@
 #!/bin/bash
 
+# Determine the script's directory (even if it's a symbolic link)
 SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
-SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-SRC_DIR="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
+while [ -h "$SOURCE" ]; do SOURCE="$(readlink "$SOURCE")"; done
+SCRIPTS_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SRC_DIR="$(cd -P "$(dirname "$SCRIPTS_DIR")" && pwd)"
 
+# List of plugins to publish
 plugins=("rastervision_pipeline" "rastervision_aws_batch" "rastervision_aws_s3" "rastervision_core" "rastervision_pytorch_learner" "rastervision_pytorch_backend" "rastervision_gdal_vsi")
+
+# Usage documentation
+function usage() {
+    echo "Usage: $(basename "$0") [--test]"
+    echo ""
+    echo "Publish Raster Vision plugins and top-level package to PyPI or TestPyPI."
+    echo ""
+    echo "Options:"
+    echo "  -y        Automatically answer 'yes' to prompts."
+    echo "  --test    Publish to TestPyPI instead of PyPI."
+}
+
+# Function to publish a package to the specified repository
+function publish_package() {
+    if [ "$publish_to_test" = true ]; then
+        echo "Publishing to TestPyPI ... "
+        twine upload --repository testpypi dist/*
+    else
+        echo "Publishing to PyPI ... "
+        twine upload dist/*
+    fi
+    echo "Done."
+}
+
+# publish a plugin
+function publish_plugin() {
+    local plugin_name="$1"
+    cd "$SRC_DIR/$plugin_name"
+    echo "Publishing $plugin_name ... "
+    publish_package
+    cd "$SRC_DIR"
+}
+
+# publish all plugins and the top-level package
+function publish_all() {
+    # Publish each plugin
+    for plugin in "${plugins[@]}"; do
+        publish_plugin "$plugin"
+    done
+
+    # Publish the top-level package
+    echo "Publishing rastervision ... "
+    publish_package
+}
+
+# Check for command-line arguments
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    usage
+    exit
+fi
 
 # Check if the --test flag is passed
 publish_to_test=false
@@ -15,29 +67,26 @@ if [[ "$1" == "--test" ]]; then
     shift
 fi
 
-# Function to publish a plugin
-publish_plugin() {
-    cd "$SRC_DIR/$1"
-    echo "Publishing $1 ... "
-    if [ "$publish_to_test" = true ]; then
-        twine upload --repository testpypi dist/*
-    else
-        twine upload dist/*
-    fi
-    echo "Done."
-    cd "$SRC_DIR"
-}
-
-# Publish each plugin
-for plugin in "${plugins[@]}"; do
-    publish_plugin "$plugin"
-done
-
-# Publish the top-level package
-echo "Publishing rastervision ... "
+# If testing: publish and exit
 if [ "$publish_to_test" = true ]; then
-    twine upload --repository testpypi dist/*
-else
-    twine upload dist/*
+    publish_all
+    exit
 fi
-echo "Done."
+
+# If actually publishing: prompt for confirmation
+if [[ "$1" == "-y" ]]; then
+    response="y"
+else
+    read -r -p "Actually publish to PyPi? (y/N): " response
+fi
+
+case "$response" in
+    [yY][eE][sS]|[yY])
+        echo "Publishing to PyPi..."
+        publish_all
+        ;;
+    *)
+        echo "Aborting."
+        ;;
+esac
+


### PR DESCRIPTION
## Overview

This PR adds scripts to build and publish packages to PyPi, thus automating a manual and tedious part of the release process. It also updates the release instructions accordingly. 

This PR is a step towards #1130.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* These scripts were used to publish v0.21.1.
* Check release process doc in CI docs build.
