### PR TITLE
Bump `jupyterlab` and `pillow` versions per security advisories

### DIFF
--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -2,7 +2,7 @@ rastervision_pipeline==0.21.4-dev
 shapely==2.0.1
 geopandas==0.13.2
 numpy==1.25.0
-pillow==10.0.1
+pillow==10.2.0
 pyproj==3.4.0
 rasterio==1.3.7
 pystac==1.9.0

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -1,7 +1,7 @@
 rastervision_pipeline==0.21.4-dev
 rastervision_core==0.21.4-dev
 numpy==1.25.0
-pillow==10.0.1
+pillow==10.2.0
 torch==2.1.2
 torchvision==0.16.2
 tensorboard==2.13.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ unify==0.5
 sphinx-autobuild==2021.3.14
 seaborn==0.12.2
 jupyter==1.0.0
-jupyterlab==4.0.4
+jupyterlab==4.0.11
 jupyter_contrib_nbextensions==0.7.0


### PR DESCRIPTION
## Overview

This PR bumps up the required `jupyterlab` and `pillow` versions to address security advisories CVE-2024-22421 and CVE-2023-50447 respectively.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A
