### PR TITLE
Add a `predict_scene` CLI command that makes predictions on a scene specified by a `SceneConfig`

### DIFF
--- a/docs/framework/cli.rst
+++ b/docs/framework/cli.rst
@@ -13,7 +13,7 @@ It has a main command, with some top level options, and several subcommands.
 
    > rastervision --help
 
-    Usage: rastervision [OPTIONS] COMMAND [ARGS]...
+    Usage: python -m rastervision.pipeline.cli [OPTIONS] COMMAND [ARGS]...
 
     The main click command.
 
@@ -26,17 +26,18 @@ It has a main command, with some top level options, and several subcommands.
     --help              Show this message and exit.
 
     Commands:
-    predict      Use a model bundle to predict on new images.
-    run          Run sequence of commands within pipeline(s).
-    run_command  Run an individual command within a pipeline.
+    predict        Use a model bundle to predict on new images.
+    predict_scene  Use a model bundle to predict on a new scene.
+    run            Run sequence of commands within pipeline(s).
+    run_command    Run an individual command within a pipeline.
 
 Subcommands
 ------------
 
 .. _run cli command:
 
-run
-^^^
+``run``
+^^^^^^^
 
 Run is the main interface into running pipelines.
 
@@ -69,15 +70,15 @@ Some specific parameters to call out:
 
 .. _split cli option:
 
--\\-splits
-~~~~~~~~~~
+``--splits``
+~~~~~~~~~~~~
 
 Use ``-s N`` or ``--splits N``, where ``N`` is the number of splits to create, to parallelize commands that can be split into parallelizable chunks. See :ref:`parallelizing commands` for more information.
 
 .. _run_command cli command:
 
-run_command
-^^^^^^^^^^^
+``run_command``
+^^^^^^^^^^^^^^^
 
 The ``run_command`` is used to run a specific command from a serialized ``PipelineConfig`` JSON file.
 This is likely only interesting to people writing :ref:`custom runners <runners>`.
@@ -86,7 +87,8 @@ This is likely only interesting to people writing :ref:`custom runners <runners>
 
     > rastervision run_command --help
 
-    Usage: rastervision run_command [OPTIONS] CFG_JSON_URI COMMAND
+    Usage: python -m rastervision.pipeline.cli run_command [OPTIONS] CFG_JSON_URI
+                                                        COMMAND
 
     Run a single COMMAND using a serialized PipelineConfig in CFG_JSON_URI.
 
@@ -99,8 +101,8 @@ This is likely only interesting to people writing :ref:`custom runners <runners>
 
 .. _predict cli command:
 
-predict
-^^^^^^^
+``predict``
+^^^^^^^^^^^
 
 Use ``predict`` to make predictions on new imagery given a :ref:`model bundle <model bundle>`.
 
@@ -108,15 +110,44 @@ Use ``predict`` to make predictions on new imagery given a :ref:`model bundle <m
 
     > rastervision predict --help
 
-    Usage: rastervision predict [OPTIONS] MODEL_BUNDLE IMAGE_URI LABEL_URI
+    Usage: python -m rastervision.pipeline.cli predict [OPTIONS] MODEL_BUNDLE
+                                                    IMAGE_URI LABEL_URI
 
-    Make predictions on the images at IMAGE_URI using MODEL_BUNDLE and store
-    the prediction output at LABEL_URI.
+    Make predictions on the images at IMAGE_URI using MODEL_BUNDLE and store the
+    prediction output at LABEL_URI.
 
     Options:
-    -a, --update-stats       Run an analysis on this individual image, as
-                            opposed to using any analysis like statistics that
-                            exist in the prediction package
-    --channel-order TEXT     List of indices comprising channel_order. Example:
-                            2 1 0
-    --help                   Show this message and exit.
+    -a, --update-stats    Run an analysis on this individual image, as opposed
+                            to using any analysis like statistics that exist in
+                            the prediction package
+    --channel-order LIST  List of indices comprising channel_order. Example: 2 1
+                            0
+    --scene-group TEXT    Name of the scene group whose stats will be used by
+                            the StatsTransformer. Requires the stats for this
+                            scene group to be present inside the bundle.
+    --help                Show this message and exit.
+
+
+``predict_scene``
+^^^^^^^^^^^^^^^^^
+
+Similar to ``predict`` but allows greater control by allowing the user to specify a full :class:`.SceneConfig` and :class:`.PredictOptions`.
+
+.. code-block:: console
+
+    > rastervision predict_scene --help
+
+    Usage: python -m rastervision.pipeline.cli predict_scene [OPTIONS]
+                                                            MODEL_BUNDLE_URI
+                                                            SCENE_CONFIG_URI
+
+    Use a model-bundle to make predictions on a scene.
+
+    MODEL_BUNDLE_URI    URI to a serialized Raster Vision model-bundle.
+    SCENE_CONFIG_URI    URI to a serialized Raster Vision SceneConfig.
+
+    Options:
+    --predict_options_uri TEXT  Optional URI to serialized Raster Vision
+                                PredictOptions config.
+    --help                      Show this message and exit.
+

--- a/rastervision_core/rastervision/core/__init__.py
+++ b/rastervision_core/rastervision/core/__init__.py
@@ -3,8 +3,9 @@
 
 def register_plugin(registry):
     registry.set_plugin_version('rastervision.core', 10)
-    from rastervision.core.cli import predict
+    from rastervision.core.cli import predict, predict_scene
     registry.add_plugin_command(predict)
+    registry.add_plugin_command(predict_scene)
 
 
 import rastervision.pipeline

--- a/rastervision_core/rastervision/core/backend/backend.py
+++ b/rastervision_core/rastervision/core/backend/backend.py
@@ -1,5 +1,5 @@
+from typing import TYPE_CHECKING, Optional
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
 from contextlib import AbstractContextManager
 
 if TYPE_CHECKING:
@@ -42,8 +42,12 @@ class Backend(ABC):
         pass
 
     @abstractmethod
-    def load_model(self):
-        """Load the model in preparation for one or more prediction calls."""
+    def load_model(self, uri: Optional[str] = None):
+        """Load the model in preparation for one or more prediction calls.
+
+        Args:
+            uri: Optional URI to load the model from.
+        """
         pass
 
     @abstractmethod

--- a/rastervision_core/rastervision/core/cli.py
+++ b/rastervision_core/rastervision/core/cli.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 import click
 
 from rastervision.pipeline.file_system import get_tmp_dir
-from rastervision.core.predictor import Predictor
+from rastervision.core.predictor import Predictor, ScenePredictor
 
 
 # https://stackoverflow.com/questions/48391777/nargs-equivalent-for-options-in-click
@@ -80,3 +80,26 @@ def predict(model_bundle: str,
         predictor = Predictor(model_bundle, tmp_dir, update_stats,
                               channel_order, scene_group)
         predictor.predict([image_uri], label_uri)
+
+
+@click.command(
+    'predict_scene',
+    short_help='Use a model bundle to predict on a new scene.')
+@click.argument('model_bundle_uri')
+@click.argument('scene_config_uri')
+@click.option(
+    '--predict_options_uri',
+    type=str,
+    default=None,
+    help='Optional URI to serialized Raster Vision PredictOptions config.')
+def predict_scene(model_bundle_uri: str,
+                  scene_config_uri: str,
+                  predict_options_uri: Optional[str] = None):
+    """Use a model-bundle to make predictions on a scene.
+
+    \b
+    MODEL_BUNDLE_URI    URI to a serialized Raster Vision model-bundle.
+    SCENE_CONFIG_URI    URI to a serialized Raster Vision SceneConfig.
+    """
+    predictor = ScenePredictor(model_bundle_uri, predict_options_uri)
+    predictor.predict(scene_config_uri)

--- a/rastervision_core/rastervision/core/predictor.py
+++ b/rastervision_core/rastervision/core/predictor.py
@@ -46,10 +46,10 @@ class Predictor():
         self.model_loaded = False
 
         bundle_path = download_if_needed(model_bundle_uri)
-        bundle_dir = join(tmp_dir, 'bundle')
-        unzip(bundle_path, bundle_dir)
+        self.bundle_dir = join(tmp_dir, 'bundle')
+        unzip(bundle_path, self.bundle_dir)
 
-        config_path = join(bundle_dir, 'pipeline-config.json')
+        config_path = join(self.bundle_dir, 'pipeline-config.json')
         config_dict = file_to_json(config_path)
         rv_config.set_everett_config(
             config_overrides=config_dict.get('rv_config'))
@@ -74,11 +74,11 @@ class Predictor():
                         f'Using stats for scene group "{t.scene_group}". '
                         'To use a different scene group, specify '
                         '--scene-group <scene-group-name>.')
-            t.update_root(bundle_dir)
+            t.update_root(self.bundle_dir)
 
         if self.update_stats:
             stats_analyzer = StatsAnalyzerConfig(
-                output_uri=join(bundle_dir, 'stats.json'))
+                output_uri=join(self.bundle_dir, 'stats.json'))
             self.config.analyzers = [stats_analyzer]
 
         self.scene.label_source = None
@@ -87,7 +87,7 @@ class Predictor():
         self.config.dataset.train_scenes = [self.scene]
         self.config.dataset.validation_scenes = [self.scene]
         self.config.dataset.test_scenes = []
-        self.config.train_uri = bundle_dir
+        self.config.train_uri = self.bundle_dir
 
         if channel_order is not None:
             self.scene.raster_source.channel_order = channel_order
@@ -109,6 +109,8 @@ class Predictor():
             if not hasattr(self.pipeline, 'predict'):
                 raise Exception(
                     'pipeline in model bundle must have predict method')
+            self.pipeline.build_backend(
+                join(self.bundle_dir, 'model-bundle.zip'))
 
         self.scene.raster_source.uris = image_uris
         self.scene.label_store.uri = label_uri

--- a/rastervision_core/rastervision/core/predictor.py
+++ b/rastervision_core/rastervision/core/predictor.py
@@ -4,8 +4,8 @@ import logging
 
 from rastervision.pipeline import rv_config_ as rv_config
 from rastervision.pipeline.config import (build_config, upgrade_config)
-from rastervision.pipeline.file_system.utils import (download_if_needed,
-                                                     file_to_json, unzip)
+from rastervision.pipeline.file_system.utils import (
+    download_if_needed, file_to_json, get_tmp_dir, unzip)
 from rastervision.core.data.raster_source import ChannelOrderError
 from rastervision.core.data import (SemanticSegmentationLabelStoreConfig,
                                     PolygonVectorOutputConfig,
@@ -13,7 +13,7 @@ from rastervision.core.data import (SemanticSegmentationLabelStoreConfig,
 from rastervision.core.analyzer import StatsAnalyzerConfig
 
 if TYPE_CHECKING:
-    from rastervision.core.rv_pipeline import RVPipelineConfig
+    from rastervision.core.rv_pipeline import RVPipeline, RVPipelineConfig
     from rastervision.core.data import SceneConfig
 
 log = logging.getLogger(__name__)
@@ -133,3 +133,57 @@ class Predictor():
                 'with channels unavailable in the imagery.\nTo set a new '
                 'channel_order that only uses channels available in the '
                 'imagery, use the --channel-order option.')
+
+
+class ScenePredictor:
+    """Class for making predictions on a scen using a model-bundle."""
+
+    def __init__(self,
+                 model_bundle_uri: str,
+                 predict_options_uri: Optional[str] = None,
+                 tmp_dir: Optional[str] = None):
+        """Creates a new Predictor.
+
+        Args:
+            model_bundle_uri: URI of the model bundle to use. Can be any
+                type of URI that Raster Vision can read.
+            tmp_dir: Temporary directory in which to store files that are used
+                by the Predictor.
+        """
+        self.tmp_dir = tmp_dir
+        if self.tmp_dir is None:
+            self._tmp_dir = get_tmp_dir()
+            self.tmp_dir = self._tmp_dir.name
+
+        bundle_path = download_if_needed(model_bundle_uri)
+        bundle_dir = join(self.tmp_dir, 'bundle')
+        unzip(bundle_path, bundle_dir)
+
+        pipeline_config_path = join(bundle_dir, 'pipeline-config.json')
+        pipeline_config_dict = file_to_json(pipeline_config_path)
+
+        if predict_options_uri is not None:
+            pred_opts_config_dict = file_to_json(predict_options_uri)
+            pipeline_config_dict['predict_options'] = pred_opts_config_dict
+
+        rv_config.set_everett_config(
+            config_overrides=pipeline_config_dict.get('rv_config'))
+        pipeline_config_dict = upgrade_config(pipeline_config_dict)
+        self.pipeline_config: 'RVPipelineConfig' = build_config(
+            pipeline_config_dict)
+
+        self.pipeline: 'RVPipeline' = self.pipeline_config.build(self.tmp_dir)
+        self.pipeline.build_backend(join(bundle_dir, 'model-bundle.zip'))
+
+    def predict(self, scene_config_uri: str) -> None:
+        """Generate predictions for the given image.
+
+        Args:
+            scene_config_uri: URI to a serialized :class:`.ScenConfig`.
+        """
+        scene_config_dict = file_to_json(scene_config_uri)
+        scene_config: 'SceneConfig' = build_config(scene_config_dict)
+        class_config = self.pipeline_config.dataset.class_config
+        scene = scene_config.build(class_config, self.tmp_dir)
+        labels = self.pipeline.predict_scene(scene)
+        scene.label_store.save(labels)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend.py
@@ -119,13 +119,14 @@ class PyTorchLearnerBackend(Backend):
             learner = self.learner_cfg.build(self.tmp_dir, training=True)
         learner.main()
 
-    def load_model(self):
-        self.learner = self._build_learner_from_bundle(training=False)
+    def load_model(self, uri: Optional[str] = None):
+        self.learner = self._build_learner_from_bundle(
+            bundle_uri=uri, training=False)
 
     def _build_learner_from_bundle(self,
-                                   bundle_uri=None,
-                                   cfg=None,
-                                   training=False):
+                                   bundle_uri: Optional[str] = None,
+                                   cfg: Optional['LearnerConfig'] = None,
+                                   training: bool = False):
         if bundle_uri is None:
             bundle_uri = self.learner_cfg.get_model_bundle_uri()
         return Learner.from_model_bundle(

--- a/tests/pytorch_backend/examples/test_tiny_spacenet.py
+++ b/tests/pytorch_backend/examples/test_tiny_spacenet.py
@@ -1,11 +1,15 @@
 import unittest
+from os.path import join
 import shutil
 
 from click.testing import CliRunner
 
 from rastervision.pipeline.cli import main
-from rastervision.pipeline.file_system.utils import get_tmp_dir
-from rastervision.core.cli import predict
+from rastervision.pipeline.file_system.utils import get_tmp_dir, json_to_file
+from rastervision.core.cli import predict, predict_scene
+from rastervision.core.data import (RasterioSourceConfig, SceneConfig,
+                                    SemanticSegmentationLabelStoreConfig)
+from rastervision.core.rv_pipeline import SemanticSegmentationPredictOptions
 
 from tests import data_file_path
 
@@ -18,7 +22,8 @@ class TestTinySpacenet(unittest.TestCase):
             'run', 'inprocess',
             'rastervision.pytorch_backend.examples.tiny_spacenet'
         ])
-        self.assertEqual(result.exit_code, 0)
+        if result.exit_code != 0:
+            raise result.exception
 
         # test predict command
         bundle_path = '/opt/data/output/tiny_spacenet/bundle/model-bundle.zip'
@@ -28,7 +33,29 @@ class TestTinySpacenet(unittest.TestCase):
                 bundle_path, img_path, tmp_dir, '--channel-order', '0', '1',
                 '2'
             ])
-        self.assertEqual(result.exit_code, 0)
+        if result.exit_code != 0:
+            raise result.exception
+
+        # test predict_scene command
+        bundle_path = '/opt/data/output/tiny_spacenet/bundle/model-bundle.zip'
+        img_path = data_file_path('small-rgb-tile.tif')
+        with get_tmp_dir() as tmp_dir:
+            pred_uri = join(tmp_dir, 'pred')
+            rs_cfg = RasterioSourceConfig(uris=img_path)
+            ls_cfg = SemanticSegmentationLabelStoreConfig(uri=pred_uri)
+            scene_cfg = SceneConfig(
+                id='', raster_source=rs_cfg, label_store=ls_cfg)
+            pred_opts = SemanticSegmentationPredictOptions()
+            scene_config_uri = join(pred_uri, 'scene-config.json')
+            json_to_file(scene_cfg.dict(), scene_config_uri)
+            pred_opts_uri = join(pred_uri, 'predict-options.json')
+            json_to_file(pred_opts.dict(), pred_opts_uri)
+            result = runner.invoke(predict_scene, [
+                bundle_path, scene_config_uri, '--predict_options_uri',
+                pred_opts_uri
+            ])
+        if result.exit_code != 0:
+            raise result.exception
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Overview

This PR adds a new `predict_scene` CLI command as an alternative to the existing `predict` command. Unlike the `predict` command, which (inelegantly) overwrites URIs in the config from the bundle, `predict_scene` allows the user to precisely specify how the image is to be read and predictions written by specifying a full `SceneConfig`.

The intended usage is as follows:
- Define a `SceneConfig`:
  ```py
  scene_config = SceneConfig(raster_source=..., label_store=...)
  ```
- Save it to file:
  ```py
  from rastervision.pipeline.file_system.utils import json_to_file
  scene_config_uri = '...'
  json_to_file(scene_config.dict(), scene_config_uri)
  ```
- (Optional) Define and save `PredictOptions` to file:
  ```py
  from rastervision.core.rv_pipeline import SemanticSegmentationPredictOptions
  pred_options = SemanticSegmentationPredictOptions(...)
  pred_opts_uri = '...'
  json_to_file(pred_options.dict(), pred_opts_uri)
  ```
- Run the command:
  ```sh
  rastervision predict_scene <model_bundle_uri> <scene_config_uri> [--predict_options_uri <predict_options_uri>]
  ```

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A.

## Testing Instructions

* See updated unit tests.