### PR TITLE
Define `XarraySource.from_stac()` for more convenient creation of an `XarraySource` from a STAC Item or ItemCollection

### DIFF
--- a/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
@@ -26,7 +26,6 @@ class XarraySource(RasterSource):
                  crs_transformer: 'CRSTransformer',
                  raster_transformers: List['RasterTransformer'] = [],
                  channel_order: Optional[Sequence[int]] = None,
-                 num_channels_raw: Optional[int] = None,
                  bbox: Optional[Box] = None,
                  temporal: bool = False):
         """Constructor.
@@ -63,8 +62,7 @@ class XarraySource(RasterSource):
         self.ndim = data_array.ndim
         self._crs_transformer = crs_transformer
 
-        if num_channels_raw is None:
-            num_channels_raw = len(data_array.band)
+        num_channels_raw = len(data_array.band)
         if channel_order is None:
             channel_order = np.arange(num_channels_raw, dtype=int)
         else:

--- a/rastervision_core/rastervision/core/data/raster_source/xarray_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/xarray_source_config.py
@@ -2,13 +2,11 @@ from typing import Any, Dict, Optional, Tuple, Union
 import logging
 
 from rastervision.pipeline.config import Field, register_config
-from rastervision.core.box import Box
 from rastervision.core.data.raster_source.raster_source_config import (
     RasterSourceConfig)
-from rastervision.core.data.crs_transformer import RasterioCRSTransformer
 from rastervision.core.data.raster_source.stac_config import (
     STACItemConfig, STACItemCollectionConfig)
-from rastervision.core.data.raster_source.xarray_source import (XarraySource)
+from rastervision.core.data.raster_source.xarray_source import XarraySource
 
 log = logging.getLogger(__name__)
 
@@ -38,43 +36,17 @@ class XarraySourceConfig(RasterSourceConfig):
     def build(self,
               tmp_dir: Optional[str] = None,
               use_transformers: bool = True) -> XarraySource:
-        import stackstac
-
         item_or_item_collection = self.stac.build()
-        data_array = stackstac.stack(item_or_item_collection,
-                                     **self.stackstac_args)
-
-        if not self.temporal and 'time' in data_array.dims:
-            if len(data_array.time) > 1:
-                raise ValueError('temporal=False but len(data_array.time) > 1')
-            data_array = data_array.isel(time=0)
-
-        if not self.allow_streaming:
-            from humanize import naturalsize
-            log.info('Loading the full DataArray into memory '
-                     f'({naturalsize(data_array.nbytes)}).')
-            data_array.load()
-
-        crs_transformer = RasterioCRSTransformer(
-            transform=data_array.transform, image_crs=data_array.crs)
         raster_transformers = ([rt.build() for rt in self.transformers]
                                if use_transformers else [])
-
-        if self.bbox is not None:
-            if self.bbox_map_coords is not None:
-                log.info('Using bbox and ignoring bbox_map_coords.')
-            bbox = Box(*self.bbox)
-        elif self.bbox_map_coords is not None:
-            bbox_map_coords = Box(*self.bbox_map_coords)
-            bbox = crs_transformer.map_to_pixel(bbox_map_coords).normalize()
-        else:
-            bbox = None
-
-        raster_source = XarraySource(
-            data_array,
-            crs_transformer=crs_transformer,
+        raster_source = XarraySource.from_stac(
+            item_or_item_collection,
             raster_transformers=raster_transformers,
             channel_order=self.channel_order,
-            bbox=bbox,
-            temporal=self.temporal)
+            bbox=self.bbox,
+            bbox_map_coords=self.bbox_map_coords,
+            temporal=self.temporal,
+            allow_streaming=self.allow_streaming,
+            stackstac_args=self.stackstac_args,
+        )
         return raster_source


### PR DESCRIPTION
## Overview

This PR moves most of the `XarraySource` creation code from `XarraySourceConfig` to `XarraySource.from_stac()`, which allows an `XarraySource` to be created directly from a STAC Item or ItemCollection without having to define an `XarraySourceConfig`. It also removes the not-useful `num_channels_raw` argument from `XarraySource.__init__()`.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A