### PR TITLE
Allow setting some `Learner`-related params via environment variables (or other Everett config options)

### DIFF
--- a/rastervision_pipeline/rastervision/pipeline/rv_config.py
+++ b/rastervision_pipeline/rastervision/pipeline/rv_config.py
@@ -1,9 +1,9 @@
+from typing import Any, Dict, List, Optional
 import os
 from tempfile import TemporaryDirectory
 from pathlib import Path
 import logging
 import json
-from typing import Optional, List, Dict
 
 from everett.manager import (ConfigManager, ConfigDictEnv, ConfigOSEnv,
                              ConfigurationMissingError)
@@ -202,6 +202,23 @@ class RVConfig:
     def get_namespace_config(self, namespace: str) -> ConfigManager:
         """Get the key-val pairs associated with a namespace."""
         return self.config.with_namespace(namespace)
+
+    def get_namespace_option(self,
+                             namespace: str,
+                             key: str,
+                             default: Optional[Any] = None,
+                             as_bool: bool = False) -> str:
+        """Get the value of an option from a namespace."""
+        namespace_options = self.config.with_namespace(namespace)
+        try:
+            val: str = namespace_options(key)
+            if as_bool:
+                val = val.lower() in ('1', 'true', 'y', 'yes')
+            return val
+        except ConfigurationMissingError:
+            if as_bool:
+                return False
+            return default
 
     def get_config_dict(
             self, rv_config_schema: Dict[str, List[str]]) -> Dict[str, str]:

--- a/rastervision_pipeline/rastervision/pipeline/rv_config.py
+++ b/rastervision_pipeline/rastervision/pipeline/rv_config.py
@@ -199,7 +199,7 @@ class RVConfig:
                 'Switch to the version being run and search for Raster Vision '
                 'Configuration.'))
 
-    def get_namespace_config(self, namespace: str) -> Dict[str, str]:
+    def get_namespace_config(self, namespace: str) -> ConfigManager:
         """Get the key-val pairs associated with a namespace."""
         return self.config.with_namespace(namespace)
 

--- a/rastervision_pipeline/rastervision/pipeline/rv_config.py
+++ b/rastervision_pipeline/rastervision/pipeline/rv_config.py
@@ -238,8 +238,9 @@ class RVConfig:
         for namespace, keys in rv_config_schema.items():
             for key in keys:
                 try:
-                    config_dict[namespace + '_' + key] = \
-                        self.get_namespace_config(namespace)(key)
+                    namespace_options = self.get_namespace_config(namespace)
+                    full_key = f'{namespace}_{key}'
+                    config_dict[full_key] = namespace_options(key)
                 except ConfigurationMissingError:
                     pass
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -641,10 +641,19 @@ class Learner(ABC):
         if return_format not in {'xyz', 'yz', 'z'}:
             raise ValueError('return_format must be one of "xyz", "yz", "z".')
 
+        cfg = self.cfg
+
+        num_workers = rv_config.get_namespace_option(
+            'rastervision',
+            'PREDICT_NUM_WORKERS',
+            default=cfg.data.num_workers)
+        batch_size = rv_config.get_namespace_option(
+            'rastervision', 'PREDICT_BATCH_SIZE', default=cfg.solver.batch_sz)
+
         dl_kw = dict(
             collate_fn=self.get_collate_fn(),
-            batch_size=self.cfg.solver.batch_sz,
-            num_workers=self.cfg.data.num_workers,
+            batch_size=int(batch_size),
+            num_workers=int(num_workers),
             shuffle=False,
             pin_memory=True)
         dl_kw.update(dataloader_kw)


### PR DESCRIPTION
## Overview

This PR 
- adds support for the following env variables:
  - `RASTERVISION_PREDICT_BATCH_SIZE` - the batch size to use during prediction.
  - `RASTERVISION_PREDICT_NUM_WORKERS` - `num_workers` to pass to the PyTorch `DataLoader` during prediction.
- refactors code so that these env variables (as well as the previously added `RASTERVISION_USE_ONNX`) are accessed through `RVConfig`.
  - This means that these variables can also be set in the [`.rastervision` profile](https://docs.rastervision.io/en/stable/setup/configure.html#profiles).

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A