### PR TITLE
Allow `ChipClassificationLabelSource` to load scores, if available, when reading labels

### DIFF
--- a/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source.py
@@ -113,9 +113,13 @@ def read_labels(labels_df: gpd.GeoDataFrame,
     if bbox is not None:
         boxes = [b for b in boxes if b.intersects(bbox)]
     class_ids = labels_df['class_id'].astype(int)
+    if 'scores' in labels_df.columns:
+        scores = labels_df['scores']
+    else:
+        scores = [None] * len(class_ids)
     cells_to_class_id = {
-        cell: (class_id, None)
-        for cell, class_id in zip(boxes, class_ids)
+        cell: (class_id, class_scores)
+        for cell, class_id, class_scores in zip(boxes, class_ids, scores)
     }
     labels = ChipClassificationLabels(cells_to_class_id)
     return labels


### PR DESCRIPTION
## Overview

<!-- Brief description of what the PR does and why it is needed. -->

This PR Allow `ChipClassificationLabelSource` to load scores if available when reading labels from a vector source.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

<!-- (Optional) Ancillary topics, caveats, alternative strategies that didn't work out, anything else. -->
N/A

## Testing Instructions

Covered by existing unit tests.