### PR TITLE
Remove usage of deprecated albumentations `Flip()` transform

### DIFF
--- a/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/utils.py
+++ b/rastervision_pytorch_backend/rastervision/pytorch_backend/examples/semantic_segmentation/utils.py
@@ -2,7 +2,8 @@ import numpy as np
 import albumentations as A
 
 example_rgb_transform = A.Compose([
-    A.Flip(),
+    A.VerticalFlip(),
+    A.HorizontalFlip(),
     A.Transpose(),
     A.RandomRotate90(),
     A.ShiftScaleRotate(),
@@ -38,7 +39,8 @@ example_rgb_transform = A.Compose([
 # not all transforms work with more than 3 channels, here are
 # some of the ones that do
 example_multiband_transform = A.Compose([
-    A.Flip(),
+    A.VerticalFlip(),
+    A.HorizontalFlip(),
     A.Transpose(),
     A.RandomRotate90(),
     A.ShiftScaleRotate(),


### PR DESCRIPTION
## Overview

This PR replaces the deprecated `A.Flip()` transform with `A.HorizontalFlip()` and `A.VerticalFlip()`.

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

N/A

