### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,29 @@
 ## Overview
 
-Brief description of what this PR does, and why it is needed.
+<!-- Brief description of what the PR does and why it is needed. -->
+
+This PR ...
 
 ### Checklist
 
-- [ ] Added `needs-backport` label if PR is bug fix that applies to previous minor release
-- [ ] Ran scripts/format_code and committed any changes
-- [ ] Documentation updated if needed
+- [ ] Added unit tests, if applicable
+- [ ] Updated documentation, if applicable
+- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
 - [ ] PR has a name that won't get you publicly shamed for vagueness
 
 ### Notes
 
-Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+<!-- (Optional) Ancillary topics, caveats, alternative strategies that didn't work out, anything else. -->
+
 
 ## Testing Instructions
 
+<!--
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as rebuilding the Docker image.
 * Include test case, and expected output if not captured by automated tests.
+-->
 
 Closes #XXX


### PR DESCRIPTION
## Overview

This PR updates the GitHub PR template.

### Checklist

- [x] Added `needs-backport` label if PR is bug fix that applies to previous minor release
- [x] Ran scripts/format_code and committed any changes
- [x] Documentation updated if needed
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A