### PR TITLE
Read TIFF chips using rasterio instead of PIL to allow reading non-RGB TIFF chips

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/utils/utils.py
@@ -7,6 +7,7 @@ from itertools import chain
 import numpy as np
 from torchvision.datasets.folder import (IMG_EXTENSIONS, DatasetFolder)
 from PIL import Image
+import rasterio as rio
 
 IMG_EXTENSIONS = tuple([*IMG_EXTENSIONS, '.npy'])
 
@@ -37,6 +38,10 @@ def load_image(path: PathLike) -> np.ndarray:
     ext = splitext(path)[-1]
     if ext == '.npy':
         img = np.load(path)
+    elif ext == '.tif' or ext == '.tiff':
+        with rio.open(path, 'r') as f:
+            img = f.read()
+            img = img.transpose(1, 2, 0)
     else:
         img = np.array(Image.open(path))
 

--- a/tests/pytorch_learner/dataset/utils/test_utils.py
+++ b/tests/pytorch_learner/dataset/utils/test_utils.py
@@ -4,9 +4,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
+import rasterio as rio
 from torchvision.datasets.folder import DatasetFolder
 
 from rastervision.pipeline.file_system import get_tmp_dir
+from rastervision.core.data.utils import write_window
 from rastervision.pytorch_learner.dataset import (discover_images, load_image,
                                                   make_image_folder_dataset)
 from rastervision.pytorch_backend.pytorch_learner_backend import write_chip
@@ -51,6 +53,14 @@ class TestUtils(unittest.TestCase):
                 0, 256, size=(100, 100, 8), dtype=np.uint8)
             path = join(tmp_dir, '3.npy')
             write_chip(chip, path)
+            np.testing.assert_array_equal(load_image(path), chip)
+
+            chip = np.random.randint(
+                0, 256, size=(100, 100, 8), dtype=np.uint8)
+            path = join(tmp_dir, '4.tif')
+            profile = dict(height=100, width=100, count=8, dtype=np.uint8)
+            with rio.open(path, 'w', **profile) as ds:
+                write_window(ds, chip)
             np.testing.assert_array_equal(load_image(path), chip)
 
     def test_make_image_folder_dataset(self):


### PR DESCRIPTION
## Overview

Previously, TIFF chips were read via `PIL` which could not read non-RGB images. This PR makes it so that `rasterio` is used instead.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Note that this `PIL` limitation applied to external pre-chipped datasets (e.g. the EuroSAT multispectral dataset) and **not** RV-produced chips. Those were and are saved as `numpy` arrays.

## Testing Instructions

* New unit test added.