### PR TITLE
Update CI workflow to free up disk space before running CI job

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,6 +18,10 @@ jobs:
 
       - run: df -hT
 
+      - run: rm -rf /opt/hostedtoolcache
+
+      - run: df -hT
+
       - run: ./scripts/cibuild
 
       - run: df -hT

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -18,12 +18,12 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         usage
     else
         DOCKER_BUILDKIT=1 docker build \
-	    --build-arg BUILDKIT_INLINE_CACHE=1 \
-	    --build-arg BUILD_TYPE=fullbuild \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg BUILD_TYPE=fullbuild \
             --platform linux/amd64 \
             --build-arg CUDA_VERSION="12.1.1" \
             --build-arg UBUNTU_VERSION="22.04" \
-	    --cache-from=quay.io/azavea/raster-vision:pytorch-latest \
+            --cache-from=quay.io/azavea/raster-vision:pytorch-latest \
             -t "raster-vision-${IMAGE_TYPE}" \
             -f Dockerfile .
     fi


### PR DESCRIPTION
## Overview

This PR attempts to fix `no space left on device` errors while building the docker image in the CI:
![image](https://github.com/azavea/raster-vision/assets/13014700/491ef102-f093-4876-8c63-b7b00c23b00f)

Supersedes #1872.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A
