### PR TITLE
Bug fix: ensure SS datasets always return label array with correct `dtype`

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/transform.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/transform.py
@@ -227,7 +227,8 @@ def semantic_segmentation_transformer(
             y = np.array(y)
             out = apply_transform(transform, image=x, mask=y)
             x, y = out['image'], out['mask']
-            y = y.astype(int)
+    if y is not None:
+        y = y.astype(int)
     return x, y
 
 

--- a/tests/pytorch_learner/dataset/test_transform.py
+++ b/tests/pytorch_learner/dataset/test_transform.py
@@ -4,7 +4,8 @@ import numpy as np
 import albumentations as A
 
 from rastervision.pytorch_learner.dataset.transform import (
-    yxyx_to_albu, albu_to_yxyx, xywh_to_albu, apply_transform)
+    yxyx_to_albu, albu_to_yxyx, xywh_to_albu, apply_transform,
+    semantic_segmentation_transformer)
 
 
 class TestTransforms(unittest.TestCase):
@@ -64,6 +65,29 @@ class TestTransforms(unittest.TestCase):
             ], dtype=float)
         boxes_albu = xywh_to_albu(boxes, (10, 10))
         np.testing.assert_allclose(boxes_albu, boxes_albu_gt)
+
+    def test_semantic_segmentation_transformer(self):
+        # w/ y, w/o transform
+        x_in, y_in = np.zeros((10, 10, 3), dtype=np.uint8), np.zeros((10, 10))
+        x_out, y_out = semantic_segmentation_transformer((x_in, y_in), None)
+        np.issubdtype(y_out.dtype, int)
+
+        # w/ y, w/ transform
+        x_out, y_out = semantic_segmentation_transformer((x_in, y_in),
+                                                         A.Resize(20, 20))
+        self.assertEqual(x_out.shape, (20, 20, 3))
+        self.assertEqual(y_out.shape, (20, 20))
+        np.issubdtype(y_out.dtype, int)
+
+        # w/o y, w/o transform
+        x_out, y_out = semantic_segmentation_transformer((x_in, None), None)
+        self.assertIsNone(y_out)
+
+        # w/o y, w/ transform
+        x_out, y_out = semantic_segmentation_transformer((x_in, None),
+                                                         A.Resize(20, 20))
+        self.assertEqual(x_out.shape, (20, 20, 3))
+        self.assertIsNone(y_out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Overview

This PR fixes a bug, reported in #1950, where SS datasets would return `y` without converting it to the right integer `dtype` first.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* See new unit tests.