### PR TITLE
Use PyTorch Estimator for SageMaker training jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,4 +166,8 @@ COPY ./rastervision_aws_sagemaker/ /opt/src/rastervision_aws_sagemaker/
 COPY ./rastervision_pytorch_backend/ /opt/src/rastervision_pytorch_backend/
 COPY ./rastervision_pytorch_learner/ /opt/src/rastervision_pytorch_learner/
 
+# needed for this image to be used by the AWS SageMaker PyTorch Estimator
+RUN pip install sagemaker_pytorch_training==2.8.1
+ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
+
 CMD ["bash"]

--- a/docs/setup/aws.rst
+++ b/docs/setup/aws.rst
@@ -80,14 +80,24 @@ Add the following to your ``~/.rastervision/default`` file.
     cpu_instance_type=ml.p3.2xlarge
     gpu_image=123.dkr.ecr.us-east-1.amazonaws.com/raster-vision
     gpu_instance_type=ml.p3.2xlarge
-    use_spot_instances=yes
+    train_image=123.dkr.ecr.us-east-1.amazonaws.com/raster-vision
+    train_instance_type=ml.p3.8xlarge
+    train_instance_count=2
+    use_spot_instances=no
+    spot_instance_max_wait_time=86400
+    max_run_time=86400
 
 * ``role`` - AWS IAM role with appropriate SageMaker permissions.
 * ``cpu_image`` - Docker image URI for CPU jobs.
 * ``cpu_instance_type`` - Instance type for CPU jobs.
 * ``gpu_image`` - Docker image URI for GPU jobs.
 * ``gpu_instance_type`` - Instance type for GPU jobs.
-* ``use_spot_instances`` - Whether to use spot instances.
+* ``train_image`` - Docker image URI for training jobs. Defaults to ``gpu_image``.
+* ``train_instance_type`` - Instance type for training jobs. Defaults to ``gpu_instance_type``.
+* ``train_instance_count`` - Number of parallel nodes to run for training jobs. Defaults to 1.
+* ``use_spot_instances`` - Whether to use spot instances. Only applies to training jobs.
+* ``spot_instance_max_wait_time`` - Maximum time, in seconds, to wait for a spot instance to be allocated. Must be greater than or equal to ``max_run_time``. Default: ``max_run_time``.
+* ``max_run_time`` - Maximum job run time in seconds. Default: 86400 (24 hours).
 
 
 Environment variables
@@ -102,14 +112,24 @@ Alternatively, you can set the following environment variables:
     SAGEMAKER_CPU_INSTANCE_TYPE="ml.p3.2xlarge"
     SAGEMAKER_GPU_IMAGE="123.dkr.ecr.us-east-1.amazonaws.com/raster-vision"
     SAGEMAKER_GPU_INSTANCE_TYPE="ml.p3.2xlarge"
-    SAGEMAKER_USE_SPOT_INSTANCES="yes"
+    SAGEMAKER_TRAIN_IMAGE="123.dkr.ecr.us-east-1.amazonaws.com/raster-vision"
+    SAGEMAKER_TRAIN_INSTANCE_TYPE="ml.p3.8xlarge"
+    SAGEMAKER_TRAIN_INSTANCE_COUNT="2"
+    SAGEMAKER_USE_SPOT_INSTANCES="no"
+    SPOT_INSTANCE_MAX_WAIT_TIME="86400"
+    MAX_RUN_TIME="86400"
 
 * ``SAGEMAKER_ROLE`` - AWS IAM role with appropriate SageMaker permissions.
 * ``SAGEMAKER_CPU_IMAGE`` - Docker image URI for CPU jobs.
 * ``SAGEMAKER_CPU_INSTANCE_TYPE`` - Instance type for CPU jobs.
 * ``SAGEMAKER_GPU_IMAGE`` - Docker image URI for GPU jobs.
 * ``SAGEMAKER_GPU_INSTANCE_TYPE`` - Instance type for GPU jobs.
-* ``SAGEMAKER_USE_SPOT_INSTANCES`` - Whether to use spot instances.
+* ``SAGEMAKER_TRAIN_IMAGE`` - Docker image URI for training jobs. Defaults to ``SAGEMAKER_GPU_IMAGE``.
+* ``SAGEMAKER_TRAIN_INSTANCE_TYPE`` - Instance type for training jobs. Defaults to ``SAGEMAKER_GPU_INSTANCE_TYPE``.
+* ``SAGEMAKER_TRAIN_INSTANCE_COUNT`` - Number of parallel nodes to run for training jobs. Defaults to 1.
+* ``SAGEMAKER_USE_SPOT_INSTANCES`` - Whether to use spot instances. Only applies to training jobs.
+* ``SPOT_INSTANCE_MAX_WAIT_TIME`` - Maximum time, in seconds, to wait for a spot instance to be allocated. Must be greater than or equal to ``MAX_RUN_TIME``. Default: ``MAX_RUN_TIME``.
+* ``MAX_RUN_TIME`` - Maximum job run time in seconds. Default: 86400 (24 hours).
 
 
 .. seealso::

--- a/rastervision_aws_batch/requirements.txt
+++ b/rastervision_aws_batch/requirements.txt
@@ -1,3 +1,3 @@
 rastervision_pipeline==0.21.4-dev
-boto3==1.28.8
-awscli==1.29.8
+boto3==1.34.14
+awscli==1.32.14

--- a/rastervision_aws_s3/requirements.txt
+++ b/rastervision_aws_s3/requirements.txt
@@ -1,5 +1,5 @@
 rastervision_pipeline==0.21.4-dev
-boto3==1.28.8
-awscli==1.29.8
+boto3==1.34.14
+awscli==1.32.14
 tqdm==4.65.0
 

--- a/rastervision_aws_sagemaker/rastervision/aws_sagemaker/__init__.py
+++ b/rastervision_aws_sagemaker/rastervision/aws_sagemaker/__init__.py
@@ -12,7 +12,12 @@ def register_plugin(registry):
         'cpu_instance_type',
         'gpu_image',
         'gpu_instance_type',
+        'train_image',
+        'train_instance_type',
+        'train_instance_count',
         'use_spot_instances',
+        'spot_instance_max_wait_time',
+        'max_run_time',
     ])
 
 

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -12,6 +12,6 @@ opencv-python-headless==4.6.0.66
 tqdm==4.65.0
 xarray==2023.2.0
 scikit-image==0.21.0
-boto3==1.28.8
+boto3==1.34.14
 stackstac==0.5.0
 humanize==4.8.0

--- a/tests/aws_sagemaker/test_aws_sagemaker_runner.py
+++ b/tests/aws_sagemaker/test_aws_sagemaker_runner.py
@@ -7,15 +7,31 @@ from sagemaker.workflow.steps import ProcessingStep, TrainingStep
 from rastervision.pipeline import rv_config_ as rv_config
 from rastervision.aws_sagemaker.aws_sagemaker_runner import AWSSageMakerRunner
 
+import boto3
+from moto import mock_s3
 
-class MockPipeline:
+
+class MockRVPipelineConfig:
+    train_uri = 's3://mock_bucket/abc/train'
+
+    def get_config_uri(self) -> str:
+        return 's3://mock_bucket/abc/config.py'
+
+
+class MockRVPipeline:
+    config = MockRVPipelineConfig()
     commands = ['analyze', 'chip', 'train', 'predict', 'eval']
     split_commands = ['chip', 'predict']
     gpu_commands = ['train', 'predict']
 
 
+@mock_s3
 class TestAWSSageMakerRunner(unittest.TestCase):
     def setUp(self):
+        self.s3 = boto3.client('s3')
+        self.bucket_name = 'mock_bucket'
+        self.s3.create_bucket(Bucket=self.bucket_name)
+
         rv_config.set_everett_config(
             config_overrides=dict(
                 SAGEMAKER_role='AmazonSageMakerExecutionRole',
@@ -23,12 +39,17 @@ class TestAWSSageMakerRunner(unittest.TestCase):
                 SAGEMAKER_cpu_instance_type='ml.p3.2xlarge',
                 SAGEMAKER_gpu_image='123.dkr.ecr.us-east-1.amazonaws.com/rv',
                 SAGEMAKER_gpu_instance_type='ml.p3.2xlarge',
+                SAGEMAKER_train_image='123.dkr.ecr.us-east-1.amazonaws.com/rv',
+                SAGEMAKER_train_instance_type='ml.p3.8xlarge',
+                SAGEMAKER_train_instance_count='2',
                 SAGEMAKER_use_spot_instances='yes',
+                SAGEMAKER_spot_instance_max_wait_time='86400',
+                SAGEMAKER_max_run_time='86400',
             ))
         os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
 
     def test_build_pipeline(self):
-        pipeline = MockPipeline()
+        pipeline = MockRVPipeline()
         runner = AWSSageMakerRunner()
         rv_config.set_verbosity(4)
         sagemaker_pipeline = runner.build_pipeline(
@@ -48,10 +69,10 @@ class TestAWSSageMakerRunner(unittest.TestCase):
         self.assertIsInstance(sagemaker_pipeline.steps[2], TrainingStep)
         self.assertEqual(len(sagemaker_pipeline.steps[2].depends_on), 2)
         # predict #1
-        self.assertIsInstance(sagemaker_pipeline.steps[3], TrainingStep)
+        self.assertIsInstance(sagemaker_pipeline.steps[3], ProcessingStep)
         self.assertEqual(len(sagemaker_pipeline.steps[3].depends_on), 3)
         # predict #2
-        self.assertIsInstance(sagemaker_pipeline.steps[4], TrainingStep)
+        self.assertIsInstance(sagemaker_pipeline.steps[4], ProcessingStep)
         self.assertEqual(len(sagemaker_pipeline.steps[4].depends_on), 3)
         # eval
         self.assertIsInstance(sagemaker_pipeline.steps[5], ProcessingStep)


### PR DESCRIPTION
## Overview

This PR replaces the use of the generic `Estimator` with the PyTorch-specific `Estimator` provided by the SageMaker Python SDK. This allows us to distribute training jobs across multiple instances using `torchrun`.

Other changes:
- Add `train_image`, `train_instance_type`, and `train_instance_count` RV config options.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

The current hack of creating a fake python script will not be necessary once https://github.com/aws/sagemaker-python-sdk/pull/4324 is merged and released.

## Testing Instructions

Sample command:
```sh
SAGEMAKER_TRAIN_INSTANCE_TYPE=ml.p3.8xlarge SAGEMAKER_TRAIN_INSTANCE_COUNT=2 rastervision run sagemaker \
	"rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py" \
	-a raw_uri "s3://raster-vision-raw-data/isprs-potsdam" \
	-a root_uri "s3://raster-vision-ahassan/rvtest/sagemaker_dist/isprs_potsdam_2024_01_23b/"
```
