### PR TITLE
Remove `setuptools_scm` from pyproject.tomls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/rastervision_aws_batch/pyproject.toml
+++ b/rastervision_aws_batch/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/rastervision_aws_s3/pyproject.toml
+++ b/rastervision_aws_s3/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/rastervision_aws_sagemaker/pyproject.toml
+++ b/rastervision_aws_sagemaker/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/rastervision_core/pyproject.toml
+++ b/rastervision_core/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/rastervision_gdal_vsi/pyproject.toml
+++ b/rastervision_gdal_vsi/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/rastervision_pipeline/pyproject.toml
+++ b/rastervision_pipeline/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/rastervision_pytorch_backend/pyproject.toml
+++ b/rastervision_pytorch_backend/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/rastervision_pytorch_learner/pyproject.toml
+++ b/rastervision_pytorch_learner/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Overview

This fixes an issue where `uv pip` installing from the repo started failing today with the error:

```
error: The build backend returned an error
  Caused by: Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

[stderr]
toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
Traceback (most recent call last):
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 58, in read_pyproject
    section = defn.get("tool", {})[tool_name]
              ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'setuptools_scm'
Traceback (most recent call last):
  File "<string>", line 14, in <module>
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=[])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
    self.run_setup()
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
    exec(code, locals())
  File "<string>", line 1, in <module>
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools/__init__.py", line 115, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 148, in setup
    _setup_distribution = dist = klass(attrs)
                                 ^^^^^^^^^^^^
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools/dist.py", line 321, in __init__
    _Distribution.__init__(self, dist_attrs)
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 309, in __init__
    self.finalize_options()
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools/dist.py", line 784, in finalize_options
    ep(self)
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools_scm/_integration/setuptools.py", line 171, in infer_version
    _assign_version(dist, config)
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools_scm/_integration/setuptools.py", line 78, in _assign_version
    _version_missing(config)
  File ".../.cache/uv/builds-v0/.tmp2YqYV0/lib/python3.12/site-packages/setuptools_scm/_get_version_impl.py", line 188, in _version_missing
    raise LookupError(error_msg)
LookupError: setuptools-scm was unable to detect version for .../.cache/uv/git-v0/checkouts/0e1821795cc4f604/558221c0/rastervision_pipeline.

Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj

Alternatively, set the version with the environment variable SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME} as described in https://setuptools-scm.readthedocs.io/en/latest/config/

hint: This usually indicates a problem with the package or the build environment.
```

### Checklist

- [ ] Added unit tests, if applicable
- [ ] Updated documentation, if applicable
- [ ] Added `needs-backport` label if the change should be back-ported to the previous release
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

N/A

## Testing Instructions

Verified to work locally.