### PR TITLE
Ignore version constraints in `setup.py`'s

### DIFF
--- a/cookiecutter_template/{{cookiecutter.project_name}}/rastervision_{{cookiecutter.project_name}}/setup.py
+++ b/cookiecutter_template/{{cookiecutter.project_name}}/rastervision_{{cookiecutter.project_name}}/setup.py
@@ -1,17 +1,34 @@
 # flake8: noqa
 
-from os import path as op
-import io
-from setuptools import (setup, find_namespace_packages)
+from os.path import abspath, dirname, join
+from setuptools import setup, find_namespace_packages
+import re
 
-here = op.abspath(op.dirname(__file__))
-with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+name = 'rastervision_{{cookiecutter.project_name}}'
+version = '{{cookiecutter.version}}'
+description = '{{cookiecutter.description}}'
+requirement_constraints = {}
 
-name='rastervision_{{cookiecutter.project_name}}'
-version='{{cookiecutter.version}}'
-description='{{cookiecutter.description}}'
+here = abspath(dirname(__file__))
+
+
+def parse_requirements(requirements_path: str) -> list[str]:
+    requirements = []
+    with open(requirements_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if 'git+' in line:
+                continue
+            # match package name, ignoring version constraints
+            match = re.match(r'^\s*([^\s<=>]+)', line)
+            if not match:
+                continue
+            package_name = match.group(1)
+            if package_name in requirement_constraints:
+                constraint = requirement_constraints[package_name]
+                package_name = f'{package_name}{constraint}'
+            requirements.append(package_name)
+    return requirements
+
 
 setup(
     name=name,
@@ -30,6 +47,5 @@ setup(
     keywords=
     'raster deep-learning ml computer-vision earth-observation geospatial geospatial-processing',
     packages=find_namespace_packages(exclude=['integration_tests*', 'tests*']),
-    install_requires=install_requires,
-    zip_safe=False
-)
+    install_requires=parse_requirements(join(here, 'requirements.txt')),
+    zip_safe=False)

--- a/rastervision_aws_batch/setup.py
+++ b/rastervision_aws_batch/setup.py
@@ -1,17 +1,34 @@
 # flake8: noqa
 
-from os import path as op
-import io
-from setuptools import (setup, find_namespace_packages)
-
-here = op.abspath(op.dirname(__file__))
-with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+from os.path import abspath, dirname, join
+from setuptools import setup, find_namespace_packages
+import re
 
 name = 'rastervision_aws_batch'
 version = '0.21.4-dev'
 description = 'A rastervision plugin that adds an AWS Batch pipeline runner'
+requirement_constraints = {}
+
+here = abspath(dirname(__file__))
+
+
+def parse_requirements(requirements_path: str) -> list[str]:
+    requirements = []
+    with open(requirements_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if 'git+' in line:
+                continue
+            # match package name, ignoring version constraints
+            match = re.match(r'^\s*([^\s<=>]+)', line)
+            if not match:
+                continue
+            package_name = match.group(1)
+            if package_name in requirement_constraints:
+                constraint = requirement_constraints[package_name]
+                package_name = f'{package_name}{constraint}'
+            requirements.append(package_name)
+    return requirements
+
 
 setup(
     name=name,
@@ -30,5 +47,5 @@ setup(
     keywords=
     'raster deep-learning ml computer-vision earth-observation geospatial geospatial-processing',
     packages=find_namespace_packages(exclude=['integration_tests*', 'tests*']),
-    install_requires=install_requires,
+    install_requires=parse_requirements(join(here, 'requirements.txt')),
     zip_safe=False)

--- a/rastervision_aws_s3/setup.py
+++ b/rastervision_aws_s3/setup.py
@@ -1,17 +1,34 @@
 # flake8: noqa
 
-from os import path as op
-import io
-from setuptools import (setup, find_namespace_packages)
-
-here = op.abspath(op.dirname(__file__))
-with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+from os.path import abspath, dirname, join
+from setuptools import setup, find_namespace_packages
+import re
 
 name = 'rastervision_aws_s3'
 version = '0.21.4-dev'
 description = 'A rastervision plugin that adds an AWS S3 file system'
+requirement_constraints = {}
+
+here = abspath(dirname(__file__))
+
+
+def parse_requirements(requirements_path: str) -> list[str]:
+    requirements = []
+    with open(requirements_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if 'git+' in line:
+                continue
+            # match package name, ignoring version constraints
+            match = re.match(r'^\s*([^\s<=>]+)', line)
+            if not match:
+                continue
+            package_name = match.group(1)
+            if package_name in requirement_constraints:
+                constraint = requirement_constraints[package_name]
+                package_name = f'{package_name}{constraint}'
+            requirements.append(package_name)
+    return requirements
+
 
 setup(
     name=name,
@@ -30,5 +47,5 @@ setup(
     keywords=
     'raster deep-learning ml computer-vision earth-observation geospatial geospatial-processing',
     packages=find_namespace_packages(exclude=['integration_tests*', 'tests*']),
-    install_requires=install_requires,
+    install_requires=parse_requirements(join(here, 'requirements.txt')),
     zip_safe=False)

--- a/rastervision_aws_sagemaker/setup.py
+++ b/rastervision_aws_sagemaker/setup.py
@@ -1,17 +1,34 @@
 # flake8: noqa
 
-from os import path as op
-import io
-from setuptools import (setup, find_namespace_packages)
-
-here = op.abspath(op.dirname(__file__))
-with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+from os.path import abspath, dirname, join
+from setuptools import setup, find_namespace_packages
+import re
 
 name = 'rastervision_aws_sagemaker'
 version = '0.21'
 description = 'A rastervision plugin that adds an AWS SageMaker pipeline runner'
+requirement_constraints = {}
+
+here = abspath(dirname(__file__))
+
+
+def parse_requirements(requirements_path: str) -> list[str]:
+    requirements = []
+    with open(requirements_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if 'git+' in line:
+                continue
+            # match package name, ignoring version constraints
+            match = re.match(r'^\s*([^\s<=>]+)', line)
+            if not match:
+                continue
+            package_name = match.group(1)
+            if package_name in requirement_constraints:
+                constraint = requirement_constraints[package_name]
+                package_name = f'{package_name}{constraint}'
+            requirements.append(package_name)
+    return requirements
+
 
 setup(
     name=name,
@@ -30,5 +47,5 @@ setup(
     keywords=
     'raster deep-learning ml computer-vision earth-observation geospatial geospatial-processing',
     packages=find_namespace_packages(exclude=['integration_tests*', 'tests*']),
-    install_requires=install_requires,
+    install_requires=parse_requirements(join(here, 'requirements.txt')),
     zip_safe=False)

--- a/rastervision_core/setup.py
+++ b/rastervision_core/setup.py
@@ -1,17 +1,34 @@
 # flake8: noqa
 
-from os import path as op
-import io
-from setuptools import (setup, find_namespace_packages)
-
-here = op.abspath(op.dirname(__file__))
-with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+from os.path import abspath, dirname, join
+from setuptools import setup, find_namespace_packages
+import re
 
 name = 'rastervision_core'
 version = '0.21.4-dev'
 description = 'A rastervision plugin that adds geospatial machine learning pipelines'
+requirement_constraints = {}
+
+here = abspath(dirname(__file__))
+
+
+def parse_requirements(requirements_path: str) -> list[str]:
+    requirements = []
+    with open(requirements_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if 'git+' in line:
+                continue
+            # match package name, ignoring version constraints
+            match = re.match(r'^\s*([^\s<=>]+)', line)
+            if not match:
+                continue
+            package_name = match.group(1)
+            if package_name in requirement_constraints:
+                constraint = requirement_constraints[package_name]
+                package_name = f'{package_name}{constraint}'
+            requirements.append(package_name)
+    return requirements
+
 
 setup(
     name=name,
@@ -30,5 +47,5 @@ setup(
     keywords=
     'raster deep-learning ml computer-vision earth-observation geospatial geospatial-processing',
     packages=find_namespace_packages(exclude=['integration_tests*', 'tests*']),
-    install_requires=install_requires,
+    install_requires=parse_requirements(join(here, 'requirements.txt')),
     zip_safe=False)

--- a/rastervision_gdal_vsi/setup.py
+++ b/rastervision_gdal_vsi/setup.py
@@ -1,17 +1,34 @@
 # flake8: noqa
 
-from os import path as op
-import io
-from setuptools import (setup, find_namespace_packages)
-
-here = op.abspath(op.dirname(__file__))
-with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+from os.path import abspath, dirname, join
+from setuptools import setup, find_namespace_packages
+import re
 
 name = 'rastervision_gdal_vsi'
 version = '0.21.4-dev'
 description = 'A rastervision plugin that adds a GDAL VSI file system'
+requirement_constraints = {}
+
+here = abspath(dirname(__file__))
+
+
+def parse_requirements(requirements_path: str) -> list[str]:
+    requirements = []
+    with open(requirements_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if 'git+' in line:
+                continue
+            # match package name, ignoring version constraints
+            match = re.match(r'^\s*([^\s<=>]+)', line)
+            if not match:
+                continue
+            package_name = match.group(1)
+            if package_name in requirement_constraints:
+                constraint = requirement_constraints[package_name]
+                package_name = f'{package_name}{constraint}'
+            requirements.append(package_name)
+    return requirements
+
 
 setup(
     name=name,
@@ -30,5 +47,5 @@ setup(
     keywords=
     'raster deep-learning ml computer-vision earth-observation geospatial geospatial-processing',
     packages=find_namespace_packages(exclude=['integration_tests*', 'tests*']),
-    install_requires=install_requires,
+    install_requires=parse_requirements(join(here, 'requirements.txt')),
     zip_safe=False)

--- a/rastervision_pipeline/requirements.txt
+++ b/rastervision_pipeline/requirements.txt
@@ -4,3 +4,4 @@ everett==3.3.0
 everett[ini]==3.3.0
 six==1.16.*
 tqdm==4.66.1
+requests==2.31.0

--- a/rastervision_pytorch_backend/setup.py
+++ b/rastervision_pytorch_backend/setup.py
@@ -1,17 +1,34 @@
 # flake8: noqa
 
-from os import path as op
-import io
-from setuptools import (setup, find_namespace_packages)
-
-here = op.abspath(op.dirname(__file__))
-with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+from os.path import abspath, dirname, join
+from setuptools import setup, find_namespace_packages
+import re
 
 name = 'rastervision_pytorch_backend'
 version = '0.21.4-dev'
 description = 'A rastervision plugin that adds PyTorch backends for rastervision.core pipelines'
+requirement_constraints = {}
+
+here = abspath(dirname(__file__))
+
+
+def parse_requirements(requirements_path: str) -> list[str]:
+    requirements = []
+    with open(requirements_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if 'git+' in line:
+                continue
+            # match package name, ignoring version constraints
+            match = re.match(r'^\s*([^\s<=>]+)', line)
+            if not match:
+                continue
+            package_name = match.group(1)
+            if package_name in requirement_constraints:
+                constraint = requirement_constraints[package_name]
+                package_name = f'{package_name}{constraint}'
+            requirements.append(package_name)
+    return requirements
+
 
 setup(
     name=name,
@@ -30,5 +47,5 @@ setup(
     keywords=
     'raster deep-learning ml computer-vision earth-observation geospatial geospatial-processing',
     packages=find_namespace_packages(exclude=['integration_tests*', 'tests*']),
-    install_requires=install_requires,
+    install_requires=parse_requirements(join(here, 'requirements.txt')),
     zip_safe=False)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
@@ -12,7 +12,6 @@ import albumentations as A
 from albumentations.core.transforms_interface import ImageOnlyTransform
 import cv2
 import pandas as pd
-import onnxruntime as ort
 
 from rastervision.pipeline.file_system.utils import (file_exists, file_to_json,
                                                      get_tmp_dir)
@@ -20,6 +19,7 @@ from rastervision.pipeline.config import (build_config, Config, ConfigError,
                                           upgrade_config)
 
 if TYPE_CHECKING:
+    import onnxruntime as ort
     from rastervision.pytorch_learner import LearnerConfig
 
 log = logging.getLogger(__name__)
@@ -456,7 +456,7 @@ class ONNXRuntimeAdapter:
     also outputs PyTorch Tensors.
     """
 
-    def __init__(self, ort_session: ort.InferenceSession) -> None:
+    def __init__(self, ort_session: 'ort.InferenceSession') -> None:
         """Constructor.
 
         Args:
@@ -482,6 +482,8 @@ class ONNXRuntimeAdapter:
         Returns:
             ONNXRuntimeAdapter: An ONNXRuntimeAdapter instance.
         """
+        import onnxruntime as ort
+
         if providers is None:
             providers = ort.get_available_providers()
             log.info(f'Using ONNX execution providers: {providers}')

--- a/rastervision_pytorch_learner/requirements.txt
+++ b/rastervision_pytorch_learner/requirements.txt
@@ -13,4 +13,3 @@ opencv-python-headless==4.9.0.80
 matplotlib==3.8.2
 tqdm==4.66.1
 onnx==1.15.0
-onnxruntime-gpu==1.17

--- a/rastervision_pytorch_learner/setup.py
+++ b/rastervision_pytorch_learner/setup.py
@@ -1,17 +1,34 @@
 # flake8: noqa
 
-from os import path as op
-import io
-from setuptools import (setup, find_namespace_packages)
-
-here = op.abspath(op.dirname(__file__))
-with io.open(op.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    all_reqs = f.read().split('\n')
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+from os.path import abspath, dirname, join
+from setuptools import setup, find_namespace_packages
+import re
 
 name = 'rastervision_pytorch_learner'
 version = '0.21.4-dev'
 description = 'A rastervision plugin that adds PyTorch training pipelines'
+requirement_constraints = {}
+
+here = abspath(dirname(__file__))
+
+
+def parse_requirements(requirements_path: str) -> list[str]:
+    requirements = []
+    with open(requirements_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if 'git+' in line:
+                continue
+            # match package name, ignoring version constraints
+            match = re.match(r'^\s*([^\s<=>]+)', line)
+            if not match:
+                continue
+            package_name = match.group(1)
+            if package_name in requirement_constraints:
+                constraint = requirement_constraints[package_name]
+                package_name = f'{package_name}{constraint}'
+            requirements.append(package_name)
+    return requirements
+
 
 setup(
     name=name,
@@ -30,5 +47,5 @@ setup(
     keywords=
     'raster deep-learning ml computer-vision earth-observation geospatial geospatial-processing',
     packages=find_namespace_packages(exclude=['integration_tests*', 'tests*']),
-    install_requires=install_requires,
+    install_requires=parse_requirements(join(here, 'requirements.txt')),
     zip_safe=False)


### PR DESCRIPTION
## Overview

This PR makes it so that `setup.py`'s ignore the pinned versions in `requirement.txt`'s. This addresses the frequent complaint of RV not being easy to use with other libraries because of the strong constraints on dependency versions. The pinned versions will now only be used for building the docker image.

If a constraint is crucial, it can be specified in the `requirement_constraints` dict in the respective `setup.py` (see the one in `rastervision_pipeline` for an example).

Additionally, the `onnxruntime-gpu` requirement has been removed, since it is hardware-dependent.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A


## Testing Instructions
```sh
mamba create --name rvtest python==3.11 -y
mamba activate rvtest
pip install -e ~/raster-vision/rastervision_pipeline/ ~/raster-vision/rastervision_aws_s3/ ~/raster-vision/rastervision_aws_batch/ ~/raster-vision/rastervision_core/ ~/raster-vision/rastervision_pytorch_learner/ ~/raster-vision/rastervision_pytorch_backend/ ~/raster-vision/rastervision_aws_sagemaker/
```

Fixes the `onnxruntime-gpu` part of #1867.
