### PR TITLE
Remove the `typing_extensions` dependency

### DIFF
--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -1,6 +1,5 @@
-from typing import (TYPE_CHECKING, Callable, Dict, List, Optional, Sequence,
-                    Tuple, Union)
-from typing_extensions import Literal
+from typing import (TYPE_CHECKING, Callable, Dict, List, Literal, Optional,
+                    Sequence, Tuple, Union)
 from pydantic import PositiveInt as PosInt, conint
 import math
 import random

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
@@ -1,5 +1,4 @@
-from typing import (List, Optional, Union)
-from typing_extensions import Literal
+from typing import (List, Literal, Optional, Union)
 from pydantic import conint
 from enum import Enum
 

--- a/rastervision_pipeline/rastervision/pipeline/config.py
+++ b/rastervision_pipeline/rastervision/pipeline/config.py
@@ -1,12 +1,11 @@
-from typing import List, Type, Union, Optional, Callable, Dict, TYPE_CHECKING
+from typing import (TYPE_CHECKING, Callable, Dict, List, Literal, Optional,
+                    Type, Union)
 import inspect
 import logging
 
 from pydantic import (  # noqa
     BaseModel, create_model, Field, root_validator, validate_model,
     ValidationError, validator)
-
-from typing_extensions import Literal
 
 from rastervision.pipeline import (registry_ as registry, rv_config_ as
                                    rv_config)

--- a/rastervision_pipeline/requirements.txt
+++ b/rastervision_pipeline/requirements.txt
@@ -1,6 +1,5 @@
 click==8.1.3
 pydantic==1.10.7
-typing_extensions==4.6.3
 everett==3.2.0
 everett[ini]==3.2.0
 six==1.16.*

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
@@ -1,5 +1,4 @@
-from typing import Union, Optional, Tuple, Any, TypeVar
-from typing_extensions import Literal
+from typing import Any, Literal, Optional, Tuple, TypeVar, Union
 import logging
 
 import numpy as np

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -1,6 +1,5 @@
 from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterator, List,
-                    Optional, Tuple, Union, Type)
-from typing_extensions import Literal
+                    Literal, Optional, Tuple, Union, Type)
 from abc import ABC, abstractmethod
 from os.path import join, isfile, basename, isdir
 import warnings

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -5,8 +5,7 @@ import uuid
 import logging
 
 from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, List,
-                    Optional, Sequence, Tuple, Union)
-from typing_extensions import Literal
+                    Literal, Optional, Sequence, Tuple, Union)
 from pydantic import (PositiveFloat, PositiveInt as PosInt, constr, confloat,
                       conint)
 from pydantic.utils import sequence_like


### PR DESCRIPTION
## Overview

This PR removes the `typing_extensions` dependency since it is no longer needed.

It was only used for the `Literal` type, but its `Literal` type is identical to `typing.Literal` for newer versions of Python.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A
