### PR TITLE
Fix typos in notebook

### DIFF
--- a/docs/usage/tutorials/reading_raster_data.ipynb
+++ b/docs/usage/tutorials/reading_raster_data.ipynb
@@ -159,7 +159,7 @@
    "id": "83a6debf-e477-4b70-b82d-8e079ef8881e",
    "metadata": {},
    "source": [
-    "`RasterSource`s support `numpy`-like array slicing, so we can read a smaller chip within the full raster like so:"
+    "`RasterSources` support `numpy`-like array slicing, so we can read a smaller chip within the full raster like so:"
    ]
   },
   {
@@ -343,7 +343,7 @@
    "source": [
     ":class:`RasterSources <raster_source.raster_source.RasterSource>` accept a list of :class:`RasterTransformers <raster_transformer.raster_transformer.RasterTransformer>`, all of which are automatically applied (in the order specified) to each chip sampled from that :class:`.RasterSource`.\n",
     "\n",
-    "Below we'll look at two such `RasterTransformer`s:\n",
+    "Below we'll look at two such `RasterTransformers`:\n",
     "\n",
     "- :class:`.MinMaxTransformer`\n",
     "- :class:`.StatsTransformer`\n",
@@ -467,7 +467,7 @@
     "tags": []
    },
    "source": [
-    "Another useful ``RasterTransformer`` is the :class:`.StatsTransformer`. \n",
+    "Another useful `RasterTransformer` is the :class:`.StatsTransformer`. \n",
     "\n",
     "Unlike `MinMaxTransformer <#MinMaxTransformer>`_, the :class:`.StatsTransformer` is able to deal with outlier values. It works by using channel means and standard deviations to convert values to z-scores and then clipping them to some number of standard deviations before scaling to 0-255 and converting to ``uint8``.\n",
     "\n",

--- a/docs/usage/tutorials/reading_vector_data.ipynb
+++ b/docs/usage/tutorials/reading_vector_data.ipynb
@@ -522,7 +522,7 @@
    "id": "024fe3ab-412b-4242-849c-fc71dd986e78",
    "metadata": {},
    "source": [
-    "## Transforming vector data using `VectorTransformer`s"
+    "## Transforming vector data using `VectorTransformers`"
    ]
   },
   {
@@ -727,7 +727,7 @@
     "tags": []
    },
    "source": [
-    "``Point`` and ``LineString`` geometries are not directly useable if doing, say, semantic segmentation. The cells below show an example of converting road geometries (given in the form of ``LineString``s) into polygons using the :class:`.BufferTransformer`."
+    "``Point`` and ``LineString`` geometries are not directly useable if doing, say, semantic segmentation. The cells below show an example of converting road geometries (given in the form of `LineString`) into polygons using the :class:`.BufferTransformer`."
    ]
   },
   {


### PR DESCRIPTION
## Overview

This PR fixes some typos and formatting issues in the notebook. 
https://docs.rastervision.io/en/0.21/usage/tutorials/reading_raster_data.html

![image](https://github.com/azavea/raster-vision/assets/5016453/ea7f354a-231d-4998-b1d3-6166e9d9818b)
![image](https://github.com/azavea/raster-vision/assets/5016453/a09017f4-70bf-4216-ae23-d4c34e3a143f)
![image](https://github.com/azavea/raster-vision/assets/5016453/1fc78f78-540a-4b7b-a9cb-b8d21c717b22)



### Checklist

- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [ ] Ran scripts/format_code and committed any changes
- [ ] Documentation updated if needed
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.

Closes #XXX
