### PR TITLE
Allow specifying class probability thresholds for semantic segmentation vectorization

### DIFF
--- a/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
+++ b/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
@@ -61,6 +61,22 @@ class SemanticSegmentationLabels(Labels):
         input window.
         """
 
+    @abstractmethod
+    def get_score_arr(self, window: Box,
+                      null_class_id: int = -1) -> np.ndarray:
+        """Get (C, H, W) array of pixel scores."""
+
+    def get_class_mask(self,
+                       window: Box,
+                       class_id: int,
+                       threshold: Optional[float] = None) -> np.ndarray:
+        """Get a binary mask representing all pixels of a class."""
+        scores = self.get_score_arr(window)
+        if threshold is None:
+            threshold = (1 / self.num_classes)
+        mask = scores[class_id] >= threshold
+        return mask
+
     def get_windows(self, **kwargs) -> List[Box]:
         """Generate sliding windows over the local extent.
 

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store.py
@@ -311,13 +311,13 @@ class SemanticSegmentationLabelStore(LabelStore):
 
         log.info('Writing vector outputs to disk.')
 
-        label_arr = labels.get_label_arr(labels.extent,
-                                         self.class_config.null_class_id)
-
+        extent = labels.extent
         with tqdm(self.vector_outputs, desc='Vectorizing predictions') as bar:
             for vo in bar:
                 bar.set_postfix(vo.dict())
-                class_mask = (label_arr == vo.class_id).astype(np.uint8)
+                class_mask = labels.get_class_mask(extent, vo.class_id,
+                                                   vo.threshold)
+                class_mask = class_mask.astype(np.uint8)
                 polys = vo.vectorize(class_mask)
                 polys = [
                     self.crs_transformer.pixel_to_map(p, bbox=self.bbox)

--- a/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
+++ b/rastervision_core/rastervision/core/data/label_store/semantic_segmentation_label_store_config.py
@@ -41,6 +41,15 @@ class VectorOutputConfig(Config):
         'intensive (especially for large images). Larger values will remove '
         'more noise and make vectorization faster but might also remove '
         'legitimate detections.')
+    threshold: Optional[float] = Field(
+        None,
+        description='Probability threshold for creating the binary mask for '
+        'the pixels of this class. Pixels will be considered to belong to '
+        'this class if their probability for this class is >= ``threshold``. '
+        'Note that Raster Vision treats classes as mutually exclusive so the '
+        'threshold should vary with the number of total classes. '
+        '``None`` is equivalent to setting this to (1 / num_classes). '
+        'Defaults to ``None``.')
 
     def vectorize(self, mask: 'np.ndarray') -> Iterator['BaseGeometry']:
         """Vectorize binary mask representing the target class into polygons.

--- a/tests/core/data/label_store/test_semantic_segmentation_label_store.py
+++ b/tests/core/data/label_store/test_semantic_segmentation_label_store.py
@@ -81,7 +81,9 @@ class TestSemanticSegmentationLabelStore(unittest.TestCase):
                 bbox=None,
                 smooth_output=True,
                 smooth_as_uint8=True,
-                vector_outputs=[PolygonVectorOutputConfig(class_id=1)])
+                vector_outputs=[
+                    PolygonVectorOutputConfig(class_id=1, threshold=0.3)
+                ])
             labels = SemanticSegmentationSmoothLabels(
                 extent=Box(0, 0, 10, 10), num_classes=len(class_config))
             labels.pixel_scores += make_random_scores(


### PR DESCRIPTION
## Overview

This PR adds a `threshold` field to `VectorOutputConfig`, such that the binary mask for class `i`'s vectorization is now computed as `probability_raster_i >= threshold`.

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

- See updated unit tests.
- Also tested with an older model bundle and verified vector outputs in QGIS.