### PR TITLE
Refactor `DataConfig` and implement `DataConfig.build_dataset()`

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/classification_learner_config.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Iterable, Optional, Union
 from enum import Enum
 import logging
 
@@ -14,6 +14,9 @@ from rastervision.pytorch_learner.dataset import (
     ClassificationImageDataset, ClassificationSlidingWindowGeoDataset,
     ClassificationRandomWindowGeoDataset)
 from rastervision.pytorch_learner.utils import adjust_conv_channels
+
+if TYPE_CHECKING:
+    from rastervision.core.data import SceneConfig
 
 log = logging.getLogger(__name__)
 
@@ -53,11 +56,13 @@ class ClassificationGeoDataConfig(ClassificationDataConfig, GeoDataConfig):
     See :mod:`rastervision.pytorch_learner.dataset.classification_dataset`.
     """
 
-    def build_scenes(self, tmp_dir: str):
-        for s in self.scene_dataset.all_scenes:
+    def build_scenes(self,
+                     scene_configs: Iterable['SceneConfig'],
+                     tmp_dir: Optional[str] = None):
+        for s in scene_configs:
             if s.label_source is not None:
                 s.label_source.lazy = True
-        return super().build_scenes(tmp_dir=tmp_dir)
+        return super().build_scenes(scene_configs, tmp_dir=tmp_dir)
 
     def scene_to_dataset(self,
                          scene: Scene,


### PR DESCRIPTION
## Overview

<!-- Brief description of what the PR does and why it is needed. -->

This PR adds a `DataConfig.build_dataset()`, to allow building a single split's (train/val/test) dataset, and implements it for the `DataConfig` subclasses.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

<!-- (Optional) Ancillary topics, caveats, alternative strategies that didn't work out, anything else. -->

This is useful for #2018.

## Testing Instructions

<!--
* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as rebuilding the Docker image.
* Include test case, and expected output if not captured by automated tests.
-->
