### PR TITLE
Use rasterio AWS session in `RasterioSource` when reading files on S3

### DIFF
--- a/tests/aws_s3/test_s3_file_system.py
+++ b/tests/aws_s3/test_s3_file_system.py
@@ -12,6 +12,21 @@ class TestS3FileSystem(unittest.TestCase):
         s3 = S3FileSystem.get_client()
         self.assertEqual(s3._client_config.signature_version, UNSIGNED)
 
+    @patch.dict('os.environ', AWS_REQUEST_PAYER='requester')
+    def test_get_request_payer_env(self):
+        request_payer = S3FileSystem.get_request_payer()
+        self.assertEqual(request_payer, 'requester')
+
+    @patch.dict('os.environ', AWS_S3_REQUESTER_PAYS='yes')
+    def test_get_request_payer_rvconfig_env_true(self):
+        request_payer = S3FileSystem.get_request_payer()
+        self.assertEqual(request_payer, 'requester')
+
+    @patch.dict('os.environ', AWS_S3_REQUESTER_PAYS='false')
+    def test_get_request_payer_rvconfig_env_false(self):
+        request_payer = S3FileSystem.get_request_payer()
+        self.assertEqual(request_payer, 'None')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

This PR makes `RasterioSource` use rasterio's `AWSSession` when reading from a raster file on S3, which makes it easier to read from requester-pays buckets (e.g. NAIP).

Previously, the following (ipython) snippet would not work even if the user was logged into an SSO session via the AWS CLI; the user would need to export all the credentials to the environment to make it work. This PR fixes that.
```py
%env AWS_REQUEST_PAYER=requester

from rastervision.core.data import RasterioSource

uri = 's3://naip-analytic/pa/2019/60cm/rgbir_cog/39075/m_3907515_nw_18_060_20191019.tif'
rs = RasterioSource(uri, allow_streaming=True)
chip = rs[:100, :100]
```

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Notes

This PR also makes `rastervision_aws_s3` recognize the `AWS_REQUEST_PAYER` environment variable and allow it to override Raster Vision's `AWS_S3_REQUESTER_PAYS` config option.


## Testing Instructions

See new unit tests.