### PR TITLE
Free up disk space in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: rm -rf /opt/hostedtoolcache
+
       - run: ./scripts/cibuild
 
       - run: docker system prune -f


### PR DESCRIPTION
## Overview

Free up disk space in release workflow, just like we do in the CI workflow (#1953).

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

* Check if workflow succeeds after merge.