### PR TITLE
Account for `bbox` when saving predictions

### DIFF
--- a/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
+++ b/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
@@ -155,8 +155,11 @@ class ChipClassificationLabels(Labels):
         for cell in labels.get_cells():
             self.set_cell(cell, *labels[cell])
 
-    def save(self, uri: str, class_config: 'ClassConfig',
-             crs_transformer: 'CRSTransformer') -> None:
+    def save(self,
+             uri: str,
+             class_config: 'ClassConfig',
+             crs_transformer: 'CRSTransformer',
+             bbox: Optional[Box] = None) -> None:
         """Save labels as a GeoJSON file.
 
         Args:
@@ -164,11 +167,14 @@ class ChipClassificationLabels(Labels):
             class_config (ClassConfig): ClassConfig to map class IDs to names.
             crs_transformer (CRSTransformer): CRSTransformer to convert from
                 pixel-coords to map-coords before saving.
+            bbox (Optional[Box]): User-specified crop of the extent. Must be
+                provided if the corresponding RasterSource has bbox != extent.
         """
         from rastervision.core.data import ChipClassificationGeoJSONStore
 
         label_store = ChipClassificationGeoJSONStore(
             uri=uri,
             class_config=class_config,
-            crs_transformer=crs_transformer)
+            crs_transformer=crs_transformer,
+            bbox=bbox)
         label_store.save(self)

--- a/rastervision_core/rastervision/core/data/label/object_detection_labels.py
+++ b/rastervision_core/rastervision/core/data/label/object_detection_labels.py
@@ -294,8 +294,11 @@ class ObjectDetectionLabels(Labels):
             score_threshold=score_thresh)
         return ObjectDetectionLabels.from_boxlist(pruned_boxlist)
 
-    def save(self, uri: str, class_config: 'ClassConfig',
-             crs_transformer: 'CRSTransformer') -> None:
+    def save(self,
+             uri: str,
+             class_config: 'ClassConfig',
+             crs_transformer: 'CRSTransformer',
+             bbox: Optional[Box] = None) -> None:
         """Save labels as a GeoJSON file.
 
         Args:
@@ -303,11 +306,14 @@ class ObjectDetectionLabels(Labels):
             class_config (ClassConfig): ClassConfig to map class IDs to names.
             crs_transformer (CRSTransformer): CRSTransformer to convert from
                 pixel-coords to map-coords before saving.
+            bbox (Optional[Box]): User-specified crop of the extent. Must be
+                provided if the corresponding RasterSource has bbox != extent.
         """
         from rastervision.core.data import ObjectDetectionGeoJSONStore
 
         label_store = ObjectDetectionGeoJSONStore(
             uri=uri,
             class_config=class_config,
-            crs_transformer=crs_transformer)
+            crs_transformer=crs_transformer,
+            bbox=bbox)
         label_store.save(self)

--- a/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
+++ b/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
@@ -357,6 +357,7 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
              uri: str,
              crs_transformer: 'CRSTransformer',
              class_config: 'ClassConfig',
+             bbox: Optional[Box] = None,
              tmp_dir: Optional[str] = None,
              save_as_rgb: bool = False,
              raster_output: bool = True,
@@ -373,6 +374,8 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
             crs_transformer (CRSTransformer): CRSTransformer to configure CRS
                 and affine transform of the output GeoTiff.
             class_config (ClassConfig): The ClassConfig.
+            bbox (Optional[Box]): User-specified crop of the extent. Must be
+                provided if the corresponding RasterSource has bbox != extent.
             tmp_dir (Optional[str], optional): Temporary directory to use. If
                 None, will be auto-generated. Defaults to None.
             save_as_rgb (bool, optional): If True, Saves labels as an RGB
@@ -397,6 +400,7 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
             uri=uri,
             crs_transformer=crs_transformer,
             class_config=class_config,
+            bbox=bbox,
             tmp_dir=tmp_dir,
             save_as_rgb=save_as_rgb,
             discrete_output=raster_output,
@@ -529,6 +533,7 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
              uri: str,
              crs_transformer: 'CRSTransformer',
              class_config: 'ClassConfig',
+             bbox: Optional[Box] = None,
              tmp_dir: Optional[str] = None,
              save_as_rgb: bool = False,
              discrete_output: bool = True,
@@ -547,6 +552,8 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
             crs_transformer (CRSTransformer): CRSTransformer to configure CRS
                 and affine transform of the output GeoTiff(s).
             class_config (ClassConfig): The ClassConfig.
+            bbox (Optional[Box]): User-specified crop of the extent. Must be
+                provided if the corresponding RasterSource has bbox != extent.
             tmp_dir (Optional[str], optional): Temporary directory to use. If
                 None, will be auto-generated. Defaults to None.
             save_as_rgb (bool, optional): If True, saves labels as an RGB
@@ -577,6 +584,7 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
             uri=uri,
             crs_transformer=crs_transformer,
             class_config=class_config,
+            bbox=bbox,
             tmp_dir=tmp_dir,
             save_as_rgb=save_as_rgb,
             discrete_output=discrete_output,

--- a/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
@@ -30,7 +30,8 @@ class ChipClassificationGeoJSONStore(LabelStore):
                 in GeoJSON file to pixel coords.
             bbox (Optional[Box], optional): User-specified crop of the extent.
                 If provided, only labels falling inside it are returned by
-                :meth:`.ChipClassificationGeoJSONStore.get_labels`.
+                :meth:`.ChipClassificationGeoJSONStore.get_labels`. Must be
+                provided if the corresponding RasterSource has bbox != extent.
         """
         self.uri = uri
         self.class_config = class_config
@@ -51,7 +52,8 @@ class ChipClassificationGeoJSONStore(LabelStore):
             class_ids,
             self.crs_transformer,
             self.class_config,
-            scores=scores)
+            scores=scores,
+            bbox=self.bbox)
         json_to_file(geojson, self.uri)
 
     def get_labels(self) -> ChipClassificationLabels:

--- a/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
@@ -32,7 +32,8 @@ class ObjectDetectionGeoJSONStore(LabelStore):
                 in GeoJSON file to pixel coords.
             bbox (Optional[Box], optional): User-specified crop of the extent.
                 If provided, only labels falling inside it are returned by
-                :meth:`.ObjectDetectionGeoJSONStore.get_labels`.
+                :meth:`.ObjectDetectionGeoJSONStore.get_labels`. Must be
+                provided if the corresponding RasterSource has bbox != extent.
         """
         self.uri = uri
         self.class_config = class_config

--- a/rastervision_core/rastervision/core/data/label_store/utils.py
+++ b/rastervision_core/rastervision/core/data/label_store/utils.py
@@ -16,8 +16,8 @@ def boxes_to_geojson(
         class_ids: Sequence[int],
         crs_transformer: 'CRSTransformer',
         class_config: 'ClassConfig',
-        scores: Optional[Sequence[Union[float, Sequence[float]]]] = None
-) -> dict:
+        scores: Optional[Sequence[Union[float, Sequence[float]]]] = None,
+        bbox: Optional['Box'] = None) -> dict:
     """Convert boxes and associated data into a GeoJSON dict.
 
     Args:
@@ -30,6 +30,8 @@ def boxes_to_geojson(
             Optional list of score or scores. If floats (one for each box),
             property name will be "score". If lists of floats, property name
             will be "scores". Defaults to None.
+        bbox (Optional[Box]): User-specified crop of the extent. Must be
+            provided if the corresponding RasterSource has bbox != extent.
 
     Returns:
         dict: Serialized GeoJSON.
@@ -46,7 +48,10 @@ def boxes_to_geojson(
             boxes,
             desc='Transforming boxes to map coords',
             delay=PROGRESSBAR_DELAY_SEC) as bar:
-        geoms = [crs_transformer.pixel_to_map(box.to_shapely()) for box in bar]
+        geoms = [
+            crs_transformer.pixel_to_map(box.to_shapely(), bbox=bbox)
+            for box in bar
+        ]
 
     # add box properties (ID and name of predicted class)
     with tqdm(


### PR DESCRIPTION
## Overview

When predictions are made on a cropped `RasterSource` (i.e. with a `bbox` specified), that `bbox` must be accounted for when saving those predictions; otherwise, the georeferencing will be wrong.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* These changes were manually tested. Without these changes the prediction outputs were misaligned with the source imagery. With these changes, they were correctly aligned.
