### PR TITLE
Use rasterio `bounds()` and `from_bounds()` to transform `Box`s

### DIFF
--- a/rastervision_core/rastervision/core/box.py
+++ b/rastervision_core/rastervision/core/box.py
@@ -271,7 +271,7 @@ class Box:
 
     def to_rasterio(self) -> RioWindow:
         """Convert to a Rasterio Window."""
-        return RioWindow.from_slices(*self.normalize().to_slices())
+        return RioWindow.from_slices(*self.to_slices())
 
     def to_slices(self, h_step: int | None = None,
                   w_step: int | None = None) -> tuple[slice, slice]:

--- a/rastervision_core/rastervision/core/data/crs_transformer/crs_transformer.py
+++ b/rastervision_core/rastervision/core/data/crs_transformer/crs_transformer.py
@@ -59,24 +59,18 @@ class CRSTransformer(ABC):
             Coordinate-transformed input in the same format.
         """
         if isinstance(inp, Box):
-            box_in = inp
-            ymin, xmin, ymax, xmax = box_in
-            xmin_tf, ymin_tf = self._map_to_pixel((xmin, ymin))
-            xmax_tf, ymax_tf = self._map_to_pixel((xmax, ymax))
-            box_out = Box(ymin_tf, xmin_tf, ymax_tf, xmax_tf)
+            box_out = self._map_to_pixel_box(inp)
             if bbox is not None:
                 box_out = box_out.to_local_coords(bbox)
             return box_out
         elif isinstance(inp, BaseGeometry):
-            geom_in = inp
-            geom_out = transform(
-                lambda x, y, z=None: self._map_to_pixel((x, y)), geom_in)
+            geom_out = self._map_to_pixel_geom(inp)
             if bbox is not None:
                 xmin, ymin = bbox.xmin, bbox.ymin
                 geom_out = translate(geom_out, xoff=-xmin, yoff=-ymin)
             return geom_out
         elif len(inp) == 2:
-            out = self._map_to_pixel(inp)
+            out = self._map_to_pixel_point(inp)
             out_x, out_y = out
             out = (np.array(out_x), np.array(out_y))
             if bbox is not None:
@@ -128,25 +122,21 @@ class CRSTransformer(ABC):
             box_in = inp
             if bbox is not None:
                 box_in = box_in.to_global_coords(bbox)
-            ymin, xmin, ymax, xmax = box_in
-            xmin_tf, ymin_tf = self._pixel_to_map((xmin, ymin))
-            xmax_tf, ymax_tf = self._pixel_to_map((xmax, ymax))
-            box_out = Box(ymin_tf, xmin_tf, ymax_tf, xmax_tf)
+            box_out = self._pixel_to_map_box(box_in)
             return box_out
         elif isinstance(inp, BaseGeometry):
             geom_in = inp
             if bbox is not None:
                 xmin, ymin = bbox.xmin, bbox.ymin
                 geom_in = translate(geom_in, xoff=xmin, yoff=ymin)
-            geom_out = transform(
-                lambda x, y, z=None: self._pixel_to_map((x, y)), geom_in)
+            geom_out = self._pixel_to_map_geom(geom_in)
             return geom_out
         elif len(inp) == 2:
             if bbox is not None:
                 xmin, ymin = bbox.xmin, bbox.ymin
                 inp_x, inp_y = inp
                 inp = (inp_x + xmin, inp_y + ymin)
-            out = self._pixel_to_map(inp)
+            out = self._pixel_to_map_point(inp)
             out_x, out_y = out
             out = (np.array(out_x), np.array(out_y))
             return out
@@ -155,25 +145,87 @@ class CRSTransformer(ABC):
                 'Input must be 2-tuple or Box or shapely geometry.')
 
     @abstractmethod
-    def _map_to_pixel(self, point: tuple[float, float]) -> tuple[int, int]:
-        """Transform point from map to pixel coordinates.
+    def _map_to_pixel_point(self,
+                            point: tuple[float, float]) -> tuple[int, int]:
+        """Transform point(s) from map to pixel coordinates.
 
         Args:
-            map_point: (x, y) tuple in map coordinates (eg. lon/lat). x and y
-            can be single values or array-like.
+            map_point: ``(x, y)`` tuple in map coordinates (eg. lon/lat). ``x``
+                and ``y`` can be single values or array-like.
 
         Returns:
-            tuple[int, int]: (x, y) tuple in pixel coordinates.
+            ``(x, y)`` tuple in pixel coordinates.
         """
+
+    def _map_to_pixel_box(self, box: Box) -> Box:
+        """Transform a :class:`Box` from map to pixel coordinates.
+
+        Args:
+            box: Box to transform.
+
+        Returns:
+            Box in pixel coordinates.
+        """
+        ymin, xmin, ymax, xmax = box
+        xmin_tf, ymin_tf = self._map_to_pixel_point((xmin, ymin))
+        xmax_tf, ymax_tf = self._map_to_pixel_point((xmax, ymax))
+        pixel_box = Box(ymin_tf, xmin_tf, ymax_tf, xmax_tf)
+        return pixel_box
+
+    def _map_to_pixel_geom(self, geom: Box) -> Box:
+        """Transform a shapely geom from map to pixel coordinates.
+
+        Args:
+            geom: Geom to transform.
+
+        Returns:
+            Geom in pixel coordinates.
+        """
+        pixel_geom = transform(
+            lambda x, y, z=None: self._map_to_pixel_point((x, y)),
+            geom,
+        )
+        return pixel_geom
 
     @abstractmethod
-    def _pixel_to_map(self, point: tuple[int, int]) -> tuple[float, float]:
-        """Transform point from pixel to map coordinates.
+    def _pixel_to_map_point(self,
+                            point: tuple[int, int]) -> tuple[float, float]:
+        """Transform point(s) from pixel to map coordinates.
 
         Args:
-            pixel_point: (x, y) tuple in pixel coordinates. x and y can be
-            single values or array-like.
+            pixel_point: ``(x, y)`` tuple in pixel coordinates. ``x`` and ``y``
+                can be single values or array-like.
 
         Returns:
-            tuple[float, float]: (x, y) tuple in map coordinates (eg. lon/lat).
+            ``(x, y)`` tuple in map coordinates (eg. lon/lat).
         """
+
+    def _pixel_to_map_box(self, box: Box) -> Box:
+        """Transform a :class:`Box` from pixel to map coordinates.
+
+        Args:
+            box: Box to transform.
+
+        Returns:
+            Box in map coordinates (eg. lon/lat).
+        """
+        ymin, xmin, ymax, xmax = box
+        xmin_tf, ymin_tf = self._pixel_to_map_point((xmin, ymin))
+        xmax_tf, ymax_tf = self._pixel_to_map_point((xmax, ymax))
+        map_box = Box(ymin_tf, xmin_tf, ymax_tf, xmax_tf)
+        return map_box
+
+    def _pixel_to_map_geom(self, geom: Box) -> Box:
+        """Transform a shapely geom from pixel to map coordinates.
+
+        Args:
+            geom: Geom to transform.
+
+        Returns:
+            Geom in map coordinates.
+        """
+        map_geom = transform(
+            lambda x, y, z=None: self._pixel_to_map_point((x, y)),
+            geom,
+        )
+        return map_geom

--- a/rastervision_core/rastervision/core/data/crs_transformer/identity_crs_transformer.py
+++ b/rastervision_core/rastervision/core/data/crs_transformer/identity_crs_transformer.py
@@ -7,7 +7,7 @@ class IdentityCRSTransformer(CRSTransformer):
     This is useful for non-georeferenced imagery.
     """
 
-    def _map_to_pixel(self, map_point):
+    def _map_to_pixel_point(self, map_point):
         """Identity function.
 
         Args:
@@ -18,7 +18,7 @@ class IdentityCRSTransformer(CRSTransformer):
         """
         return map_point
 
-    def _pixel_to_map(self, pixel_point):
+    def _pixel_to_map_point(self, pixel_point):
         """Identity function.
 
         Args:

--- a/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/multi_raster_source.py
@@ -132,7 +132,7 @@ class MultiRasterSource(RasterSource):
         crs_transformer = raster_sources[primary_source_idx].crs_transformer
         if bbox_map_coords is not None:
             bbox_map_coords = Box(*bbox_map_coords)
-            bbox = crs_transformer.map_to_pixel(bbox_map_coords).normalize()
+            bbox = crs_transformer.map_to_pixel(bbox_map_coords)
         elif bbox is not None:
             bbox = Box(*bbox)
 

--- a/rastervision_core/rastervision/core/data/raster_source/raster_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/raster_source.py
@@ -166,7 +166,7 @@ class RasterSource(ABC):
                                **kwargs) -> 'np.ndarray':
         """Same as get_chip(), but input is a window in map coords."""
         window_pixel_coords = self.crs_transformer.map_to_pixel(
-            window_map_coords, bbox=self.bbox).normalize()
+            window_map_coords, bbox=self.bbox)
         chip = self.get_chip(window_pixel_coords, *args, **kwargs)
         return chip
 

--- a/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/xarray_source.py
@@ -147,7 +147,7 @@ class XarraySource(RasterSource):
             bbox = Box(*bbox)
         elif bbox_map_coords is not None:
             bbox_map_coords = Box(*bbox_map_coords)
-            bbox = crs_transformer.map_to_pixel(bbox_map_coords).normalize()
+            bbox = crs_transformer.map_to_pixel(bbox_map_coords)
         else:
             bbox = None
 

--- a/rastervision_core/rastervision/core/data/utils/rasterio.py
+++ b/rastervision_core/rastervision/core/data/utils/rasterio.py
@@ -100,7 +100,7 @@ def write_geotiff_like_geojson(path: str,
             crs = 'epsg:4326'
     crs_wkt = pyproj.CRS(crs).to_wkt()
     geoms = unary_union(list(geojson_to_geoms(geojson)))
-    bbox = Box.from_shapely(geoms).normalize()
+    bbox = Box.from_shapely(geoms)
     write_bbox(path, arr, bbox=bbox, crs_wkt=crs_wkt, **kwargs)
 
 

--- a/rastervision_core/setup.py
+++ b/rastervision_core/setup.py
@@ -7,7 +7,9 @@ import re
 name = 'rastervision_core'
 version = '0.31.2-dev'
 description = 'A rastervision plugin that adds geospatial machine learning pipelines'
-requirement_constraints = {}
+requirement_constraints = {
+    'pyproj': '<=3.7.0',
+}
 
 here = abspath(dirname(__file__))
 

--- a/tests/core/data/crs_transformer/test_rasterio_crs_transformer.py
+++ b/tests/core/data/crs_transformer/test_rasterio_crs_transformer.py
@@ -14,8 +14,8 @@ class TestRasterioCRSTransformer(unittest.TestCase):
         self.im_path = data_file_path('3857.tif')
         self.im_dataset = rasterio.open(self.im_path)
         self.crs_trans = RasterioCRSTransformer.from_dataset(self.im_dataset)
-        self.lon_lat = (-115.3063715, 36.1268253)
-        self.pix_point = (50, 61)
+        self.lon_lat = (-115.306372, 36.126825)
+        self.pix_point = (51, 62)
 
     def test_map_to_pixel_point(self):
         # w/o bbox

--- a/tests/core/data/mock_crs_transformer.py
+++ b/tests/core/data/mock_crs_transformer.py
@@ -7,8 +7,8 @@ class DoubleCRSTransformer(CRSTransformer):
     Assumes pixel coords are 2x map coords.
     """
 
-    def _map_to_pixel(self, map_point):
+    def _map_to_pixel_point(self, map_point):
         return (map_point[0] * 2.0, map_point[1] * 2.0)
 
-    def _pixel_to_map(self, pixel_point):
+    def _pixel_to_map_point(self, pixel_point):
         return (pixel_point[0] / 2.0, pixel_point[1] / 2.0)

--- a/tests/core/data/raster_source/test_multi_raster_source.py
+++ b/tests/core/data/raster_source/test_multi_raster_source.py
@@ -244,10 +244,14 @@ class TestMultiRasterSource(unittest.TestCase):
 
         # test bbox_map_coords
         bbox_map_coords = Box(
-            ymin=29.978710, xmin=31.134949, ymax=29.977309, xmax=31.136567)
+            ymin=29.977309,
+            xmin=31.134949,
+            ymax=29.978710,
+            xmax=31.136567,
+        )
         rs = MultiRasterSource.from_stac(
             item, assets=['red', 'green'], bbox_map_coords=bbox_map_coords)
-        self.assertEqual(rs.bbox, Box(ymin=50, xmin=50, ymax=206, xmax=206))
+        self.assertEqual(rs.bbox, Box(ymin=51, xmin=50, ymax=207, xmax=206))
 
         # test error if both bbox and bbox_map_coords specified
         args = dict(

--- a/tests/core/data/utils/test_rasterio.py
+++ b/tests/core/data/utils/test_rasterio.py
@@ -24,16 +24,14 @@ class TestRasterioUtils(unittest.TestCase):
             geotiff_path = join(tmp_dir, 'test.geotiff')
             write_bbox(geotiff_path, arr1, bbox=bbox, crs_wkt=crs_wkt)
             rs = RasterioSource(geotiff_path)
-            geotiff_bbox = rs.crs_transformer.pixel_to_map(
-                rs.extent).normalize()
+            geotiff_bbox = rs.crs_transformer.pixel_to_map(rs.extent)
             np.testing.assert_array_almost_equal(
                 np.array(list(geotiff_bbox)), np.array(list(bbox)), decimal=3)
             self.assertEqual(rs.shape, (*arr1.shape, 1))
 
             write_bbox(geotiff_path, arr2, bbox=bbox, crs_wkt=crs_wkt)
             rs = RasterioSource(geotiff_path)
-            geotiff_bbox = rs.crs_transformer.pixel_to_map(
-                rs.extent).normalize()
+            geotiff_bbox = rs.crs_transformer.pixel_to_map(rs.extent)
             np.testing.assert_array_almost_equal(
                 np.array(list(geotiff_bbox)), np.array(list(bbox)), decimal=3)
             self.assertEqual(rs.shape, arr2.shape)


### PR DESCRIPTION
## Overview

This PR refactors `RasterioCRSTransformer` to make use of `rasterio.bounds()` and `rasterio.from_bounds()` when transforming `Box`s. Previously, this was done by applying `xy()` and `rowcol()` to the `Box`'s corners, which sometimes required `Box.normalize()` to be called on the result.

### Checklist

- [x] Added unit tests, if applicable
- [x] Updated documentation, if applicable
- ~[ ] Added `needs-backport` label if the change should be back-ported to the previous release~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes
- This PR also constrains the required pyproj version to <= 3.7.0.
- Some unit tests had to be adjusted to account for small differences in `RasterioCRSTransformer`'s outputs following the changes in this PR.

## Testing Instructions

See unit tests.