### PR TITLE
Fix args passed to `rasterio.transform.from_origin()` in `write_bbox()`

### DIFF
--- a/rastervision_core/rastervision/core/data/utils/rasterio.py
+++ b/rastervision_core/rastervision/core/data/utils/rasterio.py
@@ -59,7 +59,7 @@ def write_bbox(path: str, arr: np.ndarray, bbox: Box, crs_wkt: str, **kwargs):
     else:
         h_arr, w_arr, num_channels = arr.shape
     h_bbox, w_bbox = bbox.size
-    resolution = h_bbox / h_arr, w_bbox / w_arr
+    resolution = w_bbox / w_arr, h_bbox / h_arr
     transform = from_origin(bbox.xmin, bbox.ymax, *resolution)
     out_profile = dict(
         driver='GTiff',

--- a/tests/core/data/utils/test_rasterio.py
+++ b/tests/core/data/utils/test_rasterio.py
@@ -18,8 +18,8 @@ class TestRasterioUtils(unittest.TestCase):
         bbox = Box(ymin=48.815, xmin=2.224, ymax=48.902, xmax=2.469)
         crs_wkt = pyproj.CRS('epsg:4326').to_wkt()
         r = bbox.width / bbox.height
-        arr1 = np.zeros((100, int(100 * r)))
-        arr2 = np.zeros((100, int(100 * r), 4))
+        arr1 = np.zeros((50, int(100 * r)))
+        arr2 = np.zeros((50, int(100 * r), 4))
         with get_tmp_dir() as tmp_dir:
             geotiff_path = join(tmp_dir, 'test.geotiff')
             write_bbox(geotiff_path, arr1, bbox=bbox, crs_wkt=crs_wkt)


### PR DESCRIPTION
## Overview

This PR fixes a bug in `write_bbox()` where the horizontal and vertical components of the resolution were being passed in the wrong order to `rasterio.transform.from_origin()`. This wasn't caught before because the unit test for `write_bbox()` used square arrays; this test has now been updated to use rectangular arrays.

### Checklist

- [x] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

See updated unit tests.