### PR TITLE
Compute `RasterStats` from transformed `RasterSource`

### DIFF
--- a/rastervision_core/rastervision/core/__init__.py
+++ b/rastervision_core/rastervision/core/__init__.py
@@ -2,7 +2,7 @@
 
 
 def register_plugin(registry):
-    registry.set_plugin_version('rastervision.core', 13)
+    registry.set_plugin_version('rastervision.core', 14)
     from rastervision.core.cli import predict, predict_scene
     registry.add_plugin_command(predict)
     registry.add_plugin_command(predict_scene)

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -278,6 +278,6 @@ class MultiRasterSource(RasterSource):
         chip = chip[..., self.channel_order]
 
         for transformer in self.raster_transformers:
-            chip = transformer.transform(chip, self.channel_order)
+            chip = transformer.transform(chip)
 
         return chip

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -64,7 +64,10 @@ class MultiRasterSourceConfig(RasterSourceConfig):
     def build(self, tmp_dir: str | None = None,
               use_transformers: bool = True) -> MultiRasterSource:
         if use_transformers:
-            raster_transformers = [t.build() for t in self.transformers]
+            raster_transformers = [
+                t.build(channel_order=self.channel_order)
+                for t in self.transformers
+            ]
         else:
             raster_transformers = []
 

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source.py
@@ -142,7 +142,7 @@ class RasterSource(ABC):
         chip = chip[..., self.channel_order]
 
         for transformer in self.raster_transformers:
-            chip = transformer.transform(chip, self.channel_order)
+            chip = transformer.transform(chip)
 
         return chip
 

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -198,7 +198,7 @@ class RasterioSource(RasterSource):
             bands = self.bands_to_read[bands]
         chip = self._get_chip(window, out_shape=out_shape, bands=bands)
         for transformer in self.raster_transformers:
-            chip = transformer.transform(chip, self.channel_order)
+            chip = transformer.transform(chip)
         return chip
 
     def __getitem__(self, key: Any) -> 'np.ndarray':

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
@@ -34,9 +34,15 @@ class RasterioSourceConfig(RasterSourceConfig):
         False,
         description='Stream assets as needed rather than downloading them.')
 
-    def build(self, tmp_dir, use_transformers=True):
-        raster_transformers = ([rt.build() for rt in self.transformers]
-                               if use_transformers else [])
+    def build(self, tmp_dir: str | None,
+              use_transformers: bool = True) -> RasterioSource:
+        if use_transformers:
+            raster_transformers = [
+                t.build(channel_order=self.channel_order)
+                for t in self.transformers
+            ]
+        else:
+            raster_transformers = []
         bbox = Box(*self.bbox) if self.bbox is not None else None
         return RasterioSource(
             uris=self.uris,

--- a/rastervision_core/rastervision/core/data/raster_source/temporal_multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/temporal_multi_raster_source.py
@@ -115,7 +115,7 @@ class TemporalMultiRasterSource(MultiRasterSource):
         chip = np.stack(sub_chips)
 
         for transformer in self.raster_transformers:
-            chip = transformer.transform(chip, self.channel_order)
+            chip = transformer.transform(chip)
 
         return chip
 

--- a/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
@@ -263,7 +263,7 @@ class XarraySource(RasterSource):
         chip = self._get_chip(
             window, bands=bands, time=time, out_shape=out_shape)
         for transformer in self.raster_transformers:
-            chip = transformer.transform(chip, bands)
+            chip = transformer.transform(chip)
         return chip
 
     def __getitem__(self, key: Any) -> 'np.ndarray':

--- a/rastervision_core/rastervision/core/data/raster_source/xarray_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/xarray_source_config.py
@@ -36,8 +36,13 @@ class XarraySourceConfig(RasterSourceConfig):
     def build(self, tmp_dir: str | None = None,
               use_transformers: bool = True) -> XarraySource:
         item_or_item_collection = self.stac.build()
-        raster_transformers = ([rt.build() for rt in self.transformers]
-                               if use_transformers else [])
+        if use_transformers:
+            raster_transformers = [
+                t.build(channel_order=self.channel_order)
+                for t in self.transformers
+            ]
+        else:
+            raster_transformers = []
         raster_source = XarraySource.from_stac(
             item_or_item_collection,
             raster_transformers=raster_transformers,

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
@@ -19,14 +19,13 @@ class CastTransformer(RasterTransformer):
     def __repr__(self):
         return repr_with_args(self, to_dtype=str(self.to_dtype))
 
-    def transform(self, chip: np.ndarray,
-                  channel_order: list | None = None) -> np.ndarray:
-        """Cast chip to self.to_dtype.
+    def transform(self, chip: np.ndarray) -> np.ndarray:
+        """Cast chip to dtype ``self.to_dtype``.
 
         Args:
-            chip: ndarray of shape [height, width, channels]
+            chip: Array of shape (..., H, W, C).
 
         Returns:
-            [height, width, channels] numpy array
+            Array of shape (..., H, W, C)
         """
         return chip.astype(self.to_dtype)

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer_config.py
@@ -1,7 +1,7 @@
 from rastervision.pipeline.config import register_config, Field
 from rastervision.core.data.raster_transformer.raster_transformer_config import (  # noqa
     RasterTransformerConfig)
-from rastervision.core.data.raster_transformer.cast_transformer import (  # noqa
+from rastervision.core.data.raster_transformer.cast_transformer import (
     CastTransformer)
 
 
@@ -14,5 +14,5 @@ class CastTransformerConfig(RasterTransformerConfig):
         description='dtype to cast raster to. Must be a valid Numpy dtype '
         'e.g. "uint8", "float32", etc.')
 
-    def build(self):
+    def build(self, channel_order: list[int] | None = None):
         return CastTransformer(to_dtype=self.to_dtype)

--- a/rastervision_core/rastervision/core/data/raster_transformer/min_max_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/min_max_transformer.py
@@ -6,9 +6,7 @@ from rastervision.core.data.raster_transformer import RasterTransformer
 class MinMaxTransformer(RasterTransformer):
     """Transforms chips by scaling values in each channel to span 0-255."""
 
-    def transform(self,
-                  chip: np.ndarray,
-                  channel_order: list[int] | None = None) -> np.ndarray:
+    def transform(self, chip: np.ndarray) -> np.ndarray:
         c = chip.shape[-1]
         pixels = chip.reshape(-1, c)
         channel_mins = pixels.min(axis=0)

--- a/rastervision_core/rastervision/core/data/raster_transformer/min_max_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/min_max_transformer_config.py
@@ -7,5 +7,5 @@ from rastervision.core.data.raster_transformer import (RasterTransformerConfig,
 class MinMaxTransformerConfig(RasterTransformerConfig):
     """Configure a :class:`.MinMaxTransformer`."""
 
-    def build(self):
+    def build(self, channel_order: list[int] | None = None):
         return MinMaxTransformer()

--- a/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer.py
@@ -8,27 +8,22 @@ class NanTransformer(RasterTransformer):
     """Removes NaN values from float raster."""
 
     def __init__(self, to_value: float = 0.0):
-        """Construct a new NanTransformer.
+        """Constructor.
 
         Args:
-            to_value: (float) NaN values are replaced
-                with this
+            to_value: NaN values are replaced with this.
         """
         self.to_value = to_value
 
-    def transform(self, chip, channel_order=None):
-        """Transform a chip.
-
-        Removes NaN values.
+    def transform(self, chip):
+        """Removes NaN values.
 
         Args:
-            chip: ndarray of shape [height, width, channels] This is assumed to already
-                have the channel_order applied to it if channel_order is set. In other
-                words, channels should be equal to len(channel_order).
+            chip: Array of shape (..., H, W, C).
 
         Returns:
-            [height, width, channels] numpy array
-
+            Array of shape (..., H, W, C)
         """
-        chip[np.isnan(chip)] = self.to_value
+        nan_mask = np.isnan(chip)
+        chip[nan_mask] = self.to_value
         return chip

--- a/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/nan_transformer_config.py
@@ -12,5 +12,5 @@ class NanTransformerConfig(RasterTransformerConfig):
     to_value: float | None = Field(
         0.0, description=('Turn all NaN values into this value.'))
 
-    def build(self):
+    def build(self, channel_order: list[int] | None = None):
         return NanTransformer(to_value=self.to_value)

--- a/rastervision_core/rastervision/core/data/raster_transformer/raster_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/raster_transformer.py
@@ -9,17 +9,12 @@ class RasterTransformer(ABC):
     """Transforms raw chips to be input to a neural network."""
 
     @abstractmethod
-    def transform(self, chip: 'np.ndarray',
-                  channel_order=None) -> 'np.ndarray':
+    def transform(self, chip: 'np.ndarray') -> 'np.ndarray':
         """Transform a chip of a raster source.
 
         Args:
-            chip: ndarray of shape [height, width, channels] This is assumed to already
-                have the channel_order applied to it if channel_order is set. In other
-                words, channels should be equal to len(channel_order).
-            channel_order: list of indices of channels that were extracted from the
-                raw imagery.
+            chip: Array of shape (..., H, W, C).
 
         Returns:
-            (np.ndarray): Array of shape (..., H, W, C)
+            Array of shape (..., H, W, C)
         """

--- a/rastervision_core/rastervision/core/data/raster_transformer/raster_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/raster_transformer_config.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 from rastervision.pipeline.config import Config, register_config
 
 if TYPE_CHECKING:
-    from rastervision.core.data import SceneConfig
+    from rastervision.core.data import RasterTransformer, SceneConfig
     from rastervision.core.rv_pipeline import RVPipelineConfig
 
 
@@ -17,3 +17,7 @@ class RasterTransformerConfig(Config):
 
     def update_root(self, root_dir: str):
         pass
+
+    def build(self,
+              channel_order: list[int] | None = None) -> 'RasterTransformer':
+        raise NotImplementedError()

--- a/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer.py
@@ -9,30 +9,21 @@ class ReclassTransformer(RasterTransformer):
     """Maps class IDs in a label raster to other values."""
 
     def __init__(self, mapping: dict[int, int]):
-        """Construct a new ReclassTransformer.
+        """Constructor.
 
         Args:
-            mapping: (dict) Remapping dictionary
+            mapping: Remapping dictionary, value_from-->value_to.
         """
         self.mapping = mapping
 
-    def transform(self,
-                  chip: 'np.ndarray',
-                  channel_order: list[int] | None = None):
-        """Transform a chip.
-
-        Reclassify a label raster using the given mapping.
+    def transform(self, chip: 'np.ndarray'):
+        """Reclassify a label raster using the given mapping.
 
         Args:
-            chip: ndarray of shape [height, width, channels] This is assumed to already
-                have the channel_order applied to it if channel_order is set. In other
-                words, channels should be equal to len(channel_order).
-            channel_order: list of indices of channels that were extracted from the
-                raw imagery.
+            chip: Array of shape (..., H, W, C).
 
         Returns:
-            [height, width, channels] numpy array
-
+            Array of shape (..., H, W, C)
         """
         masks = []
         for (value_from, value_to) in self.mapping.items():

--- a/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/reclass_transformer_config.py
@@ -10,5 +10,6 @@ class ReclassTransformerConfig(RasterTransformerConfig):
     mapping: dict[int, int] = Field(
         ..., description=('The reclassification mapping.'))
 
-    def build(self) -> ReclassTransformer:
+    def build(self,
+              channel_order: list[int] | None = None) -> ReclassTransformer:
         return ReclassTransformer(mapping=self.mapping)

--- a/rastervision_core/rastervision/core/data/raster_transformer/rgb_class_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/rgb_class_transformer.py
@@ -37,19 +37,14 @@ class RGBClassTransformer(RasterTransformer):
             ],
             dtype=np.uint8)
 
-    def transform(self,
-                  chip: np.ndarray,
-                  channel_order: list[int] | None = None) -> np.ndarray:
+    def transform(self, chip: np.ndarray) -> np.ndarray:
         """Transform RGB array to array of class IDs or vice versa.
 
         Args:
-            chip (np.ndarray): Numpy array of shape (H, W, 3).
-            channel_order (list[int] | None): List of indices of
-                channels that were extracted from the raw imagery.
-                Defaults to None.
+            chip: Numpy array of shape (H, W, 3).
 
         Returns:
-            np.ndarray: An array of class IDs.
+            An array of class IDs of shape (H, W, 1).
         """
         return self.rgb_to_class(chip)
 

--- a/rastervision_core/rastervision/core/data/raster_transformer/rgb_class_transformer_config.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/rgb_class_transformer_config.py
@@ -13,5 +13,6 @@ class RGBClassTransformerConfig(RasterTransformerConfig):
         description=('The class config defining the mapping between '
                      'classes and colors.'))
 
-    def build(self) -> RGBClassTransformer:
+    def build(self,
+              channel_order: list[int] | None = None) -> RGBClassTransformer:
         return RGBClassTransformer(class_config=self.class_config)

--- a/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
@@ -111,39 +111,53 @@ class StatsTransformer(RasterTransformer):
         return stats_transformer
 
     @classmethod
-    def from_stats_json(cls, uri: str, **kwargs) -> Self:
+    def from_stats_json(cls,
+                        uri: str,
+                        channel_order: list[int] | None = None,
+                        **kwargs) -> Self:
         """Build with stats from a JSON file.
 
         The file is expected to be in the same format as written by
         :meth:`.RasterStats.save`.
 
         Args:
-            uri (str): URI of the JSON file.
+            uri: URI of the JSON file.
+            channel_order: Channel order to apply to the means and stds in the
+                file.
             **kwargs: Extra args for :meth:`.__init__`.
 
         Returns:
-            StatsTransformer: A StatsTransformer.
+            A StatsTransformer.
         """
         stats = RasterStats.load(uri)
-        stats_transformer = StatsTransformer.from_raster_stats(stats, **kwargs)
+        stats_transformer = StatsTransformer.from_raster_stats(
+            stats, channel_order=channel_order, **kwargs)
         return stats_transformer
 
     @classmethod
-    def from_raster_stats(cls, stats: RasterStats, **kwargs) -> Self:
+    def from_raster_stats(cls,
+                          stats: RasterStats,
+                          channel_order: list[int] | None = None,
+                          **kwargs) -> Self:
         """Build with stats from a :class:`.RasterStats` instance.
 
         The file is expected to be in the same format as written by
         :meth:`.RasterStats.save`.
 
         Args:
-            stats (RasterStats): A :class:`.RasterStats` instance with
-                non-None stats.
+            stats: A :class:`.RasterStats` instance with non-None stats.
+            channel_order: Channel order to apply to the means and stds in the
+                :class:`.RasterStats`.
             **kwargs: Extra args for :meth:`.__init__`.
 
         Returns:
-            StatsTransformer: A StatsTransformer.
+            A StatsTransformer.
         """
-        stats_transformer = StatsTransformer(stats.means, stats.stds, **kwargs)
+        means, stds = stats.means, stats.stds
+        if channel_order is not None:
+            means = means[channel_order]
+            stds = stds[channel_order]
+        stats_transformer = StatsTransformer(means, stds, **kwargs)
         return stats_transformer
 
     @property

--- a/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
@@ -32,33 +32,24 @@ class StatsTransformer(RasterTransformer):
         """Construct a new StatsTransformer.
 
         Args:
-            means (np.ndarray): Channel means.
-            means (np.ndarray): Channel standard deviations.
-            max_stds (float): Number of standard deviations to clip the
-                distribution to on both sides. Defaults to 3.
+            means: Channel means.
+            means: Channel standard deviations.
+            max_stds: Number of standard deviations to clip the distribution to
+                on both sides. Defaults to 3.
         """
         # shape = (1, 1, num_channels)
         self.means = np.array(means, dtype=float)
         self.stds = np.array(stds, dtype=float)
         self.max_stds = max_stds
 
-    def transform(self,
-                  chip: np.ndarray,
-                  channel_order: Sequence[int] | None = None) -> np.ndarray:
-        """Transform a chip.
-
-        Transforms non-uint8 to uint8 values using raster_stats.
+    def transform(self, chip: np.ndarray) -> np.ndarray:
+        """Clip values to +-max_stds std devs and convert to uint8 (0-255).
 
         Args:
-            chip: ndarray of shape [height, width, channels] This is assumed to already
-                have the channel_order applied to it if channel_order is set. In other
-                words, channels should be equal to len(channel_order).
-            channel_order: list of indices of channels that were extracted from the
-                raw imagery.
+            chip: Array of shape (..., H, W, C).
 
         Returns:
-            [height, width, channels] uint8 numpy array
-
+            Array of shape (..., H, W, C)
         """
         if chip.dtype == np.uint8:
             return chip
@@ -66,9 +57,6 @@ class StatsTransformer(RasterTransformer):
         means = self.means
         stds = self.stds
         max_stds = self.max_stds
-        if channel_order is not None:
-            means = means[channel_order]
-            stds = stds[channel_order]
 
         # Don't transform NODATA zero values.
         nodata_mask = chip == 0

--- a/rastervision_core/rastervision/core/raster_stats.py
+++ b/rastervision_core/rastervision/core/raster_stats.py
@@ -16,9 +16,9 @@ class RasterStats:
     """Band-wise means and standard deviations."""
 
     def __init__(self,
-                 means: np.ndarray | None = None,
-                 stds: np.ndarray | None = None,
-                 counts: np.ndarray | None = None):
+                 means: Sequence[float] | None = None,
+                 stds: Sequence[float] | None = None,
+                 counts: Sequence[float] | None = None):
         """Constructor.
 
         Args:
@@ -27,9 +27,9 @@ class RasterStats:
             counts: Band pixel counts (used to compute the specified means and
                 stds). Defaults to ``None``.
         """
-        self.means = means
-        self.stds = stds
-        self.counts = counts
+        self.means = np.array(means) if means is not None else None
+        self.stds = np.array(stds) if stds is not None else None
+        self.counts = np.array(counts) if counts is not None else None
 
     @classmethod
     def load(cls, stats_uri: str) -> Self:

--- a/rastervision_core/rastervision/core/raster_stats.py
+++ b/rastervision_core/rastervision/core/raster_stats.py
@@ -250,7 +250,7 @@ def get_chip(raster_source: 'RasterSource',
              window: 'Box',
              nodata_value: float | None = 0) -> np.ndarray | None:
     """Return chip or None if all values are NODATA."""
-    chip = raster_source.get_raw_chip(window).astype(float)
+    chip = raster_source.get_chip(window).astype(float)
 
     if nodata_value is None:
         return chip

--- a/tests/core/data/raster_transformer/test_stats_transformer.py
+++ b/tests/core/data/raster_transformer/test_stats_transformer.py
@@ -3,10 +3,13 @@ from os.path import join
 
 import numpy as np
 
+from rastervision.pipeline.config import build_config
 from rastervision.pipeline.file_system import get_tmp_dir
 from rastervision.core.raster_stats import RasterStats
 from rastervision.core.data import (RasterioSource, StatsTransformer,
                                     StatsTransformerConfig)
+from rastervision.core.data.raster_transformer.stats_transformer_config import (  # noqa
+    stats_transformer_config_upgrader)
 
 from tests import data_file_path
 
@@ -46,6 +49,33 @@ class TestStatsTransformerConfig(unittest.TestCase):
             np.testing.assert_array_equal(tf.means, np.array([1, 2]))
             np.testing.assert_array_equal(tf.stds, np.array([3, 4]))
 
+    def test_upgrader_v2(self):
+        cfg = StatsTransformerConfig()
+        old_cfg_dict = cfg.dict()
+        old_cfg_dict.pop('needs_channel_order')
+        new_cfg_dict = stats_transformer_config_upgrader(old_cfg_dict, 2)
+        self.assertEqual(new_cfg_dict['scene_group'], '__N/A__')
+
+    def test_upgrader_v13(self):
+        stats = RasterStats(np.array([1, 2]), np.array([3, 4]))
+
+        with get_tmp_dir() as tmp_dir:
+            stats_uri = join(tmp_dir, 'stats.json')
+            stats.save(stats_uri)
+
+            cfg = StatsTransformerConfig(stats_uri=stats_uri)
+            old_cfg_dict = cfg.dict()
+            old_cfg_dict.pop('needs_channel_order')
+            new_cfg_dict = stats_transformer_config_upgrader(old_cfg_dict, 13)
+            self.assertTrue(new_cfg_dict['needs_channel_order'])
+
+            cfg = build_config(new_cfg_dict)
+            self.assertIsInstance(cfg, StatsTransformerConfig)
+
+            tf = cfg.build(channel_order=[1, 0])
+            np.testing.assert_array_equal(tf.means, np.array([2, 1]))
+            np.testing.assert_array_equal(tf.stds, np.array([4, 3]))
+
 
 class TestStatsTransformer(unittest.TestCase):
     def test_transform(self):
@@ -72,9 +102,9 @@ class TestStatsTransformer(unittest.TestCase):
 
     def test_from_raster_stats(self):
         stats = RasterStats(np.array([1, 2]), np.array([3, 4]))
-        tf = StatsTransformer.from_raster_stats(stats)
-        np.testing.assert_array_equal(tf.means, np.array([1, 2]))
-        np.testing.assert_array_equal(tf.stds, np.array([3, 4]))
+        tf = StatsTransformer.from_raster_stats(stats, channel_order=[1, 0])
+        np.testing.assert_array_equal(tf.means, np.array([2, 1]))
+        np.testing.assert_array_equal(tf.stds, np.array([4, 3]))
 
     def test_from_stats_json(self):
         stats = RasterStats(np.array([1, 2]), np.array([3, 4]))

--- a/tests/core/data/raster_transformer/test_stats_transformer.py
+++ b/tests/core/data/raster_transformer/test_stats_transformer.py
@@ -57,15 +57,6 @@ class TestStatsTransformer(unittest.TestCase):
         chip_out_expected = np.ones((2, 2, 4)) * 170
         np.testing.assert_equal(chip_out, chip_out_expected)
 
-    def test_transform_with_channel_order(self):
-        # All values have z-score of 1, which translates to
-        # uint8 value of 170.
-        tf = StatsTransformer(np.ones((4, )), np.ones((4, )) * 2)
-        chip_in = np.ones((2, 2, 2)) * 3
-        chip_out = tf.transform(chip_in, channel_order=[1, 2])
-        chip_out_expected = np.ones((2, 2, 2)) * 170
-        np.testing.assert_equal(chip_out, chip_out_expected)
-
     def test_transform_noop(self):
         tf = StatsTransformer(np.ones((4, )), np.ones((4, )) * 2)
         chip_in = np.ones((2, 2, 4), dtype=np.uint8)


### PR DESCRIPTION
## Overview

This PR makes `RasterStats` use `RasterSource.get_chip()` instead of `RasterSource.get_chip()` when computing stats (#2177). This requires 2 further downstream changes:
- After the change, the computed stats are now in the same order as `RasterSource.channel_order` which makes the `channel_order` argument to `StatsTransformer` unnecessary. Since `StatsTransformer` was the only `RasterTransformer` using this argument, this meant that the argument could now safely be removed from all `RasterTransformer`s--and it was.
- Since older stats were computed with `RasterSource.get_raw_chip()`, they still require `channel_order` to be applied before they can be used by the `StatsTransformer`. Therefore, to maintain backward compatibility with older model-bundles, a new boolean `needs_channel_order` field has been added to `StatsTransformerConfig`, which, if `True`, causes `channel_order` to be applied when initializing the `StatsTransformer` in `StatsTransformerConfig.build()`. This field is set automatically by the config upgrader.

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

See new/updated unit tests.

Closes #2177