### PR TITLE
Allow passing `out_size` param to `SlidingWindowGeoDataset`

### DIFF
--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/object_detection_dataset.py
@@ -234,8 +234,8 @@ class ObjectDetectionRandomWindowGeoDataset(RandomWindowGeoDataset):
         else:
             self.neg_probability = None
 
-    def get_resize_transform(self, transform: A.BasicTransform,
-                             out_size: Tuple[int, int]) -> A.BasicTransform:
+    def append_resize_transform(self, transform: A.BasicTransform,
+                                out_size: tuple[int, int]) -> A.BasicTransform:
         resize_tf = A.Resize(*out_size, always_apply=True)
         if transform is None:
             transform = resize_tf

--- a/tests/pytorch_learner/dataset/test_dataset.py
+++ b/tests/pytorch_learner/dataset/test_dataset.py
@@ -174,6 +174,19 @@ class TestSlidingWindowGeoDataset(unittest.TestCase):
         )
         self.assertEqual(len(ds.windows), 4)
 
+    def test_out_size(self):
+        scene = MockScene()
+        ds = SlidingWindowGeoDataset(
+            scene,
+            size=5,
+            stride=5,
+            out_size=10,
+            transform_type=TransformType.semantic_segmentation,
+        )
+        x, y = ds[0]
+        self.assertTupleEqual(x.shape, (3, 10, 10))
+        self.assertTupleEqual(y.shape, (10, 10))
+
     def test_return_window(self):
         scene = MockScene()
         ds = SlidingWindowGeoDataset(


### PR DESCRIPTION
## Overview

This PR allows an `out_size` param to be passed to `SlidingWindowGeoDataset.__init__()`. This saves the user from having to manually specify an albumentations resize transform. It also makes it more consistent with `RandomWindowGeoDataset.__init__()`.

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes
N/A

## Testing Instructions
See new unit test.
