### PR TITLE
Add a `.run_command()` method to `Runner`s

### DIFF
--- a/rastervision_aws_batch/rastervision/aws_batch/__init__.py
+++ b/rastervision_aws_batch/rastervision/aws_batch/__init__.py
@@ -18,5 +18,4 @@ from rastervision.aws_batch.aws_batch_runner import *
 __all__ = [
     'AWS_BATCH',
     AWSBatchRunner.__name__,
-    submit_job.__name__,
 ]

--- a/rastervision_pipeline/rastervision/pipeline/runner/inprocess_runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/inprocess_runner.py
@@ -1,3 +1,4 @@
+from typing import List
 from rastervision.pipeline.cli import _run_command
 from rastervision.pipeline.runner.runner import Runner
 
@@ -23,3 +24,7 @@ class InProcessRunner(Runner):
                     _run_command(cfg_json_uri, command, split_ind, num_splits)
             else:
                 _run_command(cfg_json_uri, command, 0, 1)
+
+    def run_command(self, cmd: List[str]):
+        raise NotImplementedError(
+            'Use LocalRunner.run_command to run a command locally.')

--- a/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/local_runner.py
@@ -55,7 +55,10 @@ class LocalRunner(Runner):
         makefile_path = join(dirname(cfg_json_uri), 'Makefile')
         str_to_file(makefile, makefile_path)
         makefile_path_local = download_if_needed(makefile_path)
-        process = Popen(['make', '-j', '-f', makefile_path_local])
+        return self.run_command(['make', '-j', '-f', makefile_path_local])
+
+    def run_command(self, cmd: List[str]):
+        process = Popen(cmd)
         terminate_at_exit(process)
         exitcode = process.wait()
         if exitcode != 0:

--- a/rastervision_pipeline/rastervision/pipeline/runner/runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/runner.py
@@ -28,6 +28,15 @@ class Runner():
         """
         pass
 
+    @abstractmethod
+    def run_command(self, cmd: List[str]):
+        """Run a single command.
+
+        Args:
+            cmd: Command to run in the Docker container for the remote job as list
+                of strings.
+        """
+
     def get_split_ind(self) -> Optional[int]:
         """Get the split_ind for the process.
 

--- a/rastervision_pipeline/rastervision/pipeline/runner/runner.py
+++ b/rastervision_pipeline/rastervision/pipeline/runner/runner.py
@@ -33,8 +33,7 @@ class Runner():
         """Run a single command.
 
         Args:
-            cmd: Command to run in the Docker container for the remote job as list
-                of strings.
+            cmd: The command to run.
         """
 
     def get_split_ind(self) -> Optional[int]:


### PR DESCRIPTION
## Overview

This PR adds a `.run_command()` method to all `Runner`s. The main motivation is to make it easy to run the `predict` and `predict_scene` commands remotely.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A