### PR TITLE
Fix Type hint

### DIFF
--- a/rastervision_core/rastervision/core/data/utils/misc.py
+++ b/rastervision_core/rastervision/core/data/utils/misc.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 def color_to_triple(
-        color: str | Sequence | None = None) -> Union[list, tuple[int, int, int]]:
+        color: str | Sequence | None = None) -> list[str] | tuple[int, int, int]:
     """Given a PIL ImageColor string, return a triple of integers
     representing the red, green, and blue values.
 

--- a/rastervision_core/rastervision/core/data/utils/misc.py
+++ b/rastervision_core/rastervision/core/data/utils/misc.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 import logging
 
 import numpy as np

--- a/rastervision_core/rastervision/core/data/utils/misc.py
+++ b/rastervision_core/rastervision/core/data/utils/misc.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence, Union
 import logging
 
 import numpy as np
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 def color_to_triple(
-        color: str | Sequence | None = None) -> tuple[int, int, int]:
+        color: str | Sequence | None = None) -> Union[list, tuple[int, int, int]]:
     """Given a PIL ImageColor string, return a triple of integers
     representing the red, green, and blue values.
 

--- a/rastervision_core/rastervision/core/data/utils/misc.py
+++ b/rastervision_core/rastervision/core/data/utils/misc.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-def color_to_triple(
-        color: str | Sequence | None = None) -> list[str] | tuple[int, int, int]:
+def color_to_triple(color: str | Sequence | None = None
+                    ) -> list[str] | tuple[int, int, int]:
     """Given a PIL ImageColor string, return a triple of integers
     representing the red, green, and blue values.
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -1182,7 +1182,7 @@ class Learner(ABC):
         return ds
 
     def build_dataloaders(self, distributed: bool | None = None
-                          ) -> tuple[DataLoader, DataLoader, DataLoader]:
+                          ) -> tuple[DataLoader, DataLoader, DataLoader | None]:
         """Build DataLoaders for train, validation, and test splits."""
         if distributed is None:
             distributed = self.distributed

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -1181,8 +1181,9 @@ class Learner(ABC):
         ds = self.cfg.data.build_dataset(split=split, tmp_dir=self.tmp_dir)
         return ds
 
-    def build_dataloaders(self, distributed: bool | None = None
-                          ) -> tuple[DataLoader, DataLoader, DataLoader | None]:
+    def build_dataloaders(
+            self, distributed: bool | None = None
+    ) -> tuple[DataLoader, DataLoader, DataLoader | None]:
         """Build DataLoaders for train, validation, and test splits."""
         if distributed is None:
             distributed = self.distributed

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -862,8 +862,7 @@ class ImageDataConfig(DataConfig):
 
     def _build_dataset(self,
                        dirs: Iterable[str],
-                       tf: A.BasicTransform | None = None
-                       ) -> Dataset:
+                       tf: A.BasicTransform | None = None) -> Dataset:
         """Make datasets for a single split.
 
         Args:

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -680,7 +680,7 @@ class DataConfig(Config):
 
     @field_validator('augmentors')
     @classmethod
-    def validate_augmentors(cls, v: list[str]) -> str:
+    def validate_augmentors(cls, v: list[str]) -> list[str]:
         for aug_name in v:
             if aug_name not in augmentors:
                 raise ConfigError(f'Unsupported augmentor "{aug_name}"')
@@ -863,7 +863,7 @@ class ImageDataConfig(DataConfig):
     def _build_dataset(self,
                        dirs: Iterable[str],
                        tf: A.BasicTransform | None = None
-                       ) -> tuple[Dataset, Dataset, Dataset]:
+                       ) -> Dataset:
         """Make datasets for a single split.
 
         Args:
@@ -1224,7 +1224,7 @@ class GeoDataConfig(DataConfig):
                        split: Literal['train', 'valid', 'test'],
                        tf: A.BasicTransform | None = None,
                        tmp_dir: str | None = None,
-                       **kwargs) -> tuple[Dataset, Dataset, Dataset]:
+                       **kwargs) -> Dataset:
         """Make training, validation, and test datasets.
 
         Args:


### PR DESCRIPTION
## Description
Fix Several type check warnings reported by Pyre@Google, which were outdated after code modifications.

## Detail
1. update the return type of function `color_to_triple` from `tuple[int, int, int]` to `Union[list, tuple[int, int, int]]`, according to the condition check, `color` could be `list` and directly return after commit https://github.com/azavea/raster-vision/commit/361306167b7ff77c00358658b5e0a033a33fccd9 
2. update the return type of function `build_dataset` from `tuple[DataLoader, DataLoader, DataLoader]` to `tuple[DataLoader, DataLoader, DataLoader | None]`, the `test_dl` is init as `None` and could directly return if `self.test_ds` is `None` after commit https://github.com/azavea/raster-vision/commit/d19310964c3732732384167a82d1d50217ae2f7c
3. update the return type of function `validate_augmentors` from `str` to `list[str]`, the input `v` is `list[str]` and directly return after condition check after commit https://github.com/azavea/raster-vision/commit/adac1a2e5adc1edb193e1f75f66cf5e3801036de
4. update the return type of function `_build_dataset` from `tuple[Dataset, Dataset, Dataset]` to `Dataset`, since the function only returns a Dataset after commit https://github.com/azavea/raster-vision/commit/d19310964c3732732384167a82d1d50217ae2f7c
5.  update the return type of function `_build_dataset` from `tuple[Dataset, Dataset, Dataset]` to `Dataset`, since the function only returns a Dataset after commit https://github.com/azavea/raster-vision/commit/d19310964c3732732384167a82d1d50217ae2f7c