### PR TITLE
PyTorch DDP-related fixes and improvements

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/__init__.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/__init__.py
@@ -2,6 +2,7 @@
 
 from rastervision.pytorch_learner.utils.utils import *
 from rastervision.pytorch_learner.utils.torch_hub import *
+from rastervision.pytorch_learner.utils.distributed import *
 
 __all__ = [
     SplitTensor.__name__,
@@ -21,4 +22,6 @@ __all__ = [
     torch_hub_load_github.__name__,
     torch_hub_load_uri.__name__,
     torch_hub_load_local.__name__,
+    DDPContextManager.__name__,
+    'DDP_BACKEND',
 ]

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/distributed.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/distributed.py
@@ -1,0 +1,98 @@
+from typing import TYPE_CHECKING, Any, Optional
+import os
+from contextlib import AbstractContextManager
+import gc
+import logging
+
+import torch
+import torch.distributed as dist
+
+from rastervision.pipeline import rv_config_ as rv_config
+
+if TYPE_CHECKING:
+    from rastervision.pytorch_learner import Learner
+
+log = logging.getLogger(__name__)
+
+DDP_BACKEND = rv_config.get_namespace_option('rastervision', 'DDP_BACKEND',
+                                             'nccl')
+
+
+class DDPContextManager(AbstractContextManager):  # pragma: no cover
+    """Context manager for initializing and destroying DDP process groups.
+
+    Note that this context manager does not start processes itself, but
+    merely calls :func:`torch.distributed.init_process_group` and
+    :func:`torch.distributed.destroy_process_group` and sets DDP-related fields
+    in the :class:`Learner` to appropriate values.
+
+    If a process group is already initialized, this context manager does
+    nothing on either entry or exit.
+    """
+
+    def __init__(self,
+                 learner: 'Learner',
+                 rank: Optional[int] = None,
+                 world_size: Optional[int] = None) -> None:
+        """Constructor.
+
+        Args:
+            learner: The :class:`Learner` on which to set DDP-related fields.
+            rank: The process rank. If ``None``, will be set to
+                ``Learner.ddp_rank``. Defaults to ``None``.
+            world_size: The world size. If ``None``, will be set to
+                ``Learner.ddp_world_size``. Defaults to ``None``.
+
+        Raises:
+            ValueError: If ``rank`` or ``world_size`` not provided and aren't
+                set on the :class:`Learner`.
+        """
+        self.learner = learner
+        self.rank = learner.ddp_rank if rank is None else rank
+        self.world_size = (learner.ddp_world_size
+                           if world_size is None else world_size)
+        if self.rank is None or self.world_size is None:
+            raise ValueError('Could not determine rank and world_size.')
+        self.noop = dist.is_initialized()
+
+    def __enter__(self) -> Any:
+        if self.noop:
+            return
+
+        learner = self.learner
+        rank = self.rank
+        world_size = self.world_size
+
+        os.environ['MASTER_ADDR'] = os.environ.get('MASTER_ADDR', 'localhost')
+        os.environ['MASTER_PORT'] = os.environ.get('MASTER_PORT', '12355')
+
+        log.debug('Calling init_process_group()')
+        dist.init_process_group(DDP_BACKEND, rank=rank, world_size=world_size)
+
+        if learner.ddp_rank is None:
+            learner.ddp_rank = rank
+        if learner.ddp_local_rank is None:
+            # Implies process was spawned by learner.train(), and therefore,
+            # this is necessarily a single-node multi-GPU scenario.
+            # So global rank == local rank.
+            learner.ddp_local_rank = rank
+        if learner.ddp_world_size is None:
+            learner.ddp_world_size = world_size
+
+        log.info('DDP rank: %d, DDP local rank: %d', learner.ddp_rank,
+                 learner.ddp_local_rank)
+
+        learner.is_ddp_process = True
+        learner.is_ddp_master = learner.ddp_rank == 0
+        learner.is_ddp_local_master = learner.ddp_local_rank == 0
+
+        learner.device = torch.device(learner.device.type,
+                                      learner.ddp_local_rank)
+        torch.cuda.set_device(learner.device)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.noop:
+            return
+        dist.barrier()
+        dist.destroy_process_group()
+        gc.collect()

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -2,8 +2,8 @@ rastervision_pipeline==0.21.4-dev
 rastervision_core==0.21.4-dev
 numpy==1.25.0
 pillow==10.0.1
-torch==2.0.1
-torchvision==0.15.2
+torch==2.1.2
+torchvision==0.16.2
 tensorboard==2.13.0
 albumentations==1.3.0
 cython==0.29.35


### PR DESCRIPTION
## Overview

Follow-up to #2018. This PR makes some PyTorch DDP-related fixes and improvements. It also bumps up the required `torch` and `torchvision` versions.

Changes include:
- Refactor process group initialization and destruction into a context manager (`DDPContextManager`).
- Fix incorrect assumptions about `torchrun` scenarios (e.g. assuming that `dist.is_initialized()` is `True` before `dist.init_process_group()`).
- Download data on "local" master processes instead of only the "global" master process.
- Run the whole of `Learner.main()` within a single `DDPContextManager`.
- Replace `time.time()` with `time.perf_counter()`.
- General refactoring and doc improvements.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

These changes have been successfully tested on a 2-node, 8-GPU setup.
