### PR TITLE
feat: add keep_native_crs option to RasterioSource

### DIFF
--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source.py
@@ -44,7 +44,8 @@ class RasterioSource(RasterSource):
                  allow_streaming: bool = False,
                  channel_order: Sequence[int] | None = None,
                  bbox: Box | None = None,
-                 tmp_dir: str | None = None):
+                 tmp_dir: str | None = None,
+                 keep_native_crs: bool = False):
         """Constructor.
 
         Args:
@@ -63,9 +64,15 @@ class RasterioSource(RasterSource):
             tmp_dir: Directory to use for storing the VRT (needed if multiple
                 ``uris`` or ``allow_streaming=True``). If ``None``,
                 will be auto-generated. Defaults to ``None``.
+            keep_native_crs: If ``True``, use the input raster's native CRS
+                for both image_crs and map_crs instead of defaulting map_crs
+                to EPSG:4326. This eliminates precision loss from unnecessary
+                CRS transformations and avoids edge artifacts at tile
+                boundaries. Defaults to ``False``.
         """
         self.uris = listify_uris(uris)
         self.allow_streaming = allow_streaming
+        self.keep_native_crs = keep_native_crs
         self._num_channels = None
         self._dtype = None
 
@@ -90,8 +97,12 @@ class RasterioSource(RasterSource):
                         f'{block_shapes}. This can slow down reading. '
                         'Consider re-tiling using GDAL.')
 
-        self._crs_transformer = RasterioCRSTransformer.from_dataset(
-            self.image_dataset)
+        if keep_native_crs:
+            self._crs_transformer = RasterioCRSTransformer.from_dataset(
+                self.image_dataset, map_crs=None)
+        else:
+            self._crs_transformer = RasterioCRSTransformer.from_dataset(
+                self.image_dataset)
 
         dtype_raw = np.dtype(self.image_dataset.dtypes[0])
         num_channels_raw = self.image_dataset.count
@@ -196,7 +207,7 @@ class RasterioSource(RasterSource):
     def __repr__(self):
         arg_keys = [
             'uris', 'channel_order', 'bbox', 'raster_transformers',
-            'allow_streaming', 'tmp_dir'
+            'allow_streaming', 'tmp_dir', 'keep_native_crs'
         ]
         arg_vals = [getattr(self, k) for k in arg_keys]
         arg_strs = [f'{k}={v!r}' for k, v in zip(arg_keys, arg_vals)]

--- a/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
+++ b/rastervision_core/rastervision/core/data/raster_source/rasterio_source_config.py
@@ -33,6 +33,11 @@ class RasterioSourceConfig(RasterSourceConfig):
     allow_streaming: bool = Field(
         False,
         description='Stream assets as needed rather than downloading them.')
+    keep_native_crs: bool = Field(
+        False,
+        description='If True, use the input raster\'s native CRS for both '
+        'image_crs and map_crs instead of defaulting map_crs to EPSG:4326. '
+        'This eliminates precision loss from unnecessary CRS transformations.')
 
     def build(self, tmp_dir: str | None,
               use_transformers: bool = True) -> RasterioSource:
@@ -50,4 +55,5 @@ class RasterioSourceConfig(RasterSourceConfig):
             tmp_dir=tmp_dir,
             allow_streaming=self.allow_streaming,
             channel_order=self.channel_order,
-            bbox=bbox)
+            bbox=bbox,
+            keep_native_crs=self.keep_native_crs)

--- a/tests/core/data/raster_source/test_rasterio_source.py
+++ b/tests/core/data/raster_source/test_rasterio_source.py
@@ -267,6 +267,33 @@ class TestRasterioSource(unittest.TestCase):
         self.assertTrue(np.all(out[mask] == 1))
         self.assertTrue(np.all(out[~mask] == 0))
 
+    def test_keep_native_crs_default(self):
+        img_path = data_file_path('3857.tif')
+        config = RasterioSourceConfig(uris=[img_path])
+        source = config.build(tmp_dir=self.tmp_dir)
+        self.assertEqual(source.crs_transformer.map_crs.lower(), 'epsg:4326')
+        self.assertNotEqual(
+            source.crs_transformer.map_crs,
+            source.crs_transformer.image_crs)
+
+    def test_keep_native_crs_true(self):
+        img_path = data_file_path('3857.tif')
+        config = RasterioSourceConfig(
+            uris=[img_path], keep_native_crs=True)
+        source = config.build(tmp_dir=self.tmp_dir)
+        self.assertEqual(
+            source.crs_transformer.map_crs,
+            source.crs_transformer.image_crs)
+
+    def test_keep_native_crs_true_on_4326(self):
+        img_path = data_file_path('small-rgb-tile.tif')
+        config = RasterioSourceConfig(
+            uris=[img_path], keep_native_crs=True)
+        source = config.build(tmp_dir=self.tmp_dir)
+        self.assertEqual(
+            source.crs_transformer.map_crs,
+            source.crs_transformer.image_crs)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #2323 — adds `keep_native_crs` parameter to `RasterioSource` and `RasterioSourceConfig` that preserves the input raster's native CRS for both `image_crs` and `map_crs`, instead of defaulting `map_crs` to EPSG:4326.

## Motivation

When `RasterioSource` reads a raster with a projected CRS (e.g. EPSG:3857), the `RasterioCRSTransformer` defaults `map_crs` to EPSG:4326 even when the image_crs is already a projected coordinate system. This causes:
- Precision loss from unnecessary reprojection between two projected CRS
- Edge artifacts at tile boundaries from repeated reprojection
- Performance cost of redundant CRS transformations

## Changes

- **`RasterioSource.__init__`**: Added `keep_native_crs: bool = False` parameter.
- **`RasterioSourceConfig`**: Added `keep_native_crs: bool = Field(False)`.
- **Tests**: 3 tests — default behavior, EPSG:3857 input, EPSG:4326 input.

## Backward Compatibility

Fully backward compatible. `keep_native_crs=False` (default) preserves existing behavior.

Closes #2323.