### PR TITLE
Allow reading GeoJSONs with non-`epsg:4326` CRS's

### DIFF
--- a/integration_tests/chip_classification/config.py
+++ b/integration_tests/chip_classification/config.py
@@ -28,8 +28,7 @@ def get_config(runner, root_uri, data_uri=None, full_train=False,
     def make_scene(img_path, label_path):
         id = basename(img_path)
         label_source = ChipClassificationLabelSourceConfig(
-            vector_source=GeoJSONVectorSourceConfig(
-                uris=label_path, ignore_crs_field=True),
+            vector_source=GeoJSONVectorSourceConfig(uris=label_path),
             ioa_thresh=0.5,
             use_intersection_over_cell=False,
             pick_min_class_id=True,

--- a/rastervision_core/rastervision/core/__init__.py
+++ b/rastervision_core/rastervision/core/__init__.py
@@ -2,7 +2,7 @@
 
 
 def register_plugin(registry):
-    registry.set_plugin_version('rastervision.core', 12)
+    registry.set_plugin_version('rastervision.core', 13)
     from rastervision.core.cli import predict, predict_scene
     registry.add_plugin_command(predict)
     registry.add_plugin_command(predict_scene)

--- a/rastervision_core/rastervision/core/data/utils/factory.py
+++ b/rastervision_core/rastervision/core/data/utils/factory.py
@@ -99,7 +99,6 @@ def make_ss_scene(image_uri: Union[str, List[str]],
                 [class_inf_tf] + vector_tfs)
         vector_source = GeoJSONVectorSource(
             uris=label_vector_uri,
-            ignore_crs_field=True,
             crs_transformer=crs_transformer,
             **label_vector_source_kw)
         label_raster_source = RasterizedSource(
@@ -196,9 +195,7 @@ def make_cc_scene(image_uri: Union[str, List[str]],
             label_vector_source_kw['transformers'] = (
                 [class_inf_tf] + vector_tfs)
         geojson_cfg = GeoJSONVectorSourceConfig(
-            uris=label_vector_uri,
-            ignore_crs_field=True,
-            **label_vector_source_kw)
+            uris=label_vector_uri, **label_vector_source_kw)
         # use config to ensure required transformers are auto added
         label_source_cfg = ChipClassificationLabelSourceConfig(
             vector_source=geojson_cfg, **label_source_kw)
@@ -287,9 +284,7 @@ def make_od_scene(image_uri: Union[str, List[str]],
             label_vector_source_kw['transformers'] = (
                 [class_inf_tf] + vector_tfs)
         geojson_cfg = GeoJSONVectorSourceConfig(
-            uris=label_vector_uri,
-            ignore_crs_field=True,
-            **label_vector_source_kw)
+            uris=label_vector_uri, **label_vector_source_kw)
         # use config to ensure required transformers are auto added
         label_source_cfg = ObjectDetectionLabelSourceConfig(
             vector_source=geojson_cfg, **label_source_kw)

--- a/rastervision_core/rastervision/core/data/utils/geojson.py
+++ b/rastervision_core/rastervision/core/data/utils/geojson.py
@@ -348,10 +348,7 @@ def get_polygons_from_uris(uris: Union[str, List[str]],
     from rastervision.core.data import GeoJSONVectorSource
 
     source = GeoJSONVectorSource(
-        uris=uris,
-        ignore_crs_field=True,
-        crs_transformer=crs_transformer,
-        bbox=bbox)
+        uris=uris, crs_transformer=crs_transformer, bbox=bbox)
     polygons = source.get_geoms(to_map_coords=map_coords)
     return polygons
 

--- a/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
+++ b/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source.py
@@ -1,7 +1,9 @@
 from typing import TYPE_CHECKING, List, Optional, Union
 import logging
 
-from rastervision.pipeline.file_system import download_if_needed, file_to_json
+import geopandas as gpd
+
+from rastervision.pipeline.file_system import download_if_needed
 from rastervision.core.box import Box
 from rastervision.core.data.vector_source.vector_source import VectorSource
 from rastervision.core.data.utils import listify_uris, merge_geojsons
@@ -19,7 +21,6 @@ class GeoJSONVectorSource(VectorSource):
                  uris: Union[str, List[str]],
                  crs_transformer: 'CRSTransformer',
                  vector_transformers: List['VectorTransformer'] = [],
-                 ignore_crs_field: bool = False,
                  bbox: Optional[Box] = None):
         """Constructor.
 
@@ -30,15 +31,10 @@ class GeoJSONVectorSource(VectorSource):
                 :class:`.RasterSource`.
             vector_transformers: ``VectorTransformers`` for transforming
                 geometries. Defaults to ``[]``.
-            ignore_crs_field (bool): Ignore the CRS specified in the file and
-                assume WGS84 (EPSG:4326) coords. Only WGS84 is supported
-                currently. If False, and the file contains a CRS, will throw an
-                exception on read. Defaults to False.
             bbox (Optional[Box]): User-specified crop of the extent. If None,
                 the full extent available in the source file is used.
         """
         self.uris = listify_uris(uris)
-        self.ignore_crs_field = ignore_crs_field
         super().__init__(
             crs_transformer,
             vector_transformers=vector_transformers,
@@ -51,28 +47,8 @@ class GeoJSONVectorSource(VectorSource):
 
     def _get_geojson_single(self, uri: str) -> dict:
         # download first so that it gets cached
-        geojson = file_to_json(download_if_needed(uri))
-        if 'crs' in geojson:
-            if not self.ignore_crs_field:
-                raise NotImplementedError(
-                    f'The GeoJSON file at {uri} contains a CRS field which '
-                    'is not allowed by the current GeoJSON standard or by '
-                    'Raster Vision. All coordinates are expected to be in '
-                    'EPSG:4326 CRS. If the file uses EPSG:4326 (ie. lat/lng '
-                    'on the WGS84 reference ellipsoid) and you would like to '
-                    'ignore the CRS field, set ignore_crs_field=True.')
-            else:
-                crs = geojson['crs']
-                log.info(f'Ignoring CRS ({crs}) specified in {uri} '
-                         'and assuming EPSG:4326 instead.')
-                # Delete the CRS field to avoid discrepancies in case the
-                # geojson is passed to code that *does* respect the CRS field
-                # (e.g. geopandas).
-                del geojson['crs']
-                # Also delete any "crs" keys in features' properties.
-                for f in geojson.get('features', []):
-                    try:
-                        del f['properties']['crs']
-                    except KeyError:
-                        pass
+        path = download_if_needed(uri)
+        df: gpd.GeoDataFrame = gpd.read_file(path)
+        df = df.to_crs('epsg:4326')
+        geojson = df.__geo_interface__
         return geojson

--- a/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source_config.py
+++ b/rastervision_core/rastervision/core/data/vector_source/geojson_vector_source_config.py
@@ -10,8 +10,10 @@ if TYPE_CHECKING:
 def geojson_vector_source_config_upgrader(cfg_dict: dict,
                                           version: int) -> dict:
     if version == 7:
-        cfg_dict['uris'] = cfg_dict['uri']
-        del cfg_dict['uri']
+        cfg_dict['uris'] = cfg_dict.pop('uri', [])
+    if version == 12:
+        # removed in version 13
+        cfg_dict.pop('ignore_crs_field', None)
     return cfg_dict
 
 
@@ -22,7 +24,6 @@ class GeoJSONVectorSourceConfig(VectorSourceConfig):
 
     uris: Union[str, List[str]] = Field(
         ..., description='URI(s) of GeoJSON file(s).')
-    ignore_crs_field: bool = False
 
     def build(self,
               class_config: 'ClassConfig',
@@ -37,6 +38,5 @@ class GeoJSONVectorSourceConfig(VectorSourceConfig):
 
         return GeoJSONVectorSource(
             uris=self.uris,
-            ignore_crs_field=self.ignore_crs_field,
             crs_transformer=crs_transformer,
             vector_transformers=transformers)

--- a/rastervision_core/rastervision/core/data/vector_source/vector_source.py
+++ b/rastervision_core/rastervision/core/data/vector_source/vector_source.py
@@ -140,6 +140,10 @@ class VectorSource(ABC):
             self._bbox = self.extent
         return self._bbox
 
+    @property
+    def __geo_interface__(self):
+        return self.get_geojson()
+
 
 def sanitize_geojson(geojson: dict,
                      crs_transformer: 'CRSTransformer',

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/chip_classification/spacenet_rio.py
@@ -100,7 +100,6 @@ def get_config(runner,
         label_source = ChipClassificationLabelSourceConfig(
             vector_source=GeoJSONVectorSourceConfig(
                 uris=label_uri,
-                ignore_crs_field=True,
                 transformers=[
                     ClassInferenceTransformerConfig(default_class_id=1)
                 ]),

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/cowc_potsdam.py
@@ -100,7 +100,6 @@ def get_config(runner,
 
         vector_source = GeoJSONVectorSourceConfig(
             uris=label_uri,
-            ignore_crs_field=True,
             transformers=[ClassInferenceTransformerConfig(default_class_id=0)])
         label_source = ObjectDetectionLabelSourceConfig(
             vector_source=vector_source)

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/object_detection/xview.py
@@ -69,7 +69,6 @@ def get_config(runner,
         label_source = ObjectDetectionLabelSourceConfig(
             vector_source=GeoJSONVectorSourceConfig(
                 uris=label_uri,
-                ignore_crs_field=True,
                 transformers=[
                     ClassInferenceTransformerConfig(default_class_id=0)
                 ]))

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/spacenet_vegas.py
@@ -113,7 +113,6 @@ def build_scene(spacenet_cfg: SpacenetConfig,
     # Set a line buffer to convert line strings to polygons.
     vector_source = GeoJSONVectorSourceConfig(
         uris=label_uri,
-        ignore_crs_field=True,
         transformers=[
             ClassInferenceTransformerConfig(default_class_id=0),
             BufferTransformerConfig(

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/tiny_spacenet.py
@@ -65,9 +65,6 @@ def make_scene(scene_id: str, image_uri: str, label_uri: str,
     # configure GeoJSON reading
     vector_source = GeoJSONVectorSourceConfig(
         uris=label_uri,
-        # This assumes the CRS is WGS-84 and ignores whatever the CRS specified
-        # in the file is.
-        ignore_crs_field=True,
         # The geoms in the label GeoJSON do not have a "class_id" property, so
         # classes must be inferred. Since all geoms are for the building class,
         # this is easy to do: we just assign the building class ID to all of

--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/utils.py
@@ -63,7 +63,6 @@ def save_image_crop(
             vs = GeoJSONVectorSource(
                 uris=label_uri,
                 crs_transformer=crs_tf,
-                ignore_crs_field=True,
                 vector_transformers=[
                     ClassInferenceTransformer(
                         default_class_id=default_class_id,

--- a/tests/core/data/label_source/test_semantic_segmentation_label_source.py
+++ b/tests/core/data/label_source/test_semantic_segmentation_label_source.py
@@ -21,7 +21,6 @@ class TestSemanticSegmentationLabelSourceConfig(unittest.TestCase):
         rs_cfg = RasterizedSourceConfig(
             vector_source=GeoJSONVectorSourceConfig(
                 uris=uri,
-                ignore_crs_field=True,
                 transformers=[
                     ClassInferenceTransformerConfig(default_class_id=1)
                 ]),

--- a/tests/core/data/utils/test_misc.py
+++ b/tests/core/data/utils/test_misc.py
@@ -40,7 +40,7 @@ class TestMatchBboxes(unittest.TestCase):
         uri = join(self.tmp_dir, 'labels.json')
         json_to_file(geojson, uri)
         self.vector_source = GeoJSONVectorSource(
-            uri, self.raster_source.crs_transformer, ignore_crs_field=True)
+            uri, self.raster_source.crs_transformer)
 
     def tearDown(self) -> None:
         self._tmp_dir.cleanup()

--- a/tests/core/data/utils/test_rasterio.py
+++ b/tests/core/data/utils/test_rasterio.py
@@ -55,8 +55,7 @@ class TestRasterioUtils(unittest.TestCase):
                 geotiff_path, arr, geojson_path, crs=None)
             rs = RasterioSource(geotiff_path)
             geotiff_bbox = rs.crs_transformer.pixel_to_map(rs.extent)
-            vs = GeoJSONVectorSource(
-                geojson_path, rs.crs_transformer, ignore_crs_field=True)
+            vs = GeoJSONVectorSource(geojson_path, rs.crs_transformer)
             geojson_bbox = rs.crs_transformer.pixel_to_map(vs.extent)
             np.testing.assert_array_almost_equal(
                 np.array(list(geotiff_bbox)),


### PR DESCRIPTION
## Overview

This PR removes the old restriction on `GeoJSONVectorSource` of only being able to read `epsg:4326` GeoJSONs. Now, the GeoJSONs are read via `geopandas` and converted to `epsg:4326` internally via `gdf.to_crs('epsg:4326')`.

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This PR also adds a `__geo_interface__` property to `VectorSource`.

## Testing Instructions

See new/updated unit tests.

---
Resolves #2087.
