### PR TITLE
Remove `awscli` as a dependency

### DIFF
--- a/rastervision_aws_batch/requirements.txt
+++ b/rastervision_aws_batch/requirements.txt
@@ -1,3 +1,2 @@
 rastervision_pipeline==0.31.1-dev
 boto3==1.34.155
-awscli==1.33.37

--- a/rastervision_aws_s3/requirements.txt
+++ b/rastervision_aws_s3/requirements.txt
@@ -1,5 +1,4 @@
 rastervision_pipeline==0.31.1-dev
 boto3==1.34.155
-awscli==1.33.37
 tqdm==4.66.5
-
+botocore==1.34.158

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ jupyter==1.0.0
 jupyterlab==4.1.8
 jupyter_contrib_nbextensions==0.7.0
 pystac_client==0.8.3
+awscli==1.33.40


### PR DESCRIPTION
## Overview

This PR removes awscli (v1) as a dependency, so that it doesn't affect users' existing v2 installation.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [x] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A
