### PR TITLE
Remove legacy "test", "overfit", and "predict" modes from `Learner`

### DIFF
--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/__init__.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/__init__.py
@@ -2,7 +2,7 @@
 
 
 def register_plugin(registry):
-    registry.set_plugin_version('rastervision.pytorch_backend', 1)
+    registry.set_plugin_version('rastervision.pytorch_backend', 2)
 
 
 import rastervision.pipeline

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -51,8 +51,7 @@ def get_config(runner,
         test (bool, optional): If True, does the following simplifications:
             (1) Uses only the first 1 scene
             (2) Uses only a 600x600 crop of the scenes
-            (3) Enables test mode in the learner, which makes it use the
-                test_batch_sz and test_num_epochs, among other things.
+            (3) Trains for only 4 epochs.
             Defaults to False.
 
     Returns:
@@ -173,8 +172,7 @@ def get_config(runner,
 
     solver = SolverConfig(
         lr=1e-4,
-        num_epochs=20,
-        test_num_epochs=4,
+        num_epochs=20 if not test else 4,
         batch_sz=32,
         one_cycle=True,
         external_loss_def=external_loss_def)
@@ -183,7 +181,6 @@ def get_config(runner,
         data=data,
         model=model,
         solver=solver,
-        test_mode=test,
         log_tensorboard=True,
         run_tensorboard=False)
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
@@ -47,8 +47,7 @@ def get_config(runner,
         test (bool, optional): If True, does the following simplifications:
             (1) Uses only the first 2 scenes
             (2) Uses only a 2000x2000 crop of the scenes
-            (3) Enables test mode in the learner, which makes it use the
-                test_batch_sz and test_num_epochs, among other things.
+            (3) Trains for only 2 epochs.
             Defaults to False.
 
     Returns:
@@ -181,13 +180,13 @@ def get_config(runner,
         model=model,
         solver=SolverConfig(
             lr=1e-4,
-            num_epochs=10,
-            test_num_epochs=2,
+            num_epochs=10 if not test else 2,
             batch_sz=16,
-            one_cycle=True),
+            one_cycle=True,
+        ),
         log_tensorboard=False,
         run_tensorboard=False,
-        test_mode=test)
+    )
 
     predict_options = ObjectDetectionPredictOptions(
         merge_thresh=0.5, score_thresh=0.9)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
@@ -35,8 +35,7 @@ def get_config(runner,
         test (bool, optional): If True, does the following simplifications:
             (1) Uses only the first 2 scenes.
             (2) Uses only a 2000x2000 crop of the scenes.
-            (3) Enables test mode in the learner, which makes it use the
-                test_batch_sz and test_num_epochs, among other things.
+            (3) Trains for only 2 epochs.
             Defaults to False.
 
     Returns:
@@ -114,13 +113,13 @@ def get_config(runner,
         model=ObjectDetectionModelConfig(backbone=Backbone.resnet50),
         solver=SolverConfig(
             lr=1e-4,
-            num_epochs=10,
-            test_num_epochs=2,
+            num_epochs=10 if not test else 2,
             batch_sz=16,
-            one_cycle=True),
+            one_cycle=True,
+        ),
         log_tensorboard=True,
         run_tensorboard=False,
-        test_mode=test)
+    )
 
     return ObjectDetectionConfig(
         root_uri=root_uri,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
@@ -64,8 +64,7 @@ def get_config(runner,
         test (bool, optional): If True, does the following simplifications:
             (1) Uses only the first 2 scenes
             (2) Uses only a 600x600 crop of the scenes
-            (3) Enables test mode in the learner, which makes it use the
-                test_batch_sz and test_num_epochs, among other things.
+            (3) Trains for only 2 epochs and uses a batch size of 2.
             Defaults to False.
 
     Returns:
@@ -222,15 +221,10 @@ def get_config(runner,
         data=data,
         model=model,
         solver=SolverConfig(
-            lr=1e-4,
-            num_epochs=10,
-            test_num_epochs=2,
-            batch_sz=8,
-            test_batch_sz=2,
-            one_cycle=True),
+            lr=1e-4, num_epochs=10, batch_sz=8, one_cycle=True),
         log_tensorboard=True,
         run_tensorboard=False,
-        test_mode=test)
+    )
 
     pipeline = SemanticSegmentationConfig(
         root_uri=root_uri,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -96,8 +96,7 @@ def get_config(runner,
         test (bool, optional): If True, does the following simplifications:
             (1) Uses only the first 2 scenes
             (2) Uses only a 600x600 crop of the scenes
-            (3) Enables test mode in the learner, which makes it use the
-                test_batch_sz and test_num_epochs, among other things.
+            (3) Trains for only 2 epochs and uses a batch size of 2.
             Defaults to False.
 
     Returns:
@@ -153,13 +152,10 @@ def get_config(runner,
     # --------------------------------------------
     model_config = SemanticSegmentationModelConfig(backbone=Backbone.resnet50)
 
+    num_epochs = NUM_EPOCHS if not test else TEST_MODE_NUM_EPOCHS
+    batch_sz = BATCH_SIZE if not test else TEST_MODE_BATCH_SIZE
     solver_config = SolverConfig(
-        lr=LR,
-        num_epochs=NUM_EPOCHS,
-        batch_sz=BATCH_SIZE,
-        test_num_epochs=TEST_MODE_NUM_EPOCHS,
-        test_batch_sz=TEST_MODE_BATCH_SIZE,
-        one_cycle=ONE_CYCLE)
+        lr=LR, num_epochs=num_epochs, batch_sz=batch_sz, one_cycle=ONE_CYCLE)
 
     backend_config = PyTorchSemanticSegmentationConfig(
         data=data,
@@ -167,7 +163,7 @@ def get_config(runner,
         solver=solver_config,
         log_tensorboard=LOG_TENSORBOARD,
         run_tensorboard=RUN_TENSORBOARD,
-        test_mode=test)
+    )
 
     # -----------------------------------------------
     # Pass configurations to the pipeline config

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
@@ -147,8 +147,7 @@ def get_config(runner,
             True.
         test (bool, optional): If True, does the following simplifications:
             (1) Uses only a small subset of training and validation scenes.
-            (2) Enables test mode in the learner, which makes it use the
-                test_batch_sz and test_num_epochs, among other things.
+            (2) Trains for only 2 epochs.
             Defaults to False.
 
     Returns:
@@ -214,15 +213,10 @@ def get_config(runner,
     backend = PyTorchSemanticSegmentationConfig(
         data=data,
         model=SemanticSegmentationModelConfig(backbone=Backbone.resnet50),
-        solver=SolverConfig(
-            lr=1e-4,
-            num_epochs=5,
-            test_num_epochs=2,
-            batch_sz=8,
-            one_cycle=True),
+        solver=SolverConfig(lr=1e-4, num_epochs=5, batch_sz=8, one_cycle=True),
         log_tensorboard=True,
         run_tensorboard=False,
-        test_mode=test)
+    )
 
     return SemanticSegmentationConfig(
         root_uri=root_uri,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_chip_classification_config.py
@@ -50,7 +50,6 @@ class PyTorchChipClassificationConfig(PyTorchLearnerBackendConfig):
             data=self.data,
             model=self.model,
             solver=self.solver,
-            test_mode=self.test_mode,
             output_uri=pipeline.train_uri,
             log_tensorboard=self.log_tensorboard,
             run_tensorboard=self.run_tensorboard,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -11,7 +11,17 @@ from rastervision.pytorch_learner.learner_config import (
 log = logging.getLogger(__name__)
 
 
-@register_config('pytorch_learner_backend')
+def pytorch_learner_backend_config_upgrader(cfg_dict: dict,
+                                            version: int) -> dict:
+    if version == 1:
+        # removed in version 2
+        cfg_dict.pop('test_mode', None)
+    return cfg_dict
+
+
+@register_config(
+    'pytorch_learner_backend',
+    upgrader=pytorch_learner_backend_config_upgrader)
 class PyTorchLearnerBackendConfig(BackendConfig):
     """Configure a :class:`.PyTorchLearnerBackend`."""
 
@@ -23,12 +33,6 @@ class PyTorchLearnerBackendConfig(BackendConfig):
     run_tensorboard: bool = Field(
         False,
         description='If True, run Tensorboard server pointing at log files.')
-    test_mode: bool = Field(
-        False,
-        description=
-        ('This field is passed along to the LearnerConfig which is returned by '
-         'get_learner_config(). For more info, see the docs for'
-         'pytorch_learner.learner_config.LearnerConfig.test_mode.'))
     save_all_checkpoints: bool = Field(
         False,
         description=(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_object_detection_config.py
@@ -50,7 +50,6 @@ class PyTorchObjectDetectionConfig(PyTorchLearnerBackendConfig):
             data=self.data,
             model=self.model,
             solver=self.solver,
-            test_mode=self.test_mode,
             output_uri=pipeline.train_uri,
             log_tensorboard=self.log_tensorboard,
             run_tensorboard=self.run_tensorboard,

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_semantic_segmentation_config.py
@@ -50,7 +50,6 @@ class PyTorchSemanticSegmentationConfig(PyTorchLearnerBackendConfig):
             data=self.data,
             model=self.model,
             solver=self.solver,
-            test_mode=self.test_mode,
             output_uri=pipeline.train_uri,
             log_tensorboard=self.log_tensorboard,
             run_tensorboard=self.run_tensorboard,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
@@ -2,7 +2,7 @@
 
 
 def register_plugin(registry):
-    registry.set_plugin_version('rastervision.pytorch_learner', 4)
+    registry.set_plugin_version('rastervision.pytorch_learner', 5)
 
 
 import rastervision.pipeline

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -394,22 +394,19 @@ class Learner(ABC):
         resume if interrupted), logs stats, plots predictions, and syncs
         results to the cloud.
         """
+        cfg = self.cfg
         if not self.avoid_activating_cuda_runtime:
             log_system_details()
-        log.info(self.cfg)
+        log.info(cfg)
         log.info(f'Using device: {self.device}')
         self.log_data_stats()
         self.run_tensorboard()
 
-        cfg = self.cfg
-        if not cfg.predict_mode:
-            if not self.avoid_activating_cuda_runtime:
-                self.plot_dataloaders(self.cfg.data.preview_batch_limit)
-            self.train()
-            if cfg.save_model_bundle:
-                self.save_model_bundle()
-        else:
-            self.load_checkpoint()
+        if not self.avoid_activating_cuda_runtime:
+            self.plot_dataloaders(cfg.data.preview_batch_limit)
+        self.train()
+        if cfg.save_model_bundle:
+            self.save_model_bundle()
 
         self.stop_tensorboard()
         if cfg.eval_train:
@@ -1210,9 +1207,7 @@ class Learner(ABC):
     def build_datasets(self) -> Tuple['Dataset', 'Dataset', 'Dataset']:
         """Build Datasets for train, validation, and test splits."""
         log.info(f'Building datasets ...')
-        cfg = self.cfg
-        train_ds, val_ds, test_ds = self.cfg.data.build(
-            tmp_dir=self.tmp_dir, test_mode=cfg.test_mode)
+        train_ds, val_ds, test_ds = self.cfg.data.build(tmp_dir=self.tmp_dir)
         return train_ds, val_ds, test_ds
 
     def build_dataset(self, split: Literal['train', 'valid', 'test']
@@ -1220,8 +1215,7 @@ class Learner(ABC):
         """Build Dataset for split."""
         log.info('Building %s dataset ...', split)
         cfg = self.cfg
-        ds = cfg.data.build_dataset(
-            split=split, tmp_dir=self.tmp_dir, test_mode=cfg.test_mode)
+        ds = cfg.data.build_dataset(split=split, tmp_dir=self.tmp_dir)
         return ds
 
     def build_dataloaders(self, distributed: Optional[bool] = None

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -1449,6 +1449,7 @@ def learner_config_upgrader(cfg_dict: dict, version: int) -> dict:
         # removed in version 5
         cfg_dict.pop('overfit_mode', None)
         cfg_dict.pop('test_mode', None)
+        cfg_dict.pop('predict_mode', None)
     return cfg_dict
 
 
@@ -1459,15 +1460,10 @@ class LearnerConfig(Config):
     solver: SolverConfig
     data: DataConfig
 
-    predict_mode: bool = Field(
-        False,
-        description='If True, skips training, loads model, and does final eval.'
-    )
     eval_train: bool = Field(
         False,
-        description=
-        ('If True, runs final evaluation on training set (in addition to test set). '
-         'Useful for debugging.'))
+        description='If True, runs final evaluation on training set '
+        '(in addition to validation set). Useful for debugging.')
     save_model_bundle: bool = Field(
         True,
         description=

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/regression_learner.py
@@ -43,9 +43,6 @@ class RegressionLearner(Learner):
             ddp_rank=self.ddp_local_rank)
         return model
 
-    def on_overfit_start(self):
-        self.on_train_start()
-
     def on_train_start(self):
         ys = []
         for _, y in self.train_dl:


### PR DESCRIPTION
## Overview

This PR removes the not-very-useful and not-often-used "test", "overfit", and "predict" modes from `Learner` and related configs resulting in some code simplification.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

<!-- (Optional) Ancillary topics, caveats, alternative strategies that didn't work out, anything else. -->
N/A

## Testing Instructions

N/A
