### PR TITLE
Save model weights for each epoch 1720

### DIFF
--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
@@ -53,7 +53,8 @@ class PyTorchChipClassificationConfig(PyTorchLearnerBackendConfig):
             test_mode=self.test_mode,
             output_uri=pipeline.train_uri,
             log_tensorboard=self.log_tensorboard,
-            run_tensorboard=self.run_tensorboard)
+            run_tensorboard=self.run_tensorboard,
+            save_all_checkpoints=self.save_all_checkpoints)
         learner.update()
         learner.validate_config()
         return learner

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -30,12 +30,12 @@ class PyTorchLearnerBackendConfig(BackendConfig):
          'get_learner_config(). For more info, see the docs for'
          'pytorch_learner.learner_config.LearnerConfig.test_mode.'))
     save_all_checkpoints: bool = Field(
-        False, 
-        description=
-        ('If True, all checkpoints would be saved. The latest checkpoint '
-         'would be saved as `last-model.pth`. The checkpoints prior to '
-         'last epoch are stored as `model-ckpt-epoch-{N}.pth` where `N` '
-         'is the epoch number.'))
+        False,
+        description=(
+            'If True, all checkpoints would be saved. The latest checkpoint '
+            'would be saved as `last-model.pth`. The checkpoints prior to '
+            'last epoch are stored as `model-ckpt-epoch-{N}.pth` where `N` '
+            'is the epoch number.'))
 
     def get_bundle_filenames(self):
         return ['model-bundle.zip']

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -29,6 +29,13 @@ class PyTorchLearnerBackendConfig(BackendConfig):
         ('This field is passed along to the LearnerConfig which is returned by '
          'get_learner_config(). For more info, see the docs for'
          'pytorch_learner.learner_config.LearnerConfig.test_mode.'))
+    save_all_checkpoints: bool = Field(
+        False, 
+        description=
+        ('If True, all checkpoints would be saved. The latest checkpoint '
+         'would be saved as `last-model.pth`. The checkpoints prior to '
+         'last epoch are stored as `model-ckpt-epoch-{N}.pth` where `N` '
+         'is the epoch number.'))
 
     def get_bundle_filenames(self):
         return ['model-bundle.zip']

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -53,7 +53,8 @@ class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
             test_mode=self.test_mode,
             output_uri=pipeline.train_uri,
             log_tensorboard=self.log_tensorboard,
-            run_tensorboard=self.run_tensorboard)
+            run_tensorboard=self.run_tensorboard,
+            save_all_checkpoints=self.save_all_checkpoints)
         learner.update()
         return learner
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -53,7 +53,8 @@ class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
             test_mode=self.test_mode,
             output_uri=pipeline.train_uri,
             log_tensorboard=self.log_tensorboard,
-            run_tensorboard=self.run_tensorboard)
+            run_tensorboard=self.run_tensorboard,
+            save_all_checkpoints=self.save_all_checkpoints)
         learner.update()
         learner.validate_config()
         return learner

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -188,9 +188,10 @@ class Learner(ABC):
             log.info(f'Remote output dir: {self.output_dir}')
 
         self.modules_dir = join(self.output_dir, MODULES_DIRNAME)
-        self.checkpoints_dir_local = join(self.output_dir_local, CHECKPOINTS_DIRNAME)
+        self.checkpoints_dir_local = join(self.output_dir_local,
+                                          CHECKPOINTS_DIRNAME)
         make_dir(self.checkpoints_dir_local)
-        
+
         # ---------------------------
         self._onnx_mode = False
         self.setup_model(

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -1378,12 +1378,12 @@ class LearnerConfig(Config):
     output_uri: Optional[str] = Field(
         None, description='URI of where to save output')
     save_all_checkpoints: bool = Field(
-        False, 
-        description=
-        ('If True, all checkpoints would be saved. The latest checkpoint '
-         'would be saved as `last-model.pth`. The checkpoints prior to '
-         'last epoch are stored as `model-ckpt-epoch-{N}.pth` where `N` '
-         'is the epoch number.'))
+        False,
+        description=(
+            'If True, all checkpoints would be saved. The latest checkpoint '
+            'would be saved as `last-model.pth`. The checkpoints prior to '
+            'last epoch are stored as `model-ckpt-epoch-{N}.pth` where `N` '
+            'is the epoch number.'))
 
     @validator('run_tensorboard')
     def validate_run_tensorboard(cls, v: bool, values: dict) -> bool:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -1377,6 +1377,13 @@ class LearnerConfig(Config):
         False, description='run Tensorboard server during training')
     output_uri: Optional[str] = Field(
         None, description='URI of where to save output')
+    save_all_checkpoints: bool = Field(
+        False, 
+        description=
+        ('If True, all checkpoints would be saved. The latest checkpoint '
+         'would be saved as `last-model.pth`. The checkpoints prior to '
+         'last epoch are stored as `model-ckpt-epoch-{N}.pth` where `N` '
+         'is the epoch number.'))
 
     @validator('run_tensorboard')
     def validate_run_tensorboard(cls, v: bool, values: dict) -> bool:


### PR DESCRIPTION
## Overview

Save model weights for each epoch.

### Notes
From #1720, proposition 1 is followed. Last checkpoint is still kept as `last-model.pth`. Instead of overwriting, it copies the previous checkpoint to `model-ckpt-epoch-{N}.pth` where `N` is the epoch number.

## Testing Instructions

* From either running the notebooks or the unittests where `Learner` is extended. The option `save_all_checkpoints` can be added as in
```
learner = SemanticSegmentationLearner(
    cfg=learner_cfg,
    output_dir='./train-demo/',
    model=model,
    train_ds=train_ds,
    valid_ds=val_ds,
    save_all_checkpoints=True
)
```
Closes #1720 
