### PR TITLE
Normalize pixel values in the Spacenet Vegas examples

### DIFF
--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
@@ -17,7 +17,7 @@ from rastervision.core.backend import Backend
 from rastervision.core.rv_pipeline import TRAIN, VALIDATION
 from rastervision.pipeline.file_system.utils import (
     download_if_needed, zipdir, get_local_path, upload_or_copy, make_dir,
-    sync_to_dir, file_exists)
+    sync_from_dir, file_exists)
 
 log = logging.getLogger(__name__)
 
@@ -252,8 +252,8 @@ class RVPipeline(Pipeline):
                 shutil.copy(path, join(bundle_dir, fn))
 
             if file_exists(self.config.analyze_uri, include_dir=True):
-                sync_to_dir(self.config.analyze_uri, join(
-                    bundle_dir, 'analyze'))
+                analyze_dst = join(bundle_dir, 'analyze')
+                sync_from_dir(self.config.analyze_uri, analyze_dst)
 
             path = download_if_needed(self.config.get_config_uri(), tmp_dir)
             shutil.copy(path, join(bundle_dir, 'pipeline-config.json'))

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
@@ -98,7 +98,9 @@ def build_scene(spacenet_cfg: SpacenetConfig,
     label_uri = spacenet_cfg.get_geojson_uri(id)
 
     raster_source = RasterioSourceConfig(
-        uris=[image_uri], channel_order=channel_order)
+        uris=[image_uri],
+        channel_order=channel_order,
+        transformers=[StatsTransformerConfig()])
 
     # Set a line buffer to convert line strings to polygons.
     vector_source = GeoJSONVectorSourceConfig(


### PR DESCRIPTION
## Overview

The `StatsTransformer` was removed from these examples in v0.13, this PR adds it back. A model trained on normalized pixels is easier to transfer to new data.

This PR also fixes a bug in the bundle command that was uncovered after making this change.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* The examples have been verified to run successfully with this change.
