### PR TITLE
Consolidate prediction options into `PredictOptions` for all tasks

### DIFF
--- a/integration_tests/chip_classification/config.py
+++ b/integration_tests/chip_classification/config.py
@@ -1,8 +1,8 @@
 from os.path import join, dirname, basename
 
-from rastervision.core.rv_pipeline import (ChipClassificationConfig,
-                                           ChipOptions, WindowSamplingConfig,
-                                           WindowSamplingMethod)
+from rastervision.core.rv_pipeline import (
+    ChipClassificationConfig, ChipOptions, PredictOptions,
+    WindowSamplingConfig, WindowSamplingMethod)
 from rastervision.core.data import (
     ClassConfig, ChipClassificationLabelSourceConfig,
     GeoJSONVectorSourceConfig, RasterioSourceConfig, StatsTransformerConfig,
@@ -102,6 +102,6 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
         dataset=scene_dataset,
         backend=backend,
         chip_options=chip_options,
-        predict_chip_sz=chip_sz)
+        predict_options=PredictOptions(chip_sz=chip_sz))
 
     return config

--- a/integration_tests/object_detection/config.py
+++ b/integration_tests/object_detection/config.py
@@ -93,12 +93,11 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
         run_tensorboard=False)
 
     predict_options = ObjectDetectionPredictOptions(
-        merge_thresh=0.1, score_thresh=0.5)
+        chip_sz=chip_sz, merge_thresh=0.1, score_thresh=0.5)
 
     return ObjectDetectionConfig(
         root_uri=root_uri,
         dataset=scene_dataset,
         backend=backend,
-        predict_chip_sz=chip_sz,
         chip_options=chip_options,
         predict_options=predict_options)

--- a/integration_tests/semantic_segmentation/config.py
+++ b/integration_tests/semantic_segmentation/config.py
@@ -7,7 +7,8 @@ from rastervision.core.data import (
     RGBClassTransformerConfig)
 from rastervision.core.rv_pipeline import (
     SemanticSegmentationChipOptions, SemanticSegmentationConfig,
-    WindowSamplingConfig, WindowSamplingMethod)
+    SemanticSegmentationPredictOptions, WindowSamplingConfig,
+    WindowSamplingMethod)
 from rastervision.pytorch_backend import PyTorchSemanticSegmentationConfig
 from rastervision.pytorch_learner import (
     Backbone, SolverConfig, SemanticSegmentationModelConfig,
@@ -101,10 +102,11 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
         solver=solver,
         log_tensorboard=False,
         run_tensorboard=False)
+    predict_options = SemanticSegmentationPredictOptions(chip_sz=chip_sz)
 
     return SemanticSegmentationConfig(
         root_uri=root_uri,
         dataset=scene_dataset,
         backend=backend,
         chip_options=chip_options,
-        predict_chip_sz=chip_sz)
+        predict_options=predict_options)

--- a/rastervision_core/rastervision/core/__init__.py
+++ b/rastervision_core/rastervision/core/__init__.py
@@ -2,7 +2,7 @@
 
 
 def register_plugin(registry):
-    registry.set_plugin_version('rastervision.core', 11)
+    registry.set_plugin_version('rastervision.core', 12)
     from rastervision.core.cli import predict, predict_scene
     registry.add_plugin_command(predict)
     registry.add_plugin_command(predict_scene)

--- a/rastervision_core/rastervision/core/backend/backend.py
+++ b/rastervision_core/rastervision/core/backend/backend.py
@@ -5,7 +5,7 @@ from contextlib import AbstractContextManager
 if TYPE_CHECKING:
     from rastervision.core.data_sample import DataSample
     from rastervision.core.data import DatasetConfig, Labels, Scene
-    from rastervision.core.rv_pipeline import ChipOptions
+    from rastervision.core.rv_pipeline import ChipOptions, PredictOptions
 
 
 class SampleWriter(AbstractContextManager):
@@ -48,12 +48,13 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def predict_scene(self, scene: 'Scene', chip_sz: int,
-                      stride: int) -> 'Labels':
+    def predict_scene(self, scene: 'Scene',
+                      predict_options: 'PredictOptions') -> 'Labels':
         """Return predictions for an entire scene using the model.
 
         Args:
-            scene (Scene): Scene to run inference on.
+            scene: Scene to run inference on.
+            predict_options: Prediction options.
 
         Return:
             Labels object containing predictions

--- a/rastervision_core/rastervision/core/rv_pipeline/__init__.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/__init__.py
@@ -31,4 +31,5 @@ __all__ = [
     ChipOptions.__name__,
     WindowSamplingConfig.__name__,
     WindowSamplingMethod.__name__,
+    PredictOptions.__name__,
 ]

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection.py
@@ -1,33 +1,5 @@
-from typing import TYPE_CHECKING
-import logging
-
 from rastervision.core.rv_pipeline import RVPipeline
-from rastervision.core.data.label import ObjectDetectionLabels
-
-if TYPE_CHECKING:
-    from rastervision.core.data import Labels, Scene
-
-log = logging.getLogger(__name__)
 
 
 class ObjectDetection(RVPipeline):
-    def predict_scene(self, scene: 'Scene') -> 'Labels':
-        if self.backend is None:
-            self.build_backend()
-
-        # Use strided windowing to ensure that each object is fully visible (ie. not
-        # cut off) within some window. This means prediction takes 4x longer for object
-        # detection :(
-        chip_sz = self.config.predict_chip_sz
-        stride = chip_sz // 2
-        labels = self.backend.predict_scene(
-            scene, chip_sz=chip_sz, stride=stride)
-        labels = self.post_process_predictions(labels, scene)
-        return labels
-
-    def post_process_predictions(self, labels: ObjectDetectionLabels,
-                                 scene: 'Scene') -> ObjectDetectionLabels:
-        return ObjectDetectionLabels.prune_duplicates(
-            labels,
-            score_thresh=self.config.predict_options.score_thresh,
-            merge_thresh=self.config.predict_options.merge_thresh)
+    pass

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline.py
@@ -162,10 +162,8 @@ class RVPipeline(Pipeline):
     def predict_scene(self, scene: Scene) -> Labels:
         if self.backend is None:
             self.build_backend()
-        chip_sz = self.config.predict_chip_sz
-        stride = chip_sz
         labels = self.backend.predict_scene(
-            scene, chip_sz=chip_sz, stride=stride)
+            scene, predict_options=self.config.predict_options)
         labels = self.post_process_predictions(labels, scene)
         return labels
 

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation.py
@@ -1,53 +1,5 @@
-from typing import TYPE_CHECKING
-import logging
-
-import numpy as np
-
 from rastervision.core.rv_pipeline import RVPipeline
-
-if TYPE_CHECKING:
-    from rastervision.core.data import (
-        Labels,
-        Scene,
-    )
-    from rastervision.core.rv_pipeline.semantic_segmentation_config import (
-        SemanticSegmentationConfig)
-
-log = logging.getLogger(__name__)
 
 
 class SemanticSegmentation(RVPipeline):
-    def post_process_batch(self, windows, chips, labels):
-        # Fill in null class for any NODATA pixels.
-        null_class_id = self.config.dataset.class_config.null_class_id
-        for window, chip in zip(windows, chips):
-            nodata_mask = np.sum(chip, axis=2) == 0
-            labels.mask_fill(window, nodata_mask, fill_value=null_class_id)
-
-        return labels
-
-    def predict_scene(self, scene: 'Scene') -> 'Labels':
-        if self.backend is None:
-            self.build_backend()
-
-        cfg: 'SemanticSegmentationConfig' = self.config
-        chip_sz = cfg.predict_chip_sz
-        stride = cfg.predict_options.stride
-        crop_sz = cfg.predict_options.crop_sz
-
-        if stride is None:
-            stride = chip_sz
-
-        if crop_sz == 'auto':
-            overlap_sz = chip_sz - stride
-            if overlap_sz % 2 == 1:
-                log.warning(
-                    'Using crop_sz="auto" but overlap size (chip_sz minus '
-                    'stride) is odd. This means that one pixel row/col will '
-                    'still overlap after cropping.')
-            crop_sz = overlap_sz // 2
-
-        labels = self.backend.predict_scene(
-            scene, chip_sz=chip_sz, stride=stride, crop_sz=crop_sz)
-        labels = self.post_process_predictions(labels, scene)
-        return labels
+    pass

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -1,9 +1,9 @@
 import os
 from os.path import join
 
-from rastervision.core.rv_pipeline import (ChipClassificationConfig,
-                                           ChipOptions, WindowSamplingConfig,
-                                           WindowSamplingMethod)
+from rastervision.core.rv_pipeline import (
+    ChipClassificationConfig, ChipOptions, PredictOptions,
+    WindowSamplingConfig, WindowSamplingMethod)
 from rastervision.core.data import (
     ChipClassificationLabelSourceConfig, ClassConfig,
     ClassInferenceTransformerConfig, DatasetConfig, GeoJSONVectorSourceConfig,
@@ -192,6 +192,6 @@ def get_config(runner,
         dataset=scene_dataset,
         backend=backend,
         chip_options=chip_options,
-        predict_chip_sz=chip_sz)
+        predict_options=PredictOptions(chip_sz=chip_sz))
 
     return pipeline

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
@@ -196,14 +196,13 @@ def get_config(runner,
     )
 
     predict_options = ObjectDetectionPredictOptions(
-        merge_thresh=0.5, score_thresh=0.9)
+        chip_sz=chip_sz, merge_thresh=0.5, score_thresh=0.9)
 
     pipeline = ObjectDetectionConfig(
         root_uri=root_uri,
         dataset=scene_dataset,
         backend=backend,
         chip_options=chip_options,
-        predict_chip_sz=chip_sz,
         predict_options=predict_options)
 
     return pipeline

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
@@ -107,9 +107,6 @@ def get_config(runner,
     else:
         data = ObjectDetectionImageDataConfig(img_sz=img_sz, num_workers=4)
 
-    predict_options = ObjectDetectionPredictOptions(
-        merge_thresh=0.1, score_thresh=0.5)
-
     backend = PyTorchObjectDetectionConfig(
         data=data,
         model=ObjectDetectionModelConfig(backbone=Backbone.resnet50),
@@ -123,10 +120,12 @@ def get_config(runner,
         run_tensorboard=False,
     )
 
+    predict_options = ObjectDetectionPredictOptions(
+        chip_sz=chip_sz, merge_thresh=0.1, score_thresh=0.5)
+
     return ObjectDetectionConfig(
         root_uri=root_uri,
         dataset=scene_dataset,
         backend=backend,
-        predict_chip_sz=chip_sz,
         chip_options=chip_options,
         predict_options=predict_options)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam.py
@@ -5,7 +5,8 @@ import albumentations as A
 
 from rastervision.core.rv_pipeline import (
     SemanticSegmentationConfig, SemanticSegmentationChipOptions,
-    WindowSamplingConfig, WindowSamplingMethod)
+    SemanticSegmentationPredictOptions, WindowSamplingConfig,
+    WindowSamplingMethod)
 from rastervision.core.data import (
     ClassConfig, DatasetConfig, PolygonVectorOutputConfig,
     RasterioSourceConfig, RGBClassTransformerConfig, SceneConfig,
@@ -238,11 +239,13 @@ def get_config(runner,
         run_tensorboard=False,
     )
 
+    predict_options = SemanticSegmentationPredictOptions(chip_sz=chip_sz)
+
     pipeline = SemanticSegmentationConfig(
         root_uri=root_uri,
         dataset=scene_dataset,
         backend=backend,
         chip_options=chip_options,
-        predict_chip_sz=chip_sz)
+        predict_options=predict_options)
 
     return pipeline

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/isprs_potsdam_multi_source.py
@@ -3,7 +3,8 @@ from typing import Tuple, Union
 
 from rastervision.core.rv_pipeline import (
     SceneConfig, DatasetConfig, SemanticSegmentationChipOptions,
-    SemanticSegmentationConfig, WindowSamplingConfig, WindowSamplingMethod)
+    SemanticSegmentationConfig, SemanticSegmentationPredictOptions,
+    WindowSamplingConfig, WindowSamplingMethod)
 
 from rastervision.core.data import (
     ClassConfig, RasterioSourceConfig, MultiRasterSourceConfig,
@@ -161,15 +162,17 @@ def get_config(runner,
         run_tensorboard=RUN_TENSORBOARD,
     )
 
+    predict_options = SemanticSegmentationPredictOptions(chip_sz=CHIP_SIZE)
+
     # -----------------------------------------------
     # Pass configurations to the pipeline config
     # -----------------------------------------------
     pipeline_config = SemanticSegmentationConfig(
         root_uri=root_uri,
-        predict_chip_sz=CHIP_SIZE,
-        chip_options=chip_options,
         dataset=dataset_config,
-        backend=backend_config)
+        backend=backend_config,
+        chip_options=chip_options,
+        predict_options=predict_options)
 
     return pipeline_config
 

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
@@ -7,7 +7,8 @@ from abc import abstractmethod
 from rastervision.pipeline.file_system.utils import list_paths
 from rastervision.core.rv_pipeline import (
     SemanticSegmentationConfig, SemanticSegmentationChipOptions,
-    WindowSamplingConfig, WindowSamplingMethod)
+    SemanticSegmentationPredictOptions, WindowSamplingConfig,
+    WindowSamplingMethod)
 from rastervision.core.data import (
     BufferTransformerConfig, ClassConfig, ClassInferenceTransformerConfig,
     DatasetConfig, GeoJSONVectorSourceConfig, PolygonVectorOutputConfig,
@@ -222,9 +223,11 @@ def get_config(runner,
         run_tensorboard=False,
     )
 
+    predict_options = SemanticSegmentationPredictOptions(chip_sz=chip_sz)
+
     return SemanticSegmentationConfig(
         root_uri=root_uri,
         dataset=scene_dataset,
         backend=backend,
-        predict_chip_sz=chip_sz,
-        chip_options=chip_options)
+        chip_options=chip_options,
+        predict_options=predict_options)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
@@ -49,7 +49,7 @@ def get_config(runner) -> SemanticSegmentationConfig:
         root_uri=output_root_uri,
         dataset=scene_dataset,
         backend=backend,
-        predict_chip_sz=chip_sz)
+        predict_options=SemanticSegmentationPredictOptions(chip_sz=chip_sz))
 
 
 def make_scene(scene_id: str, image_uri: str, label_uri: str,

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -776,12 +776,10 @@ class Learner(ABC):
             'rastervision',
             'PREDICT_NUM_WORKERS',
             default=cfg.data.num_workers)
-        batch_size = rv_config.get_namespace_option(
-            'rastervision', 'PREDICT_BATCH_SIZE', default=cfg.solver.batch_sz)
 
         dl_kw = dict(
             collate_fn=self.get_collate_fn(),
-            batch_size=int(batch_size),
+            batch_size=cfg.solver.batch_sz,
             num_workers=int(num_workers),
             shuffle=False,
             pin_memory=True)

--- a/tests/core/rv_pipeline/test_object_detection_config.py
+++ b/tests/core/rv_pipeline/test_object_detection_config.py
@@ -1,0 +1,15 @@
+import unittest
+
+from rastervision.core.rv_pipeline import (ObjectDetectionPredictOptions)
+
+
+class TestObjectDetectionPredictOptions(unittest.TestCase):
+    def test_stride_validator(self):
+        cfg = ObjectDetectionPredictOptions(chip_sz=10)
+        self.assertEqual(cfg.stride, 5)
+        cfg = ObjectDetectionPredictOptions(chip_sz=11)
+        self.assertEqual(cfg.stride, 5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/rv_pipeline/test_rv_pipeline_config.py
+++ b/tests/core/rv_pipeline/test_rv_pipeline_config.py
@@ -1,0 +1,53 @@
+import unittest
+
+from rastervision.core.data import (ClassConfig, DatasetConfig)
+from rastervision.core.backend import (BackendConfig)
+from rastervision.core.rv_pipeline.rv_pipeline_config import (
+    PredictOptions, RVPipelineConfig, rv_pipeline_config_upgrader)
+
+
+class TestPredictOptions(unittest.TestCase):
+    def test_stride_validator(self):
+        cfg = PredictOptions(chip_sz=10)
+        self.assertEqual(cfg.stride, 10)
+
+
+class TestRVPipelineConfig(unittest.TestCase):
+    def test_upgrader(self):
+        cfg_dict = dict(
+            dataset=DatasetConfig(
+                class_config=ClassConfig(names=[]),
+                train_scenes=[],
+                validation_scenes=[]),
+            backend=BackendConfig(),
+            train_chip_sz=20,
+            chip_nodata_threshold=0.5,
+            predict_chip_sz=20,
+            predict_batch_sz=8)
+        cfg_dict = rv_pipeline_config_upgrader(cfg_dict, 10)
+        cfg_dict = rv_pipeline_config_upgrader(cfg_dict, 11)
+        cfg = RVPipelineConfig(**cfg_dict)
+
+        cfg_dict = dict(
+            dataset=DatasetConfig(
+                class_config=ClassConfig(names=[]),
+                train_scenes=[],
+                validation_scenes=[]),
+            backend=BackendConfig(),
+            train_chip_sz=20,
+            chip_nodata_threshold=0.5,
+            chip_options=dict(method='random'),
+            predict_chip_sz=20,
+            predict_batch_sz=8,
+            predict_options=dict())
+        cfg_dict = rv_pipeline_config_upgrader(cfg_dict, 10)
+        cfg_dict = rv_pipeline_config_upgrader(cfg_dict, 11)
+        cfg = RVPipelineConfig(**cfg_dict)
+        self.assertEqual(cfg.chip_options.get_chip_sz(), 20)
+        self.assertEqual(cfg.chip_options.nodata_threshold, 0.5)
+        self.assertEqual(cfg.predict_options.chip_sz, 20)
+        self.assertEqual(cfg.predict_options.batch_sz, 8)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/core/rv_pipeline/test_semantic_segmentation_config.py
+++ b/tests/core/rv_pipeline/test_semantic_segmentation_config.py
@@ -1,7 +1,6 @@
 from typing import Callable
 import unittest
 
-from pydantic import ValidationError
 import numpy as np
 
 from rastervision.core.data import (ClassConfig, DatasetConfig)
@@ -48,27 +47,14 @@ class TestSemanticSegmentationConfig(unittest.TestCase):
 
 
 class TestSemanticSegmentationPredictOptions(unittest.TestCase):
-    def assertNoError(self, fn: Callable, msg: str = ''):
-        try:
-            fn()
-        except Exception:
-            self.fail(msg)
+    def test_crop_sz_validator(self):
+        args = dict(chip_sz=10, stride=4, crop_sz='auto')
+        cfg = SemanticSegmentationPredictOptions(**args)
+        self.assertEqual(cfg.crop_sz, 3)
 
-    def test_upgrader(self):
-        args = dict(stride=None, crop_sz=None)
-        self.assertNoError(lambda: SemanticSegmentationPredictOptions(**args))
-
-        args = dict(stride=None, crop_sz='auto')
-        self.assertRaises(ValidationError,
-                          lambda: SemanticSegmentationPredictOptions(**args))
-
-        args = dict(stride=None, crop_sz=10)
-        self.assertRaises(ValidationError,
-                          lambda: SemanticSegmentationPredictOptions(**args))
-
-        args = dict(stride=10, crop_sz=0)
-        self.assertRaises(ValidationError,
-                          lambda: SemanticSegmentationPredictOptions(**args))
+        args = dict(chip_sz=10, stride=5, crop_sz='auto')
+        cfg = SemanticSegmentationPredictOptions(**args)
+        self.assertEqual(cfg.crop_sz, 2)
 
 
 class TestSemanticSegmentationChipOptions(unittest.TestCase):

--- a/tests/pytorch_backend/test_pytorch_chip_classification.py
+++ b/tests/pytorch_backend/test_pytorch_chip_classification.py
@@ -4,8 +4,8 @@ from rastervision.pipeline.file_system import get_tmp_dir
 from rastervision.pipeline.config import save_pipeline_config
 from rastervision.core.data import (ClassConfig, DatasetConfig)
 from rastervision.core.rv_pipeline import (
-    ChipOptions, ChipClassificationConfig, WindowSamplingConfig,
-    WindowSamplingMethod)
+    ChipOptions, ChipClassificationConfig, PredictOptions,
+    WindowSamplingConfig, WindowSamplingMethod)
 from rastervision.pytorch_backend import PyTorchChipClassificationConfig
 from rastervision.pytorch_learner import (ClassificationModelConfig,
                                           SolverConfig)
@@ -48,7 +48,8 @@ def make_pipeline(tmp_dir: str, num_channels: int, nochip: bool = False):
         root_uri=tmp_dir,
         dataset=dataset_cfg,
         backend=backend_cfg,
-        chip_options=chip_options)
+        chip_options=chip_options,
+        predict_options=PredictOptions(chip_sz=100))
     pipeline_cfg.update()
     save_pipeline_config(pipeline_cfg, pipeline_cfg.get_config_uri())
     pipeline = pipeline_cfg.build(tmp_dir)

--- a/tests/pytorch_backend/test_pytorch_object_detection.py
+++ b/tests/pytorch_backend/test_pytorch_object_detection.py
@@ -5,7 +5,8 @@ from rastervision.pipeline.config import save_pipeline_config
 from rastervision.core.data import (ClassConfig, DatasetConfig)
 from rastervision.core.rv_pipeline import (
     ObjectDetectionConfig, ObjectDetectionChipOptions,
-    ObjectDetectionWindowSamplingConfig, WindowSamplingMethod)
+    ObjectDetectionPredictOptions, ObjectDetectionWindowSamplingConfig,
+    WindowSamplingMethod)
 from rastervision.pytorch_backend import PyTorchObjectDetectionConfig
 from rastervision.pytorch_learner import (ObjectDetectionModelConfig,
                                           SolverConfig)
@@ -48,7 +49,8 @@ def make_pipeline(tmp_dir: str, num_channels: int, nochip: bool = False):
         root_uri=tmp_dir,
         dataset=dataset_cfg,
         backend=backend_cfg,
-        chip_options=chip_options)
+        chip_options=chip_options,
+        predict_options=ObjectDetectionPredictOptions(chip_sz=100, stride=50))
     pipeline_cfg.update()
     save_pipeline_config(pipeline_cfg, pipeline_cfg.get_config_uri())
     pipeline = pipeline_cfg.build(tmp_dir)

--- a/tests/pytorch_backend/test_pytorch_semantic_segmentation.py
+++ b/tests/pytorch_backend/test_pytorch_semantic_segmentation.py
@@ -5,7 +5,8 @@ from rastervision.pipeline.config import save_pipeline_config
 from rastervision.core.data import (ClassConfig, DatasetConfig)
 from rastervision.core.rv_pipeline import (
     SemanticSegmentationConfig, SemanticSegmentationChipOptions,
-    WindowSamplingConfig, WindowSamplingMethod)
+    SemanticSegmentationPredictOptions, WindowSamplingConfig,
+    WindowSamplingMethod)
 from rastervision.pytorch_backend import PyTorchSemanticSegmentationConfig
 from rastervision.pytorch_learner import (SemanticSegmentationModelConfig,
                                           SolverConfig)
@@ -34,7 +35,7 @@ def make_pipeline(tmp_dir: str, num_channels: int, nochip: bool = False):
         test_scenes=[])
     chip_options = SemanticSegmentationChipOptions(
         sampling=WindowSamplingConfig(
-            method=WindowSamplingMethod.random, size=20, max_windows=8))
+            method=WindowSamplingMethod.random, size=100, max_windows=8))
     if nochip:
         data_cfg = SemanticSegmentationGeoDataConfig(
             scene_dataset=dataset_cfg,
@@ -51,7 +52,9 @@ def make_pipeline(tmp_dir: str, num_channels: int, nochip: bool = False):
         root_uri=tmp_dir,
         dataset=dataset_cfg,
         backend=backend_cfg,
-        chip_options=chip_options)
+        chip_options=chip_options,
+        predict_options=SemanticSegmentationPredictOptions(
+            chip_sz=100, stride=50, crop_sz='auto'))
     pipeline_cfg.update()
     save_pipeline_config(pipeline_cfg, pipeline_cfg.get_config_uri())
     pipeline = pipeline_cfg.build(tmp_dir)

--- a/tests/pytorch_learner/test_classification_learner.py
+++ b/tests/pytorch_learner/test_classification_learner.py
@@ -122,14 +122,6 @@ class TestClassificationLearner(unittest.TestCase):
             learner.plot_predictions(split='valid')
             learner.save_model_bundle()
 
-            learner = None
-            backend.learner = None
-            backend.load_model()
-
-            pred_scene = dataset_cfg.validation_scenes[0].build(
-                class_config, tmp_dir)
-            _ = backend.predict_scene(pred_scene, chip_sz=100)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/pytorch_learner/test_object_detection_learner.py
+++ b/tests/pytorch_learner/test_object_detection_learner.py
@@ -124,14 +124,6 @@ class TestObjectDetectionLearner(unittest.TestCase):
             learner.plot_predictions(split='valid')
             learner.save_model_bundle()
 
-            learner = None
-            backend.learner = None
-            backend.load_model()
-
-            pred_scene = dataset_cfg.validation_scenes[0].build(
-                class_config, tmp_dir)
-            _ = backend.predict_scene(pred_scene, chip_sz=100)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/pytorch_learner/test_semantic_segmentation_learner.py
+++ b/tests/pytorch_learner/test_semantic_segmentation_learner.py
@@ -128,14 +128,6 @@ class TestSemanticSegmentationLearner(unittest.TestCase):
             learner.plot_predictions(split='valid')
             learner.save_model_bundle()
 
-            learner = None
-            backend.learner = None
-            backend.load_model()
-
-            pred_scene = dataset_cfg.validation_scenes[0].build(
-                class_config, tmp_dir)
-            _ = backend.predict_scene(pred_scene, chip_sz=100)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

This PR consolidates prediction-related options into `PredictOptions` for all tasks. Previously, there were `PredictOptions` classes for SS and OD but not CC. Also, `predict_chip_sz` and `predict_batch_sz` were top-level fields in `RVPipelineConfig`.

Changes:
- Move `predict_chip_sz` and `predict_batch_sz` to `PredictOptions`. Also add `stride`.
- Make `predict_options` a field in `RVPipelineConfig`. Previously, this was only defined in the SS and OD subclasses.
- Make `Backend.predict_scene()` take `PredictOptions` instead of `chip_sz`, `stride` etc.
- Move default `stride`, `crop_sz` initialization to pydantic validators.
- Move OD prediction post-processing to the OD PyTorch `Backend`.
- Remove unused SS post processing.
- Remove support for `RASTERVISION_PREDICT_BATCH_SIZE` `RVConfig` param that was used by `Learner.predict_dataset()`.
- Update usage in examples.
- Update unit and integration tests.

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

See new/updated unit tests.