### PR TITLE
Add Apple Silicon GPU Acceleration

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -144,8 +144,15 @@ class Learner(ABC):
             self._tmp_dir = get_tmp_dir()
             tmp_dir = self._tmp_dir.name
         self.tmp_dir = tmp_dir
-        self.device = torch.device('cuda'
-                                   if torch.cuda.is_available() else 'cpu')
+        
+        if torch.backends.mps.is_available():
+            DEFAULT_DEVICE = "mps"
+        elif torch.cuda.is_available():
+            DEFAULT_DEVICE = "cuda"
+        else:
+            DEFAULT_DEVICE = "cpu"
+        
+        self.device = torch.device(DEFAULT_DEVICE)
 
         self.train_ds = train_ds
         self.valid_ds = valid_ds

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -144,15 +144,15 @@ class Learner(ABC):
             self._tmp_dir = get_tmp_dir()
             tmp_dir = self._tmp_dir.name
         self.tmp_dir = tmp_dir
-        
-        if torch.backends.mps.is_available():
-            DEFAULT_DEVICE = "mps"
-        elif torch.cuda.is_available():
-            DEFAULT_DEVICE = "cuda"
+
+        if torch.cuda.is_available():
+            device = 'cuda'
+        elif torch.backends.mps.is_available():
+            device = 'mps'
         else:
-            DEFAULT_DEVICE = "cpu"
-        
-        self.device = torch.device(DEFAULT_DEVICE)
+            device = 'cpu'
+
+        self.device = torch.device(device)
 
         self.train_ds = train_ds
         self.valid_ds = valid_ds


### PR DESCRIPTION
## Overview

This PR introduces support for Apple Silicon GPU Acceleration by leveraging the Metal Performance Shaders (MPS) backend. This enhancement ensures that our PyTorch-based machine learning and deep learning workloads can take full advantage of the GPU capabilities provided by the Apple M1 and newer chips, significantly improving computational performance and efficiency.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [ ] PR has a name that won't get you publicly shamed for vagueness


<!--
* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.
-->

