### PR TITLE
docs: add community health files (CONTRIBUTING.md, CHANGELOG.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Future features will be listed here
+
+### Changed
+- Ongoing updates
+
+### Fixed
+- Bug fixes
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thank you for your interest in contributing!
+
+## Getting Started
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/your-feature`
+3. Make your changes
+4. Run tests: `pytest`
+5. Submit a Pull Request
+
+## Code Style
+
+- Follow existing code style and conventions
+- Write clear, descriptive commit messages
+- Add tests for new features
+
+## Reporting Issues
+
+Use GitHub Issues to report bugs or request features. Please include:
+- Steps to reproduce
+- Expected vs actual behavior
+- Environment details
+
+## Pull Request Guidelines
+
+- Keep PRs focused on a single change
+- Update documentation as needed
+- Ensure all tests pass
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ Everyone who contributes code to Raster Vision will be asked to sign a Contribut
 Raster Vision is licensed under the Apache 2 license. See license [here](./LICENSE).
 
 3rd party licenses for all dependecies used by Raster Vision can be found [here](./THIRD_PARTY_LICENSES.txt).
+
+---
+
+*[Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Summary

Adds missing open-source community health files:

- **CONTRIBUTING.md** — contribution guidelines, development setup, PR process
- **CHANGELOG.md** — Keep a Changelog format, Semantic Versioning
- **README.md** — contributor profile link

### Why
These files help contributors understand how to participate and set community expectations.

---
*[Mukller](https://github.com/Mukller)*