### PR TITLE
Fix `rastervision.core` dependencies

### DIFF
--- a/rastervision_core/rastervision/core/data/utils/misc.py
+++ b/rastervision_core/rastervision/core/data/utils/misc.py
@@ -3,6 +3,7 @@ import logging
 
 import numpy as np
 from PIL import ImageColor
+from skimage.io import imsave
 
 from rastervision.core.box import Box
 
@@ -240,3 +241,8 @@ def ensure_json_serializable(obj: Any) -> dict:
     if isinstance(obj, Box):
         return obj.to_dict()
     return obj
+
+
+def save_img(im_array: np.ndarray, output_path: str):
+    """Save numpy array as image file."""
+    imsave(output_path, im_array)

--- a/rastervision_core/rastervision/core/utils/misc.py
+++ b/rastervision_core/rastervision/core/utils/misc.py
@@ -1,12 +1,13 @@
+from typing import TYPE_CHECKING
 from pydantic import confloat
 
-import imageio
-import logging
+from skimage.io import imsave
+
+if TYPE_CHECKING:
+    import numpy as np
 
 Proportion = confloat(ge=0, le=1)
 
-log = logging.getLogger(__name__)
 
-
-def save_img(im_array, output_path):
-    imageio.imwrite(output_path, im_array)
+def save_img(im_array: 'np.ndarray', output_path: str):
+    imsave(output_path, im_array)

--- a/rastervision_core/rastervision/core/utils/misc.py
+++ b/rastervision_core/rastervision/core/utils/misc.py
@@ -1,13 +1,3 @@
-from typing import TYPE_CHECKING
 from pydantic import confloat
 
-from skimage.io import imsave
-
-if TYPE_CHECKING:
-    import numpy as np
-
 Proportion = confloat(ge=0, le=1)
-
-
-def save_img(im_array: 'np.ndarray', output_path: str):
-    imsave(output_path, im_array)

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -12,3 +12,4 @@ opencv-python-headless==4.6.0.66
 tqdm==4.65.0
 xarray==2023.2.0
 scikit-image==0.21.0
+boto3==1.28.8

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -1,16 +1,14 @@
 rastervision_pipeline==0.21.2-dev
-
 shapely==2.0.1
 geopandas==0.13.2
-
 numpy==1.25.0
 pillow==9.3.0
 pyproj==3.4.0
 rasterio==1.3.7
-imageio==2.22.1
 pystac==1.6.1
 scikit-learn==1.2.2
 scipy==1.10.1
 opencv-python-headless==4.6.0.66
 tqdm==4.65.0
 xarray==2023.2.0
+scikit-image==0.21.0

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
@@ -7,7 +7,7 @@ import numpy as np
 from rastervision.pipeline.file_system import (make_dir, upload_or_copy,
                                                zipdir)
 from rastervision.core.backend import Backend, SampleWriter
-from rastervision.core.utils.misc import save_img
+from rastervision.core.data.utils.misc import save_img
 from rastervision.pytorch_learner.learner import Learner
 
 if TYPE_CHECKING:

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -9,7 +9,7 @@ from rasterio.enums import ColorInterp
 
 from rastervision.pipeline.file_system import get_tmp_dir
 from rastervision.core import (Box, RasterStats)
-from rastervision.core.utils.misc import save_img
+from rastervision.core.data.utils.misc import save_img
 from rastervision.core.data.raster_source import (
     ChannelOrderError, RasterioSource, RasterioSourceConfig)
 from rastervision.core.data.raster_transformer import StatsTransformerConfig

--- a/tests/gdal_vsi/test_vsi_file_system.py
+++ b/tests/gdal_vsi/test_vsi_file_system.py
@@ -67,9 +67,10 @@ class TestVsiFileSystem(unittest.TestCase):
             str_to_file('def', join(tmp_dir, '2.txt'))
             str_to_file('ghi', join(tmp_dir, '3.tiff'))
             paths = fs.list_paths(dir_vsi, ext='txt')
-            self.assertListEqual(
-                paths, [join(tmp_dir, '1.txt'),
-                        join(tmp_dir, '2.txt')])
+            self.assertSetEqual(
+                set(paths),
+                set([join(tmp_dir, '1.txt'),
+                     join(tmp_dir, '2.txt')]))
 
     def test_sync_to_from(self):
         with get_tmp_dir() as src, get_tmp_dir() as dst:
@@ -80,18 +81,22 @@ class TestVsiFileSystem(unittest.TestCase):
             str_to_file('ghi', join(src, 'subdir', '3.txt'))
             fs.sync_to_dir(src_vsi, dst_vsi, delete=True)
             paths = fs.list_paths(dst_vsi)
-            self.assertListEqual(paths, [
-                join(dst, 'subdir'),
-                join(dst, '1.txt'),
-                join(dst, '2.txt'),
-            ])
+            self.assertSetEqual(
+                set(paths),
+                set([
+                    join(dst, 'subdir'),
+                    join(dst, '1.txt'),
+                    join(dst, '2.txt'),
+                ]))
             paths = fs.list_paths(dst_vsi, ext='txt')
-            self.assertListEqual(paths, [
-                join(dst, '1.txt'),
-                join(dst, '2.txt'),
-            ])
+            self.assertSetEqual(
+                set(paths), set([
+                    join(dst, '1.txt'),
+                    join(dst, '2.txt'),
+                ]))
             paths = fs.list_paths(join(dst_vsi, 'subdir'))
-            self.assertListEqual(paths, [join(dst, 'subdir', '3.txt')])
+            self.assertSetEqual(
+                set(paths), set([join(dst, 'subdir', '3.txt')]))
 
             with self.assertRaises(FileExistsError):
                 fs.sync_to_dir(src_vsi, dst_vsi, delete=False)
@@ -101,18 +106,22 @@ class TestVsiFileSystem(unittest.TestCase):
 
             fs.sync_from_dir(src_vsi, dst_vsi, delete=True)
             paths = fs.list_paths(src_vsi)
-            self.assertListEqual(paths, [
-                join(src, 'subdir'),
-                join(src, '1.txt'),
-                join(src, '2.txt'),
-            ])
+            self.assertSetEqual(
+                set(paths),
+                set([
+                    join(src, 'subdir'),
+                    join(src, '1.txt'),
+                    join(src, '2.txt'),
+                ]))
             paths = fs.list_paths(src_vsi, ext='txt')
-            self.assertListEqual(paths, [
-                join(src, '1.txt'),
-                join(src, '2.txt'),
-            ])
+            self.assertSetEqual(
+                set(paths), set([
+                    join(src, '1.txt'),
+                    join(src, '2.txt'),
+                ]))
             paths = fs.list_paths(join(src, 'subdir'))
-            self.assertListEqual(paths, [join(src, 'subdir', '3.txt')])
+            self.assertSetEqual(
+                set(paths), set([join(src, 'subdir', '3.txt')]))
 
             with self.assertRaises(FileExistsError):
                 fs.sync_from_dir(src_vsi, dst_vsi, delete=False)


### PR DESCRIPTION
## Overview

This PR makes some fixes to `rastervision.core`'s dependencies.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* Check if CI passes.