### PR TITLE
fix: add null_class_id override to SemanticSegmentationLabelSource

### DIFF
--- a/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
+++ b/rastervision_core/rastervision/core/data/label_source/semantic_segmentation_label_source.py
@@ -19,22 +19,32 @@ class SemanticSegmentationLabelSource(LabelSource):
     def __init__(self,
                  raster_source: RasterSource,
                  class_config: ClassConfig,
-                 bbox: Box | None = None):
+                 bbox: Box | None = None,
+                 null_class_id: int | None = None):
         """Constructor.
 
         Args:
             raster_source: A raster source that returns a single channel raster
                 with class_ids as values.
-            null_class_id: the null class id used as fill values for when
-                windows go over the edge of the label array. This can be
-                retrieved using ``class_config.null_class_id``.
+            class_config: Configuration for the classes used in the label
+                source.
             bbox: User-specified crop of the extent. If ``None``, the full
                 extent available in the source file is used.
+            null_class_id: Override for the null class id used as fill value
+                when windows go over the edge of the label array. If ``None``,
+                uses ``class_config.null_class_id``.
         """
         self.raster_source = raster_source
         self.class_config = class_config
+        self._null_class_id = null_class_id
         if bbox is not None:
             self.set_bbox(bbox)
+
+    @property
+    def null_class_id(self) -> int:
+        if self._null_class_id is not None:
+            return self._null_class_id
+        return self.class_config.null_class_id
 
     def get_labels(self,
                    window: Box | None = None) -> SemanticSegmentationLabels:
@@ -82,7 +92,7 @@ class SemanticSegmentationLabelSource(LabelSource):
         h, w = label_arr.shape
         if h < window.height or w < window.width:
             label_arr = pad_to_window_size(label_arr, window, self.extent,
-                                           self.class_config.null_class_id)
+                                           self.null_class_id)
         return label_arr
 
     @property

--- a/tests/core/data/label_source/test_semantic_segmentation_label_source.py
+++ b/tests/core/data/label_source/test_semantic_segmentation_label_source.py
@@ -80,6 +80,40 @@ class TestSemanticSegmentationLabelSource(unittest.TestCase):
         expected_label_arr = np.zeros((3, 3))
         np.testing.assert_array_equal(label_arr, expected_label_arr)
 
+    def test_null_class_id_default(self):
+        """Default null_class_id is taken from class_config."""
+        class_config = ClassConfig(names=['bg', 'fg', 'null'])
+        raster_source = MockRasterSource([0], 1)
+        raster_source.set_raster(np.zeros((10, 10, 1), dtype=np.uint8))
+        label_source = SemanticSegmentationLabelSource(
+            raster_source, class_config)
+        self.assertEqual(
+            label_source.null_class_id, class_config.null_class_id)
+
+    def test_null_class_id_override(self):
+        """Explicit null_class_id overrides class_config."""
+        class_config = ClassConfig(names=['bg', 'fg', 'null'])
+        raster_source = MockRasterSource([0], 1)
+        raster_source.set_raster(np.zeros((10, 10, 1), dtype=np.uint8))
+        label_source = SemanticSegmentationLabelSource(
+            raster_source, class_config, null_class_id=255)
+        self.assertEqual(label_source.null_class_id, 255)
+
+    def test_null_class_id_override_off_edge(self):
+        """Custom null_class_id is used as fill when window goes off edge."""
+        data = np.zeros((10, 10, 1), dtype=np.uint8)
+        data[7:, 7:, 0] = 1
+        class_config = ClassConfig(names=['bg', 'fg', 'null'])
+        raster_source = MockRasterSource([0], 1)
+        raster_source.set_raster(data)
+        label_source = SemanticSegmentationLabelSource(
+            raster_source, class_config, null_class_id=255)
+        window = Box.make_square(7, 7, 6)
+        label_arr = label_source.get_label_arr(window)
+        expected_label_arr = np.full((6, 6), 255)
+        expected_label_arr[0:3, 0:3] = 1
+        np.testing.assert_array_equal(label_arr, expected_label_arr)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #2326 by adding an optional `null_class_id` parameter to `SemanticSegmentationLabelSource.__init__` that overrides `class_config.null_class_id`. Also fixes the outdated docstring that referenced a `null_class_id` parameter that didn't exist in the signature.

## Changes

- **`semantic_segmentation_label_source.py`**: Added `null_class_id: int | None = None` parameter to `__init__`. Exposed via a `null_class_id` property that falls back to `class_config.null_class_id` when not set. Updated `get_label_arr` to use the lazy property. Fixed docstring to accurately describe all parameters.
- **`test_semantic_segmentation_label_source.py`**: Added 3 tests — default behavior, explicit override, and override used for off-edge padding.

## Backward Compatibility

Fully backward compatible. When `null_class_id` is `None` (default), behavior is identical to the current implementation. The lazy property approach means `class_config.null_class_id` is only evaluated when actually needed (off-edge windows), preserving the original lazy evaluation pattern.

Closes #2326.