### PR TITLE
Add support for distributed training (multi-node and multi-GPU) via PyTorch DDP

### DIFF
--- a/docs/setup/gpu.rst
+++ b/docs/setup/gpu.rst
@@ -3,7 +3,7 @@
 Using GPUs
 ==========
 
-To run Raster Vision on a realistic dataset in a reasonable amount of time, it is necessary to use a machine with a GPU. Note that Raster Vision will use a GPU if it detects that one is available. 
+To run Raster Vision on a realistic dataset in a reasonable amount of time, it is necessary to use a machine with one or more GPUs. Note that Raster Vision will automatically use all available GPUs.
 
 If you don't own a machine with a GPU, it is possible to rent one by the minute using a cloud provider such as AWS. See :doc:`aws`.
 
@@ -18,14 +18,7 @@ One way to check this is to make sure PyTorch can see the GPU(s). To do this, op
 
     import torch
     torch.cuda.is_available()
-    torch.cuda.get_device_name(0)
-
-This should print out something like:
-
-.. code-block:: console
-
-    True
-    Tesla K80
+    torch.cuda.device_count()
 
 If you have `nvidia-smi <https://developer.nvidia.com/nvidia-system-management-interface>`_  installed, you can also use this command to inspect GPU utilization while the training job is running:
 
@@ -40,10 +33,44 @@ If you would like to run Raster Vision in a Docker container with GPUs, you'll n
 
 First, you'll need to install the `nvidia-docker <https://github.com/NVIDIA/nvidia-docker>`_ runtime on your system. Follow their `Quickstart <https://github.com/NVIDIA/nvidia-docker#quickstart>`_ and installation instructions. Make sure that your GPU is supported by NVIDIA Docker - if not you might need to find another way to have your Docker container communicate with the GPU. If you figure out how to support more GPUs, please let us know so we can add the steps to this documentation!
 
-When running your Docker container, be sure to include the ``--runtime=nvidia`` option, e.g.
+When running your Docker container, be sure to include the ``--gpus=all`` option, e.g.
 
 .. code-block:: console
 
-   > docker run --runtime=nvidia --rm -it quay.io/azavea/raster-vision:pytorch-{{ version }} /bin/bash
+   > docker run --gpus=all --rm -it quay.io/azavea/raster-vision:pytorch-{{ version }} /bin/bash
 
 or use the ``--gpu`` option with the ``docker/run`` script.
+
+.. _distributed:
+
+Using multiple GPUs (distributed training)
+------------------------------------------
+
+Raster Vision supports distributed training (multi-node and multi-GPU) via `PyTorch DDP <https://pytorch.org/docs/master/notes/ddp.html>`_.
+
+It can be used in the following ways:
+
+- Run Raster Vision normally on a multi-GPU machine. Raster Vision will automatically detect the multiple GPU and use distributed training when ``Learner.train()`` is called. 
+- Run Raster Vision using the `torchrun CLI command <https://pytorch.org/docs/stable/elastic/run.html>`_. For example, to run on a single machine with 4 GPUs:
+
+  .. code-block:: console
+
+     torchrun --standalone --nnodes=1 --nproc-per-node=4 --no-python \
+        rastervision run local rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
+
+Other considerations
+~~~~~~~~~~~~~~~~~~~~
+
+- Config variables that may be :ref:`set via environment or RV config <raster vision config>` (also documented `here <https://raster-vision--2018.org.readthedocs.build/en/2018/api_reference/_generated/rastervision.pytorch_learner.learner.Learner.html#learner>`_):
+
+  - ``RASTERVISION_USE_DDP``: ``YES`` by default. Set to ``NO`` to disable distributed training.
+  - ``RASTERVISION_DDP_BACKEND``: ``nccl`` by default. This is the recommended backend for CUDA GPUs.
+  - ``RASTERVISION_DDP_START_METHOD``: One of ``spawn``, ``fork``, or ``forkserver``. Passed to :func:`torch.multiprocessing.start_processes`. Default: ``spawn``.
+
+    - ``spawn`` is what PyTorch documentation recommends (in fact, it doesn't even mention the alternatives), but it has the disadvantage that it requires everything to be pickleable, which rasterio dataset objects are not. This is also true for ``forkserver``, which needs to spawn a server process. However, ``fork`` does not have the same limitation.
+    - If not ``fork``, we avoid building the dataset in the base process and instead delay it until the worker processes are created.
+    - If ``fork`` or ``forkserver``, the CUDA runtime must not be initialized before the fork happens; otherwise, a ``RuntimeError: Cannot re-initialize CUDA in forked subprocess.`` error will be raised. We avoid this by not calling any ``torch.cuda`` functions or creating tensors on the GPU.
+    
+- To avoid having to re-download files for each process when building datasets, it is recommended to :meth:`manually specify a temporary directory <.RVConfig.set_tmp_dir_root>` (otherwise each process will use a separate randomly generated temporary directory). When a single temp directory is set, to avoid IO conflicts, Raster Vision first builds the datasets only in the master process (rank = 0) and only after in the other processes, so that they use the already downloaded files.
+- A similar problem also occurs when downloading external models/losses, but in this case, the strategy of building on the master first does not work. The model apparently needs to be created by the same line of code on each process. Therefore, we need to download files separately for each process; we do this by modifying ``TORCH_HOME`` to ``$TORCH_HOME/<local rank>``. And only the master process copies the downloaded files to the training directory.
+- Raster Vision will use all available GPUs by default. To override, set the ``WORLD_SIZE`` env var.

--- a/rastervision_pipeline/rastervision/pipeline/rv_config.py
+++ b/rastervision_pipeline/rastervision/pipeline/rv_config.py
@@ -80,10 +80,10 @@ class RVConfig:
 
         To set the value, the following rules are used in decreasing priority:
 
-        1) the tmp_dir_root argument if it is not None
-        2) an environment variable (TMPDIR, TEMP, or TMP)
-        3) a default temporary directory which is
-        4) a directory returned by tempfile.TemporaryDirectory()
+        1) the ``tmp_dir_root`` argument if it is not ``None``
+        2) an environment variable (``TMPDIR``, ``TEMP``, or ``TMP``)
+        3) a default temporary directory which is a directory returned by
+           :class:`tempfile.TemporaryDirectory`
         """
         # Check the various possibilities in order of priority.
         env_arr = [

--- a/rastervision_pipeline/rastervision/pipeline/rv_config.py
+++ b/rastervision_pipeline/rastervision/pipeline/rv_config.py
@@ -207,7 +207,7 @@ class RVConfig:
                              namespace: str,
                              key: str,
                              default: Optional[Any] = None,
-                             as_bool: bool = False) -> str:
+                             as_bool: bool = False) -> Optional[Any]:
         """Get the value of an option from a namespace."""
         namespace_options = self.config.with_namespace(namespace)
         try:
@@ -217,7 +217,7 @@ class RVConfig:
             return val
         except ConfigurationMissingError:
             if as_bool:
-                return False
+                return bool(default)
             return default
 
     def get_config_dict(

--- a/rastervision_pipeline/rastervision/pipeline/utils.py
+++ b/rastervision_pipeline/rastervision/pipeline/utils.py
@@ -1,4 +1,5 @@
-from typing import Any
+from typing import Any, Callable, Optional
+import os
 import atexit
 import logging
 from math import ceil
@@ -45,3 +46,13 @@ def repr_with_args(obj: Any, **kwargs) -> str:
     arg_strs = [f'{k}={v!r}' for k, v in kwargs.items()]
     arg_str = ', '.join(arg_strs)
     return f'{cls}({arg_str})'
+
+
+def get_env_var(key: str,
+                default: Optional[Any] = None,
+                out_type: Optional[type | Callable] = None) -> Optional[Any]:
+    val = os.environ.get(key, default)
+    if val is not None and out_type is not None:
+        if out_type == bool:
+            return val.lower() in ('1', 'true', 'y', 'yes')
+        return out_type(val)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
@@ -39,7 +39,8 @@ class RegressionLearner(Learner):
             hubconf_dir=model_def_path,
             class_names=class_names,
             pos_class_names=pos_class_names,
-            prob_class_names=prob_class_names)
+            prob_class_names=prob_class_names,
+            ddp_rank=self.ddp_local_rank)
         return model
 
     def on_overfit_start(self):
@@ -75,8 +76,8 @@ class RegressionLearner(Learner):
     def prob_to_pred(self, x):
         return x
 
-    def eval_model(self, split):
-        super().eval_model(split)
+    def _validate(self, split):
+        super()._validate(split)
 
         y, out = self.predict_dataloader(
             self.get_dataloader(split), return_format='yz', raw_out=False)

--- a/tests/pytorch_learner/utils/test_torch_hub.py
+++ b/tests/pytorch_learner/utils/test_torch_hub.py
@@ -72,8 +72,8 @@ class TestTorchHubUtils(unittest.TestCase):
             hubconf_dir = join(tmp_dir, 'focal_loss')
             loss = torch_hub_load_github(
                 repo='AdeelH/pytorch-multi-class-focal-loss:1.1',
-                hubconf_dir=hubconf_dir,
                 entrypoint='focal_loss',
+                dst_dir=hubconf_dir,
                 alpha=[.75, .25],
                 gamma=2)
             self.assertIsInstance(loss, nn.Module)
@@ -95,8 +95,8 @@ class TestTorchHubUtils(unittest.TestCase):
             # local, via torch_hub_load_uri
             loss = torch_hub_load_uri(
                 uri=hubconf_dir,
-                hubconf_dir=hubconf_dir,
                 entrypoint='focal_loss',
+                dst_dir=hubconf_dir,
                 alpha=[.75, .25],
                 gamma=2)
             self.assertIsInstance(loss, nn.Module)
@@ -110,8 +110,8 @@ class TestTorchHubUtils(unittest.TestCase):
             loss = torch_hub_load_uri(
                 uri=
                 'https://github.com/AdeelH/pytorch-multi-class-focal-loss/archive/refs/tags/1.1.zip',  # noqa
-                hubconf_dir=hubconf_dir,
                 entrypoint='focal_loss',
+                dst_dir=hubconf_dir,
                 alpha=[.75, .25],
                 gamma=2)
             self.assertIsInstance(loss, nn.Module)


### PR DESCRIPTION
## Overview

This PR adds support for distributed training (multi-node and multi-GPU) via [PyTorch DDP](https://pytorch.org/docs/master/notes/ddp.html). 

It can be used in the following ways:
- Run RV normally on a multi-GPU machine. RV will automatically detect the multiple GPU and use distributed training when `Learner.train()` is called. 
- Run RV using the [`torchrun` CLI command](https://pytorch.org/docs/stable/elastic/run.html). For example, to run on a single machine with 4 GPUs:
  ```sh
  torchrun --standalone --nnodes=1 --nproc-per-node=4 --no-python \
      rastervision run local rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
  ```


### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

- `Learner.eval_model()` has been renamed to `Learner.validate()`.
- New config variables that may be set via environment or RV config (also documented [here](https://raster-vision--2018.org.readthedocs.build/en/2018/api_reference/_generated/rastervision.pytorch_learner.learner.Learner.html#learner)):
  - `RASTERVISION_USE_DDP`: `YES` by default. Set to `NO` to disable distributed training.
  - `RASTERVISION_DDP_BACKEND`: `nccl` by default. This is the recommended backend for CUDA GPUs.
  - `RASTERVISION_DDP_START_METHOD`: One of `spawn`, `fork`, or `forkserver`. Default: `spawn`. 
    - `spawn` is what PyTorch documentation recommends (in fact, it doesn't even mention the alternatives), but it has the disadvantage that it requires everything to be pickleable, which rasterio dataset objects are not. This is also true for `forkserver`, which needs to spawn a server process. However, `fork` does not have the same limitation.
    - If not `fork`, we avoid building the dataset in the base process and instead delay it until the worker processes are created.
    - If `fork` or `forkserver`, the CUDA runtime must not be initialized before the fork happens; otherwise, a `RuntimeError: Cannot re-initialize CUDA in forked subprocess.` error will be raised. We avoid this by not calling any `torch.cuda` functions or creating tensors on the GPU. 
- To avoid having to re-download files for each process when building datasets, it is recommended to [manually specify a temporary directory](https://raster-vision--2018.org.readthedocs.build/en/2018/api_reference/_generated/rastervision.pipeline.rv_config.RVConfig.html#rastervision.pipeline.rv_config.RVConfig.set_tmp_dir_root) (otherwise each process will use a separate randomly generated temporary directory). When a single temp directory is set, to avoid IO conflicts, RV first builds the datasets only in the master process (rank = 0) and only after in the other processes so that they use the already downloaded files.
- A similar problem also occurs when downloading external models/losses, but in this case, the strategy of building on the master first does not work. The model apparently needs to be created by the same line of code on each process. Therefore, we need to download files separately for each process; we do this by modifying `TORCH_HOME` to `$TORCH_HOME/<local rank>`. And only the master process copies the downloaded files to the training directory.
- RV will use all available GPUs by default. To override, set the `WORLD_SIZE` env var.

## Testing Instructions
- See usage instructions above.
- It can also be tested on a single-GPU machine like so:
  ```sh
  torchrun --standalone --nnodes=1 --nproc-per-node=1 --no-python \
      rastervision run local rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
  ```
- Note: most of the lines related to distributed training are currently explicitly excluded from unit test coverage (via `# pragma: no cover`) since the CI machine does not have a GPU.



<details>

<summary>Sample output from running <code>isprs_potsdam.py</code> on a p3.8xlarge instance.</summary>

```sh
$ TMPDIR=/tmp/rv/ rastervision run local rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py \
> train \
> -a raw_uri "s3://raster-vision-ahassan/potsdam/data/raw" \
> -a root_uri "../out/potsdam" \
> -a batch_sz 32
```

```sh
python -m rastervision.pipeline.cli run_command ../out/potsdam/pipeline-config.json train
Running train command...
2024-01-04 17:39:54:rastervision.pytorch_learner.learner: INFO - Multiple GPUs detected (4), will use DDP for training.
2024-01-04 17:39:54:rastervision.pytorch_learner.learner: INFO - Using DDP
2024-01-04 17:39:54:rastervision.pytorch_learner.learner: INFO - World size: 4
2024-01-04 17:39:54:rastervision.pytorch_learner.learner: INFO - DDP start method: spawn
2024-01-04 17:39:54:rastervision.pytorch_learner.utils.utils: INFO - Physical CPUs: 16
2024-01-04 17:39:54:rastervision.pytorch_learner.utils.utils: INFO - Logical CPUs: 32
2024-01-04 17:39:54:rastervision.pytorch_learner.utils.utils: INFO - Total memory:  239.86 GB
2024-01-04 17:39:54:rastervision.pytorch_learner.utils.utils: INFO - Size of / volume:  124.01 GB
2024-01-04 17:39:54:rastervision.pytorch_learner.utils.utils: INFO - Python version: 3.10.12 | packaged by conda-forge | (main, Jun 23 2023, 22:40:32) [GCC 12.3.0]
/bin/sh: 1: nvcc: not found
2024-01-04 17:39:54:rastervision.pytorch_learner.utils.utils: INFO - 
2024-01-04 17:39:54:rastervision.pytorch_learner.utils.utils: INFO - Thu Jan  4 17:39:54 2024       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.54.03              Driver Version: 535.54.03    CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla V100-SXM2-16GB           On  | 00000000:00:1B.0 Off |                    0 |
| N/A   26C    P0              35W / 300W |      3MiB / 16384MiB |      1%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   1  Tesla V100-SXM2-16GB           On  | 00000000:00:1C.0 Off |                    0 |
| N/A   27C    P0              35W / 300W |      3MiB / 16384MiB |      1%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   2  Tesla V100-SXM2-16GB           On  | 00000000:00:1D.0 Off |                    0 |
| N/A   30C    P0              38W / 300W |      3MiB / 16384MiB |      1%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   3  Tesla V100-SXM2-16GB           On  | 00000000:00:1E.0 Off |                    0 |
| N/A   28C    P0              38W / 300W |      3MiB / 16384MiB |      1%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+

2024-01-04 17:39:54:rastervision.pytorch_learner.utils.utils: INFO - Devices:
2024-01-04 17:39:55:rastervision.pytorch_learner.utils.utils: INFO - index, name, driver_version, memory.total [MiB], memory.used [MiB], memory.free [MiB]
0, Tesla V100-SXM2-16GB, 535.54.03, 16384 MiB, 3 MiB, 16147 MiB
1, Tesla V100-SXM2-16GB, 535.54.03, 16384 MiB, 3 MiB, 16147 MiB
2, Tesla V100-SXM2-16GB, 535.54.03, 16384 MiB, 3 MiB, 16147 MiB
3, Tesla V100-SXM2-16GB, 535.54.03, 16384 MiB, 3 MiB, 16147 MiB

2024-01-04 17:39:55:rastervision.pytorch_learner.utils.utils: INFO - PyTorch version: 2.0.1+cu117
2024-01-04 17:39:55:rastervision.pytorch_learner.utils.utils: INFO - CUDA available: True
2024-01-04 17:39:55:rastervision.pytorch_learner.utils.utils: INFO - CUDA version: 11.7
2024-01-04 17:39:55:rastervision.pytorch_learner.utils.utils: INFO - CUDNN version: 8500
2024-01-04 17:39:55:rastervision.pytorch_learner.utils.utils: INFO - Number of CUDA devices: 4
2024-01-04 17:39:55:rastervision.pytorch_learner.utils.utils: INFO - Active CUDA Device: GPU 0
2024-01-04 17:39:55:rastervision.pytorch_learner.learner: INFO - model=SemanticSegmentationModelConfig(backbone=<Backbone.resnet50: 'resnet50'>, pretrained=True, init_weights=None, load_strict=True, external_def=ExternalModuleConfig(uri=None, github_repo='AdeelH/pytorch-fpn:0.3', name='fpn', entrypoint='make_fpn_resnet', entrypoint_args=[], entrypoint_kwargs={'name': 'resnet50', 'fpn_type': 'panoptic', 'num_classes': 7, 'fpn_channels': 256, 'in_channels': 3, 'out_size': [300, 300]}, force_reload=False), extra_args={}) solver=SolverConfig(lr=0.0001, num_epochs=10, test_num_epochs=2, test_batch_sz=2, overfit_num_steps=1, sync_interval=1, batch_sz=32, one_cycle=True, multi_stage=[], class_loss_weights=None, ignore_class_index=None, external_loss_def=None) data=SemanticSegmentationGeoDataConfig(scene_dataset='<20 train_scenes, 3 validation_scenes, 0 test_scenes>', window_opts="{'2_10': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '2_11': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '3_10': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '3_11': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '4_10': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '4_11': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '4_12': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '5_10': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '5_11': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '5_12': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '6_10': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '6_11': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '6_7': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '6_9': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '7_10': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '7_11': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '7_12': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '7_7': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '7_8': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '7_9': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '2_12': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '3_12': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True), '6_12': GeoDataWindowConfig(method=<GeoDataWindowMethod.sliding: 'sliding'>, size=300, stride=300, padding=None, pad_direction='end', size_lims=None, h_lims=None, w_lims=None, max_windows=10000, max_sample_attempts=100, efficient_aoi_sampling=True)}") predict_mode=False test_mode=False overfit_mode=False eval_train=False save_model_bundle=True log_tensorboard=True run_tensorboard=False output_uri='../out/potsdam/train' save_all_checkpoints=False
2024-01-04 17:39:55:rastervision.pytorch_learner.learner: INFO - Using device: cuda
2024-01-04 17:39:55:rastervision.pytorch_learner.learner: INFO - Spawning 4 DDP processes
2024-01-04 17:40:00:rastervision.pytorch_learner.learner: INFO - DDP rank: 0, DDP local rank: 0
2024-01-04 17:40:00:rastervision.pytorch_learner.learner: INFO - DDP rank: 1, DDP local rank: 1
2024-01-04 17:40:00:rastervision.pytorch_learner.learner: INFO - DDP rank: 2, DDP local rank: 2
2024-01-04 17:40:00:rastervision.pytorch_learner.learner: INFO - DDP rank: 3, DDP local rank: 3
2024-01-04 17:40:00:rastervision.pytorch_learner.learner_config: INFO - Fetching module definition from: AdeelH/pytorch-fpn:0.3
Downloading: "https://github.com/AdeelH/pytorch-fpn/zipball/0.3" to /home/ubuntu/.cache/torch/0/hub/0.3.zip
2024-01-04 17:40:00:rastervision.pytorch_learner.learner_config: INFO - Fetching module definition from: AdeelH/pytorch-fpn:0.3
Downloading: "https://github.com/AdeelH/pytorch-fpn/zipball/0.3" to /home/ubuntu/.cache/torch/1/hub/0.3.zip
2024-01-04 17:40:00:rastervision.pytorch_learner.learner_config: INFO - Fetching module definition from: AdeelH/pytorch-fpn:0.3
Downloading: "https://github.com/AdeelH/pytorch-fpn/zipball/0.3" to /home/ubuntu/.cache/torch/2/hub/0.3.zip
2024-01-04 17:40:00:rastervision.pytorch_learner.learner_config: INFO - Fetching module definition from: AdeelH/pytorch-fpn:0.3
Downloading: "https://github.com/AdeelH/pytorch-fpn/zipball/0.3" to /home/ubuntu/.cache/torch/3/hub/0.3.zip
Downloading: "https://download.pytorch.org/models/resnet50-0676ba61.pth" to /home/ubuntu/.cache/torch/2/hub/checkpoints/resnet50-0676ba61.pth
Downloading: "https://download.pytorch.org/models/resnet50-0676ba61.pth" to /home/ubuntu/.cache/torch/3/hub/checkpoints/resnet50-0676ba61.pth
Downloading: "https://download.pytorch.org/models/resnet50-0676ba61.pth" to /home/ubuntu/.cache/torch/0/hub/checkpoints/resnet50-0676ba61.pth
Downloading: "https://download.pytorch.org/models/resnet50-0676ba61.pth" to /home/ubuntu/.cache/torch/1/hub/checkpoints/resnet50-0676ba61.pth
100%|███████████████████████████████████████████████████████████████████████████████| 97.8M/97.8M [00:00<00:00, 311MB/s]
100%|███████████████████████████████████████████████████████████████████████████████| 97.8M/97.8M [00:00<00:00, 296MB/s]
100%|███████████████████████████████████████████████████████████████████████████████| 97.8M/97.8M [00:00<00:00, 289MB/s]
100%|███████████████████████████████████████████████████████████████████████████████| 97.8M/97.8M [00:00<00:00, 197MB/s]
2024-01-04 17:40:05:rastervision.pytorch_learner.learner: INFO - Building datasets ...
2024-01-04 17:40:05:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif...
2024-01-04 17:40:06:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_10_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_10_label.tif...
2024-01-04 17:40:08:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif...
2024-01-04 17:40:09:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_11_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_11_label.tif...
2024-01-04 17:40:11:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif...
2024-01-04 17:40:12:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_10_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_10_label.tif...
2024-01-04 17:40:13:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif...
2024-01-04 17:40:14:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_11_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_11_label.tif...
2024-01-04 17:40:16:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif...
2024-01-04 17:40:17:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_10_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_10_label.tif...
2024-01-04 17:40:18:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_11_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_11_RGBIR.tif...
2024-01-04 17:40:20:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_11_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_11_label.tif...
2024-01-04 17:40:21:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_12_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_12_RGBIR.tif...
2024-01-04 17:40:22:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_12_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_12_label.tif...
2024-01-04 17:40:24:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif...
2024-01-04 17:40:25:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_10_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_10_label.tif...
2024-01-04 17:40:27:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_11_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_11_RGBIR.tif...
2024-01-04 17:40:28:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_11_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_11_label.tif...
2024-01-04 17:40:29:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_12_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_12_RGBIR.tif...
2024-01-04 17:40:30:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_12_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_12_label.tif...
2024-01-04 17:40:31:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_10_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_10_RGBIR.tif...
2024-01-04 17:40:33:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_10_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_10_label.tif...
2024-01-04 17:40:34:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_11_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_11_RGBIR.tif...
2024-01-04 17:40:35:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_11_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_11_label.tif...
2024-01-04 17:40:37:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif...
2024-01-04 17:40:38:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_7_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_7_label.tif...
2024-01-04 17:40:39:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif...
2024-01-04 17:40:40:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_9_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_9_label.tif...
2024-01-04 17:40:42:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_10_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_10_RGBIR.tif...
2024-01-04 17:40:43:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_10_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_10_label.tif...
2024-01-04 17:40:44:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_11_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_11_RGBIR.tif...
2024-01-04 17:40:45:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_11_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_11_label.tif...
2024-01-04 17:40:47:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_12_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_12_RGBIR.tif...
2024-01-04 17:40:48:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_12_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_12_label.tif...
2024-01-04 17:40:49:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_7_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_7_RGBIR.tif...
2024-01-04 17:40:51:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_7_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_7_label.tif...
2024-01-04 17:40:52:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_8_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_8_RGBIR.tif...
2024-01-04 17:40:53:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_8_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_8_label.tif...
2024-01-04 17:40:54:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_9_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_9_RGBIR.tif...
2024-01-04 17:40:56:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_9_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_9_label.tif...
2024-01-04 17:40:57:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif...
2024-01-04 17:40:58:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif...
2024-01-04 17:40:59:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif...
2024-01-04 17:41:00:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif...
2024-01-04 17:41:02:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif...
2024-01-04 17:41:03:rastervision.pipeline.file_system.utils: INFO - Downloading s3://raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif to /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif...
2024-01-04 17:41:04:rastervision.pytorch_learner.learner: INFO - Building datasets ...
2024-01-04 17:41:04:rastervision.pytorch_learner.learner: INFO - Building datasets ...
2024-01-04 17:41:04:rastervision.pytorch_learner.learner: INFO - Building datasets ...
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_12_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_12_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_12_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_12_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_12_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_12_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_10_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_11_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_12_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_12_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_11_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_12_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_12_label.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_12_RGBIR.tif.
2024-01-04 17:41:04:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_10_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_10_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_10_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_10_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_10_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_11_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_11_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_10_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_11_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_11_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_11_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_11_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_7_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_7_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_7_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_9_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_9_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_10_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_10_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_9_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_10_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_10_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_10_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_11_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_11_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_10_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_11_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_11_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_11_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_11_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_7_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_7_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_7_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_7_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_8_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_8_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_7_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_8_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_8_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_7_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_9_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_9_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_8_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_9_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_9_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_8_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_9_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_9_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif.
2024-01-04 17:41:05:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif.
2024-01-04 17:41:05:rastervision.pytorch_learner.learner: INFO - epoch: 0
2024-01-04 17:41:05:rastervision.pytorch_learner.learner: INFO - epoch: 0
2024-01-04 17:41:05:rastervision.pytorch_learner.learner: INFO - epoch: 0
2024-01-04 17:41:05:rastervision.pytorch_learner.learner: INFO - epoch: 0
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:39<00:00,  6.25it/s]
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:39<00:00,  6.25it/s]
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:39<00:00,  6.25it/s]
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:39<00:00,  6.25it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.17it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.72it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.86it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.24it/s]
2024-01-04 17:41:49:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 0,
 'train_loss': 0.7272279262542725,
 'train_time': '0:00:39.988764',
 'val_loss': 0.4138319492340088,
 'avg_precision': 0.8501418232917786,
 'avg_recall': 0.8521997332572937,
 'avg_f1': 0.8511695265769958,
 'Car_precision': 0.803805947303772,
 'Car_recall': 0.7834592461585999,
 'Car_f1': 0.793502151966095,
 'Building_precision': 0.9052638411521912,
 'Building_recall': 0.9160950183868408,
 'Building_f1': 0.9106471538543701,
 'Low Vegetation_precision': 0.8096555471420288,
 'Low Vegetation_recall': 0.8621010184288025,
 'Low Vegetation_f1': 0.8350557088851929,
 'Tree_precision': 0.7780711054801941,
 'Tree_recall': 0.8146982789039612,
 'Tree_f1': 0.7959635853767395,
 'Impervious_precision': 0.905142605304718,
 'Impervious_recall': 0.846528172492981,
 'Impervious_f1': 0.8748546838760376,
 'Clutter_precision': 0.46228528022766113,
 'Clutter_recall': 0.14537972211837769,
 'Clutter_f1': 0.2211972177028656,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.711494'}
2024-01-04 17:41:49:rastervision.pytorch_learner.learner: INFO - epoch: 1
2024-01-04 17:41:49:rastervision.pytorch_learner.learner: INFO - epoch: 1
2024-01-04 17:41:49:rastervision.pytorch_learner.learner: INFO - epoch: 1
2024-01-04 17:41:49:rastervision.pytorch_learner.learner: INFO - epoch: 1
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.59it/s]
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.59it/s]
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.59it/s]
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.59it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.02it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.95it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.26it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.62it/s]
2024-01-04 17:42:31:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 1,
 'train_loss': 0.43648871779441833,
 'train_time': '0:00:37.927085',
 'val_loss': 0.3567490577697754,
 'avg_precision': 0.8674837946891785,
 'avg_recall': 0.8690491914749146,
 'avg_f1': 0.8682658076286316,
 'Car_precision': 0.8752817511558533,
 'Car_recall': 0.8239727020263672,
 'Car_f1': 0.8488525748252869,
 'Building_precision': 0.9384442567825317,
 'Building_recall': 0.9241905212402344,
 'Building_f1': 0.9312628507614136,
 'Low Vegetation_precision': 0.8171526789665222,
 'Low Vegetation_recall': 0.8776587247848511,
 'Low Vegetation_f1': 0.846325695514679,
 'Tree_precision': 0.8061624765396118,
 'Tree_recall': 0.8133453130722046,
 'Tree_f1': 0.8097379803657532,
 'Impervious_precision': 0.9049811959266663,
 'Impervious_recall': 0.8802449703216553,
 'Impervious_f1': 0.8924417495727539,
 'Clutter_precision': 0.532400369644165,
 'Clutter_recall': 0.19658923149108887,
 'Clutter_f1': 0.2871486246585846,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.579452'}
2024-01-04 17:42:31:rastervision.pytorch_learner.learner: INFO - epoch: 2
2024-01-04 17:42:31:rastervision.pytorch_learner.learner: INFO - epoch: 2
2024-01-04 17:42:31:rastervision.pytorch_learner.learner: INFO - epoch: 2
2024-01-04 17:42:31:rastervision.pytorch_learner.learner: INFO - epoch: 2
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.63it/s]
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.63it/s]
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.63it/s]
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.63it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.05it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.02it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.24it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.84it/s]
2024-01-04 17:43:12:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 2,
 'train_loss': 0.36711394786834717,
 'train_time': '0:00:37.707917',
 'val_loss': 0.3368813395500183,
 'avg_precision': 0.8755488395690918,
 'avg_recall': 0.876059889793396,
 'avg_f1': 0.8758043050765991,
 'Car_precision': 0.8915504813194275,
 'Car_recall': 0.8439669013023376,
 'Car_f1': 0.8671063780784607,
 'Building_precision': 0.9590390920639038,
 'Building_recall': 0.9206216931343079,
 'Building_f1': 0.9394378066062927,
 'Low Vegetation_precision': 0.8277096152305603,
 'Low Vegetation_recall': 0.8836192488670349,
 'Low Vegetation_f1': 0.8547511696815491,
 'Tree_precision': 0.8209653496742249,
 'Tree_recall': 0.8202846646308899,
 'Tree_f1': 0.820624828338623,
 'Impervious_precision': 0.8987159132957458,
 'Impervious_recall': 0.8927314281463623,
 'Impervious_f1': 0.8957136869430542,
 'Clutter_precision': 0.4589049220085144,
 'Clutter_recall': 0.29216378927230835,
 'Clutter_f1': 0.3570256531238556,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.163476'}
2024-01-04 17:43:13:rastervision.pytorch_learner.learner: INFO - epoch: 3
2024-01-04 17:43:13:rastervision.pytorch_learner.learner: INFO - epoch: 3
2024-01-04 17:43:13:rastervision.pytorch_learner.learner: INFO - epoch: 3
2024-01-04 17:43:13:rastervision.pytorch_learner.learner: INFO - epoch: 3
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.62it/s]
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.62it/s]
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.62it/s]
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.62it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.43it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.96it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.29it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.81it/s]
2024-01-04 17:43:54:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 3,
 'train_loss': 0.341424822807312,
 'train_time': '0:00:37.767869',
 'val_loss': 0.30895671248435974,
 'avg_precision': 0.8832519054412842,
 'avg_recall': 0.8854358196258545,
 'avg_f1': 0.8843425512313843,
 'Car_precision': 0.8775177001953125,
 'Car_recall': 0.8828772902488708,
 'Car_f1': 0.8801892995834351,
 'Building_precision': 0.9422222375869751,
 'Building_recall': 0.9576886296272278,
 'Building_f1': 0.9498924612998962,
 'Low Vegetation_precision': 0.8399472236633301,
 'Low Vegetation_recall': 0.8849738240242004,
 'Low Vegetation_f1': 0.8618729114532471,
 'Tree_precision': 0.8335434198379517,
 'Tree_recall': 0.8239083886146545,
 'Tree_f1': 0.8286978602409363,
 'Impervious_precision': 0.9197472333908081,
 'Impervious_recall': 0.888141930103302,
 'Impervious_f1': 0.9036682844161987,
 'Clutter_precision': 0.5375878214836121,
 'Clutter_recall': 0.25199493765830994,
 'Clutter_f1': 0.3431417644023895,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.516267'}
2024-01-04 17:43:55:rastervision.pytorch_learner.learner: INFO - epoch: 4
2024-01-04 17:43:55:rastervision.pytorch_learner.learner: INFO - epoch: 4
2024-01-04 17:43:55:rastervision.pytorch_learner.learner: INFO - epoch: 4
2024-01-04 17:43:55:rastervision.pytorch_learner.learner: INFO - epoch: 4
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.58it/s]
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.58it/s]
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.58it/s]
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:37<00:00,  6.58it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.94it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.67it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.42it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.23it/s]
2024-01-04 17:44:36:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 4,
 'train_loss': 0.3180536925792694,
 'train_time': '0:00:37.978103',
 'val_loss': 0.3190769553184509,
 'avg_precision': 0.8838623762130737,
 'avg_recall': 0.8826847672462463,
 'avg_f1': 0.883273184299469,
 'Car_precision': 0.8846034407615662,
 'Car_recall': 0.8826110363006592,
 'Car_f1': 0.8836060762405396,
 'Building_precision': 0.9570899605751038,
 'Building_recall': 0.9343024492263794,
 'Building_f1': 0.9455589056015015,
 'Low Vegetation_precision': 0.8265547752380371,
 'Low Vegetation_recall': 0.8981252908706665,
 'Low Vegetation_f1': 0.8608550429344177,
 'Tree_precision': 0.8490050435066223,
 'Tree_recall': 0.8070618510246277,
 'Tree_f1': 0.8275022506713867,
 'Impervious_precision': 0.9186795949935913,
 'Impervious_recall': 0.8893665075302124,
 'Impervious_f1': 0.9037854671478271,
 'Clutter_precision': 0.42227840423583984,
 'Clutter_recall': 0.38108307123184204,
 'Clutter_f1': 0.40062451362609863,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.387774'}
2024-01-04 17:44:37:rastervision.pytorch_learner.learner: INFO - epoch: 5
2024-01-04 17:44:37:rastervision.pytorch_learner.learner: INFO - epoch: 5
2024-01-04 17:44:37:rastervision.pytorch_learner.learner: INFO - epoch: 5
2024-01-04 17:44:37:rastervision.pytorch_learner.learner: INFO - epoch: 5
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.49it/s]
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.49it/s]
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.49it/s]
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.49it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.60it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.25it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.10it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.00it/s]
2024-01-04 17:45:19:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 5,
 'train_loss': 0.30413252115249634,
 'train_time': '0:00:38.523319',
 'val_loss': 0.30429530143737793,
 'avg_precision': 0.8881070613861084,
 'avg_recall': 0.8885219097137451,
 'avg_f1': 0.888314425945282,
 'Car_precision': 0.9041016697883606,
 'Car_recall': 0.8680385947227478,
 'Car_f1': 0.8857032060623169,
 'Building_precision': 0.952668309211731,
 'Building_recall': 0.9466252326965332,
 'Building_f1': 0.9496371746063232,
 'Low Vegetation_precision': 0.8251840472221375,
 'Low Vegetation_recall': 0.909641683101654,
 'Low Vegetation_f1': 0.865356981754303,
 'Tree_precision': 0.8725407123565674,
 'Tree_recall': 0.7935284972190857,
 'Tree_f1': 0.8311610221862793,
 'Impervious_precision': 0.9198651313781738,
 'Impervious_recall': 0.8999243974685669,
 'Impervious_f1': 0.9097855091094971,
 'Clutter_precision': 0.5166016817092896,
 'Clutter_recall': 0.3095299303531647,
 'Clutter_f1': 0.3871143162250519,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.424574'}
2024-01-04 17:45:20:rastervision.pytorch_learner.learner: INFO - epoch: 6
2024-01-04 17:45:20:rastervision.pytorch_learner.learner: INFO - epoch: 6
2024-01-04 17:45:20:rastervision.pytorch_learner.learner: INFO - epoch: 6
2024-01-04 17:45:20:rastervision.pytorch_learner.learner: INFO - epoch: 6
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.54it/s]
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.54it/s]
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.54it/s]
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.54it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.17it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.28it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.97it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.83it/s]
2024-01-04 17:46:01:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 6,
 'train_loss': 0.262077659368515,
 'train_time': '0:00:38.212673',
 'val_loss': 0.311289519071579,
 'avg_precision': 0.8872923254966736,
 'avg_recall': 0.8867098689079285,
 'avg_f1': 0.8870010375976562,
 'Car_precision': 0.9175610542297363,
 'Car_recall': 0.8701483607292175,
 'Car_f1': 0.893225908279419,
 'Building_precision': 0.9619386196136475,
 'Building_recall': 0.932563066482544,
 'Building_f1': 0.9470230937004089,
 'Low Vegetation_precision': 0.8284381031990051,
 'Low Vegetation_recall': 0.9055848717689514,
 'Low Vegetation_f1': 0.8652953505516052,
 'Tree_precision': 0.8749973773956299,
 'Tree_recall': 0.7897979617118835,
 'Tree_f1': 0.8302175402641296,
 'Impervious_precision': 0.9047462940216064,
 'Impervious_recall': 0.9092888236045837,
 'Impervious_f1': 0.907011866569519,
 'Clutter_precision': 0.4754457473754883,
 'Clutter_recall': 0.3739394545555115,
 'Clutter_f1': 0.4186273217201233,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.510891'}
2024-01-04 17:46:02:rastervision.pytorch_learner.learner: INFO - epoch: 7
2024-01-04 17:46:02:rastervision.pytorch_learner.learner: INFO - epoch: 7
2024-01-04 17:46:02:rastervision.pytorch_learner.learner: INFO - epoch: 7
2024-01-04 17:46:02:rastervision.pytorch_learner.learner: INFO - epoch: 7
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.58it/s]
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.58it/s]
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.58it/s]
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.58it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.02it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.97it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.72it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.64it/s]
2024-01-04 17:46:44:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 7,
 'train_loss': 0.2408684343099594,
 'train_time': '0:00:38.006243',
 'val_loss': 0.319356232881546,
 'avg_precision': 0.8882620334625244,
 'avg_recall': 0.8851376175880432,
 'avg_f1': 0.8866971135139465,
 'Car_precision': 0.9069323539733887,
 'Car_recall': 0.8865900635719299,
 'Car_f1': 0.8966458439826965,
 'Building_precision': 0.9537099003791809,
 'Building_recall': 0.949749231338501,
 'Building_f1': 0.9517254829406738,
 'Low Vegetation_precision': 0.8085268139839172,
 'Low Vegetation_recall': 0.9214980602264404,
 'Low Vegetation_f1': 0.8613239526748657,
 'Tree_precision': 0.8927194476127625,
 'Tree_recall': 0.7508208155632019,
 'Tree_f1': 0.8156445622444153,
 'Impervious_precision': 0.9286908507347107,
 'Impervious_recall': 0.890372097492218,
 'Impervious_f1': 0.9091278314590454,
 'Clutter_precision': 0.4468381106853485,
 'Clutter_recall': 0.405676931142807,
 'Clutter_f1': 0.4252638518810272,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.573418'}
2024-01-04 17:46:44:rastervision.pytorch_learner.learner: INFO - epoch: 8
2024-01-04 17:46:44:rastervision.pytorch_learner.learner: INFO - epoch: 8
2024-01-04 17:46:44:rastervision.pytorch_learner.learner: INFO - epoch: 8
2024-01-04 17:46:44:rastervision.pytorch_learner.learner: INFO - epoch: 8
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.56it/s]
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.56it/s]
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.56it/s]
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.56it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.86it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.63it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.50it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.29it/s]
2024-01-04 17:47:26:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 8,
 'train_loss': 0.22439810633659363,
 'train_time': '0:00:38.117266',
 'val_loss': 0.3050888776779175,
 'avg_precision': 0.8915089964866638,
 'avg_recall': 0.89113849401474,
 'avg_f1': 0.8913236856460571,
 'Car_precision': 0.8946492671966553,
 'Car_recall': 0.8982644081115723,
 'Car_f1': 0.8964532017707825,
 'Building_precision': 0.9547592997550964,
 'Building_recall': 0.9466045498847961,
 'Building_f1': 0.9506644606590271,
 'Low Vegetation_precision': 0.8375621438026428,
 'Low Vegetation_recall': 0.9021720290184021,
 'Low Vegetation_f1': 0.8686673641204834,
 'Tree_precision': 0.8822261095046997,
 'Tree_recall': 0.7928858995437622,
 'Tree_f1': 0.8351735472679138,
 'Impervious_precision': 0.915266215801239,
 'Impervious_recall': 0.9100661873817444,
 'Impervious_f1': 0.9126588106155396,
 'Clutter_precision': 0.4703214466571808,
 'Clutter_recall': 0.410855770111084,
 'Clutter_f1': 0.4385821223258972,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.304974'}
2024-01-04 17:47:26:rastervision.pytorch_learner.learner: INFO - epoch: 9
2024-01-04 17:47:26:rastervision.pytorch_learner.learner: INFO - epoch: 9
2024-01-04 17:47:26:rastervision.pytorch_learner.learner: INFO - epoch: 9
2024-01-04 17:47:26:rastervision.pytorch_learner.learner: INFO - epoch: 9
Training (GPU=1): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.53it/s]
Training (GPU=2): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.53it/s]
Training (GPU=0): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.53it/s]
Training (GPU=3): 100%|███████████████████████████████████████████████████████████████| 250/250 [00:38<00:00,  6.49it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 12.10it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.83it/s]
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 11.66it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:03<00:00, 10.48it/s]
2024-01-04 17:48:08:rastervision.pytorch_learner.learner: INFO - metrics:
{'epoch': 9,
 'train_loss': 0.20857761800289154,
 'train_time': '0:00:38.526757',
 'val_loss': 0.2985416650772095,
 'avg_precision': 0.894070565700531,
 'avg_recall': 0.8944187164306641,
 'avg_f1': 0.8942445516586304,
 'Car_precision': 0.890729546546936,
 'Car_recall': 0.9017539024353027,
 'Car_f1': 0.8962078094482422,
 'Building_precision': 0.9535107612609863,
 'Building_recall': 0.9560166001319885,
 'Building_f1': 0.9547620415687561,
 'Low Vegetation_precision': 0.8419938683509827,
 'Low Vegetation_recall': 0.9041029214859009,
 'Low Vegetation_f1': 0.8719437718391418,
 'Tree_precision': 0.8905330896377563,
 'Tree_recall': 0.7960513234138489,
 'Tree_f1': 0.8406457901000977,
 'Impervious_precision': 0.9167175889015198,
 'Impervious_recall': 0.9112258553504944,
 'Impervious_f1': 0.9139634370803833,
 'Clutter_precision': 0.47144773602485657,
 'Clutter_recall': 0.37316522002220154,
 'Clutter_f1': 0.4165881872177124,
 'null_precision': 0.0,
 'null_recall': 0.0,
 'null_f1': 0.0,
 'valid_time': '0:00:03.262216'}
2024-01-04 17:48:10:rastervision.pytorch_learner.learner: INFO - Creating bundle.
2024-01-04 17:48:10:rastervision.pytorch_learner.learner_config: INFO - Fetching module definition from: AdeelH/pytorch-fpn:0.3
Downloading: "https://github.com/AdeelH/pytorch-fpn/zipball/0.3" to /home/ubuntu/.cache/torch/hub/0.3.zip
Downloading: "https://download.pytorch.org/models/resnet50-0676ba61.pth" to /home/ubuntu/.cache/torch/hub/checkpoints/resnet50-0676ba61.pth
100%|███████████████████████████████████████████████████████████████████████████████| 97.8M/97.8M [00:00<00:00, 310MB/s]
2024-01-04 17:48:13:rastervision.pytorch_learner.learner: INFO - Loading checkpoint from ../out/potsdam/train/last-model.pth
2024-01-04 17:48:13:rastervision.pytorch_learner.learner: INFO - Building valid dataset ...
2024-01-04 17:48:13:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif.
2024-01-04 17:48:13:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif.
2024-01-04 17:48:13:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif.
2024-01-04 17:48:13:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif.
2024-01-04 17:48:13:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif.
2024-01-04 17:48:13:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif.
2024-01-04 17:48:15:rastervision.pytorch_learner.learner: INFO - Exporting to model to ONNX.
============= Diagnostic Run torch.onnx.export version 2.0.1+cu117 =============
verbose: False, log level: Level.ERROR
======================= 0 NONE 0 NOTE 0 WARNING 0 ERROR ========================

2024-01-04 17:48:19:rastervision.pytorch_learner.learner: INFO - Copying modules into bundle.
2024-01-04 17:48:19:rastervision.pytorch_learner.learner: INFO - Saving bundle to ../out/potsdam/train/model-bundle.zip.
2024-01-04 17:48:32:rastervision.pytorch_learner.learner: INFO - Spawning DDP processes
2024-01-04 17:48:36:rastervision.pytorch_learner.learner: INFO - DDP rank: 0, DDP local rank: 0
2024-01-04 17:48:36:rastervision.pytorch_learner.learner: INFO - DDP rank: 1, DDP local rank: 1
2024-01-04 17:48:36:rastervision.pytorch_learner.learner: INFO - DDP rank: 2, DDP local rank: 2
2024-01-04 17:48:36:rastervision.pytorch_learner.learner: INFO - DDP rank: 3, DDP local rank: 3
2024-01-04 17:48:36:rastervision.pytorch_learner.learner_config: INFO - Fetching module definition from: AdeelH/pytorch-fpn:0.3
Downloading: "https://github.com/AdeelH/pytorch-fpn/zipball/0.3" to /home/ubuntu/.cache/torch/0/hub/0.3.zip
2024-01-04 17:48:36:rastervision.pytorch_learner.learner_config: INFO - Fetching module definition from: AdeelH/pytorch-fpn:0.3
Using cache found in /home/ubuntu/.cache/torch/1/hub/AdeelH_pytorch-fpn_0.3
2024-01-04 17:48:36:rastervision.pytorch_learner.learner_config: INFO - Fetching module definition from: AdeelH/pytorch-fpn:0.3
Using cache found in /home/ubuntu/.cache/torch/2/hub/AdeelH_pytorch-fpn_0.3
2024-01-04 17:48:36:rastervision.pytorch_learner.learner_config: INFO - Fetching module definition from: AdeelH/pytorch-fpn:0.3
Using cache found in /home/ubuntu/.cache/torch/3/hub/AdeelH_pytorch-fpn_0.3
2024-01-04 17:48:39:rastervision.pytorch_learner.learner: INFO - Evaluating on valid set...
2024-01-04 17:48:39:rastervision.pytorch_learner.learner: INFO - Evaluating on valid set...
2024-01-04 17:48:39:rastervision.pytorch_learner.learner: INFO - Evaluating on valid set...
2024-01-04 17:48:39:rastervision.pytorch_learner.learner: INFO - Evaluating on valid set...
2024-01-04 17:48:39:rastervision.pytorch_learner.learner: INFO - Building datasets ...
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_10_label.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_11_label.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_10_label.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_11_label.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_10_label.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_11_RGBIR.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_11_label.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_12_RGBIR.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_12_label.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_10_label.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_11_RGBIR.tif.
2024-01-04 17:48:39:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_7_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_9_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_7_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_7_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_8_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_8_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_9_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_9_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif.
2024-01-04 17:48:40:rastervision.pytorch_learner.learner: INFO - Building datasets ...
2024-01-04 17:48:40:rastervision.pytorch_learner.learner: INFO - Building datasets ...
2024-01-04 17:48:40:rastervision.pytorch_learner.learner: INFO - Building datasets ...
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_4_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_4_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_5_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_5_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_7_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_7_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_7_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_7_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_9_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_9_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_9_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_9_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_10_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_10_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_11_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_11_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_12_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_12_label.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_7_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_7_RGBIR.tif.
2024-01-04 17:48:40:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_7_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_7_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_7_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_7_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_8_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_8_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_8_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_8_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_8_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_8_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_9_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_9_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_7_9_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_9_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_9_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_7_9_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_2_12_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_2_12_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_3_12_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_3_12_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/4_Ortho_RGBIR/top_potsdam_6_12_RGBIR.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif.
2024-01-04 17:48:41:rastervision.pipeline.file_system.utils: INFO - Using cached file /tmp/rv/cache/s3/raster-vision-ahassan/potsdam/data/raw/5_Labels_for_participants/top_potsdam_6_12_label.tif.
Validating (GPU=0): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:04<00:00,  9.43it/s]
Validating (GPU=1): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:04<00:00,  8.84it/s]
Validating (GPU=3): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:04<00:00,  8.78it/s]
Validating (GPU=2): 100%|███████████████████████████████████████████████████████████████| 38/38 [00:04<00:00,  8.73it/s]
2024-01-04 17:48:45:rastervision.pytorch_learner.learner: INFO - metrics: {'val_loss': 2.918607473373413, 'avg_precision': 0.17961497604846954, 'avg_recall': 0.017589515075087547, 'avg_f1': 0.032041262835264206, 'Car_precision': 0.011437511071562767, 'Car_recall': 0.0039807516150176525, 'Car_f1': 0.005905968602746725, 'Building_precision': 0.33649757504463196, 'Building_recall': 0.0029751211404800415, 'Building_f1': 0.005898094270378351, 'Low Vegetation_precision': 0.0, 'Low Vegetation_recall': 0.0, 'Low Vegetation_f1': 0.0, 'Tree_precision': 0.0, 'Tree_recall': 0.0, 'Tree_f1': 0.0, 'Impervious_precision': 0.33641985058784485, 'Impervious_recall': 0.005547774489969015, 'Impervious_f1': 0.010915545746684074, 'Clutter_precision': 0.015433155931532383, 'Clutter_recall': 0.9887244701385498, 'Clutter_f1': 0.030391918495297432, 'null_precision': 0.0, 'null_recall': 0.0, 'null_f1': 0.0, 'valid_time': '0:00:04.030409'}
2024-01-04 17:48:45:rastervision.pytorch_learner.learner: INFO - Making and plotting sample predictions on the valid set...
2024-01-04 17:48:50:rastervision.pytorch_learner.learner: INFO - Sample predictions written to ../out/potsdam/train/valid_preds.png.
```

</details>

---

Closes #1352 
