### PR TITLE
Make compatible with numpy>=2

### DIFF
--- a/rastervision_core/rastervision/core/data/utils/vectorization.py
+++ b/rastervision_core/rastervision/core/data/utils/vectorization.py
@@ -134,7 +134,7 @@ def get_kernel(rectangle: RotatedRectange,
     element_rect: RotatedRectange = (pos, dim, angle)
     element_contour = cv2.boxPoints(box=element_rect)
     # https://stackoverflow.com/questions/48350693/what-is-numpy-method-int0
-    element_contour = np.int0(element_contour)
+    element_contour = np.intp(element_contour)
 
     cv2.drawContours(
         image=kernel,

--- a/rastervision_core/requirements.txt
+++ b/rastervision_core/requirements.txt
@@ -13,6 +13,6 @@ tqdm==4.66.5
 xarray==2024.7.0
 scikit-image==0.24.0
 boto3==1.34.155
-stackstac==0.5.0
+stackstac==0.5.1
 humanize==4.10.0
 triangle==20230923


### PR DESCRIPTION
## Overview

This PR makes a couple of small fixes to make the codebase compatible with numpy>=2. However, it does **not** update the required numpy version because of #2283. This means that docker images will still be built with numpy 1 for now, but users installing via `pip` will be able to install it alongside numpy>=2.

## Testing Instructions

This was tested by updating to numpy==2.1.3 inside the docker container and then checking that unit and integration tests succeed.