### PR TITLE
Determine `num_channels` and `dtype` in `RasterSource` statically without reading a chip

### DIFF
--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -41,6 +41,8 @@ class MultiRasterSource(RasterSource):
                 extent available in the source file of the primary raster
                 source is used.
         """
+        dtype_raw = raster_sources[primary_source_idx].dtype
+
         num_channels_raw = sum(rs.num_channels for rs in raster_sources)
         if not channel_order:
             num_channels = sum(rs.num_channels for rs in raster_sources)
@@ -57,8 +59,9 @@ class MultiRasterSource(RasterSource):
             raster_sources[primary_source_idx].set_bbox(bbox)
 
         super().__init__(
-            channel_order,
-            num_channels_raw,
+            channel_order=channel_order,
+            num_channels_raw=num_channels_raw,
+            dtype_raw=dtype_raw,
             bbox=bbox,
             raster_transformers=raster_transformers)
 
@@ -175,10 +178,6 @@ class MultiRasterSource(RasterSource):
         """Shape of the raster as a (..., H, W, C) tuple."""
         *shape, _ = self.primary_source.shape
         return (*shape, self.num_channels)
-
-    @property
-    def dtype(self) -> np.dtype:
-        return self.primary_source.dtype
 
     @property
     def crs_transformer(self) -> 'CRSTransformer':

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -14,10 +14,10 @@ def multi_rs_config_upgrader(cfg_dict: dict, version: int) -> dict:
     if version == 1:
         # field renamed in version 2
         cfg_dict['primary_source_idx'] = cfg_dict.get('crs_source', 0)
-        try:
-            del cfg_dict['crs_source']
-        except KeyError:
-            pass
+        cfg_dict.pop('crs_source', None)
+    elif version == 13:
+        # field removed in version 14
+        cfg_dict.pop('force_same_dtype', None)
     return cfg_dict
 
 
@@ -36,10 +36,6 @@ class MultiRasterSourceConfig(RasterSourceConfig):
         description=
         'Index of the raster source whose CRS, dtype, and other attributes '
         'will override those of the other raster sources. Defaults to 0.')
-    force_same_dtype: bool = Field(
-        False,
-        description='Force all subchips to be of the same dtype as the '
-        'primary_source_idx-th subchip.')
     temporal: bool = Field(
         False,
         description='Stack images from sub raster sources into a time-series '
@@ -82,14 +78,12 @@ class MultiRasterSourceConfig(RasterSourceConfig):
             multi_raster_source = TemporalMultiRasterSource(
                 raster_sources=built_raster_sources,
                 primary_source_idx=self.primary_source_idx,
-                force_same_dtype=self.force_same_dtype,
                 raster_transformers=raster_transformers,
                 bbox=bbox)
         else:
             multi_raster_source = MultiRasterSource(
                 raster_sources=built_raster_sources,
                 primary_source_idx=self.primary_source_idx,
-                force_same_dtype=self.force_same_dtype,
                 channel_order=self.channel_order,
                 raster_transformers=raster_transformers,
                 bbox=bbox)

--- a/rastervision_core/rastervision/core/data/raster_source/rasterized_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterized_source.py
@@ -94,6 +94,7 @@ class RasterizedSource(RasterSource):
         super().__init__(
             channel_order=[0],
             num_channels_raw=1,
+            dtype_raw=np.uint8,
             bbox=bbox,
             raster_transformers=raster_transformers)
 

--- a/rastervision_core/rastervision/core/data/raster_source/temporal_multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/temporal_multi_raster_source.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from pydantic import NonNegativeInt as NonNegInt
 import numpy as np
@@ -8,6 +8,9 @@ from rastervision.core.data.raster_source import (RasterSource,
                                                   MultiRasterSource)
 from rastervision.core.data.utils import all_equal, parse_array_slices_Nd
 
+if TYPE_CHECKING:
+    from rastervision.core.data import RasterTransformer
+
 
 class TemporalMultiRasterSource(MultiRasterSource):
     """Merge multiple ``RasterSources`` by stacking them along a new dim."""
@@ -15,25 +18,20 @@ class TemporalMultiRasterSource(MultiRasterSource):
     def __init__(self,
                  raster_sources: Sequence[RasterSource],
                  primary_source_idx: NonNegInt = 0,
-                 force_same_dtype: bool = False,
-                 raster_transformers: Sequence = [],
+                 raster_transformers: Sequence['RasterTransformer'] = [],
                  bbox: Box | None = None):
         """Constructor.
 
         Args:
-            raster_sources (Sequence[RasterSource]): Sequence of RasterSources.
-            primary_source_idx (0 <= int < len(raster_sources)): Index of the
-                raster source whose CRS, dtype, and other attributes will
-                override those of the other raster sources.
-            force_same_dtype (bool): If true, force all sub-chips to have the
-                same dtype as the primary_source_idx-th sub-chip. No careful
-                conversion is done, just a quick cast. Use with caution.
-            raster_transformers (Sequence): Sequence of transformers.
-                Defaults to [].
-            bbox (Box | None): User-specified crop of the extent.
-                If given, the primary raster source's bbox is set to this.
-                If None, the full extent available in the source file of the
-                primary raster source is used.
+            raster_sources: Sequence of RasterSources.
+            primary_source_idx: Index of the raster source whose CRS, dtype,
+                and other attributes will override those of the other raster
+                sources.
+            raster_transformers: Sequence of transformers. Defaults to ``[]``.
+            bbox: User-specified crop of the extent. If given, the primary
+                raster source's bbox is set to this. If ``None``, the full
+                extent available in the source file of the primary raster
+                source is used.
         """
         if not all_equal([rs.num_channels for rs in raster_sources]):
             raise ValueError(
@@ -62,7 +60,6 @@ class TemporalMultiRasterSource(MultiRasterSource):
             bbox=bbox,
             raster_transformers=raster_transformers)
 
-        self.force_same_dtype = force_same_dtype
         self.raster_sources = raster_sources
         self.primary_source_idx = primary_source_idx
 

--- a/rastervision_core/rastervision/core/data/raster_source/temporal_multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/temporal_multi_raster_source.py
@@ -45,6 +45,7 @@ class TemporalMultiRasterSource(MultiRasterSource):
                              '[0, len(raster_sources)].')
 
         primary_rs = raster_sources[primary_source_idx]
+        dtype_raw = primary_rs.dtype
         num_channels_raw = primary_rs.num_channels_raw
         channel_order = None
 
@@ -55,8 +56,9 @@ class TemporalMultiRasterSource(MultiRasterSource):
 
         RasterSource.__init__(
             self,
-            channel_order,
-            num_channels_raw,
+            channel_order=channel_order,
+            num_channels_raw=num_channels_raw,
+            dtype_raw=dtype_raw,
             bbox=bbox,
             raster_transformers=raster_transformers)
 

--- a/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/cast_transformer.py
@@ -29,3 +29,6 @@ class CastTransformer(RasterTransformer):
             Array of shape (..., H, W, C)
         """
         return chip.astype(self.to_dtype)
+
+    def get_out_dtype(self, in_dtype: 'np.dtype') -> 'np.dtype':
+        return self.to_dtype

--- a/rastervision_core/rastervision/core/data/raster_transformer/min_max_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/min_max_transformer.py
@@ -14,3 +14,6 @@ class MinMaxTransformer(RasterTransformer):
         chip_normalized = (chip - channel_mins) / (channel_maxs - channel_mins)
         chip_normalized = (255 * chip_normalized).astype(np.uint8)
         return chip_normalized
+
+    def get_out_dtype(self, in_dtype: 'np.dtype') -> 'np.dtype':
+        return np.uint8

--- a/rastervision_core/rastervision/core/data/raster_transformer/raster_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/raster_transformer.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 from abc import (ABC, abstractmethod)
+from pydantic.types import PositiveInt as PosInt
 
 if TYPE_CHECKING:
     import numpy as np
@@ -18,3 +19,11 @@ class RasterTransformer(ABC):
         Returns:
             Array of shape (..., H, W, C)
         """
+
+    def get_out_channels(self, in_channels: PosInt) -> PosInt:
+        """Number of channels in output of ``transform()``."""
+        return in_channels
+
+    def get_out_dtype(self, in_dtype: 'np.dtype') -> 'np.dtype':
+        """dtype of the output of ``transform()``."""
+        return in_dtype

--- a/rastervision_core/rastervision/core/data/raster_transformer/rgb_class_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/rgb_class_transformer.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
+from pydantic.types import PositiveInt as PosInt
 
 import numpy as np
 
@@ -55,3 +56,12 @@ class RGBClassTransformer(RasterTransformer):
 
     def class_to_rgb(self, class_labels: np.ndarray) -> np.ndarray:
         return self.class_to_rgb_arr[class_labels]
+
+    def get_out_channels(self, in_channels: PosInt) -> Literal[1]:
+        if in_channels != 3:
+            raise ValueError(
+                'RGBClassTransformer only accepts 3-channel inputs.')
+        return 1
+
+    def get_out_dtype(self, in_dtype: 'np.dtype') -> 'np.dtype':
+        return np.uint8

--- a/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
@@ -168,3 +168,6 @@ class StatsTransformer(RasterTransformer):
     def __repr__(self) -> str:
         return repr_with_args(
             self, means=self.means, stds=self.stds, max_stds=self.max_stds)
+
+    def get_out_dtype(self, in_dtype: 'np.dtype') -> 'np.dtype':
+        return np.uint8

--- a/rastervision_core/rastervision/core/data/raster_transformer/utils.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/utils.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+from pydantic.types import PositiveInt as PosInt
+
+if TYPE_CHECKING:
+    import numpy as np
+    from rastervision.core.data.raster_transformer import RasterTransformer
+
+
+def get_transformed_num_channels(
+        raster_transformers: list['RasterTransformer'],
+        in_channels: PosInt) -> PosInt:
+    out_channels = in_channels
+    for tf in raster_transformers:
+        out_channels = tf.get_out_channels(out_channels)
+    return out_channels
+
+
+def get_transformed_dtype(raster_transformers: list['RasterTransformer'],
+                          in_dtype: 'np.dtype') -> 'np.dtype':
+    out_dtype = in_dtype
+    for tf in raster_transformers:
+        out_dtype = tf.get_out_dtype(out_dtype)
+    return out_dtype

--- a/tests/core/data/mock_raster_source.py
+++ b/tests/core/data/mock_raster_source.py
@@ -9,8 +9,9 @@ class MockRasterSource(RasterSource):
     def __init__(self, channel_order, num_channels_raw,
                  raster_transformers=[]):
         super().__init__(
-            channel_order,
-            num_channels_raw,
+            channel_order=channel_order,
+            num_channels_raw=num_channels_raw,
+            dtype_raw=np.uint8,
             bbox=Box.make_square(0, 0, 2),
             raster_transformers=raster_transformers)
         self.mock = Mock()

--- a/tests/core/data/raster_transformer/test_cast_transformer.py
+++ b/tests/core/data/raster_transformer/test_cast_transformer.py
@@ -2,7 +2,8 @@ import unittest
 
 import numpy as np
 
-from rastervision.core.data.raster_transformer import CastTransformerConfig
+from rastervision.core.data.raster_transformer import (CastTransformer,
+                                                       CastTransformerConfig)
 
 
 class TestCastTransformer(unittest.TestCase):
@@ -18,6 +19,17 @@ class TestCastTransformer(unittest.TestCase):
         out_chip = tf.transform(in_chip)
         self.assertEqual(out_chip.dtype, np.float32)
         self.assertEqual(str(tf), "CastTransformer(to_dtype='float32')")
+
+    def test_get_out_dtype(self):
+        tf = CastTransformer(to_dtype=np.uint8)
+        self.assertEqual(tf.get_out_dtype(np.float32), np.uint8)
+        tf = CastTransformer(to_dtype=np.float32)
+        self.assertEqual(tf.get_out_dtype(np.uint8), np.float32)
+
+    def test_get_out_channels(self):
+        tf = CastTransformer(to_dtype=np.uint8)
+        self.assertEqual(tf.get_out_channels(3), 3)
+        self.assertEqual(tf.get_out_channels(8), 8)
 
 
 if __name__ == '__main__':

--- a/tests/core/data/raster_transformer/test_min_max_transformer.py
+++ b/tests/core/data/raster_transformer/test_min_max_transformer.py
@@ -33,6 +33,17 @@ class TestMinMaxTransformer(unittest.TestCase):
         chip_out = tf.transform(chip_in)
         np.testing.assert_array_equal(chip_out, chip_expexted)
 
+    def test_get_out_dtype(self):
+        tf = MinMaxTransformer()
+        self.assertEqual(tf.get_out_dtype(np.float32), np.uint8)
+        tf = MinMaxTransformer()
+        self.assertEqual(tf.get_out_dtype(np.uint8), np.uint8)
+
+    def test_get_out_channels(self):
+        tf = MinMaxTransformer()
+        self.assertEqual(tf.get_out_channels(3), 3)
+        self.assertEqual(tf.get_out_channels(8), 8)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/core/data/raster_transformer/test_nan_transformer.py
+++ b/tests/core/data/raster_transformer/test_nan_transformer.py
@@ -34,6 +34,16 @@ class TestNanTransformer(unittest.TestCase):
         chip_out = tf.transform(chip_in)
         np.testing.assert_array_equal(chip_out, chip_expexted)
 
+    def test_get_out_dtype(self):
+        tf = NanTransformer()
+        self.assertEqual(tf.get_out_dtype(np.float32), np.float32)
+        self.assertEqual(tf.get_out_dtype(np.uint8), np.uint8)
+
+    def test_get_out_channels(self):
+        tf = NanTransformer(1)
+        self.assertEqual(tf.get_out_channels(3), 3)
+        self.assertEqual(tf.get_out_channels(8), 8)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/core/data/raster_transformer/test_rgb_class_transformer.py
+++ b/tests/core/data/raster_transformer/test_rgb_class_transformer.py
@@ -40,6 +40,14 @@ class TestRGBClassTransformer(unittest.TestCase):
         expected_rgb_image = self.rgb_image
         np.testing.assert_array_equal(rgb_image, expected_rgb_image)
 
+    def test_get_out_dtype(self):
+        self.assertEqual(self.transformer.get_out_dtype(np.float32), np.uint8)
+        self.assertEqual(self.transformer.get_out_dtype(np.uint8), np.uint8)
+
+    def test_get_out_channels(self):
+        self.assertEqual(self.transformer.get_out_channels(3), 1)
+        self.assertRaises(ValueError, self.transformer.get_out_channels, 8)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/core/data/raster_transformer/test_stats_transformer.py
+++ b/tests/core/data/raster_transformer/test_stats_transformer.py
@@ -121,6 +121,16 @@ class TestStatsTransformer(unittest.TestCase):
         self.assertTrue(np.all(tf.means == 1))
         self.assertTrue(np.all(tf.stds == 0))
 
+    def test_get_out_dtype(self):
+        tf = StatsTransformer(np.zeros((4, )), np.ones((4, )))
+        self.assertEqual(tf.get_out_dtype(np.float32), np.uint8)
+        self.assertEqual(tf.get_out_dtype(np.uint8), np.uint8)
+
+    def test_get_out_channels(self):
+        tf = StatsTransformer(np.zeros((4, )), np.ones((4, )))
+        self.assertEqual(tf.get_out_channels(3), 3)
+        self.assertEqual(tf.get_out_channels(8), 8)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

The `num_channels` and `dtype` of a `RasterSource` can be different from the underlying data source because of `RasterTransformers`. Previously, these could only be determined dynamically at runtime by reading a 1x1 chip and checking its shape and `dtype`. This can be very slow when initializing many `RasterSource`s or when initializing a `RasterSource`s with many bands.

This PR adds `get_out_channels()` and `get_out_dtype()` methods to `RasterTransformer`s, allowing `num_channels` and `dtype` to be determined statically without reading any data.

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

See new/updated unit tests.