### PR TITLE
Make `DataConfig` take a `ClassConfig` instead of `class_names` and `class_colors` separately

### DIFF
--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/pytorch_learner_backend_config.py
@@ -51,14 +51,8 @@ class PyTorchLearnerBackendConfig(BackendConfig):
             if self.data.uri is None and self.data.group_uris is None:
                 self.data.uri = pipeline.chip_uri
 
-        if not self.data.class_names:
-            # We want to defer validating class_names against class_colors
-            # until we have updated both. Hence, we use Config.copy(update=)
-            # here because it does not trigger pydantic validators.
-            self.data = self.data.copy(
-                update={'class_names': pipeline.dataset.class_config.names})
-        if not self.data.class_colors:
-            self.data.class_colors = pipeline.dataset.class_config.colors
+        if self.data.class_config is None:
+            self.data.class_config = pipeline.dataset.class_config
 
         if not self.data.img_channels:
             self.data.img_channels = self.get_img_channels(pipeline)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/__init__.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
 
 
 def register_plugin(registry: 'Registry'):
-    registry.set_plugin_version('rastervision.pytorch_learner', 6)
+    registry.set_plugin_version('rastervision.pytorch_learner', 7)
     registry.register_renamed_type_hints('geo_data_window', 'window_sampling')
 
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/visualizer/visualizer.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/visualizer/visualizer.py
@@ -10,13 +10,13 @@ import albumentations as A
 import matplotlib.pyplot as plt
 
 from rastervision.pipeline.file_system import make_dir
+from rastervision.core.data import ClassConfig
 from rastervision.pytorch_learner.utils import (
     deserialize_albumentation_transform, validate_albumentation_transform,
     MinMaxNormalize)
 from rastervision.pytorch_learner.learner_config import (
     RGBTuple,
     ChannelInds,
-    ensure_class_colors,
     validate_channel_display_groups,
     get_default_channel_display_groups,
 )
@@ -60,13 +60,20 @@ class Visualizer(ABC):
                 title is a string that will be used as the title of the subplot
                 for that group.
         """
-        self.class_names = class_names
-        self.class_colors = ensure_class_colors(self.class_names, class_colors)
+        self.class_config = ClassConfig(names=class_names, colors=class_colors)
         if transform is None:
             transform = A.to_dict(MinMaxNormalize())
         self.transform = validate_albumentation_transform(transform)
         self._channel_display_groups = validate_channel_display_groups(
             channel_display_groups)
+
+    @property
+    def class_names(self):
+        return self.class_config.names
+
+    @property
+    def class_colors(self):
+        return self.class_config.colors
 
     @abstractmethod
     def plot_xyz(self,

--- a/tests/pytorch_learner/test_classification_learner.py
+++ b/tests/pytorch_learner/test_classification_learner.py
@@ -98,8 +98,7 @@ class TestClassificationLearner(unittest.TestCase):
             data_cfg = ClassificationGeoDataConfig(
                 scene_dataset=dataset_cfg,
                 sampling=sampling_cfg,
-                class_names=class_config.names,
-                class_colors=class_config.colors,
+                class_config=class_config,
                 plot_options=PlotOptions(
                     channel_display_groups=channel_display_groups),
                 num_workers=0)

--- a/tests/pytorch_learner/test_object_detection_learner.py
+++ b/tests/pytorch_learner/test_object_detection_learner.py
@@ -102,8 +102,7 @@ class TestObjectDetectionLearner(unittest.TestCase):
                     size=200,
                     max_windows=8,
                     neg_ratio=0.5),
-                class_names=class_config.names,
-                class_colors=class_config.colors,
+                class_config=class_config,
                 plot_options=PlotOptions(
                     channel_display_groups=channel_display_groups),
                 num_workers=0)

--- a/tests/pytorch_learner/test_regression_learner.py
+++ b/tests/pytorch_learner/test_regression_learner.py
@@ -88,8 +88,7 @@ class TestRegressionLearner(unittest.TestCase):
                 sampling=WindowSamplingConfig(
                     method=WindowSamplingMethod.random, size=20,
                     max_windows=8),
-                class_names=class_config.names,
-                class_colors=class_config.colors,
+                class_config=class_config,
                 plot_options=RegressionPlotOptions(
                     channel_display_groups=channel_display_groups),
                 num_workers=0)

--- a/tests/pytorch_learner/test_semantic_segmentation_learner.py
+++ b/tests/pytorch_learner/test_semantic_segmentation_learner.py
@@ -104,8 +104,7 @@ class TestSemanticSegmentationLearner(unittest.TestCase):
                 sampling=WindowSamplingConfig(
                     method=WindowSamplingMethod.random, size=20,
                     max_windows=8),
-                class_names=class_config.names,
-                class_colors=class_config.colors,
+                class_config=class_config,
                 aug_transform=aug_tf,
                 plot_options=PlotOptions(
                     channel_display_groups=channel_display_groups),


### PR DESCRIPTION
## Overview

This PR makes `DataConfig` take a `ClassConfig` instead of `class_names` and `class_colors`. This makes things more consistent and avoids duplication of validation code. This PR also refactors `Visualizer` to use `ClassConfig` thus avoiding duplication of validation code.

`.class_names` and `.class_colors` in both `DataConfig` and `Visualizer` have been made into properties to avoid excessive changes in code that uses them.

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes
N/A


## Testing Instructions
See new/updated unit tests.