### PR TITLE
Restore compatibility with python<3.11 by only importing `typing.Self` under `if TPYE_CHECKING`

### DIFF
--- a/rastervision_core/rastervision/core/data/class_config.py
+++ b/rastervision_core/rastervision/core/data/class_config.py
@@ -1,8 +1,11 @@
-from typing import Self
+from typing import TYPE_CHECKING
 
 from rastervision.pipeline.config import (Config, register_config, ConfigError,
                                           Field, model_validator)
 from rastervision.core.data.utils import color_to_triple, normalize_color
+
+if TYPE_CHECKING:
+    from typing import Self
 
 DEFAULT_NULL_CLASS_NAME = 'null'
 DEFAULT_NULL_CLASS_COLOR = 'black'
@@ -33,7 +36,7 @@ class ClassConfig(Config):
         'added automatically.')
 
     @model_validator(mode='after')
-    def validate_colors(self) -> Self:
+    def validate_colors(self) -> 'Self':
         """Compare length w/ names. Also auto-generate if not specified."""
         names = self.names
         colors = self.colors
@@ -47,7 +50,7 @@ class ClassConfig(Config):
         return self
 
     @model_validator(mode='after')
-    def validate_null_class(self) -> Self:
+    def validate_null_class(self) -> 'Self':
         """Check if in names. If 'null' in names, use it as null class."""
         names = self.names
         null_class = self.null_class

--- a/rastervision_core/rastervision/core/data/crs_transformer/rasterio_crs_transformer.py
+++ b/rastervision_core/rastervision/core/data/crs_transformer/rasterio_crs_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any
 from pyproj import Transformer
 
 import numpy as np
@@ -8,6 +8,9 @@ from rasterio import Affine
 
 from rastervision.core.data.crs_transformer import (CRSTransformer,
                                                     IdentityCRSTransformer)
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 class RasterioCRSTransformer(CRSTransformer):

--- a/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
+++ b/rastervision_core/rastervision/core/data/label/chip_classification_labels.py
@@ -1,4 +1,4 @@
-from typing import (TYPE_CHECKING, Any, Iterable, Self)
+from typing import (TYPE_CHECKING, Any, Iterable)
 from dataclasses import dataclass
 
 import numpy as np
@@ -8,6 +8,7 @@ from rastervision.core.data.label import Labels
 from rastervision.core.utils.types import Vector
 
 if TYPE_CHECKING:
+    from typing import Self
     from rastervision.core.data import (ClassConfig, CRSTransformer)
     from shapely.geometry import Polygon
 
@@ -38,11 +39,11 @@ class ChipClassificationLabels(Labels):
     def __len__(self) -> int:
         return len(self.cell_to_label)
 
-    def __eq__(self, other: Self) -> bool:
+    def __eq__(self, other: 'Self') -> bool:
         return (isinstance(other, ChipClassificationLabels)
                 and self.cell_to_label == other.cell_to_label)
 
-    def __add__(self, other: Self) -> Self:
+    def __add__(self, other: 'Self') -> 'Self':
         result = ChipClassificationLabels()
         result.extend(self)
         result.extend(other)
@@ -66,7 +67,7 @@ class ChipClassificationLabels(Labels):
         return super().from_predictions(windows, predictions)
 
     @classmethod
-    def make_empty(cls) -> Self:
+    def make_empty(cls) -> 'Self':
         return ChipClassificationLabels()
 
     def filter_by_aoi(self, aoi_polygons: Iterable['Polygon']):
@@ -140,7 +141,7 @@ class ChipClassificationLabels(Labels):
         """Return list of class_ids and scores for all cells."""
         return list(self.cell_to_label.values())
 
-    def extend(self, labels: Self) -> None:
+    def extend(self, labels: 'Self') -> None:
         """Adds cells contained in labels.
 
         Args:

--- a/rastervision_core/rastervision/core/data/label/labels.py
+++ b/rastervision_core/rastervision/core/data/label/labels.py
@@ -1,9 +1,10 @@
 """Defines the abstract Labels class."""
 
-from typing import TYPE_CHECKING, Any, Iterable, Self
+from typing import TYPE_CHECKING, Any, Iterable
 from abc import ABC, abstractmethod
 
 if TYPE_CHECKING:
+    from typing import Self
     from shapely.geometry import Polygon
     from rastervision.core.box import Box
 
@@ -16,14 +17,14 @@ class Labels(ABC):
     """
 
     @abstractmethod
-    def __add__(self, other: Self):
+    def __add__(self, other: 'Self'):
         """Add labels to these labels.
 
         Returns a concatenation of this and the other labels.
         """
 
     @abstractmethod
-    def filter_by_aoi(self, aoi_polygons: list['Polygon']) -> Self:
+    def filter_by_aoi(self, aoi_polygons: list['Polygon']) -> 'Self':
         """Return a copy of these labels filtered by given AOI polygons.
 
         Args:
@@ -41,7 +42,7 @@ class Labels(ABC):
 
     @classmethod
     @abstractmethod
-    def make_empty(cls) -> Self:
+    def make_empty(cls) -> 'Self':
         """Instantiate an empty instance of this class.
 
         Returns:
@@ -51,7 +52,7 @@ class Labels(ABC):
 
     @classmethod
     def from_predictions(cls, windows: Iterable['Box'],
-                         predictions: Iterable[Any]) -> Self:
+                         predictions: Iterable[Any]) -> 'Self':
         """Instantiate from windows and their corresponding predictions.
 
         This makes no assumptions about the type or format of the predictions.

--- a/rastervision_core/rastervision/core/data/label/object_detection_labels.py
+++ b/rastervision_core/rastervision/core/data/label/object_detection_labels.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable, Self
+from typing import TYPE_CHECKING, Iterable
 import numpy as np
 from shapely.geometry import shape
 
@@ -10,6 +10,7 @@ from rastervision.core.data.label.tfod_utils.np_box_list_ops import (
     non_max_suppression)
 
 if TYPE_CHECKING:
+    from typing import Self
     from rastervision.core.data import (ClassConfig, CRSTransformer)
     from shapely.geometry import Polygon
 
@@ -43,10 +44,10 @@ class ObjectDetectionLabels(Labels):
             scores = np.ones(class_ids.shape)
         self.boxlist.add_field('scores', scores)
 
-    def __add__(self, other: Self) -> Self:
+    def __add__(self, other: 'Self') -> 'Self':
         return ObjectDetectionLabels.concatenate(self, other)
 
-    def __eq__(self, other: Self) -> bool:
+    def __eq__(self, other: 'Self') -> bool:
         return (isinstance(other, ObjectDetectionLabels)
                 and self.to_dict() == other.to_dict())
 
@@ -60,10 +61,10 @@ class ObjectDetectionLabels(Labels):
         concatenated_labels = self + new_labels
         self.boxlist = concatenated_labels.boxlist
 
-    def __getitem__(self, window: Box) -> Self:
+    def __getitem__(self, window: Box) -> 'Self':
         return ObjectDetectionLabels.get_overlapping(self, window)
 
-    def assert_equal(self, expected_labels: Self):
+    def assert_equal(self, expected_labels: 'Self'):
         np.testing.assert_array_equal(self.get_npboxes(),
                                       expected_labels.get_npboxes())
         np.testing.assert_array_equal(self.get_class_ids(),
@@ -95,7 +96,7 @@ class ObjectDetectionLabels(Labels):
             np.array(new_boxes), np.array(new_class_ids), np.array(new_scores))
 
     @classmethod
-    def make_empty(cls) -> Self:
+    def make_empty(cls) -> 'Self':
         npboxes = np.empty((0, 4))
         class_ids = np.empty((0, ))
         scores = np.empty((0, ))
@@ -113,7 +114,7 @@ class ObjectDetectionLabels(Labels):
     def from_geojson(geojson: dict,
                      bbox: Box | None = None,
                      ioa_thresh: float = 0.8,
-                     clip: bool = True) -> Self:
+                     clip: bool = True) -> 'Self':
         """Convert GeoJSON to ObjectDetectionLabels object.
 
         If bbox is provided, filter out the boxes that lie "more than a little
@@ -228,10 +229,10 @@ class ObjectDetectionLabels(Labels):
         return npboxes * np.array([[height, width, height, width]])
 
     @staticmethod
-    def get_overlapping(labels: Self,
+    def get_overlapping(labels: 'Self',
                         window: Box,
                         ioa_thresh: float = 0.5,
-                        clip: bool = False) -> Self:
+                        clip: bool = False) -> 'Self':
         """Return subset of labels that overlap with window.
 
         Args:
@@ -253,16 +254,16 @@ class ObjectDetectionLabels(Labels):
         return ObjectDetectionLabels.from_boxlist(boxlist)
 
     @staticmethod
-    def concatenate(labels1: Self, labels2: Self) -> Self:
+    def concatenate(labels1: 'Self', labels2: 'Self') -> 'Self':
         """Return concatenation of labels."""
         new_boxlist = concatenate([labels1.to_boxlist(), labels2.to_boxlist()])
         return ObjectDetectionLabels.from_boxlist(new_boxlist)
 
     @staticmethod
-    def prune_duplicates(labels: Self,
+    def prune_duplicates(labels: 'Self',
                          score_thresh: float,
                          merge_thresh: float,
-                         max_output_size: int | None = None) -> Self:
+                         max_output_size: int | None = None) -> 'Self':
         """Remove duplicate boxes via non-maximum suppression.
 
         Args:

--- a/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
+++ b/rastervision_core/rastervision/core/data/label/semantic_segmentation_labels.py
@@ -1,4 +1,4 @@
-from typing import (TYPE_CHECKING, Any, Iterable, Self, Sequence)
+from typing import (TYPE_CHECKING, Any, Iterable, Sequence)
 from abc import abstractmethod
 
 import numpy as np
@@ -10,6 +10,7 @@ from rastervision.core.data.label import Labels
 from rastervision.core.data.label.utils import discard_prediction_edges
 
 if TYPE_CHECKING:
+    from typing import Self
     from shapely.geometry import Polygon
     from rastervision.core.data import (ClassConfig, CRSTransformer,
                                         VectorOutputConfig)
@@ -32,7 +33,7 @@ class SemanticSegmentationLabels(Labels):
         self.dtype = dtype
 
     @abstractmethod
-    def __add__(self, other: Self) -> Self:
+    def __add__(self, other: 'Self') -> 'Self':
         """Merge self with other labels."""
 
     def __setitem__(self, window: Box, values: np.ndarray) -> None:
@@ -94,7 +95,7 @@ class SemanticSegmentationLabels(Labels):
         return self.extent.get_windows(size, size, **kwargs)
 
     def filter_by_aoi(self, aoi_polygons: list['Polygon'], null_class_id: int,
-                      **kwargs) -> Self:
+                      **kwargs) -> 'Self':
         """Keep only the values that lie inside the AOI.
 
         This is an inplace operation.
@@ -155,7 +156,7 @@ class SemanticSegmentationLabels(Labels):
 
     @classmethod
     def make_empty(cls, extent: Box, num_classes: int,
-                   smooth: bool = False) -> Self:
+                   smooth: bool = False) -> 'Self':
         """Instantiate an empty instance.
 
         Args:
@@ -188,7 +189,7 @@ class SemanticSegmentationLabels(Labels):
                          extent: Box,
                          num_classes: int,
                          smooth: bool = False,
-                         crop_sz: int | None = None) -> Self:
+                         crop_sz: int | None = None) -> 'Self':
         """Instantiate from windows and their corresponding predictions.
 
         Args:
@@ -270,7 +271,7 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
         # track which pixels have been hit at all
         self.hit_mask = np.zeros((self.height, self.width), dtype=bool)
 
-    def __add__(self, other: Self) -> Self:
+    def __add__(self, other: 'Self') -> 'Self':
         """Merge self with other labels by adding the pixel counts."""
         if self.extent != other.extent:
             raise ValueError('Cannot add labels with unqeual extents.')
@@ -278,7 +279,7 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
         self.pixel_counts += other.pixel_counts
         return self
 
-    def __eq__(self, other: Self) -> bool:
+    def __eq__(self, other: 'Self') -> bool:
         if not isinstance(other, SemanticSegmentationDiscreteLabels):
             return False
         if self.extent != other.extent:
@@ -347,7 +348,7 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
         self.pixel_counts[class_id, y0:y1, x0:x1][mask] = 1
 
     @classmethod
-    def make_empty(cls, extent: Box, num_classes: int) -> Self:
+    def make_empty(cls, extent: Box, num_classes: int) -> 'Self':
         """Instantiate an empty instance."""
         return cls(extent=extent, num_classes=num_classes)
 
@@ -357,7 +358,7 @@ class SemanticSegmentationDiscreteLabels(SemanticSegmentationLabels):
                          predictions: Iterable[Any],
                          extent: Box,
                          num_classes: int,
-                         crop_sz: int | None = None) -> Self:
+                         crop_sz: int | None = None) -> 'Self':
         labels = cls.make_empty(extent, num_classes)
         labels.add_predictions(windows, predictions, crop_sz=crop_sz)
         return labels
@@ -447,7 +448,7 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
             (self.num_classes, self.height, self.width), dtype=self.dtype)
         self.pixel_hits = np.zeros((self.height, self.width), dtype=dtype_hits)
 
-    def __add__(self, other: Self) -> Self:
+    def __add__(self, other: 'Self') -> 'Self':
         """Merge self with other by adding pixel scores and hits."""
         if self.extent != other.extent:
             raise ValueError('Cannot add labels with unqeual extents.')
@@ -456,7 +457,7 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
         self.pixel_hits += other.pixel_hits
         return self
 
-    def __eq__(self, other: Self) -> bool:
+    def __eq__(self, other: 'Self') -> bool:
         if not isinstance(other, SemanticSegmentationSmoothLabels):
             return False
         if self.extent != other.extent:
@@ -523,7 +524,7 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
         self.pixel_hits[y0:y1, x0:x1][mask] = 1
 
     @classmethod
-    def make_empty(cls, extent: Box, num_classes: int) -> Self:
+    def make_empty(cls, extent: Box, num_classes: int) -> 'Self':
         """Instantiate an empty instance."""
         return cls(extent=extent, num_classes=num_classes)
 
@@ -533,7 +534,7 @@ class SemanticSegmentationSmoothLabels(SemanticSegmentationLabels):
                          predictions: Iterable[Any],
                          extent: Box,
                          num_classes: int,
-                         crop_sz: int | None = None) -> Self:
+                         crop_sz: int | None = None) -> 'Self':
         labels = cls.make_empty(extent, num_classes)
         labels.add_predictions(windows, predictions, crop_sz=crop_sz)
         return labels

--- a/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source_config.py
+++ b/rastervision_core/rastervision/core/data/label_source/chip_classification_label_source_config.py
@@ -1,4 +1,4 @@
-from typing import Self
+from typing import TYPE_CHECKING
 
 from rastervision.core.data.vector_source import (VectorSourceConfig)
 from rastervision.core.data.label_source import (LabelSourceConfig,
@@ -7,6 +7,9 @@ from rastervision.pipeline.config import (ConfigError, register_config, Field,
                                           field_validator, model_validator)
 from rastervision.core.data.vector_transformer import (
     ClassInferenceTransformerConfig, BufferTransformerConfig)
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 def cc_label_source_config_upgrader(cfg_dict: dict, version: int) -> dict:
@@ -86,7 +89,7 @@ class ChipClassificationLabelSourceConfig(LabelSourceConfig):
         return v
 
     @model_validator(mode='after')
-    def ensure_bg_class_id_if_inferring(self) -> Self:
+    def ensure_bg_class_id_if_inferring(self) -> 'Self':
         infer_cells = self.infer_cells
         has_bg_class_id = self.background_class_id is not None
         if infer_cells and not has_bg_class_id:

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Sequence, Self
+from typing import TYPE_CHECKING, Sequence
 
 from pydantic import NonNegativeInt as NonNegInt
 import numpy as np
@@ -10,6 +10,7 @@ from rastervision.core.data.raster_source.stac_config import subset_assets
 from rastervision.core.data.utils import all_equal
 
 if TYPE_CHECKING:
+    from typing import Self
     from rastervision.core.data import RasterTransformer, CRSTransformer
 
 
@@ -81,7 +82,7 @@ class MultiRasterSource(RasterSource):
             channel_order: Sequence[int] | None = None,
             bbox: Box | tuple[int, int, int, int] | None = None,
             bbox_map_coords: Box | tuple[int, int, int, int] | None = None,
-            allow_streaming: bool = False) -> Self:
+            allow_streaming: bool = False) -> 'Self':
         """Construct a ``MultiRasterSource`` from a STAC Item.
 
         This creates a :class:`.RasterioSource` for each asset and puts all

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source_config.py
@@ -1,4 +1,4 @@
-from typing import Self
+from typing import TYPE_CHECKING
 
 from typing_extensions import Annotated
 from pydantic import NonNegativeInt as NonNegInt
@@ -8,6 +8,9 @@ from rastervision.pipeline.config import (Field, register_config,
 from rastervision.core.box import Box
 from rastervision.core.data.raster_source import (RasterSourceConfig,
                                                   MultiRasterSource)
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 def multi_rs_config_upgrader(cfg_dict: dict, version: int) -> dict:
@@ -42,7 +45,7 @@ class MultiRasterSourceConfig(RasterSourceConfig):
         'of shape (T, H, W, C) instead of concatenating bands.')
 
     @model_validator(mode='after')
-    def validate_primary_source_idx(self) -> Self:
+    def validate_primary_source_idx(self) -> 'Self':
         primary_source_idx = self.primary_source_idx
         raster_sources = self.raster_sources
         if not (0 <= primary_source_idx < len(raster_sources)):
@@ -51,7 +54,7 @@ class MultiRasterSourceConfig(RasterSourceConfig):
         return self
 
     @model_validator(mode='after')
-    def validate_temporal(self) -> Self:
+    def validate_temporal(self) -> 'Self':
         if self.temporal and self.channel_order is not None:
             raise ValueError(
                 'Setting channel_order is not allowed if temporal=True.')

--- a/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
+++ b/rastervision_core/rastervision/core/data/raster_transformer/stats_transformer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Self, Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
 
@@ -7,6 +7,7 @@ from rastervision.core.raster_stats import RasterStats
 from rastervision.pipeline.utils import repr_with_args
 
 if TYPE_CHECKING:
+    from typing import Self
     from rastervision.core.data import RasterSource
 
 
@@ -86,7 +87,7 @@ class StatsTransformer(RasterTransformer):
                             raster_sources: list['RasterSource'],
                             sample_prob: float | None = 0.1,
                             max_stds: float = 3.,
-                            chip_sz: int = 300) -> Self:
+                            chip_sz: int = 300) -> 'Self':
         """Build with stats from the given raster sources.
 
         Args:
@@ -114,7 +115,7 @@ class StatsTransformer(RasterTransformer):
     def from_stats_json(cls,
                         uri: str,
                         channel_order: list[int] | None = None,
-                        **kwargs) -> Self:
+                        **kwargs) -> 'Self':
         """Build with stats from a JSON file.
 
         The file is expected to be in the same format as written by
@@ -138,7 +139,7 @@ class StatsTransformer(RasterTransformer):
     def from_raster_stats(cls,
                           stats: RasterStats,
                           channel_order: list[int] | None = None,
-                          **kwargs) -> Self:
+                          **kwargs) -> 'Self':
         """Build with stats from a :class:`.RasterStats` instance.
 
         The file is expected to be in the same format as written by

--- a/rastervision_core/rastervision/core/evaluation/class_evaluation_item.py
+++ b/rastervision_core/rastervision/core/evaluation/class_evaluation_item.py
@@ -1,8 +1,11 @@
 """Defines ``ClassEvaluationItem``."""
-from typing import Self
+from typing import TYPE_CHECKING
 import numpy as np
 
 from rastervision.core.evaluation import EvaluationItem
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 class ClassEvaluationItem(EvaluationItem):
@@ -55,7 +58,7 @@ class ClassEvaluationItem(EvaluationItem):
 
     @classmethod
     def from_multiclass_conf_mat(cls, conf_mat: np.ndarray, class_id: int,
-                                 class_name: str, **kwargs) -> Self:
+                                 class_name: str, **kwargs) -> 'Self':
         """Construct from a multi-class confusion matrix and a target class ID.
 
         Args:

--- a/rastervision_core/rastervision/core/raster_stats.py
+++ b/rastervision_core/rastervision/core/raster_stats.py
@@ -1,4 +1,4 @@
-from typing import (TYPE_CHECKING, Iterable, Iterator, Self, Sequence)
+from typing import (TYPE_CHECKING, Iterable, Iterator, Sequence)
 
 import numpy as np
 from tqdm.auto import tqdm
@@ -8,6 +8,7 @@ from rastervision.pipeline.file_system import file_to_json, json_to_file
 from rastervision.core.data.utils import ensure_json_serializable
 
 if TYPE_CHECKING:
+    from typing import Self
     from rastervision.core.box import Box
     from rastervision.core.data import RasterSource
 
@@ -32,7 +33,7 @@ class RasterStats:
         self.counts = np.array(counts) if counts is not None else None
 
     @classmethod
-    def load(cls, stats_uri: str) -> Self:
+    def load(cls, stats_uri: str) -> 'Self':
         """Load stats from file."""
         stats_json = file_to_json(stats_uri)
         assert 'means' in stats_json and 'stds' in stats_json

--- a/rastervision_core/rastervision/core/rv_pipeline/chip_options.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/chip_options.py
@@ -1,4 +1,4 @@
-from typing import (Any, Literal, Self)
+from typing import (TYPE_CHECKING, Any, Literal)
 from enum import Enum
 
 from pydantic import NonNegativeInt as NonNegInt, PositiveInt as PosInt
@@ -8,6 +8,9 @@ from rastervision.core.rv_pipeline.utils import nodata_below_threshold
 from rastervision.core.utils import Proportion
 from rastervision.pipeline.config import (Config, ConfigError, Field,
                                           register_config, model_validator)
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 class WindowSamplingMethod(Enum):
@@ -87,7 +90,7 @@ class WindowSamplingConfig(Config):
         'intersecting the AOI will also be allowed.')
 
     @model_validator(mode='after')
-    def validate_options(self) -> Self:
+    def validate_options(self) -> 'Self':
         method = self.method
         size = self.size
         if method == WindowSamplingMethod.sliding:

--- a/rastervision_core/rastervision/core/rv_pipeline/object_detection_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/object_detection_config.py
@@ -1,4 +1,4 @@
-from typing import Self
+from typing import TYPE_CHECKING
 
 from rastervision.pipeline.config import (Field, register_config,
                                           model_validator)
@@ -6,6 +6,9 @@ from rastervision.core.rv_pipeline import (
     ChipOptions, RVPipelineConfig, PredictOptions, WindowSamplingConfig)
 from rastervision.core.data.label_store import ObjectDetectionGeoJSONStoreConfig
 from rastervision.core.evaluation import ObjectDetectionEvaluatorConfig
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 @register_config('object_detection_window_sampling')
@@ -61,7 +64,7 @@ class ObjectDetectionPredictOptions(PredictOptions):
          ))
 
     @model_validator(mode='after')
-    def validate_stride(self) -> Self:
+    def validate_stride(self) -> 'Self':
         if self.stride is None:
             self.stride = self.chip_sz // 2
         return self

--- a/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/rv_pipeline_config.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING
 from os.path import join
 
 from rastervision.pipeline.pipeline_config import PipelineConfig
@@ -13,6 +13,7 @@ from rastervision.pipeline.config import (Config, Field, register_config,
                                           model_validator)
 
 if TYPE_CHECKING:
+    from typing import Self
     from rastervision.core.backend.backend import Backend  # noqa
 
 
@@ -28,7 +29,7 @@ class PredictOptions(Config):
         8, description='Batch size to use during prediction.')
 
     @model_validator(mode='after')
-    def validate_stride(self) -> Self:
+    def validate_stride(self) -> 'Self':
         if self.stride is None:
             self.stride = self.chip_sz
         return self

--- a/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
+++ b/rastervision_core/rastervision/core/rv_pipeline/semantic_segmentation_config.py
@@ -1,4 +1,4 @@
-from typing import Literal, Self
+from typing import TYPE_CHECKING, Literal
 import logging
 
 from pydantic import NonNegativeInt as NonNegInt
@@ -12,6 +12,9 @@ from rastervision.core.rv_pipeline.chip_options import (ChipOptions,
                                                         WindowSamplingConfig)
 from rastervision.core.data import SemanticSegmentationLabelStoreConfig
 from rastervision.core.evaluation import SemanticSegmentationEvaluatorConfig
+
+if TYPE_CHECKING:
+    from typing import Self
 
 log = logging.getLogger(__name__)
 
@@ -94,7 +97,7 @@ class SemanticSegmentationPredictOptions(PredictOptions):
         'if stride is less than chip_sz. Defaults to None.')
 
     @model_validator(mode='after')
-    def set_auto_crop_sz(self) -> Self:
+    def set_auto_crop_sz(self) -> 'Self':
         if self.crop_sz == 'auto':
             if self.stride is None:
                 self.validate_stride()

--- a/rastervision_pipeline/rastervision/pipeline/config.py
+++ b/rastervision_pipeline/rastervision/pipeline/config.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal, Self
+from typing import TYPE_CHECKING, Literal
 from collections.abc import Callable
 import inspect
 import logging
@@ -13,6 +13,7 @@ from rastervision.pipeline.file_system import (file_to_json, json_to_file,
                                                str_to_file)
 
 if TYPE_CHECKING:
+    from typing import Self
     from rastervision.pipeline.pipeline_config import PipelineConfig
 
 log = logging.getLogger(__name__)
@@ -103,7 +104,7 @@ class Config(BaseModel):
             if val not in valid_options:
                 raise ConfigError(f'{val} is not a valid option for {field}')
 
-    def copy(self) -> Self:
+    def copy(self) -> 'Self':
         return self.model_copy()
 
     def dict(self, with_rv_metadata: bool = False, **kwargs) -> dict:
@@ -136,7 +137,7 @@ class Config(BaseModel):
             str_to_file(cfg_json, uri)
 
     @classmethod
-    def deserialize(cls, inp: 'str | dict | Config') -> Self:
+    def deserialize(cls, inp: 'str | dict | Config') -> 'Self':
         """Deserialize Config from a JSON file or dict, upgrading if possible.
 
         If ``inp`` is already a :class:`.Config`, it is returned as is.
@@ -153,7 +154,7 @@ class Config(BaseModel):
         raise TypeError(f'Cannot deserialize Config from type: {type(inp)}.')
 
     @classmethod
-    def from_file(cls, uri: str) -> Self:
+    def from_file(cls, uri: str) -> 'Self':
         """Deserialize Config from a JSON file, upgrading if possible.
 
         Args:
@@ -164,7 +165,7 @@ class Config(BaseModel):
         return cfg
 
     @classmethod
-    def from_dict(cls, cfg_dict: dict) -> Self:
+    def from_dict(cls, cfg_dict: dict) -> 'Self':
         """Deserialize Config from a dict.
 
         Args:

--- a/rastervision_pipeline/rastervision/pipeline/pipeline_config.py
+++ b/rastervision_pipeline/rastervision/pipeline/pipeline_config.py
@@ -1,10 +1,11 @@
+from typing import TYPE_CHECKING
 from os.path import join
-from typing import TYPE_CHECKING, Self
 
 from rastervision.pipeline.config import Config, Field
 from rastervision.pipeline.config import register_config
 
 if TYPE_CHECKING:
+    from typing import Self
     from rastervision.pipeline.pipeline import Pipeline
 
 
@@ -51,7 +52,7 @@ class PipelineConfig(Config):
         return cfg_dict
 
     @classmethod
-    def from_dict(cls, cfg_dict: dict) -> Self:
+    def from_dict(cls, cfg_dict: dict) -> 'Self':
         # override to retain plugin_versions
         from rastervision.pipeline.config import build_config, upgrade_config
         cfg_dict: dict = upgrade_config(cfg_dict)

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/dataset/dataset.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Literal, Self
+from typing import TYPE_CHECKING, Any, Literal
 import logging
 
 import numpy as np
@@ -16,6 +16,7 @@ from rastervision.pytorch_learner.dataset.transform import (TransformType,
                                                             TF_TYPE_TO_TF_FUNC)
 
 if TYPE_CHECKING:
+    from typing import Self
     from shapely.geometry import MultiPolygon, Polygon
 
 log = logging.getLogger(__name__)
@@ -173,7 +174,7 @@ class GeoDataset(AlbumentationsDataset):
         raise NotImplementedError()
 
     @classmethod
-    def from_uris(cls, *args, **kwargs) -> Self:
+    def from_uris(cls, *args, **kwargs) -> 'Self':
         raise NotImplementedError()
 
 

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner.py
@@ -1,4 +1,4 @@
-from typing import (TYPE_CHECKING, Any, Iterator, Literal, Self)
+from typing import (TYPE_CHECKING, Any, Iterator, Literal)
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from os.path import join, isfile, basename, isdir
@@ -40,6 +40,7 @@ from rastervision.pytorch_learner.utils import (
 from rastervision.pytorch_learner.dataset.visualizer import Visualizer
 
 if TYPE_CHECKING:
+    from typing import Self
     from torch.optim import Optimizer
     from torch.optim.lr_scheduler import _LRScheduler
     from torch.utils.data import Dataset, Sampler
@@ -265,7 +266,7 @@ class Learner(ABC):
                           cfg: 'LearnerConfig | None' = None,
                           training: bool = False,
                           use_onnx_model: bool | None = None,
-                          **kwargs) -> Self:
+                          **kwargs) -> 'Self':
         """Create a Learner from a model bundle.
 
         .. note::

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/learner_config.py
@@ -1,4 +1,4 @@
-from typing import (TYPE_CHECKING, Any, Iterable, Literal, Self, Sequence)
+from typing import (TYPE_CHECKING, Any, Iterable, Literal, Sequence)
 from collections.abc import Callable
 import os
 from os.path import join, isdir
@@ -33,6 +33,7 @@ from rastervision.pytorch_learner.utils import (
     torch_hub_load_local, torch_hub_load_github, torch_hub_load_uri)
 
 if TYPE_CHECKING:
+    from typing import Self
     from rastervision.core.data import SceneConfig
     from rastervision.pytorch_learner.learner import Learner
 
@@ -159,7 +160,7 @@ class ExternalModuleConfig(Config):
         False, description='Force reload of module definition.')
 
     @model_validator(mode='after')
-    def check_either_uri_or_repo(self) -> Self:
+    def check_either_uri_or_repo(self) -> 'Self':
         has_uri = self.uri is not None
         has_repo = self.github_repo is not None
         if has_uri == has_repo:
@@ -368,7 +369,7 @@ class SolverConfig(Config):
         'from this external source, using Torch Hub.')
 
     @model_validator(mode='after')
-    def check_no_loss_opts_if_external(self) -> Self:
+    def check_no_loss_opts_if_external(self) -> 'Self':
         has_external_loss_def = self.external_loss_def is not None
         has_ignore_class_index = self.ignore_class_index is not None
         has_class_loss_weights = self.class_loss_weights is not None
@@ -687,7 +688,7 @@ class DataConfig(Config):
         return v
 
     @model_validator(mode='after')
-    def validate_plot_options(self) -> Self:
+    def validate_plot_options(self) -> 'Self':
         if self.plot_options is not None and self.img_channels is not None:
             self.plot_options.update(img_channels=self.img_channels)
         return self
@@ -834,7 +835,7 @@ class ImageDataConfig(DataConfig):
         '(one for each group).')
 
     @model_validator(mode='after')
-    def validate_group_uris(self) -> Self:
+    def validate_group_uris(self) -> 'Self':
         group_train_sz = self.group_train_sz
         group_train_sz_rel = self.group_train_sz_rel
         group_uris = self.group_uris
@@ -1183,7 +1184,7 @@ class GeoDataConfig(DataConfig):
         return out
 
     @model_validator(mode='after')
-    def validate_sampling(self) -> Self:
+    def validate_sampling(self) -> 'Self':
         if not isinstance(self.sampling, dict):
             return self
 
@@ -1203,7 +1204,7 @@ class GeoDataConfig(DataConfig):
         return self
 
     @model_validator(mode='after')
-    def get_class_config_from_dataset_if_needed(self) -> Self:
+    def get_class_config_from_dataset_if_needed(self) -> 'Self':
         if self.class_config is None and self.scene_dataset is not None:
             self.class_config = self.scene_dataset.class_config
         return self
@@ -1377,14 +1378,14 @@ class LearnerConfig(Config):
             'is the epoch number.'))
 
     @model_validator(mode='after')
-    def validate_run_tensorboard(self) -> Self:
+    def validate_run_tensorboard(self) -> 'Self':
         if self.run_tensorboard and not self.log_tensorboard:
             raise ConfigError(
                 'Cannot run tensorboard if log_tensorboard is False')
         return self
 
     @model_validator(mode='after')
-    def validate_class_loss_weights(self) -> Self:
+    def validate_class_loss_weights(self) -> 'Self':
         if self.solver is None:
             return self
         class_loss_weights = self.solver.class_loss_weights

--- a/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
+++ b/rastervision_pytorch_learner/rastervision/pytorch_learner/utils/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Container, Iterable, Self, Sequence
+from typing import TYPE_CHECKING, Any, Container, Iterable, Sequence
 from os.path import basename, join, isfile
 import logging
 
@@ -17,6 +17,7 @@ from rastervision.pipeline.config import (build_config, Config, ConfigError,
                                           upgrade_config)
 
 if TYPE_CHECKING:
+    from typing import Self
     import onnxruntime as ort
     from rastervision.pytorch_learner import LearnerConfig
 
@@ -457,7 +458,8 @@ class ONNXRuntimeAdapter:
         self.input_key = inputs[0].name
 
     @classmethod
-    def from_file(cls, path: str, providers: list[str] | None = None) -> Self:
+    def from_file(cls, path: str,
+                  providers: list[str] | None = None) -> 'Self':
         """Construct from file.
 
         Args:


### PR DESCRIPTION
## Overview

`typing.Self` is only available in python>=3.11. v0.31.1 therefore broke compatibility with earlier python versions by making use of it in type hints. This PR moves the import of `typing.Self` to `if TYPE_CHECKING` blocks to fix that.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [x] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A