### PR TITLE
[BACKPORT] Backport changes to the 0.21 branch for v0.21.3 release 

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,6 +18,10 @@ jobs:
 
       - run: df -hT
 
+      - run: rm -rf /opt/hostedtoolcache
+
+      - run: df -hT
+
       - run: ./scripts/cibuild
 
       - run: df -hT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: rm -rf /opt/hostedtoolcache
+
       - run: ./scripts/cibuild
 
       - run: docker system prune -f

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -60,6 +60,13 @@ Minor or Major Version Release
         docker push quay.io/azavea/raster-vision:pytorch-<version>
 
 #.  Make a GitHub `tag <https://github.com/azavea/raster-vision/tags>`_ and `release <https://github.com/azavea/raster-vision/releases>`_ using the previous release as a template.
+#. Remove artifacts from previous builds. From the repo root:
+
+    .. code-block:: console
+
+        rm -rf build/ dist/ *.egg-info
+        rm -rf rastervision_*/build rastervision_*/dist rastervision_*/*.egg-info
+
 #.  Publish all packages to PyPI. This step requires `twine <https://twine.readthedocs.io/en/stable/>`__ which you can install with
 
     .. code-block:: console
@@ -105,12 +112,20 @@ Minor or Major Version Release
 #.  Announce the new release in our `forum <https://github.com/azavea/raster-vision/discussions>`_, and with a blog post if it's a big release.
 #.  Make a PR to the master branch that updates the version number to the next development version, ``X.Y.Z-dev``. For example, if the last release was ``0.20.1``, update the version to ``0.20.2-dev``.
 
-Bug Fix Release
+Patch Release
 -----------------
 
-This describes how to create a new bug fix release, using incrementing from 0.8.0 to 0.8.1 as an example. This assumes that there is already a branch for a minor release called ``0.8``.
+This describes how to create a new patch release (AKA a bug-fix release), using an increment from 0.8.0 to 0.8.1 as an example. This assumes that there is already a branch for a minor release called ``0.8``.
 
-#.  To create a bug fix release (version 0.8.1), we need to backport all the bug fix commits on the ``master`` branch that have been added since the last bug fix release onto the ``0.8`` branch. For each bug fix PR on ``master``, we need to create a PR against the ``0.8`` branch based on a branch of ``0.8`` that has cherry-picked the commits from the original PR. The title of the PR should start with [BACKPORT].
-#.  Make and merge a PR against ``0.8`` (but not ``master``) that increments the version in each ``setup.py`` file to ``0.8.1``. Then wait for the ``0.8`` branch to be built by GitHub Actions and the ``0.8`` Docker images to be published to Quay. If that is successful, we can proceed to the next steps of actually publishing a release.
-#.  Using the GitHub UI, make a new release. Use ``0.8.1`` as the tag, and the ``0.8`` branch as the target.
-#.  Publish the new version to PyPI. Follow the same instructions for PyPI that are listed above for minor/major version releases.
+#. Backport changes to the ``0.8`` branch. To create a patch release (version 0.8.1), we need to backport all the commits on the ``master`` branch that have been added since the last patch release onto the ``0.8`` branch. To do this:
+
+   #. Create a new branch from the ``0.8`` branch. Let's call it ``backport``.
+   #. Cherry-pick each commit that we want to include from the ``master`` branch onto the ``backport`` branch.
+   #. Make a PR against the ``0.8`` branch from the ``backport`` branch. The title of the PR should start with ``[BACKPORT]``.
+#. Update changelog and version on the ``0.8`` branch. Make and merge a PR against ``0.8`` (but not ``master``) that adds a changelog for the new release and increments the version to ``0.8.1`` throughout the repo. Wait for the ``0.8`` branch to be built by GitHub Actions and the ``0.8`` Docker images to be published to Quay. If that is successful, we can proceed to the next steps of actually publishing a release.
+#. Publish the new version to PyPI. Follow the same instructions for PyPI as listed above for minor/major version releases.
+#. Using the GitHub UI, make a new release. Use ``v0.8.1`` as the tag, and the ``0.8`` branch as the target.
+#. Update changelog and version on the ``master`` branch. Make and merge a PR against ``master`` that 
+
+   * includes the cherry-picked commit that updates the changelog for ``0.8.1`` and 
+   * increments the version to ``0.8.2-dev`` throughout the repo.

--- a/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
+++ b/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
@@ -155,8 +155,11 @@ class ChipClassificationLabels(Labels):
         for cell in labels.get_cells():
             self.set_cell(cell, *labels[cell])
 
-    def save(self, uri: str, class_config: 'ClassConfig',
-             crs_transformer: 'CRSTransformer') -> None:
+    def save(self,
+             uri: str,
+             class_config: 'ClassConfig',
+             crs_transformer: 'CRSTransformer',
+             bbox: Optional[Box] = None) -> None:
         """Save labels as a GeoJSON file.
 
         Args:
@@ -164,11 +167,14 @@ class ChipClassificationLabels(Labels):
             class_config (ClassConfig): ClassConfig to map class IDs to names.
             crs_transformer (CRSTransformer): CRSTransformer to convert from
                 pixel-coords to map-coords before saving.
+            bbox (Optional[Box]): User-specified crop of the extent. Must be
+                provided if the corresponding RasterSource has bbox != extent.
         """
         from rastervision.core.data import ChipClassificationGeoJSONStore
 
         label_store = ChipClassificationGeoJSONStore(
             uri=uri,
             class_config=class_config,
-            crs_transformer=crs_transformer)
+            crs_transformer=crs_transformer,
+            bbox=bbox)
         label_store.save(self)

--- a/rastervision_core/rastervision/core/data/label/object_detection_labels.py
+++ b/rastervision_core/rastervision/core/data/label/object_detection_labels.py
@@ -294,8 +294,11 @@ class ObjectDetectionLabels(Labels):
             score_threshold=score_thresh)
         return ObjectDetectionLabels.from_boxlist(pruned_boxlist)
 
-    def save(self, uri: str, class_config: 'ClassConfig',
-             crs_transformer: 'CRSTransformer') -> None:
+    def save(self,
+             uri: str,
+             class_config: 'ClassConfig',
+             crs_transformer: 'CRSTransformer',
+             bbox: Optional[Box] = None) -> None:
         """Save labels as a GeoJSON file.
 
         Args:
@@ -303,11 +306,14 @@ class ObjectDetectionLabels(Labels):
             class_config (ClassConfig): ClassConfig to map class IDs to names.
             crs_transformer (CRSTransformer): CRSTransformer to convert from
                 pixel-coords to map-coords before saving.
+            bbox (Optional[Box]): User-specified crop of the extent. Must be
+                provided if the corresponding RasterSource has bbox != extent.
         """
         from rastervision.core.data import ObjectDetectionGeoJSONStore
 
         label_store = ObjectDetectionGeoJSONStore(
             uri=uri,
             class_config=class_config,
-            crs_transformer=crs_transformer)
+            crs_transformer=crs_transformer,
+            bbox=bbox)
         label_store.save(self)

--- a/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
+++ b/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
@@ -357,6 +357,7 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
              uri: str,
              crs_transformer: 'CRSTransformer',
              class_config: 'ClassConfig',
+             bbox: Optional[Box] = None,
              tmp_dir: Optional[str] = None,
              save_as_rgb: bool = False,
              raster_output: bool = True,
@@ -373,6 +374,8 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
             crs_transformer (CRSTransformer): CRSTransformer to configure CRS
                 and affine transform of the output GeoTiff.
             class_config (ClassConfig): The ClassConfig.
+            bbox (Optional[Box]): User-specified crop of the extent. Must be
+                provided if the corresponding RasterSource has bbox != extent.
             tmp_dir (Optional[str], optional): Temporary directory to use. If
                 None, will be auto-generated. Defaults to None.
             save_as_rgb (bool, optional): If True, Saves labels as an RGB
@@ -397,6 +400,7 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
             uri=uri,
             crs_transformer=crs_transformer,
             class_config=class_config,
+            bbox=bbox,
             tmp_dir=tmp_dir,
             save_as_rgb=save_as_rgb,
             discrete_output=raster_output,
@@ -529,6 +533,7 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
              uri: str,
              crs_transformer: 'CRSTransformer',
              class_config: 'ClassConfig',
+             bbox: Optional[Box] = None,
              tmp_dir: Optional[str] = None,
              save_as_rgb: bool = False,
              discrete_output: bool = True,
@@ -547,6 +552,8 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
             crs_transformer (CRSTransformer): CRSTransformer to configure CRS
                 and affine transform of the output GeoTiff(s).
             class_config (ClassConfig): The ClassConfig.
+            bbox (Optional[Box]): User-specified crop of the extent. Must be
+                provided if the corresponding RasterSource has bbox != extent.
             tmp_dir (Optional[str], optional): Temporary directory to use. If
                 None, will be auto-generated. Defaults to None.
             save_as_rgb (bool, optional): If True, saves labels as an RGB
@@ -577,6 +584,7 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
             uri=uri,
             crs_transformer=crs_transformer,
             class_config=class_config,
+            bbox=bbox,
             tmp_dir=tmp_dir,
             save_as_rgb=save_as_rgb,
             discrete_output=discrete_output,

--- a/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/chip_classification_geojson_store.py
@@ -30,7 +30,8 @@ class ChipClassificationGeoJSONStore(LabelStore):
                 in GeoJSON file to pixel coords.
             bbox (Optional[Box], optional): User-specified crop of the extent.
                 If provided, only labels falling inside it are returned by
-                :meth:`.ChipClassificationGeoJSONStore.get_labels`.
+                :meth:`.ChipClassificationGeoJSONStore.get_labels`. Must be
+                provided if the corresponding RasterSource has bbox != extent.
         """
         self.uri = uri
         self.class_config = class_config
@@ -51,7 +52,8 @@ class ChipClassificationGeoJSONStore(LabelStore):
             class_ids,
             self.crs_transformer,
             self.class_config,
-            scores=scores)
+            scores=scores,
+            bbox=self.bbox)
         json_to_file(geojson, self.uri)
 
     def get_labels(self) -> ChipClassificationLabels:

--- a/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/object_detection_geojson_store.py
@@ -32,7 +32,8 @@ class ObjectDetectionGeoJSONStore(LabelStore):
                 in GeoJSON file to pixel coords.
             bbox (Optional[Box], optional): User-specified crop of the extent.
                 If provided, only labels falling inside it are returned by
-                :meth:`.ObjectDetectionGeoJSONStore.get_labels`.
+                :meth:`.ObjectDetectionGeoJSONStore.get_labels`. Must be
+                provided if the corresponding RasterSource has bbox != extent.
         """
         self.uri = uri
         self.class_config = class_config

--- a/rastervision_core/rastervision/core/data/label_store/utils.py
+++ b/rastervision_core/rastervision/core/data/label_store/utils.py
@@ -16,8 +16,8 @@ def boxes_to_geojson(
         class_ids: Sequence[int],
         crs_transformer: 'CRSTransformer',
         class_config: 'ClassConfig',
-        scores: Optional[Sequence[Union[float, Sequence[float]]]] = None
-) -> dict:
+        scores: Optional[Sequence[Union[float, Sequence[float]]]] = None,
+        bbox: Optional['Box'] = None) -> dict:
     """Convert boxes and associated data into a GeoJSON dict.
 
     Args:
@@ -30,6 +30,8 @@ def boxes_to_geojson(
             Optional list of score or scores. If floats (one for each box),
             property name will be "score". If lists of floats, property name
             will be "scores". Defaults to None.
+        bbox (Optional[Box]): User-specified crop of the extent. Must be
+            provided if the corresponding RasterSource has bbox != extent.
 
     Returns:
         dict: Serialized GeoJSON.
@@ -46,7 +48,10 @@ def boxes_to_geojson(
             boxes,
             desc='Transforming boxes to map coords',
             delay=PROGRESSBAR_DELAY_SEC) as bar:
-        geoms = [crs_transformer.pixel_to_map(box.to_shapely()) for box in bar]
+        geoms = [
+            crs_transformer.pixel_to_map(box.to_shapely(), bbox=bbox)
+            for box in bar
+        ]
 
     # add box properties (ID and name of predicted class)
     with tqdm(

--- a/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
@@ -97,7 +97,8 @@ class StatsTransformer(RasterTransformer):
     def from_raster_sources(cls,
                             raster_sources: List['RasterSource'],
                             sample_prob: Optional[float] = 0.1,
-                            max_stds: float = 3.) -> 'StatsTransformer':
+                            max_stds: float = 3.,
+                            chip_sz: int = 300) -> 'StatsTransformer':
         """Build with stats from the given raster sources.
 
         Args:
@@ -113,7 +114,10 @@ class StatsTransformer(RasterTransformer):
             StatsTransformer: A StatsTransformer.
         """
         stats = RasterStats()
-        stats.compute(raster_sources=raster_sources, sample_prob=sample_prob)
+        stats.compute(
+            raster_sources=raster_sources,
+            sample_prob=sample_prob,
+            chip_sz=chip_sz)
         stats_transformer = StatsTransformer.from_raster_stats(
             stats, max_stds=max_stds)
         return stats_transformer

--- a/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
@@ -166,4 +166,4 @@ class StatsTransformer(RasterTransformer):
 
     def __repr__(self) -> str:
         return repr_with_args(
-            self, means=self.means, std=self.stds, max_stds=self.max_stds)
+            self, means=self.means, stds=self.stds, max_stds=self.max_stds)

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
@@ -17,7 +17,7 @@ from rastervision.core.backend import Backend
 from rastervision.core.rv_pipeline import TRAIN, VALIDATION
 from rastervision.pipeline.file_system.utils import (
     download_if_needed, zipdir, get_local_path, upload_or_copy, make_dir,
-    sync_to_dir, file_exists)
+    sync_from_dir, file_exists)
 
 log = logging.getLogger(__name__)
 
@@ -252,8 +252,8 @@ class RVPipeline(Pipeline):
                 shutil.copy(path, join(bundle_dir, fn))
 
             if file_exists(self.config.analyze_uri, include_dir=True):
-                sync_to_dir(self.config.analyze_uri, join(
-                    bundle_dir, 'analyze'))
+                analyze_dst = join(bundle_dir, 'analyze')
+                sync_from_dir(self.config.analyze_uri, analyze_dst)
 
             path = download_if_needed(self.config.get_config_uri(), tmp_dir)
             shutil.copy(path, join(bundle_dir, 'pipeline-config.json'))

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -2,7 +2,7 @@ rastervision_pipeline==0.21.2
 shapely==2.0.1
 geopandas==0.13.2
 numpy==1.25.0
-pillow==9.3.0
+pillow==10.0.1
 pyproj==3.4.0
 rasterio==1.3.7
 pystac==1.6.1

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
@@ -98,7 +98,9 @@ def build_scene(spacenet_cfg: SpacenetConfig,
     label_uri = spacenet_cfg.get_geojson_uri(id)
 
     raster_source = RasterioSourceConfig(
-        uris=[image_uri], channel_order=channel_order)
+        uris=[image_uri],
+        channel_order=channel_order,
+        transformers=[StatsTransformerConfig()])
 
     # Set a line buffer to convert line strings to polygons.
     vector_source = GeoJSONVectorSourceConfig(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/test.py
@@ -11,13 +11,13 @@ from rastervision.pipeline.file_system import (
     file_to_json, sync_from_dir, upload_or_copy, download_or_copy, file_exists,
     sync_to_dir, NotReadableError, download_if_needed)
 
-NEW_VERSION = '0.21'
+NEW_VERSION_FULL = '0.21.2'
 NEW_VERSION_MAJOR_MINOR = '0.21'
 
 EXAMPLES_MODULE_ROOT = 'rastervision.pytorch_backend.examples'
 EXAMPLES_PATH_ROOT = '/opt/src/rastervision_pytorch_backend/rastervision/pytorch_backend/examples'  # noqa
-REMOTE_PROCESSED_ROOT = f's3://raster-vision/examples/{NEW_VERSION}/processed-data'
-REMOTE_OUTPUT_ROOT = f's3://raster-vision/examples/{NEW_VERSION}/output'
+REMOTE_PROCESSED_ROOT = f's3://raster-vision/examples/{NEW_VERSION_FULL}/processed-data'
+REMOTE_OUTPUT_ROOT = f's3://raster-vision/examples/{NEW_VERSION_FULL}/output'
 LOCAL_RAW_ROOT = '/opt/data/raw-data'
 LOCAL_PROCESSED_ROOT = '/opt/data/examples/processed-data'
 LOCAL_OUTPUT_ROOT = '/opt/data/examples/output'

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/transform.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/transform.py
@@ -227,7 +227,8 @@ def semantic_segmentation_transformer(
             y = np.array(y)
             out = apply_transform(transform, image=x, mask=y)
             x, y = out['image'], out['mask']
-            y = y.astype(int)
+    if y is not None:
+        y = y.astype(int)
     return x, y
 
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/utils/utils.py
@@ -7,6 +7,7 @@ from itertools import chain
 import numpy as np
 from torchvision.datasets.folder import (IMG_EXTENSIONS, DatasetFolder)
 from PIL import Image
+import rasterio as rio
 
 IMG_EXTENSIONS = tuple([*IMG_EXTENSIONS, '.npy'])
 
@@ -37,6 +38,10 @@ def load_image(path: PathLike) -> np.ndarray:
     ext = splitext(path)[-1]
     if ext == '.npy':
         img = np.load(path)
+    elif ext == '.tif' or ext == '.tiff':
+        with rio.open(path, 'r') as f:
+            img = f.read()
+            img = img.transpose(1, 2, 0)
     else:
         img = np.array(Image.open(path))
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/visualizer/visualizer.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/visualizer/visualizer.py
@@ -119,7 +119,8 @@ class Visualizer(ABC):
             batch_sz, T, *_ = x.shape
             params['fig_args']['figsize'][1] *= T
             fig = plt.figure(**params['fig_args'])
-            subfigs = fig.subfigures(nrows=batch_sz, ncols=1, hspace=0.0)
+            subfigs = fig.subfigures(
+                nrows=batch_sz, ncols=1, hspace=0.0, squeeze=False)
             subfig_axs = [
                 subfig.subplots(
                     nrows=T, ncols=params['subplot_args']['ncols'])

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -1,7 +1,7 @@
 rastervision_pipeline==0.21.2
 rastervision_core==0.21.2
 numpy==1.25.0
-pillow==9.3.0
+pillow==10.0.1
 torch==2.0.1
 torchvision==0.15.2
 tensorboard==2.13.0

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -18,12 +18,12 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         usage
     else
         DOCKER_BUILDKIT=1 docker build \
-	    --build-arg BUILDKIT_INLINE_CACHE=1 \
-	    --build-arg BUILD_TYPE=fullbuild \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg BUILD_TYPE=fullbuild \
             --platform linux/amd64 \
             --build-arg CUDA_VERSION="12.1.1" \
             --build-arg UBUNTU_VERSION="22.04" \
-	    --cache-from=quay.io/azavea/raster-vision:pytorch-latest \
+            --cache-from=quay.io/azavea/raster-vision:pytorch-latest \
             -t "raster-vision-${IMAGE_TYPE}" \
             -f Dockerfile .
     fi

--- a/scripts/pypi_publish
+++ b/scripts/pypi_publish
@@ -77,12 +77,12 @@ fi
 if [[ "$1" == "-y" ]]; then
     response="y"
 else
-    read -r -p "Actually publish to PyPi? (y/N): " response
+    read -r -p "Actually publish to PyPI? (y/N): " response
 fi
 
 case "$response" in
     [yY][eE][sS]|[yY])
-        echo "Publishing to PyPi..."
+        echo "Publishing to PyPI..."
         publish_all
         ;;
     *)

--- a/tests/pytorch_learner/dataset/test_transform.py
+++ b/tests/pytorch_learner/dataset/test_transform.py
@@ -4,7 +4,8 @@ import numpy as np
 import albumentations as A
 
 from rastervision.pytorch_learner.dataset.transform import (
-    yxyx_to_albu, albu_to_yxyx, xywh_to_albu, apply_transform)
+    yxyx_to_albu, albu_to_yxyx, xywh_to_albu, apply_transform,
+    semantic_segmentation_transformer)
 
 
 class TestTransforms(unittest.TestCase):
@@ -64,6 +65,29 @@ class TestTransforms(unittest.TestCase):
             ], dtype=float)
         boxes_albu = xywh_to_albu(boxes, (10, 10))
         np.testing.assert_allclose(boxes_albu, boxes_albu_gt)
+
+    def test_semantic_segmentation_transformer(self):
+        # w/ y, w/o transform
+        x_in, y_in = np.zeros((10, 10, 3), dtype=np.uint8), np.zeros((10, 10))
+        x_out, y_out = semantic_segmentation_transformer((x_in, y_in), None)
+        np.issubdtype(y_out.dtype, int)
+
+        # w/ y, w/ transform
+        x_out, y_out = semantic_segmentation_transformer((x_in, y_in),
+                                                         A.Resize(20, 20))
+        self.assertEqual(x_out.shape, (20, 20, 3))
+        self.assertEqual(y_out.shape, (20, 20))
+        np.issubdtype(y_out.dtype, int)
+
+        # w/o y, w/o transform
+        x_out, y_out = semantic_segmentation_transformer((x_in, None), None)
+        self.assertIsNone(y_out)
+
+        # w/o y, w/ transform
+        x_out, y_out = semantic_segmentation_transformer((x_in, None),
+                                                         A.Resize(20, 20))
+        self.assertEqual(x_out.shape, (20, 20, 3))
+        self.assertIsNone(y_out)
 
 
 if __name__ == '__main__':

--- a/tests/pytorch_learner/dataset/utils/test_utils.py
+++ b/tests/pytorch_learner/dataset/utils/test_utils.py
@@ -4,9 +4,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
+import rasterio as rio
 from torchvision.datasets.folder import DatasetFolder
 
 from rastervision.pipeline.file_system import get_tmp_dir
+from rastervision.core.data.utils import write_window
 from rastervision.pytorch_learner.dataset import (discover_images, load_image,
                                                   make_image_folder_dataset)
 from rastervision.pytorch_backend.pytorch_learner_backend import write_chip
@@ -51,6 +53,14 @@ class TestUtils(unittest.TestCase):
                 0, 256, size=(100, 100, 8), dtype=np.uint8)
             path = join(tmp_dir, '3.npy')
             write_chip(chip, path)
+            np.testing.assert_array_equal(load_image(path), chip)
+
+            chip = np.random.randint(
+                0, 256, size=(100, 100, 8), dtype=np.uint8)
+            path = join(tmp_dir, '4.tif')
+            profile = dict(height=100, width=100, count=8, dtype=np.uint8)
+            with rio.open(path, 'w', **profile) as ds:
+                write_window(ds, chip)
             np.testing.assert_array_equal(load_image(path), chip)
 
     def test_make_image_folder_dataset(self):

--- a/tests/pytorch_learner/dataset/visualizer/test_semantic_segmentation_visualizer.py
+++ b/tests/pytorch_learner/dataset/visualizer/test_semantic_segmentation_visualizer.py
@@ -40,6 +40,8 @@ class TestClassificationVisualizer(unittest.TestCase):
         x = torch.randn(size=(2, 3, 4, 256, 256))
         y = (torch.randn(size=(2, 256, 256)) > 0).long()
         self.assertNoError(lambda: viz.plot_batch(x, y))
+        # w/o z, batch size = 1
+        self.assertNoError(lambda: viz.plot_batch(x[[0]], y[[0]]))
 
         # w/ z
         viz = SemanticSegmentationVisualizer(
@@ -50,3 +52,5 @@ class TestClassificationVisualizer(unittest.TestCase):
         y = (torch.randn(size=(2, 256, 256)) > 0).long()
         z = torch.randn(size=(2, num_classes, 256, 256)).softmax(dim=-3)
         self.assertNoError(lambda: viz.plot_batch(x, y, z=z))
+        # w/ z, batch size = 1
+        self.assertNoError(lambda: viz.plot_batch(x[[0]], y[[0]]))


### PR DESCRIPTION
This PR backports #1930, #1931, #1932, #1933, #1934, #1952, #1953, #1954, #1958, #1959 to the `0.21` branch.