### PR TITLE
Fix handing of some edge cases when reading chips from `XarraySource`

### DIFF
--- a/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
@@ -135,21 +135,21 @@ class XarraySource(RasterSource):
 
         window_within_bbox = window.intersection(self.bbox)
 
-        yslice, xsclice = window_within_bbox.to_slices()
+        yslice, xslice = window_within_bbox.to_slices()
         if self.temporal:
             chip = self.data_array.isel(
-                x=xsclice, y=yslice, band=bands, time=time).to_numpy()
+                x=xslice, y=yslice, band=bands, time=time).to_numpy()
         else:
             chip = self.data_array.isel(
-                x=xsclice, y=yslice, band=bands).to_numpy()
+                x=xslice, y=yslice, band=bands).to_numpy()
 
         if window != window_within_bbox:
             *batch_dims, h, w, c = chip.shape
             # coords of window_within_bbox within window
-            yslice, xsclice = window_within_bbox.to_local_coords(
+            yslice, xslice = window_within_bbox.to_local_coords(
                 window).to_slices()
             tmp = np.zeros((*batch_dims, *window.size, c))
-            tmp[..., yslice, xsclice, :] = chip
+            tmp[..., yslice, xslice, :] = chip
             chip = tmp
 
         chip = fill_overflow(self.bbox, window, chip)

--- a/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
@@ -79,6 +79,13 @@ class XarraySource(RasterSource):
         self.full_extent = Box(0, 0, height, width)
         if bbox is None:
             bbox = self.full_extent
+        else:
+            if bbox not in self.full_extent:
+                new_bbox = bbox.intersection(self.full_extent)
+                log.warning(f'Clipping ({bbox}) to the DataArray\'s '
+                            f'full extent ({self.full_extent}). '
+                            f'New bbox={new_bbox}')
+                bbox = new_bbox
 
         super().__init__(
             channel_order,

--- a/tests/core/data/raster_source/test_xarray_source.py
+++ b/tests/core/data/raster_source/test_xarray_source.py
@@ -101,6 +101,29 @@ class TestXarraySource(unittest.TestCase):
         chip_expected = np.array([[[0, 1, 2, 3]]], dtype=arr.dtype)
         np.testing.assert_array_equal(chip, chip_expected)
 
+    def test_get_raw_chip_overflowing_window(self):
+        arr = np.arange(100).reshape(10, 10, 1)
+        da = DataArray(arr, dims=['y', 'x', 'band'])
+        rs = XarraySource(da, IdentityCRSTransformer(), bbox=Box(2, 2, 7, 7))
+
+        chip = rs.get_raw_chip(Box(3, 3, 7, 7))
+        chip_expected = np.zeros((4, 4, 1))
+        chip_expected[:2, :2] = arr[5:7, 5:7]
+        np.testing.assert_array_equal(chip, chip_expected)
+
+        chip = rs.get_raw_chip(Box(-2, -2, 2, 2))
+        chip_expected = np.zeros((4, 4, 1))
+        chip_expected[2:, 2:] = arr[2:4, 2:4]
+        np.testing.assert_array_equal(chip, chip_expected)
+
+        chip = rs.get_raw_chip(Box(-5, -5, 0, 0))
+        chip_expected = np.zeros((5, 5, 1))
+        np.testing.assert_array_equal(chip, chip_expected)
+
+        chip = rs.get_raw_chip(Box(6, 6, 9, 9))
+        chip_expected = np.zeros((3, 3, 1))
+        np.testing.assert_array_equal(chip, chip_expected)
+
     def test_get_chip(self):
         arr = np.ones((5, 5, 4), dtype=np.uint8)
         arr *= np.arange(4, dtype=np.uint8)

--- a/tests/core/data/raster_source/test_xarray_source.py
+++ b/tests/core/data/raster_source/test_xarray_source.py
@@ -124,6 +124,12 @@ class TestXarraySource(unittest.TestCase):
         chip_expected = np.zeros((3, 3, 1))
         np.testing.assert_array_equal(chip, chip_expected)
 
+    def test_get_bbox_overflows_full_extent(self):
+        arr = np.empty((5, 5, 1))
+        da = DataArray(arr, dims=['y', 'x', 'band'])
+        rs = XarraySource(da, IdentityCRSTransformer(), bbox=Box(2, 2, 5, 7))
+        self.assertEqual(rs.bbox, Box(2, 2, 5, 5))
+
     def test_get_chip(self):
         arr = np.ones((5, 5, 4), dtype=np.uint8)
         arr *= np.arange(4, dtype=np.uint8)


### PR DESCRIPTION
## Overview

This PR ensures that `XarraySource._get_chip(window)` always returns a chip of the same size as the `window`, even if the `window` is not fully or partially contained within the `XarraySource`'s `bbox`. It also handles the subtle case of the user-specified `bbox` overflowing the full extent of the `DataArray`.

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

- See new unit tests.