### PR TITLE
Handle non-deterministic pyproj failure

### DIFF
--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -40,6 +40,10 @@ class Box:
             ymax: maximum y value
             xmax: maximum x value
         """
+        if not all(math.isfinite(v) for v in (ymin, xmin, ymax, xmax)):
+            raise ValueError(
+                f'Invalid Box coordinates: {(ymin, xmin, ymax, xmax)}.')
+
         self.ymin = ymin
         self.xmin = xmin
         self.ymax = ymax

--- a/tests/core/test_box.py
+++ b/tests/core/test_box.py
@@ -443,6 +443,11 @@ class TestBox(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             _ = '' in Box(0, 0, 1, 1)
 
+    def test_error_on_nonfinite_inputs(self):
+        self.assertRaises(ValueError, lambda: Box(np.inf, 0, 0, 0))
+        self.assertRaises(ValueError, lambda: Box(-np.inf, 0, 0, 0))
+        self.assertRaises(ValueError, lambda: Box(np.nan, 0, 0, 0))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

This PR fixes a problem reported in #2257 and #2243 where `RasterioSource.get_chip()` would result in the error below:
```
  File "/opt/src/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py", line 79, in get_label_arr
    label_arr = self.raster_source.get_chip(window)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/src/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py", line 172, in get_chip
    chip = self._get_chip(window, out_shape=out_shape, bands=bands)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/src/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py", line 147, in _get_chip
    chip = fill_overflow(self.bbox, window, chip)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/src/rastervision_core/rastervision/core/data/utils/raster.py", line 35, in fill_overflow
    chip[..., :, xmax:, :] = fill_value
    ~~~~^^^^^^^^^^^^^^^^^^
TypeError: slice indices must be integers or None or have an __index__ method
```

This was tracked down to be the result of `pyproj.Transformer.transform()` non-deterministically returning `inf`s in some cases ... apparently due to network connectivity issues! More discussion:
- https://github.com/pyproj4/pyproj/issues/705
- https://github.com/pyproj4/pyproj/discussions/1421
- https://github.com/geopandas/geopandas/issues/3433

This PR also adds some validation code in the `Box` constructor to disallow non-finite values. This will allow similar errors to be caught earlier in the future.

### Checklist

- [x] Added unit tests, if applicable
- [x] Updated documentation, if applicable
- [x] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A


## Testing Instructions

- This was tested in a copy of the Kaggle notebook shared in #2257.

---

Closes #2257 
